### PR TITLE
Lumen support

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -12,10 +12,13 @@ return [
     | setup more endpoints, ej: pointing to the controller value inside your route file
     |
     */
+    'route_name' => 'graphql',
+
     'route' => [
-        'prefix' => 'graphql',
+        'prefix' => '',
         // 'middleware' => ['web','api'],    // [ 'loghttp']
     ],
+
 
     /*
     |--------------------------------------------------------------------------

--- a/config/config.php
+++ b/config/config.php
@@ -3,6 +3,22 @@
 return [
     /*
     |--------------------------------------------------------------------------
+    | LightHouse endpoint & middleware
+    |--------------------------------------------------------------------------
+    |
+    | Setup this values as required,
+    | default route endpoints its yourdomain.com/graphql
+    | setup middleware here for all request,
+    | setup more endpoints, ej: pointing to the controller value inside your route file
+    |
+    */
+    'route' => [
+        'prefix' => 'graphql',
+        // 'middleware' => ['web','api'],    // [ 'loghttp']
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Directive registry
     |--------------------------------------------------------------------------
     |

--- a/src/Schema/Directives/Fields/CanDirective.php
+++ b/src/Schema/Directives/Fields/CanDirective.php
@@ -48,7 +48,7 @@ class CanDirective implements FieldMiddleware
                 $model = $model ?: get_class($args[0]);
 
                 $can = collect($policies)->reduce(function ($allowed, $policy) use ($model) {
-                    if (! auth()->user()->can($policy, $model)) {
+                    if (! \Auth::user()->can($policy, $model)) {
                         return false;
                     }
 

--- a/src/Support/Http/Controllers/GraphQLController.php
+++ b/src/Support/Http/Controllers/GraphQLController.php
@@ -40,7 +40,7 @@ class GraphQLController extends Controller
 
         return graphql()->execute(
             $query,
-            new Context($request, auth()->user()),
+            new Context($request, \Auth::user()),
             $variables
         );
     }

--- a/src/Support/Http/routes.php
+++ b/src/Support/Http/routes.php
@@ -1,8 +1,9 @@
 <?php
 
 $route = config('lighthouse.route', []);
+$route_name = config('lighthouse.route_name', 'graphql');
 $controller = config('lighthouse.controller');
 
-Route::group($route, function () use ($controller) {
-    Route::post('graphql', ['as' => 'graphql', 'uses' => $controller]);
+Route::group($route, function () use ($controller, $route_name) {
+    Route::post($route_name, ['as' => 'lighthouse.graphql', 'uses' => $controller]);
 });


### PR DESCRIPTION
With this Lumen does not break on getting the context.
@auth directive can't be used.
instead of using `\Auth::user()` it could be obtained from the `$request->user()`.

Im going to add full auth with passport on the lumen demo, you can take from there what you need for your documentation, no need to ask.

NOTE: tried to split the commits but obviously I forgot to roll back before last!