### PR TITLE
Enable GET requests to the graphql endpoint when app is in debug mode

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -7,12 +7,15 @@ return [
     |--------------------------------------------------------------------------
     |
     | Setup this values as required,
-    | default route endpoints its yourdomain.com/graphql
+    | default route endpoints is yourdomain.com/graphql
+    | get requests default to only being enabled in debug mode
     | setup middleware here for all request,
     | setup more endpoints, ej: pointing to the controller value inside your route file
     |
     */
     'route_name' => 'graphql',
+
+    'route_enable_get' => config('app.debug'),
 
     'route' => [
         'prefix' => '',

--- a/config/config.php
+++ b/config/config.php
@@ -8,14 +8,14 @@ return [
     |
     | Setup this values as required,
     | default route endpoints is yourdomain.com/graphql
-    | get requests default to only being enabled in debug mode
+    | get requests to your graphql endpoint are disabled by default, you may enable them below
     | setup middleware here for all request,
     | setup more endpoints, ej: pointing to the controller value inside your route file
     |
     */
     'route_name' => 'graphql',
 
-    'route_enable_get' => config('app.debug'),
+    'route_enable_get' => false,
 
     'route' => [
         'prefix' => '',

--- a/src/Support/Http/routes.php
+++ b/src/Support/Http/routes.php
@@ -2,8 +2,13 @@
 
 $route = config('lighthouse.route', []);
 $route_name = config('lighthouse.route_name', 'graphql');
+$route_enable_get = config('lighthouse.route_enable_get', false);
 $controller = config('lighthouse.controller');
 
-app('router')->group($route, function () use ($controller, $route_name) {
-    app('router')->post($route_name, ['as' => 'lighthouse.graphql', 'uses' => $controller]);
+app('router')->group($route, function () use ($controller, $route_name, $route_enable_get) {
+    app('router')->match(
+      $route_enable_get ? ['get', 'post'] : ['post'],
+      $route_name, 
+      ['as' => 'lighthouse.graphql', 'uses' => $controller]
+    );
 });


### PR DESCRIPTION
Being able to hit the graphql endpoint with a get request is extremely useful for debugging