### PR TITLE
Require php >= 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "source": "https://github.com/nuwave/lighthouse"
     },
     "require": {
+        "php" : ">= 7.0",
         "illuminate/contracts": "^5.4",
         "illuminate/http": "^5.4",
         "illuminate/pagination": "^5.4",


### PR DESCRIPTION
We are already using features that are not in PHP 5.6, so we might as well make it official.