### PR TITLE
Remove dependencies on Facades

### DIFF
--- a/src/Schema/Directives/Fields/AuthDirective.php
+++ b/src/Schema/Directives/Fields/AuthDirective.php
@@ -35,7 +35,7 @@ class AuthDirective implements FieldResolver
         );
 
         return $value->setResolver(function () use ($guard) {
-            return auth($guard)->user();
+            return app('auth')->guard($guard)->user();
         });
     }
 }

--- a/src/Schema/Directives/Fields/AuthDirective.php
+++ b/src/Schema/Directives/Fields/AuthDirective.php
@@ -35,7 +35,7 @@ class AuthDirective implements FieldResolver
         );
 
         return $value->setResolver(function () use ($guard) {
-            return app('auth')->guard($guard)->user();
+            return auth()->guard($guard)->user();
         });
     }
 }

--- a/src/Schema/Directives/Fields/AuthDirective.php
+++ b/src/Schema/Directives/Fields/AuthDirective.php
@@ -35,7 +35,7 @@ class AuthDirective implements FieldResolver
         );
 
         return $value->setResolver(function () use ($guard) {
-            return auth()->guard($guard)->user();
+            return auth($guard)->user();
         });
     }
 }

--- a/src/Schema/Directives/Fields/CanDirective.php
+++ b/src/Schema/Directives/Fields/CanDirective.php
@@ -48,7 +48,7 @@ class CanDirective implements FieldMiddleware
                 $model = $model ?: get_class($args[0]);
 
                 $can = collect($policies)->reduce(function ($allowed, $policy) use ($model) {
-                    if (! \Auth::user()->can($policy, $model)) {
+                    if (! app('auth')->user()->can($policy, $model)) {
                         return false;
                     }
 

--- a/src/Support/DataLoader/QueryBuilder.php
+++ b/src/Support/DataLoader/QueryBuilder.php
@@ -103,7 +103,7 @@ class QueryBuilder
         })->implode(' UNION ALL ');
 
         $table = $related->getTable();
-        $results = \DB::select("SELECT `{$table}`.* FROM ({$sql}) AS `{$table}`", $bindings);
+        $results = app('db')->select("SELECT `{$table}`.* FROM ({$sql}) AS `{$table}`", $bindings);
         $hydrated = $this->hydrate($related, $relation, $results);
         $matched = $relation->match($models, $related->newCollection($hydrated), $options['name']);
 

--- a/src/Support/Http/Controllers/GraphQLController.php
+++ b/src/Support/Http/Controllers/GraphQLController.php
@@ -40,7 +40,7 @@ class GraphQLController extends Controller
 
         return graphql()->execute(
             $query,
-            new Context($request, \Auth::user()),
+            new Context($request, app('auth')->user()),
             $variables
         );
     }

--- a/src/Support/Http/routes.php
+++ b/src/Support/Http/routes.php
@@ -3,6 +3,6 @@
 $route = config('lighthouse.route', []);
 $controller = config('lighthouse.controller');
 
-Route::group($route, function () use ($controller) {
-    Route::post('graphql', ['as' => 'graphql', 'uses' => $controller]);
+app('router')->group($route, function () use ($controller) {
+    app('router')->post('graphql', ['as' => 'graphql', 'uses' => $controller]);
 });

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -75,3 +75,16 @@ if (! function_exists('app_path')) {
         return app()->basePath().'/app'.($path ? '/'.$path : $path);
     }
 }
+
+if (!function_exists('resolve')) {
+    /**
+     * Resolve a service from the container.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    function resolve($name)
+    {
+        return app($name);
+    }
+}

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -12,6 +12,18 @@ if (! function_exists('graphql')) {
     }
 }
 
+if (! function_exists('auth')) {
+    /**
+     * Get instance of auth container.
+     *
+     * @return \Illuminate\Auth\AuthManager
+     */
+    function auth()
+    {
+        return app('auth');
+    }
+}
+
 if (! function_exists('schema')) {
     /**
      * Get instance of schema container.

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -13,7 +13,7 @@ class DBTestCase extends TestCase
 
         $this->loadMigrationsFrom(__DIR__.'/database/migrations');
         $this->withFactories(__DIR__.'/database/factories');
-        $this->artisan('migrate', ['--database' => 'lighthouse']);
+        $this->artisan('migrate', ['--database' => env('DB_DATABASE', 'lighthouse')]);
     }
 
     /**
@@ -27,7 +27,7 @@ class DBTestCase extends TestCase
 
         $connection = [
             'driver' => 'mysql',
-            'database' => 'lighthouse',
+            'database' => env('DB_DATABASE', 'lighthouse'),
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '3306'),
             'prefix' => '',
@@ -35,7 +35,7 @@ class DBTestCase extends TestCase
             'password' => env('DB_PASSWORD', ''),
         ];
 
-        $app['config']->set('database.default', 'lighthouse');
-        $app['config']->set('database.connections.lighthouse', $connection);
+        $app['config']->set('database.default', env('DB_DATABASE', 'lighthouse'));
+        $app['config']->set('database.connections.' . env('DB_DATABASE', 'lighthouse'), $connection);
     }
 }


### PR DESCRIPTION
Hi @chrissm79,

with the help of ao @kikoseijo I managed to get things working nicely without the need for facades.
As you can see, the changes are quite minimal, I'm just not 100% sure if this won't break anyhting on the Laravel part.

I do already have a workaround in place since Laravel's Passport is also still depending on facades.  The workaround is fairly simpel though: create your own PassportServiceProvider in app/Providers, extending the Laravel Passport service provider and override the offending methods `registerGuard()`, `makeGuard()` and `deleteCookieOnLogout()`. (I've requested the removal of facade calls in Passport months ago but the willingness of the passport team to change this seems very low).

So please feel free to test this in your full laravel projects and I'll be happy to adjust where needed (if needed).

Kind regards,

Erik

