### PR TITLE
Allow setting description on Connections

### DIFF
--- a/src/Schema/Registrars/ConnectionRegistrar.php
+++ b/src/Schema/Registrars/ConnectionRegistrar.php
@@ -83,6 +83,10 @@ class ConnectionRegistrar extends BaseRegistrar
         $connectionName = (!preg_match('/Connection$/', $instanceName)) ? $instanceName.'Connection' : $instanceName;
         $connection->setName(studly_case($connectionName));
 
+        if($isConnection && is_callable([$name, 'description'])) {
+            $connection->setDescription($name->description());
+        }
+
         $pageInfoType = $this->getSchema()->typeInstance('pageInfo');
         $edgeType = $this->getSchema()->edgeInstance($instanceName, $nodeType);
 

--- a/src/Support/Definition/RelayConnectionType.php
+++ b/src/Support/Definition/RelayConnectionType.php
@@ -47,6 +47,13 @@ class RelayConnectionType extends GraphQLType
     protected $name = '';
 
     /**
+     * The description of the connection (i.e. `A connection between the User and it's Tasks`)
+     *
+     * @var string
+     */
+    protected $description = 'A connection to a list of items.';
+
+    /**
      * Special fields present on this connection type.
      *
      * @return array
@@ -165,7 +172,7 @@ class RelayConnectionType extends GraphQLType
 
         return [
             'name' => ucfirst($this->name),
-            'description' => 'A connection to a list of items.',
+            'description' => $this->description,
             'fields' => $fields,
             'resolve' => function ($root, $args, $context, ResolveInfo $info) {
                 return $this->resolve($root, $args, $context, $info, $this->name);
@@ -197,6 +204,16 @@ class RelayConnectionType extends GraphQLType
     public function setName($name)
     {
         $this->name = $name;
+    }
+
+    /**
+     * Set description of connection.
+     *
+     * @param string $description
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
     }
 
     /**


### PR DESCRIPTION
Currently the connection descriptions are hard coded to `A connection to a list of items.`.

This small update allows you to add a `description(){}` method to your `Connection` to override this.

This is useful in the instance where you have several relations named in a similar fashion where the name itself is not enough to distinguish the purpose.