### PR TITLE
Set minimum PHP requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         }
     ],
     "require": {
+        "php": ">=5.5.9",
         "illuminate/console": "^5.2",
         "illuminate/contracts": "^5.2",
         "illuminate/database": "^5.2",


### PR DESCRIPTION
Set minimum PHP requirement

---

Laravel 5.2 requires PHP>=5.5.9

---

Requires https://github.com/nuwave/lighthouse/pull/33