### PR TITLE
Keep routes compatible with Lumen framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,11 @@
         "source": "https://github.com/nuwave/lighthouse"
     },
     "require": {
-        "laravel/lumen-framework": "^5.6",
+        "illuminate/contracts": "^5.4",
+        "illuminate/http": "^5.4",
+        "illuminate/pagination": "^5.4",
+        "illuminate/routing": "^5.4",
+        "illuminate/support": "^5.4",
         "opis/closure": "^3.0",
         "webonyx/graphql-php": "^0.11.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,7 @@
         "source": "https://github.com/nuwave/lighthouse"
     },
     "require": {
-        "illuminate/contracts": "^5.4",
-        "illuminate/http": "^5.4",
-        "illuminate/pagination": "^5.4",
-        "illuminate/routing": "^5.4",
-        "illuminate/support": "^5.4",
+        "laravel/lumen-framework": "^5.6",
         "opis/closure": "^3.0",
         "webonyx/graphql-php": "^0.11.5"
     },

--- a/src/Support/Http/routes.php
+++ b/src/Support/Http/routes.php
@@ -6,9 +6,12 @@ $route_enable_get = config('lighthouse.route_enable_get', false);
 $controller = config('lighthouse.controller');
 
 app('router')->group($route, function () use ($controller, $route_name, $route_enable_get) {
-    app('router')->match(
-      $route_enable_get ? ['get', 'post'] : ['post'],
-      $route_name, 
+    if ($route_enable_get) {
+        app('router')->get($route_name,
+          ['as' => 'lighthouse.graphql', 'uses' => $controller]
+        );
+    }
+    app('router')->post($route_name,
       ['as' => 'lighthouse.graphql', 'uses' => $controller]
     );
 });


### PR DESCRIPTION
Lumen routing has no concept of ::match, therefor I just split the one-liner into two, adding the ::get if allowed, whilst keeping the default ::post