### PR TITLE
More flexible directives

### DIFF
--- a/src/Schema/Directives/Fields/PaginateDirective.php
+++ b/src/Schema/Directives/Fields/PaginateDirective.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
+use Illuminate\Pagination\Paginator;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 use Nuwave\Lighthouse\Support\Database\QueryFilter;
@@ -89,7 +90,10 @@ class PaginateDirective implements FieldResolver
                 call_user_func_array([$query, $scope], [$args]);
             }
 
-            return $query->paginate($first, ['*'], 'page', $page);
+            Paginator::currentPageResolver(function() use ($page) {
+                return $page;
+            });
+            return $query->paginate($first);
         };
     }
 
@@ -118,7 +122,10 @@ class PaginateDirective implements FieldResolver
                 call_user_func_array([$query, $scope], [$args]);
             }
 
-            return $query->paginate($first, ['*'], 'page', $page);
+            Paginator::currentPageResolver(function() use ($page) {
+                return $page;
+            });
+            return $query->paginate($first);
         };
     }
 

--- a/src/Support/Database/QueryFilter.php
+++ b/src/Support/Database/QueryFilter.php
@@ -66,7 +66,7 @@ class QueryFilter
                 'resolveArgs' => array_get($filter, 'resolveArgs', []),
             ]);
 
-            $resolve($query, $key, $resolveArgs);
+            $query = $resolve($query, $key, $resolveArgs);
         }
 
         return $query;

--- a/tests/Integration/Schema/Directives/Fields/PaginateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/PaginateDirectiveTest.php
@@ -4,6 +4,8 @@ namespace Tests\Integration\Schema\Directives\Fields;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\DBTestCase;
+use Tests\Utils\Models\Comment;
+use Tests\Utils\Models\Post;
 use Tests\Utils\Models\User;
 
 class PaginateDirectiveTest extends DBTestCase
@@ -46,6 +48,74 @@ class PaginateDirectiveTest extends DBTestCase
         $this->assertEquals(10, array_get($result->data, 'users.paginatorInfo.total'));
         $this->assertEquals(1, array_get($result->data, 'users.paginatorInfo.currentPage'));
         $this->assertCount(5, array_get($result->data, 'users.data'));
+    }
+
+    /**
+     * @test
+     */
+    public function itCanCreateQueryPaginatorsWithDifferentPages()
+    {
+        $users = factory(User::class, 10)->create();
+        $posts = factory(Post::class, 10)->create([
+            'user_id' => $users->first()->id
+        ]);
+        $comments = factory(Comment::class, 10)->create([
+            'post_id' => $posts->first()->id
+        ]);
+
+        $schema = '
+        type User {
+            id: ID!
+            name: String!
+            posts: [Post!]! @paginate(type: "paginator" model: "Post")
+        }
+        
+        type Post {
+            id: ID!
+            comments: [Comment!]! @paginate(type: "paginator" model: "Comment")
+        }
+        
+        type Comment {
+            id: ID!
+        }
+        
+        type Query {
+            users: [User!]! @paginate(type: "paginator" model: "User")
+        }
+        ';
+
+        $query = '{
+            users(count:3 page: 1) {
+                paginatorInfo {
+                    count
+                    total
+                    currentPage
+                }
+                data {
+                    posts(count:2 page: 2) {
+                        paginatorInfo {
+                            count
+                            total
+                            currentPage
+                        }
+                        data {
+                            comments(count:1 page: 3) {
+                                paginatorInfo {
+                                    count
+                                    total
+                                    currentPage
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }';
+
+        $result = $this->execute($schema, $query, true);
+        $this->assertEquals(1, array_get($result->data, 'users.paginatorInfo.currentPage'));
+        $this->assertEquals(2, array_get($result->data, 'users.data.0.posts.paginatorInfo.currentPage'));
+        $this->assertEquals(3, array_get($result->data, 'users.data.0.posts.data.0.comments.paginatorInfo.currentPage'));
     }
 
     /**

--- a/tests/Utils/Models/Comment.php
+++ b/tests/Utils/Models/Comment.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Tests\Utils\Models;
+
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+
+}

--- a/tests/Utils/Models/Post.php
+++ b/tests/Utils/Models/Post.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace Tests\Utils\Models;
+
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    public function comments() {
+        return $this->hasMany(Comment::class);
+    }
+}

--- a/tests/Utils/Models/User.php
+++ b/tests/Utils/Models/User.php
@@ -23,4 +23,9 @@ class User extends Authenticatable
     {
         return $this->hasMany(Task::class);
     }
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
 }

--- a/tests/database/factories/CommentFactory.php
+++ b/tests/database/factories/CommentFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+use Faker\Generator as Faker;
+use Tests\Utils\Models\Comment;
+use Tests\Utils\Models\Company;
+use Tests\Utils\Models\Post;
+use Tests\Utils\Models\Team;
+use Tests\Utils\Models\User;
+
+$factory->define(Comment::class, function (Faker $faker) {
+    return [
+        'comment' => $faker->sentence,
+        'user_id' => function () {
+            return factory(User::class)->create()->getKey();
+        },
+        'post_id' => function () {
+            return factory(Post::class)->create()->getKey();
+        },
+    ];
+});

--- a/tests/database/factories/PostFactory.php
+++ b/tests/database/factories/PostFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+use Faker\Generator as Faker;
+use Tests\Utils\Models\Company;
+use Tests\Utils\Models\Post;
+use Tests\Utils\Models\Team;
+use Tests\Utils\Models\User;
+
+$factory->define(Post::class, function (Faker $faker) {
+    return [
+        'title' => $faker->title,
+        'body' => $faker->sentence,
+        'user_id' => function () {
+            return factory(User::class)->create()->getKey();
+        },
+    ];
+});

--- a/tests/database/migrations/2018_02_28_000004_create_testbench_posts_table.php
+++ b/tests/database/migrations/2018_02_28_000004_create_testbench_posts_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTestbenchPostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->string('body');
+            $table->unsignedInteger('user_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::drop('posts');
+    }
+}

--- a/tests/database/migrations/2018_02_28_000005_create_testbench_comments_table.php
+++ b/tests/database/migrations/2018_02_28_000005_create_testbench_comments_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTestbenchCommentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('comment');
+            $table->unsignedInteger('user_id');
+            $table->unsignedInteger('post_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::drop('comments');
+    }
+}


### PR DESCRIPTION
- Changed so pagination now uses `pageresolvers`, so we don't have to write default parameters in our code. (This also gives more flexibility when creating custom directives)
- Changed so query filters now uses the returned query as the new query. This gives us a lot of flexibility, now we can even return a whole other query, with a filter directive. 


These changed was also required before I could implement a Scout directive, or at least to implement it really easy. #93 