### PR TITLE
Rule Factory

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -15,7 +15,7 @@ return PhpCsFixer\Config::create()
         'array_syntax' => ['syntax' => 'short'],
         'linebreak_after_opening_tag' => true,
         'not_operator_with_successor_space' => true,
-        'no_unused_imports' => false,
+        'no_unused_imports' => true,
         'ordered_imports' => true,
         'phpdoc_order' => true,
         'not_operator_with_successor_space' => true

--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -2,7 +2,9 @@
 
 namespace Nuwave\Lighthouse\Schema\AST;
 
+use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeList;
+use GraphQL\Utils\AST;
 
 class ASTHelper
 {
@@ -28,5 +30,17 @@ class ASTHelper
         }
 
         return $original->merge($addition);
+    }
+
+    /**
+     * Clone definition node.
+     *
+     * @param Node $node
+     *
+     * @return Node
+     */
+    public static function cloneDefinition(Node $node)
+    {
+        return AST::fromArray($node->toArray(true));
     }
 }

--- a/src/Schema/AST/DocumentAST.php
+++ b/src/Schema/AST/DocumentAST.php
@@ -135,6 +135,16 @@ class DocumentAST
     }
 
     /**
+     * Get all definitions for input types.
+     *
+     * @return Collection
+     */
+    public function inputTypes()
+    {
+        return $this->definitionsByType(InputObjectTypeDefinitionNode::class);
+    }
+
+    /**
      * Get all interface definitions.
      *
      * @return Collection

--- a/src/Schema/Directives/Args/RulesDirective.php
+++ b/src/Schema/Directives/Args/RulesDirective.php
@@ -3,14 +3,15 @@
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
 use GraphQL\Language\AST\DirectiveNode;
-use GraphQL\Language\AST\FieldDefinitionNode;
-use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use GraphQL\Language\AST\InputObjectTypeDefinitionNode;
+use GraphQL\Language\AST\InputValueDefinitionNode;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Factories\RuleFactory;
+use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
-use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
+use Nuwave\Lighthouse\Support\Contracts\InputValueManipulator;
 
-class RulesDirective implements ArgMiddleware, FieldManipulator
+class RulesDirective implements ArgMiddleware, InputValueManipulator
 {
     /**
      * Name of the directive.
@@ -23,25 +24,25 @@ class RulesDirective implements ArgMiddleware, FieldManipulator
     }
 
     /**
-     * @param FieldDefinitionNode      $fieldDefinition
-     * @param ObjectTypeDefinitionNode $parentType
-     * @param DocumentAST              $current
-     * @param DocumentAST              $original
+     * @param InputValueDefinitionNode      $inputValue
+     * @param InputObjectTypeDefinitionNode $parentType
+     * @param DocumentAST                   $current
+     * @param DocumentAST                   $original
      *
      * @return DocumentAST
      */
     public function manipulateSchema(
-        FieldDefinitionNode $fieldDefinition,
-        ObjectTypeDefinitionNode $parentType,
+        InputValueDefinitionNode $inputValue,
+        InputObjectTypeDefinitionNode $parentType,
         DocumentAST $current,
         DocumentAST $original
     ) {
-        $directive = collect($fieldDefinition->directives)
+        $directive = collect($inputValue->directives)
             ->first(function (DirectiveNode $directive) {
-                return $directive->name->value === $this->rules();
+                return $directive->name->value === $this->name();
             });
 
-        return RuleFactory::build($directive, $field, $parentType, $current);
+        return RuleFactory::build($directive, $inputValue, $parentType, $current);
     }
 
     /**

--- a/src/Schema/Directives/Args/RulesDirective.php
+++ b/src/Schema/Directives/Args/RulesDirective.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Directives\Args;
+
+use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
+use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
+
+class RulesDirective implements ArgMiddleware, FieldManipulator
+{
+    /**
+     * @param FieldDefinitionNode      $fieldDefinition
+     * @param ObjectTypeDefinitionNode $parentType
+     * @param DocumentAST              $current
+     * @param DocumentAST              $original
+     *
+     * @return DocumentAST
+     */
+    public function manipulateSchema(
+        FieldDefinitionNode $fieldDefinition,
+        ObjectTypeDefinitionNode $parentType,
+        DocumentAST $current,
+        DocumentAST $original
+    ) {
+        return $current;
+    }
+
+    /**
+     * Apply transformations on the ArgumentValue.
+     *
+     * @param ArgumentValue $value
+     *
+     * @return ArgumentValue
+     */
+    public function handleArgument(ArgumentValue $value)
+    {
+        return $value;
+    }
+}

--- a/src/Schema/Directives/Args/RulesDirective.php
+++ b/src/Schema/Directives/Args/RulesDirective.php
@@ -2,11 +2,26 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
+use GraphQL\Language\AST\DirectiveNode;
+use GraphQL\Language\AST\FieldDefinitionNode;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+use Nuwave\Lighthouse\Schema\Factories\RuleFactory;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
 use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
 
 class RulesDirective implements ArgMiddleware, FieldManipulator
 {
+    /**
+     * Name of the directive.
+     *
+     * @return string
+     */
+    public function name()
+    {
+        return 'rules';
+    }
+
     /**
      * @param FieldDefinitionNode      $fieldDefinition
      * @param ObjectTypeDefinitionNode $parentType
@@ -21,7 +36,12 @@ class RulesDirective implements ArgMiddleware, FieldManipulator
         DocumentAST $current,
         DocumentAST $original
     ) {
-        return $current;
+        $directive = collect($fieldDefinition->directives)
+            ->first(function (DirectiveNode $directive) {
+                return $directive->name->value === $this->rules();
+            });
+
+        return RuleFactory::build($directive, $field, $parentType, $current);
     }
 
     /**

--- a/src/Schema/Factories/RuleFactory.php
+++ b/src/Schema/Factories/RuleFactory.php
@@ -110,7 +110,7 @@ class RuleFactory
                         }
 
                         $directiveClone = ASTHelper::cloneDefinition($directive);
-                        $this->appendPath($directiveClone, $arg, $this->includesList($arg));
+                        $this->appendPath($directiveClone, $arg, $this->includesList($arg), true);
 
                         $arg->directives = ASTHelper::mergeNodeList(
                             $arg->directives, NodeList::create([$directiveClone])
@@ -142,8 +142,12 @@ class RuleFactory
      *
      * @return DirectiveNode
      */
-    protected function appendPath(DirectiveNode $directive, InputValueDefinitionNode $arg, $list)
-    {
+    protected function appendPath(
+        DirectiveNode $directive,
+        InputValueDefinitionNode $arg,
+        $list,
+        $final = false
+    ) {
         $currentPath = $this->directiveArgValue($directive, 'path', '');
         $fullPath = $arg->name->value;
 
@@ -153,6 +157,11 @@ class RuleFactory
 
         if (! empty($currentPath)) {
             $fullPath = "{$fullPath}.{$currentPath}";
+        }
+
+        $pop = ['.', '*'];
+        while ($final && ends_with($fullPath, $pop)) {
+            $fullPath = substr_replace($fullPath, '', -1);
         }
 
         $inputType = PartialParser::inputObjectTypeDefinition("

--- a/src/Schema/Factories/RuleFactory.php
+++ b/src/Schema/Factories/RuleFactory.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Factories;
+
+use GraphQL\Language\AST\DirectiveNode;
+use GraphQL\Language\AST\FieldDefinitionNode;
+use GraphQL\Language\AST\InputObjectTypeDefinitionNode;
+use GraphQL\Language\AST\InputValueDefinitionNode;
+use GraphQL\Language\AST\NodeList;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use Nuwave\Lighthouse\Schema\AST\ASTHelper;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+use Nuwave\Lighthouse\Schema\AST\PartialParser;
+use Nuwave\Lighthouse\Support\Traits\HandlesDirectives;
+
+class RuleFactory
+{
+    // NOTE: This will be replaced w/ a utility class.
+    use HandlesDirectives;
+
+    /**
+     * Build rules for field.
+     *
+     * @param DirectiveNode                 $directive
+     * @param InputValueDefinitionNode      $input
+     * @param InputObjectTypeDefinitionNode $input
+     * @param DocumentAST                   $document
+     *
+     * @return DocumentAST
+     */
+    public static function build(
+        DirectiveNode $directive,
+        InputValueDefinitionNode $field,
+        InputObjectTypeDefinitionNode $input,
+        DocumentAST $documentAST
+    ) {
+        // $instance = new static();
+        // $documentAST = $instance->applyToMutation($directive, $input, $documentAST);
+        // $documentAST = self::applyToInputTypes();
+
+        return $documentAST;
+    }
+
+    /**
+     * Apply rules to input types.
+     */
+    protected function applyToInputTypes()
+    {
+        $documentAST->inputTypes()
+            ->each(function (InputObjectTypeDefinitionNode $inputType) use ($input) {
+                collect($inputType->fields)->filter(function (InputValueDefinitionNode $field) use ($input, $inputType) {
+                    return $field->type->name->value === $input->name->value;
+                })->each(function ($field) use ($inputType) {
+                    // Recursively walk up tree to find mutation field.
+                    // dd($field->name->value, $inputType);
+                });
+            });
+    }
+
+    /**
+     * Apply rules to mutation fields.
+     *
+     * @param DirectiveNode                 $directive
+     * @param InputObjectTypeDefinitionNode $input
+     * @param DocumentAST                   $documentAST
+     *
+     * @return DocumentAST
+     */
+    protected function applyToMutation(
+        DirectiveNode $directive,
+        InputObjectTypeDefinitionNode $input,
+        DocumentAST $documentAST
+    ) {
+        $mutation = $documentAST->mutationType();
+
+        $fields = collect($mutation->fields)
+            ->map(function (FieldDefinitionNode $node) use ($directive, $input) {
+                $arguments = collect($node->arguments)
+                    ->filter(function (InputValueDefinitionNode $arg) use ($input) {
+                        return $arg->type->name->value === $input->name->value;
+                    })->map(function (InputValueDefinitionNode $arg) use ($directive) {
+                        $currentPath = $this->directiveArgValue($directive, 'path', '');
+                        $fullPath = $arg->name->value;
+
+                        if (! empty($currentPath)) {
+                            $fullPath = "{$fullPath}.{$currentPath}";
+                        }
+
+                        $inputType = PartialParser::inputObjectTypeDefinition("
+                        input Dummy {
+                            dummy: String @rules(path: \"{$fullPath}\")
+                        }");
+
+                        $path = $inputType->fields[0]->directives[0];
+                        $directive->arguments = ASTHelper::mergeNodeList(
+                            $directive->arguments, $path->arguments
+                        );
+
+                        $arg->directives = ASTHelper::mergeNodeList(
+                            $arg->directives, NodeList::create([$directive])
+                        );
+
+                        return $arg;
+                    })->toArray();
+
+                $node->arguments = ASTHelper::mergeNodeList(
+                    $node->arguments,
+                    new NodeList($arguments)
+                );
+
+                return $node;
+            })->toArray();
+
+        $mutation->fields = ASTHelper::mergeNodeList(
+            $mutation->fields,
+            new NodeList($fields)
+        );
+
+        $documentAST->setDefinition($mutation);
+
+        return $documentAST;
+    }
+}

--- a/src/Support/Contracts/InputValueManipulator.php
+++ b/src/Support/Contracts/InputValueManipulator.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Nuwave\Lighthouse\Support\Contracts;
+
+use GraphQL\Language\AST\InputObjectTypeDefinitionNode;
+use GraphQL\Language\AST\InputValueDefinitionNode;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+
+interface InputValueManipulator extends Directive
+{
+    /**
+     * @param InputValueDefinitionNode      $inputValue
+     * @param InputObjectTypeDefinitionNode $parentType
+     * @param DocumentAST                   $current
+     * @param DocumentAST                   $original
+     *
+     * @return DocumentAST
+     */
+    public function manipulateSchema(
+        InputValueDefinitionNode $inputValue,
+        InputObjectTypeDefinitionNode $parentType,
+        DocumentAST $current,
+        DocumentAST $original
+    );
+}

--- a/tests/Unit/Schema/Directives/Args/RulesDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/Args/RulesDirectiveTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit\Schema\Directives\Args;
+
+use Tests\TestCase;
+
+class RulesDirectiveTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itCanApplyRulesToInputTypes()
+    {
+        $resolver = addslashes(self::class);
+        $schema = "
+        input FooInput {
+            bar: String @rules(apply: [\"required\"])
+            baz: String @rules(apply: [\"required\"])
+        }
+
+        type Query {}
+
+        type Mutation {
+            foo(input: FooInput!): String 
+                @field(resolver: \"{$resolver}@resolve\")
+        }";
+
+        $result = $this->executeAndFormat($schema, 'mutation { foo(input: { bar: "" }) }');
+        $this->assertNull(array_get($result, 'data.foo'));
+        $this->assertCount(2, array_get($result, 'errors.0.validation'));
+    }
+
+    /**
+     * @return string
+     */
+    public function resolve()
+    {
+        return 'foo';
+    }
+}

--- a/tests/Unit/Schema/Factories/RuleFactoryTest.php
+++ b/tests/Unit/Schema/Factories/RuleFactoryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit\Schema\Factories;
+
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+use Nuwave\Lighthouse\Schema\AST\PartialParser;
+use Nuwave\Lighthouse\Schema\Factories\RuleFactory;
+use Nuwave\Lighthouse\Support\Traits\HandlesDirectives;
+use Tests\TestCase;
+
+class RuleFactoryTest extends TestCase
+{
+    use HandlesDirectives;
+
+    /**
+     * @test
+     */
+    public function itCanBuildRulesForInputField()
+    {
+        $documentAST = DocumentAST::fromSource('
+        input UserInput {
+            email: String @rules(apply: ["required", "email"])
+        }
+        
+        type Mutation {
+            createUser(input: UserInput): String
+        }');
+
+        $inputType = $documentAST->inputTypes()->first();
+        $input = $inputType->fields[0];
+
+        $documentAST = RuleFactory::build(
+            $input->directives[0],
+            $input,
+            $inputType,
+            $documentAST
+        );
+
+        $inputArg = $documentAST->mutationType()->fields[0]->arguments[0];
+
+        $this->assertCount(1, $inputArg->directives);
+
+        $this->assertEquals(
+            'input',
+            $this->directiveArgValue($inputArg->directives[0], 'path')
+        );
+
+        $this->assertEquals(
+            ['required', 'email'],
+            $this->directiveArgValue($inputArg->directives[0], 'apply')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itCanBuildRulesForNestedInputField()
+    {
+        $documentAST = DocumentAST::fromSource('
+        input AddressInput {
+            street: String @rules(apply: ["required"])
+        }
+
+        input UserInput {
+            email: String @rules(apply: ["required", "email"])
+            address: AddressInput
+        }
+        
+        type Mutation {
+            createUser(input: UserInput): String
+        }');
+
+        $inputType = $documentAST->inputTypes()->first();
+        $input = $inputType->fields[0];
+
+        $documentAST = RuleFactory::build(
+            $input->directives[0],
+            $input,
+            $inputType,
+            $documentAST
+        );
+
+        // TODO: Test Document
+    }
+}

--- a/tests/Unit/Schema/Factories/RuleFactoryTest.php
+++ b/tests/Unit/Schema/Factories/RuleFactoryTest.php
@@ -126,4 +126,21 @@ class RuleFactoryTest extends TestCase
             $this->directiveArgValue($inputArg->directives[1], 'apply')
         );
     }
+
+    /**
+     * @test
+     */
+    public function itCanApplyRulesToResolver()
+    {
+        $schema = $this->buildSchemaWithDefaultQuery('
+        input UserInput {
+            email: String @rules(apply: ["required", "email"])
+        }
+        
+        type Mutation {
+            createUser(input: UserInput): String
+        }');
+
+        dd($schema);
+    }
 }


### PR DESCRIPTION
This PR adds a new `@rules` directive that can be applied to both mutation arguments as well as nested input object fields.

The directive takes advantage of schema manipulation to flatten out nested rules onto the mutation field which will be run before processing a mutation and provide Laravel validation error(s) in the response meta.

If the `@rules` directive is placed on list, the path will automatically include the `*` notation used by Laravel's validator.

Example Usage:

```graphql
input AddressInput {
  street: String @rules(apply: ["required"])
}

input UserInput {
  name: String @rules(apply: ["required"])
  email: String @rules(apply: ["required", "email"])
  address: [AddressInput]
}

type Mutation {
  createUser(input: UserInput): String
}
```

Will automatically manipulate the schema and place the following directives on the mutation field:

```graphql
type Mutation {
  createUser(input: UserInput): String
    @rules(path: "input.name", rules: ["required"])
    @rules(path: "input.email", rules: ["required", "email"])
    @rules(path: "input.address.*.street", rules: ["required"])
}
```