### PR TITLE
Refactor and cleanup DocumentAST

### DIFF
--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -46,7 +46,7 @@ class ASTBuilder
     {
         $originalDocument = $document;
 
-        return $document->typeExtensions()
+        return $document->typeExtensionDefinitions()
         // Unwrap extended types so they can be treated same as other types
             ->map(function (TypeExtensionDefinitionNode $typeExtension) {
                 return $typeExtension->definition;
@@ -69,10 +69,10 @@ class ASTBuilder
 
     protected static function mergeTypeExtensions(DocumentAST $document)
     {
-        $document->objectTypes()->each(function (ObjectTypeDefinitionNode $objectType) use ($document) {
+        $document->objectTypeDefinitions()->each(function (ObjectTypeDefinitionNode $objectType) use ($document) {
             $name = $objectType->name->value;
 
-            $document->typeExtensions($name)->reduce(function (
+            $document->typeExtensionDefinitions($name)->reduce(function (
                 ObjectTypeDefinitionNode $relatedObjectType,
                 TypeExtensionDefinitionNode $typeExtension
             ) {
@@ -99,7 +99,7 @@ class ASTBuilder
     {
         $originalDocument = $document;
 
-        return $document->objectTypes()->reduce(function (
+        return $document->objectTypeDefinitions()->reduce(function (
             DocumentAST $document,
             ObjectTypeDefinitionNode $objectType
         ) use ($originalDocument) {
@@ -129,7 +129,7 @@ class ASTBuilder
     {
         $originalDocument = $document;
 
-        return $document->objectTypes()->reduce(
+        return $document->objectTypeDefinitions()->reduce(
             function (DocumentAST $document, ObjectTypeDefinitionNode $parentType) use ($originalDocument) {
                 return collect($parentType->fields)->reduce(
                     function (DocumentAST $document, FieldDefinitionNode $parentField) use (
@@ -170,7 +170,7 @@ class ASTBuilder
      */
     protected static function addNodeSupport(DocumentAST $document)
     {
-        $hasTypeImplementingNode = $document->objectTypes()->contains(function (ObjectTypeDefinitionNode $objectType) {
+        $hasTypeImplementingNode = $document->objectTypeDefinitions()->contains(function (ObjectTypeDefinitionNode $objectType) {
             return collect($objectType->interfaces)->contains(function (NamedTypeNode $interface) {
                 return 'Node' === $interface->name->value;
             });

--- a/src/Schema/Factories/RuleFactory.php
+++ b/src/Schema/Factories/RuleFactory.php
@@ -86,7 +86,7 @@ class RuleFactory
      */
     protected function getMutationField(DocumentAST $documentAST, $fieldName)
     {
-        return collect($documentAST->mutationType()->fields)
+        return collect($documentAST->mutationTypeDefinition()->fields)
             ->first(function (FieldDefinitionNode $field) use ($fieldName) {
                 return $field->name->value === $fieldName;
             });
@@ -153,7 +153,7 @@ class RuleFactory
             if ($node instanceof InputObjectTypeDefinitionNode) {
                 $arguments = $node->fields;
             } elseif ($node instanceof InputValueDefinitionNode) {
-                $inputType = $documentAST->inputType($this->unwrapType($node->type)->name->value);
+                $inputType = $documentAST->inputObjectTypeDefinition($this->unwrapType($node->type)->name->value);
                 $arguments = $inputType ? $inputType->fields : null;
             } elseif ($node instanceof FieldDefinitionNode) {
                 $arguments = $node->arguments;
@@ -177,7 +177,7 @@ class RuleFactory
 
         $list = $this->includesList($input);
         $type = $this->unwrapType($input);
-        $inputType = $documentAST->inputType($type->name->value);
+        $inputType = $documentAST->inputObjectTypeDefinition($type->name->value);
 
         return $inputType ? $this->getFieldRules($inputType->fields, $resolvedPath->implode('.'), $list) : null;
     }

--- a/src/Schema/MiddlewareManager.php
+++ b/src/Schema/MiddlewareManager.php
@@ -32,9 +32,9 @@ class MiddlewareManager
     public function forRequest($request)
     {
         $document = DocumentAST::fromSource($request);
-        $fragments = $document->fragments();
+        $fragments = $document->fragmentDefinitions();
 
-        return $document->operations()
+        return $document->operationDefinitions()
             ->map(function (OperationDefinitionNode $node) use ($fragments) {
                 $definition = AST::toArray($node);
                 $operation = array_get($definition, 'operation');
@@ -133,18 +133,5 @@ class MiddlewareManager
     public function mutation($name)
     {
         return array_get($this->mutations, $name, []);
-    }
-
-    /**
-     * Get middleware by node.
-     *
-     * @param OperationDefinitionNode $node
-     * @param  string
-     *
-     * @return void
-     */
-    protected function byNode(OperationDefinitionNode $node, $operation)
-    {
-        dd('here');
     }
 }

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -121,7 +121,7 @@ class SchemaBuilder
      */
     protected function convertDirectives(DocumentAST $document)
     {
-        return $document->directives()->map(function (DirectiveDefinitionNode $directive) {
+        return $document->directiveDefinitions()->map(function (DirectiveDefinitionNode $directive) {
             return new Directive([
                 'name' => $directive->name->value,
                 'locations' => collect($directive->locations)->map(function ($location) {

--- a/tests/Unit/Schema/AST/ASTBuilderTest.php
+++ b/tests/Unit/Schema/AST/ASTBuilderTest.php
@@ -29,7 +29,7 @@ class ASTBuilderTest extends TestCase
             }
         ');
 
-        $this->assertCount(3, $ast->objectType('Query')->fields);
+        $this->assertCount(3, $ast->objectTypeDefinition('Query')->fields);
     }
 
     /**
@@ -42,9 +42,9 @@ class ASTBuilderTest extends TestCase
             email: String
         }');
 
-        $originalDocument = new DocumentAST($documentAST->documentNode());
+        $originalDocument = new DocumentAST($documentAST->document());
 
-        $userType = $documentAST->objectType('User');
+        $userType = $documentAST->objectTypeDefinition('User');
         $this->assertCount(1, $userType->fields);
 
         $dummyType = PartialParser::objectTypeDefinition('
@@ -57,10 +57,10 @@ class ASTBuilderTest extends TestCase
             $dummyType->fields
         );
 
-        $this->assertCount(1, $documentAST->objectType('User')->fields);
+        $this->assertCount(1, $documentAST->objectTypeDefinition('User')->fields);
 
         $documentAST->setDefinition($userType);
-        $this->assertCount(2, $documentAST->objectType('User')->fields);
-        $this->assertCount(1, $originalDocument->objectType('User')->fields);
+        $this->assertCount(2, $documentAST->objectTypeDefinition('User')->fields);
+        $this->assertCount(1, $originalDocument->objectTypeDefinition('User')->fields);
     }
 }


### PR DESCRIPTION
- Optimize setDefinition() to only look at the new definition once
- declare(strict_types=1)
- Add return types and scalar type hints
- Clean up method names to follow the same naming convention that PartialParser follows
- Remove unused methods