### PR TITLE
Fixed a bug with DeleteDirective when using a globalId

### DIFF
--- a/src/Schema/Directives/Fields/DeleteDirective.php
+++ b/src/Schema/Directives/Fields/DeleteDirective.php
@@ -61,7 +61,7 @@ class DeleteDirective implements FieldResolver
         }
 
         return $value->setResolver(function ($root, array $args) use ($class, $idArg, $globalId) {
-            $id = $globalId ? $this->decodeGlobalId(array_get($args, $idArg)) : array_get($args, $idArg);
+            $id = $globalId ? $this->decodeGlobalId(array_get($args, $idArg))[1] : array_get($args, $idArg);
             $model = $class::find($id);
 
             if ($model) {

--- a/src/Schema/Directives/Fields/UpdateDirective.php
+++ b/src/Schema/Directives/Fields/UpdateDirective.php
@@ -60,7 +60,7 @@ class UpdateDirective implements FieldResolver
         }
 
         return $value->setResolver(function ($root, array $args) use ($class, $idArg, $globalId) {
-            $id = $globalId ? $this->decodeGlobalId(array_get($args, $idArg)) : array_get($args, $idArg);
+            $id = $globalId ? $this->decodeGlobalId(array_get($args, $idArg))[1] : array_get($args, $idArg);
             $model = $class::find($id);
 
             if ($model) {

--- a/src/Schema/Directives/Fields/UpdateDirective.php
+++ b/src/Schema/Directives/Fields/UpdateDirective.php
@@ -8,10 +8,11 @@ use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 use Nuwave\Lighthouse\Support\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Support\Traits\HandlesDirectives;
+use Nuwave\Lighthouse\Support\Traits\HandlesGlobalId;
 
 class UpdateDirective implements FieldResolver
 {
-    use HandlesDirectives;
+    use HandlesDirectives, HandlesGlobalId;
 
     /**
      * Name of the directive.


### PR DESCRIPTION
When you use the delete directive with a global ID $id comes back as an array with `['modelName', 'id']`, so $model::find($id) returns a collection instead of the model instance. I'm simply access the first index of the global ID resolver, so we get the actual model instance back when doing the `$model::find($id)` operation.