### PR TITLE
[WIP] Only generate minimal needed rules

### DIFF
--- a/tests/Unit/Schema/Factories/RuleFactoryTest.php
+++ b/tests/Unit/Schema/Factories/RuleFactoryTest.php
@@ -179,4 +179,35 @@ class RuleFactoryTest extends TestCase
             'input.settings.*.setting.value' => ['required'],
         ], $rules);
     }
+
+    /**
+     * @test
+     */
+    public function itGeneratesOnlyMinimalNeededRules()
+    {
+        $documentAST = ASTBuilder::generate('
+        input FooInput {
+            self: FooInput
+            email: String @rules(apply: ["email"])
+        }
+        type Mutation {
+            createFoo(input: FooInput @rules(apply: ["required"])): String
+        }');
+
+        $variables = [
+            'input' => [
+                'self' => [
+                    'self' => [
+                        'email' => 'asdf'
+                    ],
+                ],
+            ],
+        ];
+
+        $rules = $this->factory->build($documentAST, $variables, 'createFoo');
+        $this->assertEquals([
+            'input' => ['required'],
+            'input.self.self.email' => ['email'],
+        ], $rules);
+    }
 }

--- a/tests/Unit/Schema/Factories/RuleFactoryTest.php
+++ b/tests/Unit/Schema/Factories/RuleFactoryTest.php
@@ -230,21 +230,25 @@ class RuleFactoryTest extends TestCase
     /**
      * @test
      */
-    public function itAlwaysGeneratesRequiredRulesForNestedInputs()
+    public function itAlwaysGeneratesRulesForRequiredNestedInputs()
     {
         $documentAST = ASTBuilder::generate('
         input FooInput {
-            self: FooInput
             required: String @rules(apply: ["required"])
         }
         type Mutation {
-            createFoo(input: FooInput @rules(apply: ["required"])): String
+            createFoo(
+                requiredSDL: FooInput!
+                requiredRules: FooInput @rules(apply: ["required"])
+                requiredBoth: FooInput! @rules(apply: ["required"])
+            ): String
         }');
 
         $rules = $this->factory->build($documentAST, [], 'createFoo');
         $this->assertEquals([
-            'input' => ['required'],
-            'input.required' => ['required'],
+            'requiredSDL.required' => ['required'],
+            'requiredBoth' => ['required'],
+            'requiredBoth.required' => ['required'],
         ], $rules);
     }
     


### PR DESCRIPTION
The generated rules array should be as small as possible. Else, heavily nested and large Input Objects might cause the rules array to grow too large.