### PR TITLE
use valid dummy graphql query if request query is empty

### DIFF
--- a/src/Support/Http/Controllers/GraphQLController.php
+++ b/src/Support/Http/Controllers/GraphQLController.php
@@ -18,7 +18,7 @@ class GraphQLController extends Controller
         graphql()->prepSchema();
 
         $this->middleware(graphql()->middleware()->forRequest(
-            $request->input('query', '')
+            $request->input('query', '{ empty }')
         ));
     }
 


### PR DESCRIPTION
@chrissm79 When I use artisan CLI command:
 `php artisan route:list`
I catch error:
```
   GraphQL\Error\SyntaxError  : Syntax Error GraphQL (1:1) Unexpected <EOF>
  at /Users/latik/Dev/projects/lighthouse/vendor/webonyx/graphql-php/src/Language/Parser.php: 236
```
It happening because if request query is empty we put the empty string in Parser and it not a valid GraphQL query. 
I not sure that "{ empty }" string is the best decision but it works fine for this case.
