### PR TITLE
Enable code coverage with Codecov.io.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: off

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 
 /assets export-ignore
  /tests export-ignore
+ .codecov.yml export-ignore
 .editorconfig export-ignore
 .php_cs export-ignore
 .styleci.yml export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,5 @@ install:
 script:
   - vendor/bin/phpunit
 
+after_success:
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Enable code coverage with Codecov.io

After the repo is enabled at https://codecov.io - a coverage report status will be created for each build

---

**Note:**

Codecov is free for public repositories.