### PR TITLE
DocumentAST Lock

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -65,9 +65,9 @@ class GraphQL
      * Create instance of graphql container.
      *
      * @param DirectiveRegistry $directives
-     * @param TypeRegistry $types
+     * @param TypeRegistry      $types
      * @param MiddlewareManager $middleware
-     * @param NodeContainer $nodes
+     * @param NodeContainer     $nodes
      */
     public function __construct(
         DirectiveRegistry $directives,
@@ -136,6 +136,7 @@ class GraphQL
     public function queryAndReturnResult($query, $context = null, $variables = [], $rootValue = null)
     {
         $schema = $this->graphqlSchema ?: $this->buildSchema();
+        $this->documentAST->lock();
 
         return GraphQLBase::executeQuery(
             $schema,

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -136,7 +136,6 @@ class GraphQL
     public function queryAndReturnResult($query, $context = null, $variables = [], $rootValue = null)
     {
         $schema = $this->graphqlSchema ?: $this->buildSchema();
-        $this->documentAST->lock();
 
         return GraphQLBase::executeQuery(
             $schema,
@@ -174,7 +173,7 @@ class GraphQL
                 : $this->buildAST();
         }
 
-        return $this->documentAST;
+        return $this->documentAST->lock();
     }
 
     /**

--- a/src/Schema/AST/DocumentAST.php
+++ b/src/Schema/AST/DocumentAST.php
@@ -21,6 +21,7 @@ use GraphQL\Language\AST\TypeExtensionDefinitionNode;
 use GraphQL\Language\AST\UnionTypeDefinitionNode;
 use GraphQL\Language\Parser;
 use Illuminate\Support\Collection;
+use Nuwave\Lighthouse\Support\Exceptions\DocumentASTException;
 
 class DocumentAST
 {
@@ -313,6 +314,12 @@ class DocumentAST
      */
     public function setDefinition(DefinitionNode $newDefinition): DocumentAST
     {
+        if ($this->locked) {
+            $nodeName = data_get($newDefinition, 'name.value', 'Node');
+            $message = "{$nodeName} cannot be added to the DocumentAST while it is locked.";
+            throw new DocumentASTException($message);
+        }
+
         $originalDefinitions = collect($this->documentNode->definitions);
 
         if (! $newHashID = data_get($newDefinition, 'spl_object_hash')) {

--- a/src/Support/Exceptions/DocumentASTException.php
+++ b/src/Support/Exceptions/DocumentASTException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Nuwave\Lighthouse\Support\Exceptions;
+
+use Exception;
+
+class DocumentASTException extends Exception
+{
+}


### PR DESCRIPTION
Adding a lock to the DocumentAST allows us to bypass generating clones for nodes (performance). It also prevents accidental schema manipulation after node/field/arg manipulators have been run. A `unlock` method is provided if needed by the user.