### PR TITLE
Add tests and fixes to ensure Query and Mutation fields are treated equally

### DIFF
--- a/src/Schema/Directives/Args/RulesDirective.php
+++ b/src/Schema/Directives/Args/RulesDirective.php
@@ -30,10 +30,7 @@ class RulesDirective extends BaseDirective implements Directive, ArgMiddleware
      */
     public function handleArgument(ArgumentValue $value)
     {
-        // Mutation arguments are handled in the RuleFactory. This check
-        // should be unnecessary when additional interfaces are created for
-        // more fine-grain control.
-        if ('Mutation' === $value->getField()->getNodeName()) {
+        if (in_array($value->getField()->getNodeName(), ['Query', 'Mutation'])) {
             return $value;
         }
 

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -239,10 +239,10 @@ class FieldFactory
             })
             ->filter();
 
-        // Rules are applied to the fields which are on the root Mutation type.
+        // Rules are applied to the fields which are on one of the root operation types.
         // Nested fields are excluded because they are validated as part of the root field.
         $parentOperationType = data_get($resolveInfo, 'parentType.name');
-        if ('Mutation' === $parentOperationType) {
+        if ('Mutation' === $parentOperationType || 'Query' === $parentOperationType) {
             $documentAST = graphql()->documentAST();
             $rules = $rules->merge((new RuleFactory())->build(
                 $documentAST,

--- a/tests/Unit/Schema/Directives/Args/RulesDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/Args/RulesDirectiveTest.php
@@ -11,15 +11,27 @@ class RulesDirectiveTest extends TestCase
      */
     public function itCanValidateQueryRootFieldArguments()
     {
-        $query = '{
-            me {
+        $query = '
+        {
+            foo {
                 first_name
             }
-        }';
+        }
+        ';
 
         $result = $this->executeAndFormat($this->schema(), $query, false, [], true);
         $this->assertCount(1, array_get($result, 'errors.0.validation'));
-        $this->assertNull($result['data']['me']);
+        $this->assertNull($result['data']['foo']);
+        
+        $mutation = '
+        mutation {
+            foo {
+                first_name
+            }
+        }
+        ';
+        $mutationResult = $this->executeAndFormat($this->schema(), $mutation, false, [], true);
+        $this->assertSame($result, $mutationResult);
     }
 
     /**
@@ -27,19 +39,34 @@ class RulesDirectiveTest extends TestCase
      */
     public function itCanReturnValidFieldsAndErrorMessagesForInvalidFields()
     {
-        $query = '{
-            me(required: "foo") {
+        $query = '
+        {
+            foo(bar: "foo") {
                 first_name
                 last_name
                 full_name
             }
-        }';
+        }
+        ';
 
         $result = $this->executeAndFormat($this->schema(), $query, false, [], true);
-        $this->assertEquals('John', array_get($result, 'data.me.first_name'));
-        $this->assertEquals('Doe', array_get($result, 'data.me.last_name'));
-        $this->assertNull(array_get($result, 'data.me.full_name'));
+        $this->assertEquals('John', array_get($result, 'data.foo.first_name'));
+        $this->assertEquals('Doe', array_get($result, 'data.foo.last_name'));
+        $this->assertNull(array_get($result, 'data.foo.full_name'));
         $this->assertCount(1, array_get($result, 'errors.0.validation'));
+    
+        $mutation = '
+        mutation {
+            foo(bar: "foo") {
+                first_name
+                last_name
+                full_name
+            }
+        }
+        ';
+        
+        $mutationResult = $this->executeAndFormat($this->schema(), $mutation, false, [], true);
+        $this->assertSame($result, $mutationResult);
     }
 
     /**
@@ -54,11 +81,25 @@ class RulesDirectiveTest extends TestCase
                 last_name
                 full_name
             }
-        }';
+        }
+        ';
 
         $result = $this->executeAndFormat($this->schema(), $mutation, false, [], true);
         $this->assertNull(array_get($result, 'data.foo'));
         $this->assertCount(1, array_get($result, 'errors.0.validation'));
+        
+        $query = '
+        {
+            foo {
+                first_name
+                last_name
+                full_name
+            }
+        }
+        ';
+    
+        $queryResult = $this->executeAndFormat($this->schema(), $query, false, [], true);
+        $this->assertSame($result, $queryResult);
     }
 
     /**
@@ -73,13 +114,27 @@ class RulesDirectiveTest extends TestCase
                 last_name
                 full_name
             }
-        }';
+        }
+        ';
 
         $result = $this->executeAndFormat($this->schema(), $mutation, false, [], true);
         $this->assertEquals('John', array_get($result, 'data.foo.first_name'));
         $this->assertEquals('Doe', array_get($result, 'data.foo.last_name'));
         $this->assertNull(array_get($result, 'data.foo.full_name'));
         $this->assertCount(1, array_get($result, 'errors.0.validation'));
+    
+        $query = '
+        {
+            foo(bar: "foo") {
+                first_name
+                last_name
+                full_name
+            }
+        }
+        ';
+    
+        $queryResult = $this->executeAndFormat($this->schema(), $query, false, [], true);
+        $this->assertSame($result, $queryResult);
     }
 
     public function resolve()
@@ -106,7 +161,7 @@ class RulesDirectiveTest extends TestCase
                 @field(resolver: \"{$resolver}\")
         }
         type Query {
-            me(required: String @rules(apply: [\"required\"])): User
+            foo(bar: String @rules(apply: [\"required\"])): User
                 @field(resolver: \"{$resolver}\")
         }";
     }

--- a/tests/Unit/Schema/Factories/RuleFactoryTest.php
+++ b/tests/Unit/Schema/Factories/RuleFactoryTest.php
@@ -8,18 +8,6 @@ use Nuwave\Lighthouse\Schema\Factories\RuleFactory;
 
 class RuleFactoryTest extends TestCase
 {
-    protected $factory;
-
-    /**
-     * Set up test environment.
-     */
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->factory = new RuleFactory();
-    }
-
     /**
      * @test
      */
@@ -30,7 +18,7 @@ class RuleFactoryTest extends TestCase
             createUser(email: String @rules(apply: ["required", "email"])): String
         }');
 
-        $rules = $this->factory->build(
+        $rules = (new RuleFactory())->build(
             $documentAST,
             $documentAST->objectTypeDefinition('Mutation'),
             [],
@@ -61,7 +49,7 @@ class RuleFactoryTest extends TestCase
             ],
         ];
 
-        $rules = $this->factory->build(
+        $rules = (new RuleFactory())->build(
             $documentAST,
             $documentAST->objectTypeDefinition('Mutation'),
             $variables,
@@ -100,7 +88,7 @@ class RuleFactoryTest extends TestCase
             ],
         ];
 
-        $rules = $this->factory->build(
+        $rules = (new RuleFactory())->build(
             $documentAST,
             $documentAST->objectTypeDefinition('Mutation'),
             $variables,
@@ -142,7 +130,7 @@ class RuleFactoryTest extends TestCase
             ],
         ];
 
-        $rules = $this->factory->build(
+        $rules = (new RuleFactory())->build(
             $documentAST,
             $documentAST->objectTypeDefinition('Mutation'),
             $variables,
@@ -192,7 +180,7 @@ class RuleFactoryTest extends TestCase
             ],
         ];
 
-        $rules = $this->factory->build(
+        $rules = (new RuleFactory())->build(
             $documentAST,
             $documentAST->objectTypeDefinition('Mutation'),
             $variables,
@@ -220,7 +208,7 @@ class RuleFactoryTest extends TestCase
             createFoo(required: String @rules(apply: ["required"])): String
         }');
 
-        $rules = $this->factory->build(
+        $rules = (new RuleFactory())->build(
             $documentAST,
             $documentAST->objectTypeDefinition('Mutation'),
             [],
@@ -249,7 +237,7 @@ class RuleFactoryTest extends TestCase
             ): String
         }');
 
-        $rules = $this->factory->build(
+        $rules = (new RuleFactory())->build(
             $documentAST,
             $documentAST->objectTypeDefinition('Mutation'),
             [],
@@ -284,7 +272,7 @@ class RuleFactoryTest extends TestCase
             ],
         ];
 
-        $rules = $this->factory->build(
+        $rules = (new RuleFactory())->build(
             $documentAST,
             $documentAST->objectTypeDefinition('Mutation'),
             $variables,
@@ -296,5 +284,45 @@ class RuleFactoryTest extends TestCase
             'input.required' => ['required'],
             'input.self.required' => ['required'],
         ], $rules);
+    }
+    
+    /**
+     * @test
+     */
+    public function itHandlesNestedRulesOnQueriesAndMutations()
+    {
+        $documentAST = ASTBuilder::generate('
+        input Foo {
+            bar: Int @rules(apply: ["required"])
+        }
+        type Mutation {
+            foo(input: Foo): String
+        }
+        type Query {
+            foo(input: Foo): String
+        }
+        ');
+    
+        $variables = [
+            'input' => [
+                'bar' => 42,
+            ],
+        ];
+    
+        $mutationRules = (new RuleFactory())->build(
+            $documentAST,
+            $documentAST->objectTypeDefinition('Mutation'),
+            $variables,
+            'foo'
+        );
+        
+        $queryRules = (new RuleFactory())->build(
+            $documentAST,
+            $documentAST->objectTypeDefinition('Query'),
+            $variables,
+            'foo'
+        );
+        
+        $this->assertSame($mutationRules, $queryRules);
     }
 }


### PR DESCRIPTION
Enhanced the existing tests and added an additional test for nested Inputs, that were previously only considered on Mutations.

Changed the implementation so that no difference is made between queries and mutations.