### PR TITLE
Add toConnection macro onto Relation

### DIFF
--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -105,14 +105,14 @@ class LaravelServiceProvider extends ServiceProvider
             $currentPage = $first && $after ? floor(($first + $after) / $first) : 1;
 
             if($this instanceof Relation){
-                $builder = $this->getQuery();
-                $items = $builder->forPage($currentPage, $first)->get();
+                $count = $this->getQuery()->count();
+                $items = $this->getQuery()->forPage($currentPage, $first)->get();
             } else {
-                $builder = $this;
-                $items = $builder->forPage($currentPage, $first);
+                $count = $this->count();
+                $items = $this->forPage($currentPage, $first);
             }
 
-            return new LengthAwarePaginator($items, $builder->count(), $first, $currentPage);
+            return new LengthAwarePaginator($items, $count, $first, $currentPage);
         };
 
         Collection::macro($name, $connectionMacro);


### PR DESCRIPTION
Currently the docs state you should be able to do e.g. `$user->roles()->toConnection()`to trigger the macro.

However this doesn't actually work because the macro is registered onto `Collection` meaning you actually need to do `$user->roles->toConnection()` the downside of this of course is that you've now fetched every single role instead of the paginated set and then you slice it.

This patch adds the macro onto both `Collection` and `Relation` with some minor tweaks to make it work for the Relation so it only fetches the required subset of the data.

Now the issue with this pull request is that it *will* cause the tests to fail because Relation only became macroable in Laravel 5.4.

So we either need to check if Relation has the trait, only apply the macro to Relation if it does, and document that in 5.3 you need to use `->relation->toCollection()` and the relevant pitfalls.

Or we bump the minimum version to 5.4. Thoughts?

--
Side note, we should really setup a working travis config.