### PR TITLE
Custom Validator

### DIFF
--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -2,12 +2,15 @@
 
 namespace Nuwave\Lighthouse\Providers;
 
-use Illuminate\Support\Collection;
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Nuwave\Lighthouse\GraphQL;
-use Nuwave\Lighthouse\Schema\Source\SchemaSourceProvider;
+use Illuminate\Support\Collection;
+use Illuminate\Support\ServiceProvider;
+use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Support\Facades\Validator;
 use Nuwave\Lighthouse\Schema\Source\SchemaStitcher;
+use Nuwave\Lighthouse\Schema\Source\SchemaSourceProvider;
+use Nuwave\Lighthouse\Support\Validator\ValidatorFactory;
 use Nuwave\Lighthouse\Support\Collection as LighthouseCollection;
 
 class LighthouseServiceProvider extends ServiceProvider
@@ -25,6 +28,7 @@ class LighthouseServiceProvider extends ServiceProvider
         }
 
         $this->registerMacros();
+        $this->registerValidator();
     }
 
     /**
@@ -57,7 +61,7 @@ class LighthouseServiceProvider extends ServiceProvider
                 return new SchemaStitcher(config('lighthouse.schema.register', ''));
             }
         );
-        
+
         if ($this->app->runningInConsole()) {
             $this->commands([
                 \Nuwave\Lighthouse\Console\ClearCacheCommand::class,
@@ -73,5 +77,31 @@ class LighthouseServiceProvider extends ServiceProvider
     public function registerMacros()
     {
         Collection::mixin(new LighthouseCollection());
+    }
+
+    /**
+     * Register graphql validator.
+     */
+    public function registerValidator()
+    {
+        // TODO: Check compatibility w/ Lumen
+        app(\Illuminate\Validation\Factory::class)->resolver(function (
+            $translator,
+            $data,
+            $rules,
+            $messages,
+            $customAttributes
+        ) {
+            return ValidatorFactory::resolve(
+                $translator,
+                $data,
+                $rules,
+                $messages,
+                $customAttributes
+            );
+        });
+
+        Validator::extendImplicit('required_with_mutation', ValidatorFactory::class.'@requiredWithMutation');
+        Validator::extendImplicit('required_with_query', ValidatorFactory::class.'@requiredWithQuery');
     }
 }

--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -102,6 +102,5 @@ class LighthouseServiceProvider extends ServiceProvider
         });
 
         Validator::extendImplicit('required_with_mutation', ValidatorFactory::class.'@requiredWithMutation');
-        Validator::extendImplicit('required_with_query', ValidatorFactory::class.'@requiredWithQuery');
     }
 }

--- a/src/Schema/Directives/Args/RulesDirective.php
+++ b/src/Schema/Directives/Args/RulesDirective.php
@@ -2,9 +2,14 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
+use GraphQL\Language\AST\ArgumentNode;
+use GraphQL\Language\AST\DirectiveNode;
+use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
 use Nuwave\Lighthouse\Support\Contracts\Directive;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
 
-class RulesDirective implements Directive
+class RulesDirective extends BaseDirective implements Directive, ArgMiddleware
 {
     /**
      * Name of the directive.
@@ -14,5 +19,30 @@ class RulesDirective implements Directive
     public function name()
     {
         return 'rules';
+    }
+
+    /**
+     * Resolve the field directive.
+     *
+     * @param ArgumentValue $value
+     *
+     * @return ArgumentValue
+     */
+    public function handleArgument(ArgumentValue $value)
+    {
+        // Mutation arguments are handled in the RuleFactory. This check
+        // should be unnecessary when additional interfaces are created for
+        // more fine-grain control.
+        if ('Mutation' === $value->getField()->getNodeName()) {
+            return $value;
+        }
+
+        $current = $value->getValue();
+        $current['rules'] = array_merge(
+            array_get($value->getArg(), 'rules', []),
+            $this->directiveArgValue('apply')
+        );
+
+        return $value->setValue($current);
     }
 }

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -166,7 +166,7 @@ class FieldFactory
 
             if (sizeof($rules)) {
                 $validator = validator($inputArgs, $rules, [], [
-                    'root' => $root,
+                    'root' => $rootValue,
                     'context' => $context,
                     'resolveInfo' => $resolveInfo,
                 ]);

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -157,6 +157,16 @@ class FieldFactory
             });
     }
 
+    /**
+     * Wrap field resolver function w/ validation logic.
+     *
+     * @param \Closure                       $resolver
+     * @param \Illuminate\Support\Collection $inputValueDefinitions
+     *
+     * @throws \Nuwave\Lighthouse\Support\Exceptions\ValidationError
+     *
+     * @return \Closure
+     */
     protected function wrapResolverWithValidation(\Closure $resolver, $inputValueDefinitions)
     {
         return function ($rootValue, $inputArgs, $context = null, $resolveInfo = null) use ($resolver, $inputValueDefinitions) {
@@ -229,10 +239,10 @@ class FieldFactory
             })
             ->filter();
 
-        // Rules are applied to the fields which are on the root operation types
-        // Nested fields are excluded because they are validated as part of the root field
+        // Rules are applied to the fields which are on the root Mutation type.
+        // Nested fields are excluded because they are validated as part of the root field.
         $parentOperationType = data_get($resolveInfo, 'parentType.name');
-        if ('Mutation' === $parentOperationType || 'Query' === $parentOperationType) {
+        if ('Mutation' === $parentOperationType) {
             $documentAST = graphql()->documentAST();
             $rules = $rules->merge((new RuleFactory())->build(
                 $documentAST,

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -165,7 +165,12 @@ class FieldFactory
             $rules = $this->getRules($rootValue, $inputArgs, $context, $resolveInfo, $inputValueDefinitions);
 
             if (sizeof($rules)) {
-                $validator = validator($inputArgs, $rules);
+                $validator = validator($inputArgs, $rules, [], [
+                    'root' => $root,
+                    'context' => $context,
+                    'resolveInfo' => $resolveInfo,
+                ]);
+
                 if ($validator->fails()) {
                     throw with(new ValidationError('validation'))->setValidator($validator);
                 }

--- a/src/Support/Validator/GraphQLValidator.php
+++ b/src/Support/Validator/GraphQLValidator.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Nuwave\Lighthouse\Support\Validator;
+
+use Illuminate\Validation\Validator;
+
+class GraphQLValidator extends Validator
+{
+    /**
+     * Get root object.
+     *
+     * @return mixed
+     */
+    public function getRoot()
+    {
+        return array_get($this->customAttributes, 'root');
+    }
+
+    /**
+     * Get context object.
+     *
+     * @return \Nuwave\Lighthouse\Schema\Context
+     */
+    public function getContext()
+    {
+        return array_get($this->customAttributes, 'context');
+    }
+
+    /**
+     * Get field resolve info.
+     *
+     * @return \GraphQL\Type\Definition\ResolveInfo
+     */
+    public function getResolveInfo()
+    {
+        return array_get($this->customAttributes, 'resolveInfo');
+    }
+}

--- a/src/Support/Validator/ValidatorFactory.php
+++ b/src/Support/Validator/ValidatorFactory.php
@@ -2,8 +2,8 @@
 
 namespace Nuwave\Lighthouse\Support\Validator;
 
-use Illuminate\Validation\Validator;
 use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Validation\Validator;
 
 class ValidatorFactory
 {
@@ -47,31 +47,6 @@ class ValidatorFactory
         $info = $validator->getResolveInfo();
 
         if ('Mutation' !== data_get($info, 'parentType.name')) {
-            return true;
-        }
-
-        if (in_array($info->fieldName, $parameters)) {
-            return ! empty($value);
-        }
-
-        return true;
-    }
-
-    /**
-     * Validate the value is present on a query field.
-     *
-     * @param string           $attribute
-     * @param mixed            $value
-     * @param array            $parameters
-     * @param GraphQLValidator $validator
-     *
-     * @return bool
-     */
-    public function requiredWithQuery($attribute, $value, $parameters, $validator)
-    {
-        $info = $validator->getResolveInfo();
-
-        if ('Query' !== data_get($info, 'parentType.name')) {
             return true;
         }
 

--- a/src/Support/Validator/ValidatorFactory.php
+++ b/src/Support/Validator/ValidatorFactory.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Nuwave\Lighthouse\Support\Validator;
+
+use Illuminate\Validation\Validator;
+use GraphQL\Type\Definition\ResolveInfo;
+
+class ValidatorFactory
+{
+    /**
+     * Resolve a new Validator instance.
+     *
+     * @param \Illuminate\Contracts\Translation\Translator $translator
+     * @param array                                        $data
+     * @param array                                        $rules
+     * @param array                                        $messages
+     * @param array                                        $customAttributes
+     *
+     * @return \Illuminate\Validation\Validator
+     */
+    public static function resolve(
+        $translator,
+        array $data,
+        array $rules,
+        array $messages,
+        array $customAttributes
+    ) {
+        $resolveInfo = array_get($customAttributes, 'resolveInfo');
+
+        return $resolveInfo instanceof ResolveInfo
+            ? new GraphQLValidator($translator, $data, $rules, $messages, $customAttributes)
+            : new Validator($translator, $data, $rules, $messages, $customAttributes);
+    }
+
+    /**
+     * Validate the value is present on a mutation field.
+     *
+     * @param string           $attribute
+     * @param mixed            $value
+     * @param array            $parameters
+     * @param GraphQLValidator $validator
+     *
+     * @return bool
+     */
+    public function requiredWithMutation($attribute, $value, $parameters, $validator)
+    {
+        $info = $validator->getResolveInfo();
+
+        if ('Mutation' !== data_get($info, 'parentType.name')) {
+            return true;
+        }
+
+        if (in_array($info->fieldName, $parameters)) {
+            return ! empty($value);
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate the value is present on a query field.
+     *
+     * @param string           $attribute
+     * @param mixed            $value
+     * @param array            $parameters
+     * @param GraphQLValidator $validator
+     *
+     * @return bool
+     */
+    public function requiredWithQuery($attribute, $value, $parameters, $validator)
+    {
+        $info = $validator->getResolveInfo();
+
+        if ('Query' !== data_get($info, 'parentType.name')) {
+            return true;
+        }
+
+        if (in_array($info->fieldName, $parameters)) {
+            return ! empty($value);
+        }
+
+        return true;
+    }
+}

--- a/tests/Unit/Schema/Directives/Args/RulesDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/Args/RulesDirectiveTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Unit\Schema\Directives\Args;
+
+use Tests\TestCase;
+
+class RulesDirectiveTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itCanValidateQueryRootFieldArguments()
+    {
+        $query = '{
+            me {
+                first_name
+            }
+        }';
+
+        $result = $this->executeAndFormat($this->schema(), $query, false, [], true);
+        $this->assertCount(1, array_get($result, 'errors.0.validation'));
+        $this->assertNull($result['data']['me']);
+    }
+
+    /**
+     * @test
+     */
+    public function itCanReturnValidFieldsAndErrorMessagesForInvalidFields()
+    {
+        $query = '{
+            me(required: "foo") {
+                first_name
+                last_name
+                full_name
+            }
+        }';
+
+        $result = $this->executeAndFormat($this->schema(), $query, false, [], true);
+        $this->assertEquals('John', array_get($result, 'data.me.first_name'));
+        $this->assertEquals('Doe', array_get($result, 'data.me.last_name'));
+        $this->assertNull(array_get($result, 'data.me.full_name'));
+        $this->assertCount(1, array_get($result, 'errors.0.validation'));
+    }
+
+    /**
+     * @test
+     */
+    public function itCanValidateRootMutationFieldArgs()
+    {
+        $mutation = '
+        mutation {
+            foo {
+                first_name
+                last_name
+                full_name
+            }
+        }';
+
+        $result = $this->executeAndFormat($this->schema(), $mutation, false, [], true);
+        $this->assertNull(array_get($result, 'data.foo'));
+        $this->assertCount(1, array_get($result, 'errors.0.validation'));
+    }
+
+    /**
+     * @test
+     */
+    public function itCanProcessMutationsWithInvalidRetunObjectFields()
+    {
+        $mutation = '
+        mutation {
+            foo(bar: "foo") {
+                first_name
+                last_name
+                full_name
+            }
+        }';
+
+        $result = $this->executeAndFormat($this->schema(), $mutation, false, [], true);
+        $this->assertEquals('John', array_get($result, 'data.foo.first_name'));
+        $this->assertEquals('Doe', array_get($result, 'data.foo.last_name'));
+        $this->assertNull(array_get($result, 'data.foo.full_name'));
+        $this->assertCount(1, array_get($result, 'errors.0.validation'));
+    }
+
+    public function resolve()
+    {
+        return [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'full_name' => 'John Doe',
+        ];
+    }
+
+    protected function schema()
+    {
+        $resolver = addslashes(self::class).'@resolve';
+
+        return "
+        type User {
+            first_name: String
+            last_name: String
+            full_name(formatted: Boolean @rules(apply: [\"required\"])): String
+        }
+        type Mutation {
+            foo(bar: String @rules(apply: [\"required\"])): User
+                @field(resolver: \"{$resolver}\")
+        }
+        type Query {
+            me(required: String @rules(apply: [\"required\"])): User
+                @field(resolver: \"{$resolver}\")
+        }";
+    }
+}


### PR DESCRIPTION
This PR introduces a new custom validator which allows you to grab the `root`, `context` and `resolve` info used on the field in your own custom validation classes. 

Additionally, a new `required_with_mutation` rule has been created to mark certain fields as required with certain mutation fields. For example, with the following schema:

```graphql
input UserInput {
  first_name: String @rules(apply: ["required_with_mutation:createUser"])
  # ...
}

extend type Mutation {
  createUser(input: UserInput): User
  updateUser(input: UserInput): User
}
```

the `first_name` is only required if the `createUser` mutation is being processed.

This PR also allows `@rules` to be placed on ObjectType field arguments so part of the query can still return a response if a nested field fails validation.