### PR TITLE
Implement WebSockets Subscriptions

### DIFF
--- a/assets/introspection-4.12.txt
+++ b/assets/introspection-4.12.txt
@@ -2,9 +2,7 @@ query IntrospectionQuery {
     __schema {
       queryType { name }
       mutationType { name }
-#      Currently this package does not support subscriptions...
-#      but maybe in the future!
-#      subscriptionType { name }
+      subscriptionType { name }
       types {
         ...FullType
       }

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,14 @@
         "source": "https://github.com/nuwave/lighthouse"
     },
     "require": {
+        "cboden/ratchet": "^0.4.1",
         "illuminate/contracts": "^5.4",
         "illuminate/http": "^5.4",
         "illuminate/pagination": "^5.4",
         "illuminate/routing": "^5.4",
         "illuminate/support": "^5.4",
         "opis/closure": "^3.0",
+        "ratchet/pawl": "^0.3.1",
         "webonyx/graphql-php": "^0.11.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "illuminate/routing": "^5.4",
         "illuminate/support": "^5.4",
         "opis/closure": "^3.0",
-        "ratchet/pawl": "^0.3.1",
+        "textalk/websocket": "^1.2",
         "webonyx/graphql-php": "^0.11.5"
     },
     "require-dev": {

--- a/config/config.php
+++ b/config/config.php
@@ -47,7 +47,6 @@ return [
     'namespaces' => [
         'models' => 'App\\Models',
         'mutations' => 'App\\Http\\GraphQL\\Mutations',
-        'subscriptions' => 'App\\Http\\GraphQL\\Subscriptions',
         'queries' => 'App\\Http\\GraphQL\\Queries',
         'scalars' => 'App\\Http\\GraphQL\\Scalars',
     ],

--- a/config/config.php
+++ b/config/config.php
@@ -45,6 +45,7 @@ return [
     'namespaces' => [
         'models' => 'App\\Models',
         'mutations' => 'App\\Http\\GraphQL\\Mutations',
+        'subscriptions' => 'App\\Http\\GraphQL\\Subscriptions',
         'queries' => 'App\\Http\\GraphQL\\Queries',
         'scalars' => 'App\\Http\\GraphQL\\Scalars',
     ],

--- a/config/config.php
+++ b/config/config.php
@@ -14,6 +14,8 @@ return [
     */
     'route_name' => 'graphql',
 
+    'auth_guard' => 'api',
+
     'route' => [
         'prefix' => '',
         // 'middleware' => ['web','api'],    // [ 'loghttp']

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -63,9 +63,7 @@ class GraphQL
      */
     public function prepSchema()
     {
-        if ($this->graphqlSchema == null){
-            $this->graphqlSchema = $this->buildSchema();
-        }
+        $this->graphqlSchema = $this->graphqlSchema ?: $this->buildSchema()
     }
 
     /**

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -57,7 +57,7 @@ class GraphQL
      * @var Schema
      */
     protected $graphqlSchema;
-
+    
     /**
      * Prepare graphql schema.
      */

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -63,7 +63,7 @@ class GraphQL
      */
     public function prepSchema()
     {
-        $this->graphqlSchema = $this->graphqlSchema ?: $this->buildSchema()
+        $this->graphqlSchema = $this->graphqlSchema ?: $this->buildSchema();
     }
 
     /**

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -63,7 +63,9 @@ class GraphQL
      */
     public function prepSchema()
     {
-        $this->graphqlSchema = $this->buildSchema();
+        if ($this->graphqlSchema == null){
+            $this->graphqlSchema = $this->buildSchema();
+        }
     }
 
     /**

--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -62,14 +62,14 @@ class LighthouseServiceProvider extends ServiceProvider
         $this->app->when('Nuwave\Lighthouse\Support\WebSockets\WebSocketController')
             ->needs('$resourceServer')
             ->give(function ($app) {
-                if (array_key_exists('League\OAuth2\Server\ResourceServer', $app)) return $app['League\OAuth2\Server\ResourceServer'];
+                if (class_exists('League\OAuth2\Server\ResourceServer')) return $app['League\OAuth2\Server\ResourceServer'];
                 else return null;
             });
 
         $this->app->when('Nuwave\Lighthouse\Support\WebSockets\WebSocketController')
             ->needs('$tokenRepository')
             ->give(function ($app) {
-                if (array_key_exists('Laravel\Passport\TokenRepository', $app)) return $app['Laravel\Passport\TokenRepository'];
+                if (class_exists('Laravel\Passport\TokenRepository')) return $app['Laravel\Passport\TokenRepository'];
                 else return null;
             });
 

--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -7,14 +7,20 @@ use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\GraphQL;
 use Nuwave\Lighthouse\Support\DataLoader\QueryBuilder;
 use Nuwave\Lighthouse\Support\WebSockets\WebSocketServer;
+use Nuwave\Lighthouse\Support\Broadcaster\SubscriptionBroadcaster;
 
 class LighthouseServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap any application services.
      */
-    public function boot()
+    public function boot(BroadcastManager $broadcastManager)
     {
+
+        $broadcastManager->extend('lighthouse', function (Application $app, array $config) {
+            return new SubscriptionBroadcaster;
+        });
+
         $this->publishes([__DIR__.'/../../config/config.php' => config_path('lighthouse.php')]);
         $this->mergeConfigFrom(__DIR__.'/../../config/config.php', 'lighthouse');
 

--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -59,6 +59,13 @@ class LighthouseServiceProvider extends ServiceProvider
                 return $auth->createUserProvider($config['provider'] ?: null);
             });
 
+        $this->app->when('Nuwave\Lighthouse\Support\WebSockets\WebSocketController')
+            ->needs('$resourceServer')
+            ->give(function ($app) {
+                if (array_key_exists($app, 'League\OAuth2\Server\ResourceServer')) return $app['League\OAuth2\Server\ResourceServer'];
+                else return null;
+            });
+
         $this->app->bind('Ratchet\WebSocket\WsServerInterface', function($app){
             return new WebSocketServer($this->app['Nuwave\Lighthouse\Support\WebSockets\WebSocketController']);
         });

--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -9,6 +9,7 @@ use Nuwave\Lighthouse\GraphQL;
 use Nuwave\Lighthouse\Support\DataLoader\QueryBuilder;
 use Nuwave\Lighthouse\Support\WebSockets\WebSocketServer;
 use Nuwave\Lighthouse\Support\Broadcaster\SubscriptionBroadcaster;
+use Illuminate\Foundation\Application;
 
 class LighthouseServiceProvider extends ServiceProvider
 {

--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -66,6 +66,14 @@ class LighthouseServiceProvider extends ServiceProvider
                 else return null;
             });
 
+        $this->app->when('Nuwave\Lighthouse\Support\WebSockets\WebSocketController')
+            ->needs('$tokenRepository')
+            ->give(function ($app) {
+                if (array_key_exists('Laravel\Passport\TokenRepository', $app)) return $app['Laravel\Passport\TokenRepository'];
+                else return null;
+            });
+
+
         $this->app->bind('Ratchet\WebSocket\WsServerInterface', function($app){
             return new WebSocketServer($this->app['Nuwave\Lighthouse\Support\WebSockets\WebSocketController']);
         });

--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -62,7 +62,7 @@ class LighthouseServiceProvider extends ServiceProvider
         $this->app->when('Nuwave\Lighthouse\Support\WebSockets\WebSocketController')
             ->needs('$resourceServer')
             ->give(function ($app) {
-                if (array_key_exists($app, 'League\OAuth2\Server\ResourceServer')) return $app['League\OAuth2\Server\ResourceServer'];
+                if (array_key_exists('League\OAuth2\Server\ResourceServer', $app)) return $app['League\OAuth2\Server\ResourceServer'];
                 else return null;
             });
 

--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -38,7 +38,21 @@ class LighthouseServiceProvider extends ServiceProvider
 
         $this->commands([
             \Nuwave\Lighthouse\Support\Console\Commands\CacheCommand::class,
+            \Nuwave\Lighthouse\Support\Console\Commands\WebSocketCommand::class,
         ]);
+
+        $this->app->when('Nuwave\Lighthouse\Support\WebSockets\WebSocketController')
+            ->needs('Illuminate\Contracts\Auth\UserProvider')
+            ->give(function ($app) {
+                $auth = $this->app['auth'];
+                $driver = $auth->getDefaultDriver();
+                $config = $this->app['config']["auth.guards.{$driver}"];
+                return $auth->createUserProvider($config['provider'] ?: null);
+            });
+
+        $this->app->bind('Ratchet\WebSocket\WsServerInterface', function($app){
+            return new WebSocketServer($this->app['Nuwave\Lighthouse\Support\WebSockets\WebSocketController']);
+        });
     }
 
     /**

--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Providers;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Broadcasting\BroadcastManager;
 use Nuwave\Lighthouse\GraphQL;
 use Nuwave\Lighthouse\Support\DataLoader\QueryBuilder;
 use Nuwave\Lighthouse\Support\WebSockets\WebSocketServer;

--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -46,8 +46,8 @@ class LighthouseServiceProvider extends ServiceProvider
             ->needs('Illuminate\Contracts\Auth\UserProvider')
             ->give(function ($app) {
                 $auth = $this->app['auth'];
-                $driver = $auth->getDefaultDriver();
-                $config = $this->app['config']["auth.guards.{$driver}"];
+                $guard =  app('config')['lighthouse.auth_guard'] ?: $auth->getDefaultDriver();
+                $config = $this->app['config']["auth.guards.{$guard}"];
                 return $auth->createUserProvider($config['provider'] ?: null);
             });
 

--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\GraphQL;
 use Nuwave\Lighthouse\Support\DataLoader\QueryBuilder;
+use Nuwave\Lighthouse\Support\WebSockets\WebSocketServer;
 
 class LighthouseServiceProvider extends ServiceProvider
 {

--- a/src/Schema/Context.php
+++ b/src/Schema/Context.php
@@ -18,15 +18,25 @@ class Context
      */
     public $user;
 
+
+    /**
+     * Subscription Event
+     * 
+     * @var mixed
+     */
+    public $event;
+
     /**
      * Create new context.
      *
      * @param \Illuminate\Http\Request $request
      * @param mixed                    $user
+     * @param mixed                    $event
      */
-    public function __construct($request, $user)
+    public function __construct($request, $user, $event = null)
     {
         $this->request = $request;
         $this->user = $user;
+        $this->event = $event;
     }
 }

--- a/src/Schema/Directives/Fields/EventDirective.php
+++ b/src/Schema/Directives/Fields/EventDirective.php
@@ -37,6 +37,9 @@ class EventDirective implements FieldMiddleware
         return $value->setResolver(function () use ($resolver, $event) {
             $args = func_get_args();
             $value = call_user_func_array($resolver, $args);
+
+            $event = new $event($value);
+
             event(new $event($value));
 
             return $value;

--- a/src/Schema/Directives/Fields/EventDirective.php
+++ b/src/Schema/Directives/Fields/EventDirective.php
@@ -37,9 +37,6 @@ class EventDirective implements FieldMiddleware
         return $value->setResolver(function () use ($resolver, $event) {
             $args = func_get_args();
             $value = call_user_func_array($resolver, $args);
-
-            $event = new $event($value);
-
             event(new $event($value));
 
             return $value;

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -157,7 +157,7 @@ class FieldFactory
     protected function subscriptionResolver(FieldValue $value)
     {
         return function ($obj, array $args, $context = null, $info = null) use ($value) {
-            return $context->event->resolve($obj, $args, $context, $info)
+            return $context->event->resolve($obj, $args, $context, $info);
         };
     }
 

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -133,7 +133,7 @@ class FieldFactory
 
     /**
      * Get default query resolver.
-     *l
+     *
      * @param FieldValue $value
      *
      * @return \Closure

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -87,6 +87,8 @@ class FieldFactory
                 return $this->mutationResolver($value);
             case 'Query':
                 return $this->queryResolver($value);
+            case 'Subscription':
+                return $this->subscriptionResolver($value);
             default:
                 return $this->defaultResolver($value);
         }
@@ -142,6 +144,26 @@ class FieldFactory
             $class = config('lighthouse.namespaces.queries').'\\'.studly_case($value->getFieldName());
 
             return (new $class($obj, $args, $context, $info))->resolve();
+        };
+    }
+
+    /**
+     * Get default subscription resolver.
+     *
+     * @param FieldValue $value
+     *
+     * @return \Closure
+     */
+    protected function subscriptionResolver(FieldValue $value)
+    {
+        return function ($obj, array $args, $context = null, $info = null) use ($value) {
+            $class = config('lighthouse.namespaces.subscriptions').'\\'.studly_case($value->getFieldName());
+            
+            if (class_exists($class)){
+                return (new $class($obj, $args, $context, $info))->resolve();
+            }
+
+            return $context->event;           
         };
     }
 

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -157,13 +157,7 @@ class FieldFactory
     protected function subscriptionResolver(FieldValue $value)
     {
         return function ($obj, array $args, $context = null, $info = null) use ($value) {
-            $class = config('lighthouse.namespaces.subscriptions').'\\'.studly_case($value->getFieldName());
-            
-            if (class_exists($class)){
-                return (new $class($obj, $args, $context, $info))->resolve();
-            }
-
-            return $context->event;           
+            return $context->event->resolve($obj, $args, $context, $info)
         };
     }
 

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -133,7 +133,7 @@ class FieldFactory
 
     /**
      * Get default query resolver.
-     *
+     *l
      * @param FieldValue $value
      *
      * @return \Closure
@@ -157,7 +157,7 @@ class FieldFactory
     protected function subscriptionResolver(FieldValue $value)
     {
         return function ($obj, array $args, $context = null, $info = null) use ($value) {
-            return $context->event->resolve($obj, $args, $context, $info);
+            return $context->event->fillAndResolve($obj, $args, $context, $info);
         };
     }
 

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -54,9 +54,10 @@ class SchemaBuilder
         $types = $this->register($schema);
         $query = $types->firstWhere('name', 'Query');
         $mutation = $types->firstWhere('name', 'Mutation');
+        $subscription = $types->firstWhere('name', 'Subscription');
 
         $types = $types->filter(function ($type) {
-            return ! in_array($type->name, ['Query', 'Mutation']);
+            return ! in_array($type->name, ['Query', 'Mutation', 'Subscription']);
         })->toArray();
 
         $directives = $this->directives;
@@ -64,7 +65,7 @@ class SchemaBuilder
             return $this->instance($name);
         };
 
-        return new Schema(compact('query', 'mutation', 'types', 'directives', 'typeLoader'));
+        return new Schema(compact('query', 'mutation', 'subscription', 'types', 'directives', 'typeLoader'));
     }
 
     /**

--- a/src/Support/Broadcaster/SubscriptionBroadcaster.php
+++ b/src/Support/Broadcaster/SubscriptionBroadcaster.php
@@ -1,10 +1,9 @@
 <?php
 namespace Nuwave\Lighthouse\Support\Broadcaster;
 
-use Ratchet\Client;
-use Ratchet\Client\WebSocket;
 use Nuwave\Lighthouse\Support\WebSockets\Protocol;
 use Illuminate\Contracts\Broadcasting\Broadcaster;
+use WebSocket\Client;
 
 class SubscriptionBroadcaster implements Broadcaster
 {
@@ -29,15 +28,14 @@ class SubscriptionBroadcaster implements Broadcaster
      */
     public function broadcast(array $channels, $event, array $payload = [])
     {
-    	Client\connect('ws://' . app('config')['broadcasting.connections.graphql.url'] ?: '127.0.0.1' . ':' . app('config')['broadcasting.connections.graphql.port'], ['graphql-ws'])
-            ->then(function (WebSocket $conn) use ($event, $payload) {
-            $request = [
+        $url = 'ws://' . (app('config')['broadcasting.connections.graphql.url'] ?: '127.0.0.1' . ':' . app('config')['broadcasting.connections.graphql.port']);
+
+        $client = new Client($url);
+        $request = [
                 'type'         => Protocol::GQL_DATA,
                 'subscription' => $event,
                 'payload'      => serialize($payload),
             ];
-            $conn->send(json_encode($request));
-            $conn->close();
-        });
+        $client->send(json_encode($request));
     }
 }

--- a/src/Support/Broadcaster/SubscriptionBroadcaster.php
+++ b/src/Support/Broadcaster/SubscriptionBroadcaster.php
@@ -26,18 +26,18 @@ class SubscriptionBroadcaster extends Broadcaster
     /**
      * {@inheritdoc}
      */
-    public function broadcast(array $channels, $event, array $payload = [])
+    public function broadcast(array $class, $subscription, array $params = [])
     {   
         $url = 'ws://' . (app('config')['broadcasting.connections.graphql.url'] ?: '127.0.0.1' . ':' . app('config')['broadcasting.connections.graphql.port']);
 
+        $class = $this->formatChannels($class)[0];
+
         $client = new Client($url, ['headers' => ['Sec-WebSocket-Protocol' => 'graphql-ws']]);
-        foreach ($this->formatChannels($channels) as $channel) {
-             $request = [
-                'type'         => Protocol::GQL_DATA,
-                'subscription' => $channel,
-                'payload'      => ['class' => $event, 'params' => $payload],
-            ];
-            $client->send(json_encode($request));
-        }       
+        $request = [
+            'type'         => Protocol::GQL_DATA,
+            'subscription' => $subscription,
+            'payload'      => ['class' => $class, 'params' => $params],
+        ];
+        $client->send(json_encode($request));
     }
 }

--- a/src/Support/Broadcaster/SubscriptionBroadcaster.php
+++ b/src/Support/Broadcaster/SubscriptionBroadcaster.php
@@ -6,7 +6,7 @@ use Ratchet\Client\WebSocket;
 use Nuwave\Lighthouse\Support\WebSockets\Protocol;
 use Illuminate\Contracts\Broadcasting\Broadcaster;
 
-class SubscriptionBroadcaster extends Broadcaster
+class SubscriptionBroadcaster implements Broadcaster
 {
     /**
      * {@inheritdoc}

--- a/src/Support/Broadcaster/SubscriptionBroadcaster.php
+++ b/src/Support/Broadcaster/SubscriptionBroadcaster.php
@@ -1,0 +1,42 @@
+<?php
+namespace Nuwave\Lighthouse\Support\Broadcaster;
+
+use Ratchet\Client;
+use Ratchet\Client\WebSocket;
+use Nuwave\Lighthouse\Support\WebSockets\Protocol;
+
+class SubscriptionBroadcaster extends Broadcaster
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function auth($request)
+    {
+        //
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validAuthenticationResponse($request, $result)
+    {
+        //
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function broadcast(array $channels, $event, array $payload = [])
+    {
+    	Client\connect('ws://' . app('config')['broadcasting.connections.graphql.url'] ?: '127.0.0.1' . ':' . app('config')['broadcasting.connections.graphql.port'], ['graphql-ws'])
+            ->then(function (WebSocket $conn) use ($event, $payload) {
+            $request = [
+                'type'         => Protocol::GQL_DATA,
+                'subscription' => $event,
+                'payload'      => serialize($payload),
+            ];
+            $conn->send(json_encode($request));
+            $conn->close();
+        });
+    }
+}

--- a/src/Support/Broadcaster/SubscriptionBroadcaster.php
+++ b/src/Support/Broadcaster/SubscriptionBroadcaster.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Support\Broadcaster;
 use Ratchet\Client;
 use Ratchet\Client\WebSocket;
 use Nuwave\Lighthouse\Support\WebSockets\Protocol;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
 
 class SubscriptionBroadcaster extends Broadcaster
 {

--- a/src/Support/Console/Commands/WebSocketCommand.php
+++ b/src/Support/Console/Commands/WebSocketCommand.php
@@ -49,7 +49,6 @@ class WebSocketCommand extends Command
      */
     public function handle()
     {
-        \Log::info("Start Server");
         $server = IoServer::factory(
              new HttpServer(
                  new WsServer(

--- a/src/Support/Console/Commands/WebSocketCommand.php
+++ b/src/Support/Console/Commands/WebSocketCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace Nuwave\Lighthouse\Support\Console\Commands;
 
 use Illuminate\Console\Command;
 use Ratchet\Server\IoServer;

--- a/src/Support/Console/Commands/WebSocketCommand.php
+++ b/src/Support/Console/Commands/WebSocketCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Ratchet\Server\IoServer;
+use Ratchet\Http\HttpServer;
+use Ratchet\WebSocket\WsServer;
+use Ratchet\WebSocket\WsServerInterface;
+
+class WebSocketServer extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'lighthouse:websocket {port=8080}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Rub the WebSocket Subscriptions Server';
+
+    /**
+     * The WebSocket Server.
+     *
+     * @var Ratchet\WebSocket\WsServerInterface;
+     */
+    protected $server;
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct(WsServerInterface $server)
+    {
+    	$this->server = $server;
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        \Log::info("Start Server");
+        $server = IoServer::factory(
+             new HttpServer(
+                 new WsServer(
+                     $this->server
+                 )
+             ),
+             $this->argument('port')
+        );
+        $server->run();
+    }
+}

--- a/src/Support/Console/Commands/WebSocketCommand.php
+++ b/src/Support/Console/Commands/WebSocketCommand.php
@@ -8,7 +8,7 @@ use Ratchet\Http\HttpServer;
 use Ratchet\WebSocket\WsServer;
 use Ratchet\WebSocket\WsServerInterface;
 
-class WebSocketServer extends Command
+class WebSocketCommand extends Command
 {
     /**
      * The name and signature of the console command.

--- a/src/Support/Console/Commands/WebSocketCommand.php
+++ b/src/Support/Console/Commands/WebSocketCommand.php
@@ -15,7 +15,7 @@ class WebSocketCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'lighthouse:websocket {port=8080}';
+    protected $signature = 'lighthouse:websocket';
 
     /**
      * The console command description.
@@ -56,7 +56,7 @@ class WebSocketCommand extends Command
                      $this->server
                  )
              ),
-             $this->argument('port')
+             app('config')['broadcasting.connections.graphql.port']
         );
         $server->run();
     }

--- a/src/Support/Http/Controllers/GraphQLController.php
+++ b/src/Support/Http/Controllers/GraphQLController.php
@@ -38,9 +38,10 @@ class GraphQLController extends Controller
             $variables = json_decode($variables, true);
         }
 
+        $guard = app('config')['lighthouse.auth_guard'] ?: app('auth')->getDefaultDriver();
         return graphql()->execute(
             $query,
-            new Context($request, app('auth')->user()),
+            new Context($request, app('auth')->guard($guard)->user()),
             $variables
         );
     }

--- a/src/Support/Schema/GraphQLSubscription.php
+++ b/src/Support/Schema/GraphQLSubscription.php
@@ -3,6 +3,7 @@
 namespace Nuwave\Lighthouse\Support\Schema;
 
 use Illuminate\Broadcasting\Channel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
 abstract class GraphQLSubscription implements ShouldBroadcast
 {
@@ -43,7 +44,7 @@ abstract class GraphQLSubscription implements ShouldBroadcast
      * @param ResolveInfo $info
      * @return mixed
      */
-    public function resolve($obj, $args = null, $context = null, $info = null)
+    public function fillAndResolve($obj, $args = null, $context = null, $info = null)
     {
         $this->obj = $obj;
         $this->args = $args;

--- a/src/Support/Schema/GraphQLSubscription.php
+++ b/src/Support/Schema/GraphQLSubscription.php
@@ -2,6 +2,65 @@
 
 namespace Nuwave\Lighthouse\Support\Schema;
 
-abstract class GraphQLSubscription extends GraphQLResolver
+use Illuminate\Broadcasting\Channel;
+
+abstract class GraphQLSubscription implements ShouldBroadcast
 {
+    /**
+     * Root object.
+     *
+     * @var mixed
+     */
+    protected $obj;
+
+    /**
+     * Field arguments.
+     *
+     * @var array
+     */
+    protected $args = [];
+
+    /**
+     * Query context.
+     *
+     * @var Context
+     */
+    protected $context;
+
+    /**
+     * Field resolve info.
+     *
+     * @var ResolveInfo
+     */
+    protected $info;
+
+    /**
+     * Resolve the mutation.
+     *
+     * @param mixed       $obj
+     * @param array       $args
+     * @param Context     $context
+     * @param ResolveInfo $info
+     * @return mixed
+     */
+    public function resolve($obj, $args = null, $context = null, $info = null)
+    {
+        $this->obj = $obj;
+        $this->args = $args;
+        $this->context = $context;
+        $this->info = $info;
+        return $this->resolve();
+    }
+
+    /**
+     * Resolve the mutation.
+     *
+     * @return mixed
+     */
+    abstract public function resolve();
+
+    public function broadcastOn()
+    {
+        return new Channel('graphql');
+    }
 }

--- a/src/Support/Schema/GraphQLSubscription.php
+++ b/src/Support/Schema/GraphQLSubscription.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Nuwave\Lighthouse\Support\Schema;
+
+abstract class GraphQLSubscription extends GraphQLResolver
+{
+}

--- a/src/Support/Schema/GraphQLSubscription.php
+++ b/src/Support/Schema/GraphQLSubscription.php
@@ -66,6 +66,11 @@ abstract class GraphQLSubscription implements ShouldBroadcast
      */
     abstract public function resolve();
 
+    public function broadcastOn()
+    {
+        return get_class($this);
+    }
+
     /**
      * Prepare the instance for serialization.
      *

--- a/src/Support/Schema/GraphQLSubscription.php
+++ b/src/Support/Schema/GraphQLSubscription.php
@@ -61,6 +61,6 @@ abstract class GraphQLSubscription implements ShouldBroadcast
 
     public function broadcastOn()
     {
-        return new Channel('graphql');
+        return new Channel('lighthouse.graphql');
     }
 }

--- a/src/Support/WebSockets/Protocol.php
+++ b/src/Support/WebSockets/Protocol.php
@@ -1,0 +1,21 @@
+<?php
+namespace Nuwave\Lighthouse\Support\WebSockets;
+
+static class Protocol{
+	
+	/**
+	 * Protocol messages.
+	 *
+	 * @see https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/message-types.ts
+	 */
+	const GQL_CONNECTION_INIT = 'connection_init'; // Client -> Server
+	const GQL_CONNECTION_ACK = 'connection_ack'; // Server -> Client
+	const GQL_CONNECTION_ERROR = 'connection_error'; // Server -> Client
+	const GQL_CONNECTION_KEEP_ALIVE = 'ka'; // Server -> Client
+	const GQL_CONNECTION_TERMINATE = 'connection_terminate'; // Client -> Server
+	const GQL_START = 'start'; // Client -> Server
+	const GQL_DATA = 'data'; // Server -> Client
+	const GQL_ERROR = 'error'; // Server -> Client
+	const GQL_COMPLETE = 'complete'; // Server -> Client
+	const GQL_STOP = 'stop'; // Client -> Server
+}

--- a/src/Support/WebSockets/Protocol.php
+++ b/src/Support/WebSockets/Protocol.php
@@ -1,7 +1,7 @@
 <?php
 namespace Nuwave\Lighthouse\Support\WebSockets;
 
-static class Protocol{
+class Protocol{
 	
 	/**
 	 * Protocol messages.

--- a/src/Support/WebSockets/WebSocketController.php
+++ b/src/Support/WebSockets/WebSocketController.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Psr7\ServerRequest;
 use Nuwave\Lighthouse\Schema\Context;
 use Illuminate\Contracts\Auth\UserProvider;
 use ReflectionClass;
+use Nuwave\Lighthouse\Support\WebSockets\Protocol;
 
 class WebSocketController{
 
@@ -77,14 +78,14 @@ class WebSocketController{
 			
             $this->connStorage->offsetSet($conn, ['auth' => $auth]);
             $response = [
-                'type'    => WebSocketController::GQL_CONNECTION_ACK,
+                'type'    => Protocol::GQL_CONNECTION_ACK,
                 'payload' => [],
             ];
 
             $conn->send(json_encode($response));
         } catch (\Exception $e) {
             $response = [
-                'type'    => WebSocketController::GQL_CONNECTION_ERROR,
+                'type'    => Protocol::GQL_CONNECTION_ERROR,
                 'payload' => $e->getMessage(),
             ];
             //\Log::info($response);
@@ -140,7 +141,7 @@ class WebSocketController{
 			    );
 
 		        $response = [
-		            'type'    => WebSocketController::GQL_DATA,
+		            'type'    => Protocol::GQL_DATA,
 		            'id'      => $data['id'],
 		            'payload' => "test",
 		        ];
@@ -148,21 +149,21 @@ class WebSocketController{
 		        $conn->send(json_encode($response));
 
                 $response = [
-                    'type' => WebSocketController::GQL_COMPLETE,
+                    'type' => Protocol::GQL_COMPLETE,
                     'id'   => $data['id'],
                 ];
                 $conn->send(json_encode($response));
             }
         } catch (\Exception $e) {
             $response = [
-                'type'    => WebSocketController::GQL_ERROR,
+                'type'    => Protocol::GQL_ERROR,
                 'id'      => $data['id'],
                 'payload' => $e->getMessage(),
             ];
             \Log::error($e);
             $conn->send(json_encode($response));
             $response = [
-                'type' => WebSocketController::GQL_COMPLETE,
+                'type' => Protocol::GQL_COMPLETE,
                 'id'   => $data['id'],
             ];
             // \Log::info($response);
@@ -217,7 +218,7 @@ class WebSocketController{
                 );
 
                 $response = [
-                    'type'    => WebSocketController::GQL_DATA,
+                    'type'    => Protocol::GQL_DATA,
                     'id'      => $subscription['id'],
                     'payload' => $result,
                 ];
@@ -225,7 +226,7 @@ class WebSocketController{
 
             } catch (\Exception $e) {
                 $response = [
-                    'type'    => WebSocketController::GQL_ERROR,
+                    'type'    => Protocol::GQL_ERROR,
                     'id'      => $subscription['id'],
                     'payload' => $e->getMessage(),
                 ];

--- a/src/Support/WebSockets/WebSocketController.php
+++ b/src/Support/WebSockets/WebSocketController.php
@@ -1,0 +1,288 @@
+<?php
+namespace Nuwave\Lighthouse\Support\WebSockets;
+
+use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Language\Parser;
+use GraphQL\Type\Schema;
+use Ratchet\ConnectionInterface;
+use Firebase\JWT\JWT;
+use GuzzleHttp\Psr7\ServerRequest;
+use League\OAuth2\Server\ResourceServer;
+use Nuwave\Lighthouse\Schema\Context;
+use Laravel\Passport\TokenRepository;
+use Illuminate\Contracts\Auth\UserProvider;
+
+class WebSocketController{
+
+    /**
+     * The Resource Server instance.
+     *
+     * @var \League\OAuth2\Server\ResourceServer
+     */
+    protected $resourceServer;
+
+    /**
+     * The Passport Token Repository
+     *
+	 * @var Laravel\Passport\TokenRepository
+	 */
+    protected $tokenRepository;
+
+    /**
+     * The Laravel Auth User Provider
+     *
+     * @var \Illuminate\Contracts\Auth\UserProvider
+     */
+    protected $userProvider;
+
+    /**
+     * Subscription Storage 
+     *
+     * @var array
+     */
+    protected $subscriptions;
+
+    /**
+     * Connection Storage
+     *
+     * @var \SplObjectStorage
+     */
+    protected $connStorage;
+
+    public function __construct(ResourceServer $resourceServer, TokenRepository $tokenRepository, UserProvider $userProvider){
+    	$this->subscriptions = [];
+    	$this->connStorage = new \SplObjectStorage();
+    	$this->resourceServer = $resourceServer;
+    	$this->tokenRepository = $tokenRepository;
+    	$this->userProvider = $userProvider;
+
+    	graphql()->prepSchema();
+    }
+
+    /**
+     * @param ConnectionInterface $conn
+     *
+     * @return void
+     */
+    public function handleConnectionInit(ConnectionInterface $conn, array $data){
+        try {
+        	$payload = array_get($data, 'payload');
+  			$psr = new ServerRequest("ws", "", $payload, null, '1.1', []);
+
+			if ($psr->hasHeader('authorization')){
+	            $psr = $this->server->validateAuthenticatedRequest($psr);
+	            $auth = $psr->getHeader('authorization');
+			}
+			
+            $this->connStorage->offsetSet($conn, ['auth' => $auth]);
+            $response = [
+                'type'    => WebSocketController::GQL_CONNECTION_ACK,
+                'payload' => [],
+            ];
+
+            $conn->send(json_encode($response));
+        } catch (\Exception $e) {
+            $response = [
+                'type'    => WebSocketController::GQL_CONNECTION_ERROR,
+                'payload' => $e->getMessage(),
+            ];
+            \Log::info($response);
+            $conn->send(json_encode($response));
+            $conn->close();
+        }
+    }
+
+    /**
+     * @param ConnectionInterface $conn
+     * @param array               $data
+     *
+     * @return void
+     */
+    public function handleStart(ConnectionInterface $conn, array $data)
+    {
+        try {
+            $payload = array_get($data, 'payload');
+            $query = array_get($payload, 'query');
+            if (is_null($query)) {
+                throw new \Exception('Missing query parameter from payload');
+            }
+            $variables = array_get($payload, 'variables');
+            $document = Parser::parse($query);
+            /** @psalm-suppress NoInterfaceProperties */
+            $operation = $document->definitions[0]->operation;
+            if ($operation == 'subscription') {
+                $data['name'] = $this->getSubscriptionName($document);
+                $data['conn'] = $conn;
+
+                \Log::info("New Subscription: " . $data['name'] . "");
+
+                $this->subscriptions[$data['name']][] = $data;
+                end($this->subscriptions[$data['name']]);
+                $data['index'] = key($this->subscriptions[$data['name']]);
+
+                $connData = $this->connStorage->offsetExists($conn) ?
+                	$this->connStorage->offsetGet($conn) : [];
+
+                $connData['subscriptions'][$data['id']] = $data;
+
+                $this->connStorage->offsetSet($conn, $connData);
+            } else {
+
+            	$connData = $this->connStorage->offsetExists($conn) ? $this->connStorage->offsetGet($conn) : [];
+            	$psr = new ServerRequest("ws", "", ['authorization' => $connData['auth']], null, '1.1', []);
+
+				if ($psr->hasHeader('authorization')){
+		            $psr = $this->server->validateAuthenticatedRequest($psr);
+		            $auth = $psr->getAttributes();
+
+					$token = $this->tokenRepository->find($auth['oauth_access_token_id']);
+                    $user = $this->userProvider->retrieveById($auth['oauth_user_id'])->withAccessToken($token);
+				}
+
+                if (app('auth')->user() != $user){
+                    if ($user == null) app('auth')->logout();
+                    else app('auth')->setUser($user);
+                }
+
+            	$result = graphql()->execute(
+			        $query,
+			        new Context(null, $user),
+			        $variables
+			    );
+
+		        $response = [
+		            'type'    => WebSocketController::GQL_DATA,
+		            'id'      => $data['id'],
+		            'payload' => "test",
+		        ];
+
+		        $conn->send(json_encode($response));
+
+                $response = [
+                    'type' => WebSocketController::GQL_COMPLETE,
+                    'id'   => $data['id'],
+                ];
+                $conn->send(json_encode($response));
+            }
+        } catch (\Exception $e) {
+            $response = [
+                'type'    => WebSocketController::GQL_ERROR,
+                'id'      => $data['id'],
+                'payload' => $e->getMessage(),
+            ];
+            \Log::info($response);
+            $conn->send(json_encode($response));
+            $response = [
+                'type' => WebSocketController::GQL_COMPLETE,
+                'id'   => $data['id'],
+            ];
+            \Log::info($response);
+            $conn->send(json_encode($response));
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function handleData(array $data)
+    {
+    	$subscriptionName = 'on' . ucfirst($data['subscription']);
+    	$event = unserialize($data['payload']);
+
+    	\Log::info('Event Fired: ' . $subscriptionName);
+
+        $subscriptions = array_get($this->subscriptions, $subscriptionName);
+        if (is_null($subscriptions)) {
+            return;
+        }
+        foreach ($subscriptions as $subscription) {
+        	try{
+        		$event = unserialize(array_get($data, 'payload'));
+
+                $query = array_get($subscription['payload'], 'query');
+                $variables = array_get($subscription['payload'], 'variables');
+
+                $conn = $subscription['conn'];
+
+                $connData = $this->connStorage->offsetExists($conn) ? $this->connStorage->offsetGet($conn) : [];
+
+                $psr = new ServerRequest("ws", "", ['authorization' => $connData['auth']], null, '1.1', []);
+
+				if ($psr->hasHeader('authorization')){
+		            $psr = $this->server->validateAuthenticatedRequest($psr);
+		            $auth = $psr->getAttributes();
+
+					$token = $this->tokenRepository->find($auth['oauth_access_token_id']);
+                    $user = $this->userProvider->retrieveById($auth['oauth_user_id'])->withAccessToken($token);
+				}
+
+                if (app('auth')->user() != $user){
+                    if ($user == null) app('auth')->logout();
+                    else app('auth')->setUser($user);
+                }
+                
+				$result = graphql()->execute(
+		            $query,
+		            new Context(null, $user, $event->event),
+		            $variables
+		        );
+
+                $response = [
+                    'type'    => WebSocketController::GQL_DATA,
+                    'id'      => $subscription['id'],
+                    'payload' => $result,
+                ];
+                $conn->send(json_encode($response));
+
+        	} catch (\Exception $e) {
+                $response = [
+                    'type'    => WebSocketController::GQL_ERROR,
+                    'id'      => $subscription['id'],
+                    'payload' => $e->getMessage(),
+                ];
+                \Log::info($response);
+                $subscription['conn']->send(json_encode($response));
+            }
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function handleStop(ConnectionInterface $conn, array $data)
+    {
+        $connSubscriptions = $this->connStorage->offsetGet($conn);
+        $subscription = array_get($connSubscriptions, $data['id']);
+        if (!is_null($subscription)) {
+            unset($this->subscriptions[$subscription['name']][$subscription['index']]);
+            unset($connSubscriptions[$subscription['id']]);
+            $this->connStorage->offsetSet($conn, $connSubscriptions);
+        }
+    }
+
+
+    /**
+     * @param DocumentNode $document
+     *
+     * @return string
+     */
+    public function getSubscriptionName(DocumentNode $document) : string
+    {
+        /** @psalm-suppress NoInterfaceProperties */
+        return $document->definitions[0]
+            ->selectionSet
+            ->selections[0]
+            ->name
+            ->value;
+    }
+
+    public function getSubscriptions() : array
+    {
+        return $this->subscriptions;
+    }
+
+    public function getConnStorage() : \SplObjectStorage
+    {
+        return $this->connStorage;
+    }
+}

--- a/src/Support/WebSockets/WebSocketController.php
+++ b/src/Support/WebSockets/WebSocketController.php
@@ -1,5 +1,5 @@
 <?php
-namespace Nuwave\Lighthouse\Support\WebSockets;
+namespace App\GraphQL\Controllers;
 
 use Ratchet\MessageComponentInterface;
 use Ratchet\WebSocket\WsServerInterface;
@@ -13,69 +13,130 @@ use League\OAuth2\Server\ResourceServer;
 use Nuwave\Lighthouse\Schema\Context;
 use Laravel\Passport\TokenRepository;
 use Illuminate\Contracts\Auth\UserProvider;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionParameter;
 
-class WebSocketController{
-
+class WebSocketController implements MessageComponentInterface, WsServerInterface{
+    
     /**
-     * The Resource Server instance.
+     * Protocol messages.
+     *
+     * @see https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/message-types.ts
+     */
+    const GQL_CONNECTION_INIT = 'connection_init'; // Client -> Server
+    const GQL_CONNECTION_ACK = 'connection_ack'; // Server -> Client
+    const GQL_CONNECTION_ERROR = 'connection_error'; // Server -> Client
+    const GQL_CONNECTION_KEEP_ALIVE = 'ka'; // Server -> Client
+    const GQL_CONNECTION_TERMINATE = 'connection_terminate'; // Client -> Server
+    const GQL_START = 'start'; // Client -> Server
+    const GQL_DATA = 'data'; // Server -> Client
+    const GQL_ERROR = 'error'; // Server -> Client
+    const GQL_COMPLETE = 'complete'; // Server -> Client
+    const GQL_STOP = 'stop'; // Client -> Server
+
+    /* The Resource Server instance.
      *
      * @var \League\OAuth2\Server\ResourceServer
      */
-    protected $resourceServer;
+    protected $server;
 
-    /**
-     * The Passport Token Repository
+    /* The Passport Token Repository
      *
-	 * @var Laravel\Passport\TokenRepository
-	 */
+     * @var Laravel\Passport\TokenRepository
+     */
     protected $tokenRepository;
 
-    /**
-     * The Laravel Auth User Provider
+    /* The Laravel Auth User Provider
      *
      * @var \Illuminate\Contracts\Auth\UserProvider
      */
     protected $userProvider;
 
     /**
-     * Subscription Storage 
-     *
      * @var array
      */
     protected $subscriptions;
 
     /**
-     * Connection Storage
-     *
      * @var \SplObjectStorage
      */
     protected $connStorage;
 
-    public function __construct(ResourceServer $resourceServer, TokenRepository $tokenRepository, UserProvider $userProvider){
-    	$this->subscriptions = [];
-    	$this->connStorage = new \SplObjectStorage();
-    	$this->resourceServer = $resourceServer;
-    	$this->tokenRepository = $tokenRepository;
-    	$this->userProvider = $userProvider;
+    public function __construct(ResourceServer $server, TokenRepository $tokenRepository){
+        $this->subscriptions = [];
+        $this->connStorage = new \SplObjectStorage();
+        $this->server = $server;
+        $this->tokenRepository = $tokenRepository;
 
-    	graphql()->prepSchema();
+        $auth = app('auth');
+        $driver = $auth->getDefaultDriver();
+        $config = app('config')["auth.guards.{$driver}"];
+        $this->userProvider = app('auth')->createUserProvider($config['provider'] ?: null);
+        graphql()->prepSchema();
     }
 
-        /**
+    /**
+     * @return void
+     */
+    public function onOpen(ConnectionInterface $conn){}
+
+    /**
+     * @return void
+     */
+    public function onMessage(ConnectionInterface $conn, $message)
+    {
+        // \Log::info($message);
+        $data = json_decode($message, true);
+        switch ($data['type']) {
+            case WebSocketController::GQL_CONNECTION_INIT:
+                $this->handleConnectionInit($conn, $data);
+                break;
+            case WebSocketController::GQL_START:
+                $this->handleStart($conn, $data);
+                break;
+            case WebSocketController::GQL_DATA:
+                $this->handleData($data);
+                break;
+            case WebSocketController::GQL_STOP:
+                $this->handleStop($conn, $data);
+                break;
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function onClose(ConnectionInterface $conn){}
+
+    /**
+     * @return void
+     */
+    public function onError(ConnectionInterface $conn, \Exception $exception)
+    {
+        \Log::error($exception);
+    }
+
+    public function getSubProtocols() : array
+    {
+        return ['graphql-ws'];
+    }
+
+    /**
      * @param ConnectionInterface $conn
      *
      * @return void
      */
     public function handleConnectionInit(ConnectionInterface $conn, array $data){
         try {
-        	$payload = array_get($data, 'payload');
-  			$psr = new ServerRequest("ws", "", $payload, null, '1.1', []);
+            $payload = array_get($data, 'payload');
+            $psr = new ServerRequest("ws", "", $payload, null, '1.1', []);
 
-			if ($psr->hasHeader('authorization')){
-	            $psr = $this->server->validateAuthenticatedRequest($psr);
-	            $auth = $psr->getHeader('authorization');
-			}
-			
+            if ($psr->hasHeader('authorization')){
+                $psr = $this->server->validateAuthenticatedRequest($psr);
+                $auth = $psr->getHeader('authorization');
+            }
+            
             $this->connStorage->offsetSet($conn, ['auth' => $auth]);
             $response = [
                 'type'    => WebSocketController::GQL_CONNECTION_ACK,
@@ -123,30 +184,30 @@ class WebSocketController{
                 $data['index'] = key($this->subscriptions[$data['name']]);
 
                 $connData = $this->connStorage->offsetExists($conn) ?
-                	$this->connStorage->offsetGet($conn) : [];
+                    $this->connStorage->offsetGet($conn) : [];
 
                 $connData['subscriptions'][$data['id']] = $data;
 
                 $this->connStorage->offsetSet($conn, $connData);
             } else {
 
-            	$connData = $this->connStorage->offsetExists($conn) ? $this->connStorage->offsetGet($conn) : [];
-            	$user = $this->getUser($connData['auth']);
+                $connData = $this->connStorage->offsetExists($conn) ? $this->connStorage->offsetGet($conn) : [];
+                $user = $this->getUser($connData['auth']);
                 $this->authUser($user);
 
-            	$result = graphql()->execute(
-			        $query,
-			        new Context(null, $user),
-			        $variables
-			    );
+                $result = graphql()->execute(
+                    $query,
+                    new Context(null, $user),
+                    $variables
+                );
 
-		        $response = [
-		            'type'    => WebSocketController::GQL_DATA,
-		            'id'      => $data['id'],
-		            'payload' => "test",
-		        ];
+                $response = [
+                    'type'    => WebSocketController::GQL_DATA,
+                    'id'      => $data['id'],
+                    'payload' => "test",
+                ];
 
-		        $conn->send(json_encode($response));
+                $conn->send(json_encode($response));
 
                 $response = [
                     'type' => WebSocketController::GQL_COMPLETE,
@@ -176,19 +237,31 @@ class WebSocketController{
      */
     public function handleData(array $data)
     {
-    	$subscriptionName = 'on' . ucfirst($data['subscription']);
-    	$event = unserialize($data['payload']);
+        $subscriptionName = $data['subscription'];
+        $payload = $data['payload'];
+        $class = $payload['class'];
+        $params = $payload['params'];
 
-    	\Log::info('Event Fired: ' . $subscriptionName);
+        $constructor = (new ReflectionClass($class))->getConstructor();  
+        $parameters = $constructor->getParameters();
+
+        $args = [];
+
+        foreach ($parameters as $parameter) {
+            $args[$parameter->getPosition()] = $params[$parameter->getName()];
+        }
+
+        $event = new $class(...$args);
+        $event->wakeup();
+
+        \Log::info('Event Fired: ' . $subscriptionName);
 
         $subscriptions = array_get($this->subscriptions, $subscriptionName);
         if (is_null($subscriptions)) {
             return;
         }
         foreach ($subscriptions as $subscription) {
-        	try{
-        		$event = unserialize(array_get($data, 'payload'));
-
+            try{
                 $query = array_get($subscription['payload'], 'query');
                 $variables = array_get($subscription['payload'], 'variables');
 
@@ -199,11 +272,11 @@ class WebSocketController{
                 $user = $this->getUser($connData['auth']);
                 $this->authUser($user);
                 
-				$result = graphql()->execute(
-		            $query,
-		            new Context(null, $user, $event),
-		            $variables
-		        );
+                $result = graphql()->execute(
+                    $query,
+                    new Context(null, $user, $event),
+                    $variables
+                );
 
                 $response = [
                     'type'    => WebSocketController::GQL_DATA,
@@ -212,7 +285,7 @@ class WebSocketController{
                 ];
                 $conn->send(json_encode($response));
 
-        	} catch (\Exception $e) {
+            } catch (\Exception $e) {
                 $response = [
                     'type'    => WebSocketController::GQL_ERROR,
                     'id'      => $subscription['id'],

--- a/src/Support/WebSockets/WebSocketController.php
+++ b/src/Support/WebSockets/WebSocketController.php
@@ -88,7 +88,7 @@ class WebSocketController{
                 'type'    => WebSocketController::GQL_CONNECTION_ERROR,
                 'payload' => $e->getMessage(),
             ];
-            \Log::info($response);
+            //\Log::info($response);
             $conn->send(json_encode($response));
             $conn->close();
         }
@@ -116,7 +116,7 @@ class WebSocketController{
                 $data['name'] = $this->getSubscriptionName($document);
                 $data['conn'] = $conn;
 
-                \Log::info("New Subscription: " . $data['name'] . "");
+                //\Log::info("New Subscription: " . $data['name'] . "");
 
                 $this->subscriptions[$data['name']][] = $data;
                 end($this->subscriptions[$data['name']]);
@@ -160,13 +160,13 @@ class WebSocketController{
                 'id'      => $data['id'],
                 'payload' => $e->getMessage(),
             ];
-            \Log::info($response);
+            \Log::error($e);
             $conn->send(json_encode($response));
             $response = [
                 'type' => WebSocketController::GQL_COMPLETE,
                 'id'   => $data['id'],
             ];
-            \Log::info($response);
+            // \Log::info($response);
             $conn->send(json_encode($response));
         }
     }
@@ -193,7 +193,7 @@ class WebSocketController{
         $event = new $class(...$args);
         $event->wakeup();
 
-        \Log::info('Event Fired: ' . $subscriptionName);
+        // \Log::info('Event Fired: ' . $subscriptionName);
 
         $subscriptions = array_get($this->subscriptions, $subscriptionName);
         if (is_null($subscriptions)) {
@@ -230,7 +230,7 @@ class WebSocketController{
                     'id'      => $subscription['id'],
                     'payload' => $e->getMessage(),
                 ];
-                \Log::info($response);
+                \Log::error($e);
                 $subscription['conn']->send(json_encode($response));
             }
         }

--- a/src/Support/WebSockets/WebSocketController.php
+++ b/src/Support/WebSockets/WebSocketController.php
@@ -201,7 +201,7 @@ class WebSocketController{
                 
 				$result = graphql()->execute(
 		            $query,
-		            new Context(null, $user, $event->event),
+		            new Context(null, $user, $event),
 		            $variables
 		        );
 

--- a/src/Support/WebSockets/WebSocketController.php
+++ b/src/Support/WebSockets/WebSocketController.php
@@ -9,9 +9,7 @@ use GraphQL\Type\Schema;
 use Ratchet\ConnectionInterface;
 use Firebase\JWT\JWT;
 use GuzzleHttp\Psr7\ServerRequest;
-// use League\OAuth2\Server\ResourceServer;
 use Nuwave\Lighthouse\Schema\Context;
-use Laravel\Passport\TokenRepository;
 use Illuminate\Contracts\Auth\UserProvider;
 
 class WebSocketController{
@@ -51,7 +49,7 @@ class WebSocketController{
      */
     protected $connStorage;
 
-    public function __construct($resourceServer = null, TokenRepository $tokenRepository, UserProvider $userProvider){
+    public function __construct($resourceServer = null, $tokenRepository = null, UserProvider $userProvider){
     	$this->subscriptions = [];
     	$this->connStorage = new \SplObjectStorage();
     	$this->resourceServer = $resourceServer;
@@ -253,7 +251,7 @@ class WebSocketController{
     public function getUser($authHeader){
         $psr = new ServerRequest("ws", "", $authHeader != null ? ['authorization' => $authHeader] : [], null, '1.1', []);
 
-        if ($psr->hasHeader('authorization') && $this->resourceServer != null){
+        if ($psr->hasHeader('authorization') && $this->resourceServer != null && $this->tokenRepository != null){
             $psr = $this->resourceServer->validateAuthenticatedRequest($psr);
             $auth = $psr->getAttributes();
 

--- a/src/Support/WebSockets/WebSocketController.php
+++ b/src/Support/WebSockets/WebSocketController.php
@@ -1,5 +1,5 @@
 <?php
-namespace App\GraphQL\Controllers;
+namespace Nuwave\Lighthouse\Support\WebSockets;
 
 use Ratchet\MessageComponentInterface;
 use Ratchet\WebSocket\WsServerInterface;
@@ -13,130 +13,69 @@ use League\OAuth2\Server\ResourceServer;
 use Nuwave\Lighthouse\Schema\Context;
 use Laravel\Passport\TokenRepository;
 use Illuminate\Contracts\Auth\UserProvider;
-use ReflectionClass;
-use ReflectionMethod;
-use ReflectionParameter;
 
-class WebSocketController implements MessageComponentInterface, WsServerInterface{
-    
+class WebSocketController{
+
     /**
-     * Protocol messages.
-     *
-     * @see https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/message-types.ts
-     */
-    const GQL_CONNECTION_INIT = 'connection_init'; // Client -> Server
-    const GQL_CONNECTION_ACK = 'connection_ack'; // Server -> Client
-    const GQL_CONNECTION_ERROR = 'connection_error'; // Server -> Client
-    const GQL_CONNECTION_KEEP_ALIVE = 'ka'; // Server -> Client
-    const GQL_CONNECTION_TERMINATE = 'connection_terminate'; // Client -> Server
-    const GQL_START = 'start'; // Client -> Server
-    const GQL_DATA = 'data'; // Server -> Client
-    const GQL_ERROR = 'error'; // Server -> Client
-    const GQL_COMPLETE = 'complete'; // Server -> Client
-    const GQL_STOP = 'stop'; // Client -> Server
-
-    /* The Resource Server instance.
+     * The Resource Server instance.
      *
      * @var \League\OAuth2\Server\ResourceServer
      */
-    protected $server;
+    protected $resourceServer;
 
-    /* The Passport Token Repository
+    /**
+     * The Passport Token Repository
      *
-     * @var Laravel\Passport\TokenRepository
-     */
+	 * @var Laravel\Passport\TokenRepository
+	 */
     protected $tokenRepository;
 
-    /* The Laravel Auth User Provider
+    /**
+     * The Laravel Auth User Provider
      *
      * @var \Illuminate\Contracts\Auth\UserProvider
      */
     protected $userProvider;
 
     /**
+     * Subscription Storage 
+     *
      * @var array
      */
     protected $subscriptions;
 
     /**
+     * Connection Storage
+     *
      * @var \SplObjectStorage
      */
     protected $connStorage;
 
-    public function __construct(ResourceServer $server, TokenRepository $tokenRepository){
-        $this->subscriptions = [];
-        $this->connStorage = new \SplObjectStorage();
-        $this->server = $server;
-        $this->tokenRepository = $tokenRepository;
+    public function __construct(ResourceServer $resourceServer, TokenRepository $tokenRepository, UserProvider $userProvider){
+    	$this->subscriptions = [];
+    	$this->connStorage = new \SplObjectStorage();
+    	$this->resourceServer = $resourceServer;
+    	$this->tokenRepository = $tokenRepository;
+    	$this->userProvider = $userProvider;
 
-        $auth = app('auth');
-        $driver = $auth->getDefaultDriver();
-        $config = app('config')["auth.guards.{$driver}"];
-        $this->userProvider = app('auth')->createUserProvider($config['provider'] ?: null);
-        graphql()->prepSchema();
+    	graphql()->prepSchema();
     }
 
-    /**
-     * @return void
-     */
-    public function onOpen(ConnectionInterface $conn){}
-
-    /**
-     * @return void
-     */
-    public function onMessage(ConnectionInterface $conn, $message)
-    {
-        // \Log::info($message);
-        $data = json_decode($message, true);
-        switch ($data['type']) {
-            case WebSocketController::GQL_CONNECTION_INIT:
-                $this->handleConnectionInit($conn, $data);
-                break;
-            case WebSocketController::GQL_START:
-                $this->handleStart($conn, $data);
-                break;
-            case WebSocketController::GQL_DATA:
-                $this->handleData($data);
-                break;
-            case WebSocketController::GQL_STOP:
-                $this->handleStop($conn, $data);
-                break;
-        }
-    }
-
-    /**
-     * @return void
-     */
-    public function onClose(ConnectionInterface $conn){}
-
-    /**
-     * @return void
-     */
-    public function onError(ConnectionInterface $conn, \Exception $exception)
-    {
-        \Log::error($exception);
-    }
-
-    public function getSubProtocols() : array
-    {
-        return ['graphql-ws'];
-    }
-
-    /**
+        /**
      * @param ConnectionInterface $conn
      *
      * @return void
      */
     public function handleConnectionInit(ConnectionInterface $conn, array $data){
         try {
-            $payload = array_get($data, 'payload');
-            $psr = new ServerRequest("ws", "", $payload, null, '1.1', []);
+        	$payload = array_get($data, 'payload');
+  			$psr = new ServerRequest("ws", "", $payload, null, '1.1', []);
 
-            if ($psr->hasHeader('authorization')){
-                $psr = $this->server->validateAuthenticatedRequest($psr);
-                $auth = $psr->getHeader('authorization');
-            }
-            
+			if ($psr->hasHeader('authorization')){
+	            $psr = $this->server->validateAuthenticatedRequest($psr);
+	            $auth = $psr->getHeader('authorization');
+			}
+			
             $this->connStorage->offsetSet($conn, ['auth' => $auth]);
             $response = [
                 'type'    => WebSocketController::GQL_CONNECTION_ACK,
@@ -184,30 +123,30 @@ class WebSocketController implements MessageComponentInterface, WsServerInterfac
                 $data['index'] = key($this->subscriptions[$data['name']]);
 
                 $connData = $this->connStorage->offsetExists($conn) ?
-                    $this->connStorage->offsetGet($conn) : [];
+                	$this->connStorage->offsetGet($conn) : [];
 
                 $connData['subscriptions'][$data['id']] = $data;
 
                 $this->connStorage->offsetSet($conn, $connData);
             } else {
 
-                $connData = $this->connStorage->offsetExists($conn) ? $this->connStorage->offsetGet($conn) : [];
-                $user = $this->getUser($connData['auth']);
+            	$connData = $this->connStorage->offsetExists($conn) ? $this->connStorage->offsetGet($conn) : [];
+            	$user = $this->getUser($connData['auth']);
                 $this->authUser($user);
 
-                $result = graphql()->execute(
-                    $query,
-                    new Context(null, $user),
-                    $variables
-                );
+            	$result = graphql()->execute(
+			        $query,
+			        new Context(null, $user),
+			        $variables
+			    );
 
-                $response = [
-                    'type'    => WebSocketController::GQL_DATA,
-                    'id'      => $data['id'],
-                    'payload' => "test",
-                ];
+		        $response = [
+		            'type'    => WebSocketController::GQL_DATA,
+		            'id'      => $data['id'],
+		            'payload' => "test",
+		        ];
 
-                $conn->send(json_encode($response));
+		        $conn->send(json_encode($response));
 
                 $response = [
                     'type' => WebSocketController::GQL_COMPLETE,
@@ -235,7 +174,7 @@ class WebSocketController implements MessageComponentInterface, WsServerInterfac
     /**
      * @return void
      */
-    public function handleData(array $data)
+   public function handleData(array $data)
     {
         $subscriptionName = $data['subscription'];
         $payload = $data['payload'];

--- a/src/Support/WebSockets/WebSocketController.php
+++ b/src/Support/WebSockets/WebSocketController.php
@@ -57,8 +57,6 @@ class WebSocketController{
         $this->resourceServer = $resourceServer;
         $this->tokenRepository = $tokenRepository;
         $this->userProvider = $userProvider;
-
-        graphql()->prepSchema();
     }
 
         /**
@@ -68,6 +66,7 @@ class WebSocketController{
      */
     public function handleConnectionInit(ConnectionInterface $conn, array $data){
         try {
+            graphql()->prepSchema();
             $payload = array_get($data, 'payload');
             $psr = new ServerRequest("ws", "", $payload, null, '1.1', []);
             $auth = null;

--- a/src/Support/WebSockets/WebSocketController.php
+++ b/src/Support/WebSockets/WebSocketController.php
@@ -11,6 +11,7 @@ use Firebase\JWT\JWT;
 use GuzzleHttp\Psr7\ServerRequest;
 use Nuwave\Lighthouse\Schema\Context;
 use Illuminate\Contracts\Auth\UserProvider;
+use ReflectionClass;
 
 class WebSocketController{
 

--- a/src/Support/WebSockets/WebSocketController.php
+++ b/src/Support/WebSockets/WebSocketController.php
@@ -51,7 +51,7 @@ class WebSocketController{
      */
     protected $connStorage;
 
-    public function __construct(ResourceServer $resourceServer, TokenRepository $tokenRepository, UserProvider $userProvider){
+    public function __construct(ResourceServer $resourceServer = null, TokenRepository $tokenRepository, UserProvider $userProvider){
     	$this->subscriptions = [];
     	$this->connStorage = new \SplObjectStorage();
     	$this->resourceServer = $resourceServer;
@@ -71,8 +71,8 @@ class WebSocketController{
         	$payload = array_get($data, 'payload');
   			$psr = new ServerRequest("ws", "", $payload, null, '1.1', []);
 
-			if ($psr->hasHeader('authorization')){
-	            $psr = $this->server->validateAuthenticatedRequest($psr);
+			if ($psr->hasHeader('authorization') && $this->resourceServer != null){
+	            $psr = $this->resourceServer->validateAuthenticatedRequest($psr);
 	            $auth = $psr->getHeader('authorization');
 			}
 			
@@ -253,8 +253,8 @@ class WebSocketController{
     public function getUser($authHeader){
         $psr = new ServerRequest("ws", "", $authHeader != null ? ['authorization' => $authHeader] : [], null, '1.1', []);
 
-        if ($psr->hasHeader('authorization')){
-            $psr = $this->server->validateAuthenticatedRequest($psr);
+        if ($psr->hasHeader('authorization') && $this->resourceServer != null{
+            $psr = $this->resourceServer->validateAuthenticatedRequest($psr);
             $auth = $psr->getAttributes();
 
             $token = $this->tokenRepository->find($auth['oauth_access_token_id']);

--- a/src/Support/WebSockets/WebSocketController.php
+++ b/src/Support/WebSockets/WebSocketController.php
@@ -9,7 +9,7 @@ use GraphQL\Type\Schema;
 use Ratchet\ConnectionInterface;
 use Firebase\JWT\JWT;
 use GuzzleHttp\Psr7\ServerRequest;
-use League\OAuth2\Server\ResourceServer;
+// use League\OAuth2\Server\ResourceServer;
 use Nuwave\Lighthouse\Schema\Context;
 use Laravel\Passport\TokenRepository;
 use Illuminate\Contracts\Auth\UserProvider;
@@ -51,7 +51,7 @@ class WebSocketController{
      */
     protected $connStorage;
 
-    public function __construct(ResourceServer $resourceServer = null, TokenRepository $tokenRepository, UserProvider $userProvider){
+    public function __construct($resourceServer = null, TokenRepository $tokenRepository, UserProvider $userProvider){
     	$this->subscriptions = [];
     	$this->connStorage = new \SplObjectStorage();
     	$this->resourceServer = $resourceServer;

--- a/src/Support/WebSockets/WebSocketController.php
+++ b/src/Support/WebSockets/WebSocketController.php
@@ -253,7 +253,7 @@ class WebSocketController{
     public function getUser($authHeader){
         $psr = new ServerRequest("ws", "", $authHeader != null ? ['authorization' => $authHeader] : [], null, '1.1', []);
 
-        if ($psr->hasHeader('authorization') && $this->resourceServer != null{
+        if ($psr->hasHeader('authorization') && $this->resourceServer != null){
             $psr = $this->resourceServer->validateAuthenticatedRequest($psr);
             $auth = $psr->getAttributes();
 

--- a/src/Support/WebSockets/WebSocketController.php
+++ b/src/Support/WebSockets/WebSocketController.php
@@ -58,10 +58,6 @@ class WebSocketController{
         $this->tokenRepository = $tokenRepository;
         $this->userProvider = $userProvider;
 
-        \Log::info(json_encode($resourceServer));
-        \Log::info(json_encode($tokenRepository));
-        \Log::info(json_encode($userProvider));
-
         graphql()->prepSchema();
     }
 

--- a/src/Support/WebSockets/WebSocketServer.php
+++ b/src/Support/WebSockets/WebSocketServer.php
@@ -1,0 +1,65 @@
+<?php
+namespace Nuwave\Lighthouse\Support\WebSockets;
+
+use Ratchet\MessageComponentInterface;
+use Ratchet\WebSocket\WsServerInterface;
+use Ratchet\ConnectionInterface;
+
+class WebSocketServer implements MessageComponentInterface, WsServerInterface{
+    
+
+    /** The WebSocketController
+     *
+     * @Var \Nuwave\Lighthouse\Support\WebSockets\WebSocketController
+     */
+	protected $controller;
+
+	public function __construct(WebSocketController $controller){
+		$this->controller = $controller;
+	}
+
+    /**
+     * @return void
+     */
+    public function onOpen(ConnectionInterface $conn){}
+
+    /**
+     * @return void
+     */
+    public function onMessage(ConnectionInterface $conn, $message)
+    {
+        $data = json_decode($message, true);
+        switch ($data['type']) {
+            case Protocol::GQL_CONNECTION_INIT:
+                $controller->handleConnectionInit($conn, $data);
+                break;
+            case Protocol::GQL_START:
+                $controller->handleStart($conn, $data);
+                break;
+            case Protocol::GQL_DATA:
+                $controller->handleData($data);
+                break;
+            case Protocol::GQL_STOP:
+                $controller->handleStop($conn, $data);
+                break;
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function onClose(ConnectionInterface $conn){}
+
+    /**
+     * @return void
+     */
+    public function onError(ConnectionInterface $conn, \Exception $exception)
+    {
+    	\Log::error($exception);
+    }
+
+    public function getSubProtocols() : array
+    {
+        return ['graphql-ws'];
+    }
+}

--- a/src/Support/WebSockets/WebSocketServer.php
+++ b/src/Support/WebSockets/WebSocketServer.php
@@ -37,6 +37,8 @@ class WebSocketServer implements MessageComponentInterface, WsServerInterface{
                 $controller->handleStart($conn, $data);
                 break;
             case Protocol::GQL_DATA:
+                if ($conn->remoteAddress != "127.0.0.1")
+                    throw new Exception("Can't accept data from " . $conn->remoteAddress);
                 $controller->handleData($data);
                 break;
             case Protocol::GQL_STOP:

--- a/src/Support/WebSockets/WebSocketServer.php
+++ b/src/Support/WebSockets/WebSocketServer.php
@@ -31,18 +31,18 @@ class WebSocketServer implements MessageComponentInterface, WsServerInterface{
         $data = json_decode($message, true);
         switch ($data['type']) {
             case Protocol::GQL_CONNECTION_INIT:
-                $controller->handleConnectionInit($conn, $data);
+                $this->controller->handleConnectionInit($conn, $data);
                 break;
             case Protocol::GQL_START:
-                $controller->handleStart($conn, $data);
+                $this->controller->handleStart($conn, $data);
                 break;
             case Protocol::GQL_DATA:
                 if ($conn->remoteAddress != "127.0.0.1")
                     throw new Exception("Can't accept data from " . $conn->remoteAddress);
-                $controller->handleData($data);
+                $this->controller->handleData($data);
                 break;
             case Protocol::GQL_STOP:
-                $controller->handleStop($conn, $data);
+                $this->controller->handleStop($conn, $data);
                 break;
         }
     }


### PR DESCRIPTION
Full Subscriptions Implementation #88 

The only code needed for a Subscription is:
```php
<?php

namespace App\GraphQL\Subscriptions;

use Illuminate\Queue\SerializesModels;
use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
use Nuwave\Lighthouse\Support\Schema\GraphQLSubscription;
use Illuminate\Broadcasting\Channel;

class ChatMessageSubscription extends GraphQLSubscription
{
    public $message;

    public function __construct($message)
    {
        $this->message = $message;
    }

    public function broadcastAs()
    {
        return 'onChatMessage';
    }


  public function resolve(){
	return $this->message;
  }
}
```
with schema
```graphql
type Mutation{
	chatMessage(message: String): Message
		@create(model: "App\\Models\\ChatMessage")
		@inject(context: "user.id", name: "user_id")
		@event(fire: "App\\GraphQL\\Subscriptions\\ChatMessageSubscription")
}

type Subscription{
	onChatMessage: Message
}

type Message{
	id: ID!
	user: User
	message: String
	updated_at: DateTime
	created_at: DateTime
}
```
and the following broadcasting config. You also need to run `php artisan queue:work` and `php artisan websocket:init`
```php
'graphql' => [
    'driver' => 'lighthouse',
    'port' => 8080,
]
```
