### PR TITLE
added the ability to override the default naming of custom connections.

### DIFF
--- a/src/Schema/Field.php
+++ b/src/Schema/Field.php
@@ -53,7 +53,7 @@ class Field
     /**
      * Attach middleware to field.
      *
-     * @param array $attributes
+     * @param array $middleware
      */
     public function addMiddleware(array $middleware)
     {

--- a/src/Schema/Registrars/ConnectionRegistrar.php
+++ b/src/Schema/Registrars/ConnectionRegistrar.php
@@ -112,8 +112,11 @@ class ConnectionRegistrar extends BaseRegistrar
     protected function instanceName($name)
     {
         if ($name instanceof Connection) {
-            $class = (new ReflectionClass($name))->getName();
+            if($name->name() != null){
+                return $name->name();
+            }
 
+            $class = (new ReflectionClass($name))->getName();
             return strtolower(snake_case((str_replace('\\', '_', $class))));
         }
 

--- a/src/Schema/Registrars/ConnectionRegistrar.php
+++ b/src/Schema/Registrars/ConnectionRegistrar.php
@@ -112,12 +112,7 @@ class ConnectionRegistrar extends BaseRegistrar
     protected function instanceName($name)
     {
         if ($name instanceof Connection) {
-            if($name->name() != null){
-                return $name->name();
-            }
-
-            $class = (new ReflectionClass($name))->getName();
-            return strtolower(snake_case((str_replace('\\', '_', $class))));
+            return strtolower(snake_case((str_replace('\\', '_', $name->name()))));
         }
 
         return $name;

--- a/src/Support/Console/Commands/stubs/relay_connection.stub
+++ b/src/Support/Console/Commands/stubs/relay_connection.stub
@@ -9,12 +9,12 @@ class DummyClass implements Connection
 {
 
     /**
-     * get the name of the connection. if this is
-     * null it will default to the full classname including namespaces
+     * Get the name of the connection.
+     * Note: Connection names must be unique
      * @return string
      */
     public function name(){
-        return null;
+        return (new ReflectionClass(new static))->getName();
     }
 
     /**

--- a/src/Support/Console/Commands/stubs/relay_connection.stub
+++ b/src/Support/Console/Commands/stubs/relay_connection.stub
@@ -7,6 +7,16 @@ use Nuwave\Lighthouse\Support\Interfaces\Connection;
 
 class DummyClass implements Connection
 {
+
+    /**
+     * get the name of the connection. if this is
+     * null it will default to the full classname including namespaces
+     * @return string
+     */
+    public function name(){
+        return null;
+    }
+
     /**
      * Get name of connection.
      *

--- a/src/Support/Interfaces/Connection.php
+++ b/src/Support/Interfaces/Connection.php
@@ -6,8 +6,18 @@ use GraphQL\Type\Definition\ResolveInfo;
 
 interface Connection
 {
+
+
     /**
-     * Get name of connection.
+     * get the name of the connection. if this is
+     * null it will default to the full classname including namespaces
+     * @return string
+     */
+    public function name();
+
+
+    /**
+     * Get the type of connection.
      *
      * @return string
      */

--- a/src/Support/Interfaces/Connection.php
+++ b/src/Support/Interfaces/Connection.php
@@ -9,8 +9,8 @@ interface Connection
 
 
     /**
-     * get the name of the connection. if this is
-     * null it will default to the full classname including namespaces
+     * Get the name of the connection.
+     * Note: Connection names must be unique
      * @return string
      */
     public function name();

--- a/tests/Support/GraphQL/Connections/TaskConnection.php
+++ b/tests/Support/GraphQL/Connections/TaskConnection.php
@@ -8,6 +8,17 @@ use Nuwave\Lighthouse\Tests\Support\Models\Task;
 
 class TaskConnection implements Connection
 {
+
+    /**
+     * get the name of the connection. if this is
+     * null it will default to the full classname including namespaces
+     * @return string
+     */
+    public function name()
+    {
+        return "TaskConnection";
+    }
+
     /**
      * Get name of connection.
      *
@@ -42,4 +53,5 @@ class TaskConnection implements Connection
             $query->where('id', $parent->id);
         })->getConnection($args);
     }
+
 }


### PR DESCRIPTION
I'm integrating this project into a work project, and I wanted to have clean connection names. I found that the default names where a bit unwieldy especially if you have your custom connections nested deep in some namespaces. No worries if you don't want to merge this in. 