### PR TITLE
 Add scalar & return type hints

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,12 +3,6 @@
 Hey, thank you for contributing to Lighthouse. Here are some tips to make
 it easy for you.
 
-## Have a question?
-
-If you can not figure out something works in Lighthouse, want to know more
-about it or have any other questions, you can always hop into our
-[Slack Channel](https://join.slack.com/t/lighthouse-php/shared_invite/enQtMzc1NzQwNTUxMjk3LWI1ZDQ1YWM1NmM2MmQ0NTU0NGNjZWFkMTJhY2VjMDAwZmMyZDFlZTc1Mjc3ZGY0MWM1Y2Q5MWNjYmJmYWJkYmU)
-
 ## Testing
 
 We use **PHPUnit** for unit tests and integration tests.
@@ -50,3 +44,10 @@ Look through some of the code to get a feel for the naming conventi qons.
 Use type hints whenever possible and make sure to include proper **PHPDocs**
 
 Prefer explicit naming and short functions over excessive comments.
+
+## Documentation
+
+The docs for Lighthouse are maintained in a [seperate repo](https://github.com/nuwave/lighthouse-docs)
+
+Head over there if you want to contribute to the docs, or if you made a PR
+here and want to document your changes.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,6 +3,12 @@
 Hey, thank you for contributing to Lighthouse. Here are some tips to make
 it easy for you.
 
+## Have a question?
+
+If you can not figure out something works in Lighthouse, want to know more
+about it or have any other questions, you can always hop into our
+[Slack Channel](https://join.slack.com/t/lighthouse-php/shared_invite/enQtMzc1NzQwNTUxMjk3LWI1ZDQ1YWM1NmM2MmQ0NTU0NGNjZWFkMTJhY2VjMDAwZmMyZDFlZTc1Mjc3ZGY0MWM1Y2Q5MWNjYmJmYWJkYmU)
+
 ## Testing
 
 We use **PHPUnit** for unit tests and integration tests.
@@ -44,10 +50,3 @@ Look through some of the code to get a feel for the naming conventi qons.
 Use type hints whenever possible and make sure to include proper **PHPDocs**
 
 Prefer explicit naming and short functions over excessive comments.
-
-## Documentation
-
-The docs for Lighthouse are maintained in a [seperate repo](https://github.com/nuwave/lighthouse-docs)
-
-Head over there if you want to contribute to the docs, or if you made a PR
-here and want to document your changes.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report a bug to help us improve Lighthouse
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Schema**
+
+```graphql
+# Add in relevant parts of your schema definition
+```
+
+**Output/Logs**
+
+```
+Relevant log output or error messages.
+```
+
+**Environment**
+
+Lighthouse Version:
+Laravel Version:
+PHP Version:
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+**Related Issue(s)**
+
+Link to related issues this PR corresponds to or resolves
+
+**PR Type**
+
+What kind of change does this PR introduce? (Bugfix, Feature, Reformat, Refactor, Build/CI, Docs, ...)
+
+**Changes**
+
+Detail the changes in behaviour this PR introduces.
+
+**Breaking changes**
+
+If there are any breaking changes, list them here.

--- a/README.md
+++ b/README.md
@@ -2,32 +2,12 @@
 
 [![Build Status](https://travis-ci.org/nuwave/lighthouse.svg?branch=master)](https://travis-ci.org/nuwave/lighthouse)
 [![codecov](https://codecov.io/gh/nuwave/lighthouse/branch/master/graph/badge.svg)](https://codecov.io/gh/nuwave/lighthouse)
-[![Packagist](https://img.shields.io/packagist/dt/nuwave/lighthouse.svg)](https://packagist.org/packages/nuwave/lighthouse)
-[![GitHub license](https://img.shields.io/github/license/nuwave/lighthouse.svg)](https://github.com/nuwave/lighthouse/blob/master/LICENSE)
 [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://join.slack.com/t/lighthouse-php/shared_invite/enQtMzc1NzQwNTUxMjk3LWI1ZDQ1YWM1NmM2MmQ0NTU0NGNjZWFkMTJhY2VjMDAwZmMyZDFlZTc1Mjc3ZGY0MWM1Y2Q5MWNjYmJmYWJkYmU)
 
-**GraphQL Server for Laravel**
+## Lighthouse v2.1
 
-Lighthouse is a PHP package that allows you to serve a GraphQL endpoint from your
-Laravel application. It greatly reduces the boilerplate required to create a schema,
-it integrates well with any Laravel project, and it's highly customizable
-giving you full control over your data.
+### GraphQL Server for Laravel
 
-## Get started
+Lighthouse is a PHP package that allows you to serve a GraphQL endpoint from your Laravel application. It greatly reduces the boilerplate required to create a schema, it integrates well with any Laravel project, and it's highly customizable giving you full control over your data.
 
-If you have an existing Laravel project, all you really need is two steps:
-
-1. Install via `compose require nuwave/lighthouse`
-
-2. Define your schema in `routes/graphql/schema.graphql`
-
-Learn about Lighthouse in the **[Documentation](https://lighthouse-php.netlify.com/)**
-
-## Get involved
-
-We welcome contributions of any kind.
-
-- Have a question? [Hop into Slack](https://join.slack.com/t/lighthouse-php/shared_invite/enQtMzc1NzQwNTUxMjk3LWI1ZDQ1YWM1NmM2MmQ0NTU0NGNjZWFkMTJhY2VjMDAwZmMyZDFlZTc1Mjc3ZGY0MWM1Y2Q5MWNjYmJmYWJkYmU) 
-- Found a bug? [Report a bug](https://github.com/nuwave/lighthouse/issues/new?template=bug_report.md)
-- Need a feature? [Open a feature request](https://github.com/nuwave/lighthouse/issues/new?template=feature_request.md)
-- Want to improve Lighthouse? [Read our contribution guidelines](https://github.com/nuwave/lighthouse/blob/master/.github/CONTRIBUTING.md)
+[Documentation](https://lighthouse-php.netlify.com/)

--- a/README.md
+++ b/README.md
@@ -2,12 +2,32 @@
 
 [![Build Status](https://travis-ci.org/nuwave/lighthouse.svg?branch=master)](https://travis-ci.org/nuwave/lighthouse)
 [![codecov](https://codecov.io/gh/nuwave/lighthouse/branch/master/graph/badge.svg)](https://codecov.io/gh/nuwave/lighthouse)
+[![Packagist](https://img.shields.io/packagist/dt/nuwave/lighthouse.svg)](https://packagist.org/packages/nuwave/lighthouse)
+[![GitHub license](https://img.shields.io/github/license/nuwave/lighthouse.svg)](https://github.com/nuwave/lighthouse/blob/master/LICENSE)
 [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://join.slack.com/t/lighthouse-php/shared_invite/enQtMzc1NzQwNTUxMjk3LWI1ZDQ1YWM1NmM2MmQ0NTU0NGNjZWFkMTJhY2VjMDAwZmMyZDFlZTc1Mjc3ZGY0MWM1Y2Q5MWNjYmJmYWJkYmU)
 
-## Lighthouse v2.1
+**GraphQL Server for Laravel**
 
-### GraphQL Server for Laravel
+Lighthouse is a PHP package that allows you to serve a GraphQL endpoint from your
+Laravel application. It greatly reduces the boilerplate required to create a schema,
+it integrates well with any Laravel project, and it's highly customizable
+giving you full control over your data.
 
-Lighthouse is a PHP package that allows you to serve a GraphQL endpoint from your Laravel application. It greatly reduces the boilerplate required to create a schema, it integrates well with any Laravel project, and it's highly customizable giving you full control over your data.
+## Get started
 
-[Documentation](https://lighthouse-php.netlify.com/)
+If you have an existing Laravel project, all you really need is two steps:
+
+1. Install via `compose require nuwave/lighthouse`
+
+2. Define your schema in `routes/graphql/schema.graphql`
+
+Learn about Lighthouse in the **[Documentation](https://lighthouse-php.netlify.com/)**
+
+## Get involved
+
+We welcome contributions of any kind.
+
+- Have a question? [Hop into Slack](https://join.slack.com/t/lighthouse-php/shared_invite/enQtMzc1NzQwNTUxMjk3LWI1ZDQ1YWM1NmM2MmQ0NTU0NGNjZWFkMTJhY2VjMDAwZmMyZDFlZTc1Mjc3ZGY0MWM1Y2Q5MWNjYmJmYWJkYmU) 
+- Found a bug? [Report a bug](https://github.com/nuwave/lighthouse/issues/new?template=bug_report.md)
+- Need a feature? [Open a feature request](https://github.com/nuwave/lighthouse/issues/new?template=feature_request.md)
+- Want to improve Lighthouse? [Read our contribution guidelines](https://github.com/nuwave/lighthouse/blob/master/.github/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<img src="logo.png" width="150" height="150">
+
 # Lighthouse
 
 [![Build Status](https://travis-ci.org/nuwave/lighthouse.svg?branch=master)](https://travis-ci.org/nuwave/lighthouse)

--- a/assets/default-schema.graphql
+++ b/assets/default-schema.graphql
@@ -1,0 +1,27 @@
+type Query {
+    users: [User!]! @paginate(type: "paginator" model: "User")
+    user(id: ID @eq): User @find(model: "User")
+}
+
+type Mutation {
+    createUser(
+        name: String @rules(apply: ["required"])
+        email: String @rules(apply: ["required", "email", "unique:users,email"])
+    ): User @create(model: "User")
+    updateUser(
+        id: ID @rules(apply: ["required"])
+        name: String
+        email: String @rules(apply: ["email"])
+    ): User @update(model: "User")
+    deleteUser(
+        id: ID @rules(apply: ["required"])
+    ): User @delete(model: "User")
+}
+
+type User {
+    id: ID!
+    name: String!
+    email: String!
+    created_at: DateTime!
+    updated_at: DateTime!
+}

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -103,7 +103,7 @@ class GraphQL
      *
      * @return array
      */
-    public function execute($query, $context = null, $variables = [], $rootValue = null): array
+    public function execute(string $query, $context = null, array $variables = [], $rootValue = null): array
     {
         $result = $this->queryAndReturnResult($query, $context, $variables, $rootValue);
 
@@ -137,7 +137,7 @@ class GraphQL
      *
      * @return \GraphQL\Executor\ExecutionResult
      */
-    public function queryAndReturnResult($query, $context = null, $variables = [], $rootValue = null): ExecutionResult
+    public function queryAndReturnResult(string $query, $context = null, array $variables = [], $rootValue = null): ExecutionResult
     {
         $schema = $this->graphqlSchema ?: $this->buildSchema();
 
@@ -212,7 +212,7 @@ class GraphQL
      *
      * @return \GraphQL\Deferred
      */
-    public function batch($abstract, $key, array $data = [], $name = null): Deferred
+    public function batch(string $abstract, $key, array $data = [], $name = null): Deferred
     {
         $name = $name ?: $abstract;
         $instance = app()->has($name)

--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -20,7 +20,10 @@ class LighthouseServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->publishes([__DIR__.'/../../config/config.php' => config_path('lighthouse.php')]);
+        $this->publishes([
+            __DIR__.'/../../config/config.php' => config_path('lighthouse.php'),
+            __DIR__.'/../../assets/default-schema.graphql' => config('lighthouse.schema.register'),
+        ]);
         $this->mergeConfigFrom(__DIR__.'/../../config/config.php', 'lighthouse');
 
         if (config('lighthouse.controller')) {

--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -19,8 +19,9 @@ class ASTBuilder
      * @param string $schema
      *
      * @return DocumentAST
+     * @throws \Nuwave\Lighthouse\Support\Exceptions\ParseException
      */
-    public static function generate($schema)
+    public static function generate(string $schema): DocumentAST
     {
         $document = DocumentAST::fromSource($schema);
 
@@ -42,7 +43,7 @@ class ASTBuilder
      *
      * @return DocumentAST
      */
-    protected static function applyNodeManipulators(DocumentAST $document)
+    protected static function applyNodeManipulators(DocumentAST $document): DocumentAST
     {
         $originalDocument = $document;
 
@@ -67,7 +68,12 @@ class ASTBuilder
             }, $document);
     }
 
-    protected static function mergeTypeExtensions(DocumentAST $document)
+    /**
+     * @param DocumentAST $document
+     *
+     * @return DocumentAST
+     */
+    protected static function mergeTypeExtensions(DocumentAST $document): DocumentAST
     {
         $document->objectTypeDefinitions()->each(function (ObjectTypeDefinitionNode $objectType) use ($document) {
             $name = $objectType->name->value;
@@ -164,11 +170,12 @@ class ASTBuilder
      *
      * @param DocumentAST $document
      *
-     * @throws \Nuwave\Lighthouse\Support\Exceptions\ParseException
-     *
      * @return DocumentAST
+     *
+     * @throws \Nuwave\Lighthouse\Support\Exceptions\ParseException
+     * @throws \Nuwave\Lighthouse\Support\Exceptions\DocumentASTException
      */
-    protected static function addNodeSupport(DocumentAST $document)
+    protected static function addNodeSupport(DocumentAST $document): DocumentAST
     {
         $hasTypeImplementingNode = $document->objectTypeDefinitions()->contains(function (ObjectTypeDefinitionNode $objectType) {
             return collect($objectType->interfaces)->contains(function (NamedTypeNode $interface) {

--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -19,7 +19,7 @@ class ASTHelper
      * Remove this method (and possibly the entire class) once it is resolved.
      *
      * @param NodeList|array $original
-     * @param array          $addition
+     * @param NodeList|array $addition
      *
      * @return NodeList
      */
@@ -37,7 +37,7 @@ class ASTHelper
      * be removed from the original list if the name exists in both lists.
      *
      * @param NodeList|array $original
-     * @param array          $addition
+     * @param NodeList|array $addition
      *
      * @return NodeList
      */
@@ -58,7 +58,7 @@ class ASTHelper
      *
      * @return Node
      */
-    public static function cloneNode(Node $node)
+    public static function cloneNode(Node $node): Node
     {
         return AST::fromArray($node->toArray(true));
     }

--- a/src/Schema/AST/DocumentAST.php
+++ b/src/Schema/AST/DocumentAST.php
@@ -62,9 +62,9 @@ class DocumentAST
     /**
      * Mark the AST as locked.
      *
-     * @return self
+     * @return DocumentAST
      */
-    public function lock()
+    public function lock(): DocumentAST
     {
         $this->locked = true;
 
@@ -74,9 +74,9 @@ class DocumentAST
     /**
      * Mark the AST as unlocked.
      *
-     * @return self
+     * @return DocumentAST
      */
-    public function unlock()
+    public function unlock(): DocumentAST
     {
         $this->locked = false;
 
@@ -359,9 +359,10 @@ class DocumentAST
     }
 
     /**
-     * Get node's original/current has.
+     * Get node's original/current hash.
      *
      * @param DefinitionNode $node
+     * @param bool $unwrap
      *
      * @return string
      */

--- a/src/Schema/AST/PartialParser.php
+++ b/src/Schema/AST/PartialParser.php
@@ -25,7 +25,7 @@ class PartialParser
      *
      * @return ObjectTypeDefinitionNode[]
      */
-    public static function objectTypeDefinitions($objectTypes)
+    public static function objectTypeDefinitions(array $objectTypes): array
     {
         return array_map(function ($objectType) {
             return self::objectTypeDefinition($objectType);
@@ -39,7 +39,7 @@ class PartialParser
      *
      * @return ObjectTypeDefinitionNode
      */
-    public static function objectTypeDefinition($definition)
+    public static function objectTypeDefinition(string $definition): ObjectTypeDefinitionNode
     {
         return self::getFirstAndValidateType(
             Parser::parse($definition)->definitions,
@@ -54,7 +54,7 @@ class PartialParser
      *
      * @return InputValueDefinitionNode
      */
-    public static function inputValueDefinition($inputValueDefinition)
+    public static function inputValueDefinition(string $inputValueDefinition): InputValueDefinitionNode
     {
         return self::getFirstAndValidateType(
             self::fieldDefinition("field($inputValueDefinition): String")->arguments,
@@ -67,7 +67,7 @@ class PartialParser
      *
      * @return InputValueDefinitionNode[]
      */
-    public static function inputValueDefinitions($inputValueDefinitions)
+    public static function inputValueDefinitions(array $inputValueDefinitions): array
     {
         return array_map(function ($inputValueDefinition) {
             return self::inputValueDefinition($inputValueDefinition);
@@ -81,7 +81,7 @@ class PartialParser
      *
      * @return NodeList
      */
-    public static function argument($argumentDefinition)
+    public static function argument(string $argumentDefinition): NodeList
     {
         return self::getFirstAndValidateType(
             self::field("field($argumentDefinition): String")->arguments,
@@ -94,7 +94,7 @@ class PartialParser
      *
      * @return InputValueDefinitionNode[]
      */
-    public static function arguments($argumentDefinitions)
+    public static function arguments(array $argumentDefinitions): array
     {
         return array_map(function ($argumentDefinition) {
             return self::argument($argumentDefinition);
@@ -108,7 +108,7 @@ class PartialParser
      *
      * @return FieldNode
      */
-    public static function field($field)
+    public static function field(string $field): FieldNode
     {
         return self::getFirstAndValidateType(
             self::operationDefinition("{ $field }")->selectionSet->selections,
@@ -123,7 +123,7 @@ class PartialParser
      *
      * @return OperationDefinitionNode
      */
-    public static function operationDefinition($operation)
+    public static function operationDefinition(string $operation): OperationDefinitionNode
     {
         return self::getFirstAndValidateType(
             Parser::parse($operation)->definitions,
@@ -138,7 +138,7 @@ class PartialParser
      *
      * @return FieldDefinitionNode
      */
-    public static function fieldDefinition($fieldDefinition)
+    public static function fieldDefinition(string $fieldDefinition): FieldDefinitionNode
     {
         return self::getFirstAndValidateType(
             self::objectTypeDefinition("type Dummy { $fieldDefinition }")->fields,
@@ -153,7 +153,7 @@ class PartialParser
      *
      * @return DirectiveNode
      */
-    public static function directive($directive)
+    public static function directive(string $directive): DirectiveNode
     {
         return self::getFirstAndValidateType(
             self::objectTypeDefinition("type Dummy $directive {}")->directives,
@@ -166,7 +166,7 @@ class PartialParser
      *
      * @return DirectiveNode[]
      */
-    public static function directives($directives)
+    public static function directives(array $directives): array
     {
         return array_map(function ($directive) {
             return self::inputValueDefinition($directive);
@@ -180,7 +180,7 @@ class PartialParser
      *
      * @return DirectiveDefinitionNode
      */
-    public static function directiveDefinition($directiveDefinition)
+    public static function directiveDefinition(string $directiveDefinition): DirectiveDefinitionNode
     {
         return self::getFirstAndValidateType(
             Parser::parse($directiveDefinition)->definitions,
@@ -193,7 +193,7 @@ class PartialParser
      *
      * @return DirectiveDefinitionNode[]
      */
-    public static function directiveDefinitions($directiveDefinitions)
+    public static function directiveDefinitions(array $directiveDefinitions): array
     {
         return array_map(function ($directiveDefinition) {
             return self::inputValueDefinition($directiveDefinition);
@@ -201,13 +201,13 @@ class PartialParser
     }
 
     /**
-     * @param $interfaceDefinition
+     * @param string $interfaceDefinition
      *
      * @throws ParseException
      *
      * @return InterfaceTypeDefinitionNode
      */
-    public static function interfaceTypeDefinition($interfaceDefinition)
+    public static function interfaceTypeDefinition(string $interfaceDefinition): InterfaceTypeDefinitionNode
     {
         return self::getFirstAndValidateType(
             Parser::parse($interfaceDefinition)->definitions,
@@ -222,7 +222,7 @@ class PartialParser
      *
      * @return InputObjectTypeDefinitionNode
      */
-    public static function inputObjectTypeDefinition($inputTypeDefinition)
+    public static function inputObjectTypeDefinition(string $inputTypeDefinition): InputObjectTypeDefinitionNode
     {
         return self::getFirstAndValidateType(
             Parser::parse($inputTypeDefinition)->definitions,
@@ -237,7 +237,7 @@ class PartialParser
      *
      * @return ScalarTypeDefinitionNode
      */
-    public static function scalarTypeDefinition($scalarDefinition)
+    public static function scalarTypeDefinition(string $scalarDefinition): ScalarTypeDefinitionNode
     {
         return self::getFirstAndValidateType(
             Parser::parse($scalarDefinition)->definitions,
@@ -246,13 +246,13 @@ class PartialParser
     }
 
     /**
-     * @param $enumDefinition
+     * @param string $enumDefinition
      *
      * @throws ParseException
      *
-     * @return mixed
+     * @return EnumTypeDefinitionNode
      */
-    public static function enumTypeDefinition($enumDefinition)
+    public static function enumTypeDefinition(string $enumDefinition): EnumTypeDefinitionNode
     {
         return self::getFirstAndValidateType(
             Parser::parse($enumDefinition)->definitions,
@@ -270,7 +270,7 @@ class PartialParser
      *
      * @return mixed
      */
-    protected static function getFirstAndValidateType(NodeList $list, $expectedType)
+    protected static function getFirstAndValidateType(NodeList $list, string $expectedType)
     {
         if (1 !== $list->count()) {
             throw new ParseException('  More than one definition was found in the passed in schema.');

--- a/src/Schema/AST/PartialParser.php
+++ b/src/Schema/AST/PartialParser.php
@@ -5,12 +5,15 @@ namespace Nuwave\Lighthouse\Schema\AST;
 use GraphQL\Language\AST\ArgumentNode;
 use GraphQL\Language\AST\DirectiveDefinitionNode;
 use GraphQL\Language\AST\DirectiveNode;
+use GraphQL\Language\AST\DocumentNode;
 use GraphQL\Language\AST\EnumTypeDefinitionNode;
 use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\FieldNode;
 use GraphQL\Language\AST\InputObjectTypeDefinitionNode;
 use GraphQL\Language\AST\InputValueDefinitionNode;
 use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
+use GraphQL\Language\AST\NamedTypeNode;
+use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeList;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Language\AST\OperationDefinitionNode;
@@ -42,7 +45,7 @@ class PartialParser
     public static function objectTypeDefinition(string $definition): ObjectTypeDefinitionNode
     {
         return self::getFirstAndValidateType(
-            Parser::parse($definition)->definitions,
+            self::parse($definition)->definitions,
             ObjectTypeDefinitionNode::class
         );
     }
@@ -126,7 +129,7 @@ class PartialParser
     public static function operationDefinition(string $operation): OperationDefinitionNode
     {
         return self::getFirstAndValidateType(
-            Parser::parse($operation)->definitions,
+            self::parse($operation)->definitions,
             OperationDefinitionNode::class
         );
     }
@@ -183,7 +186,7 @@ class PartialParser
     public static function directiveDefinition(string $directiveDefinition): DirectiveDefinitionNode
     {
         return self::getFirstAndValidateType(
-            Parser::parse($directiveDefinition)->definitions,
+            self::parse($directiveDefinition)->definitions,
             DirectiveDefinitionNode::class
         );
     }
@@ -210,7 +213,7 @@ class PartialParser
     public static function interfaceTypeDefinition(string $interfaceDefinition): InterfaceTypeDefinitionNode
     {
         return self::getFirstAndValidateType(
-            Parser::parse($interfaceDefinition)->definitions,
+            self::parse($interfaceDefinition)->definitions,
             InterfaceTypeDefinitionNode::class
         );
     }
@@ -225,7 +228,7 @@ class PartialParser
     public static function inputObjectTypeDefinition(string $inputTypeDefinition): InputObjectTypeDefinitionNode
     {
         return self::getFirstAndValidateType(
-            Parser::parse($inputTypeDefinition)->definitions,
+            self::parse($inputTypeDefinition)->definitions,
             InputObjectTypeDefinitionNode::class
         );
     }
@@ -240,7 +243,7 @@ class PartialParser
     public static function scalarTypeDefinition(string $scalarDefinition): ScalarTypeDefinitionNode
     {
         return self::getFirstAndValidateType(
-            Parser::parse($scalarDefinition)->definitions,
+            self::parse($scalarDefinition)->definitions,
             ScalarTypeDefinitionNode::class
         );
     }
@@ -255,9 +258,45 @@ class PartialParser
     public static function enumTypeDefinition(string $enumDefinition): EnumTypeDefinitionNode
     {
         return self::getFirstAndValidateType(
-            Parser::parse($enumDefinition)->definitions,
+            self::parse($enumDefinition)->definitions,
             EnumTypeDefinitionNode::class
         );
+    }
+
+    /**
+     * @param string $typeName
+     *
+     * @return NamedTypeNode
+     * @throws ParseException
+     */
+    public static function namedType(string $typeName): NamedTypeNode
+    {
+        return self::validateType(
+            self::parseType($typeName),
+            NamedTypeNode::class
+        );
+    }
+
+    /**
+     * @param string $definition
+     *
+     * @return \GraphQL\Language\AST\DocumentNode
+     */
+    protected static function parse(string $definition): DocumentNode
+    {
+        // Ignore location since it only bloats the AST
+        return Parser::parse($definition, ['noLocation' => true]);
+    }
+
+    /**
+     * @param string $definition
+     *
+     * @return Node
+     */
+    protected static function parseType(string $definition): Node
+    {
+        // Ignore location since it only bloats the AST
+        return Parser::parseType($definition, ['noLocation' => true]);
     }
 
     /**
@@ -268,17 +307,29 @@ class PartialParser
      *
      * @throws ParseException
      *
-     * @return mixed
+     * @return Node
      */
-    protected static function getFirstAndValidateType(NodeList $list, string $expectedType)
+    protected static function getFirstAndValidateType(NodeList $list, string $expectedType): Node
     {
         if (1 !== $list->count()) {
-            throw new ParseException('  More than one definition was found in the passed in schema.');
+            throw new ParseException('More than one definition was found in the passed in schema.');
         }
 
         $node = $list[0];
 
-        if (! $node instanceof $expectedType) {
+        return self::validateType($node, $expectedType);
+    }
+
+    /**
+     * @param Node $node
+     * @param string $expectedType
+     *
+     * @return Node
+     * @throws ParseException
+     */
+    protected static function validateType(Node $node, string $expectedType): Node
+    {
+        if (!$node instanceof $expectedType) {
             throw new ParseException("The given definition was not of type: $expectedType");
         }
 

--- a/src/Schema/Context.php
+++ b/src/Schema/Context.php
@@ -2,12 +2,14 @@
 
 namespace Nuwave\Lighthouse\Schema;
 
+use Illuminate\Http\Request;
+
 class Context
 {
     /**
      * Http request.
      *
-     * @var \Illuminate\Http\Request
+     * @var Request
      */
     public $request;
 
@@ -21,10 +23,10 @@ class Context
     /**
      * Create new context.
      *
-     * @param \Illuminate\Http\Request $request
-     * @param mixed                    $user
+     * @param Request $request
+     * @param mixed   $user
      */
-    public function __construct($request, $user)
+    public function __construct(Request $request, $user)
     {
         $this->request = $request;
         $this->user = $user;

--- a/src/Schema/Directives/Args/BcryptDirective.php
+++ b/src/Schema/Directives/Args/BcryptDirective.php
@@ -13,7 +13,7 @@ class BcryptDirective extends BaseDirective implements ArgMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'bcrypt';
     }
@@ -21,13 +21,13 @@ class BcryptDirective extends BaseDirective implements ArgMiddleware
     /**
      * Resolve the field directive.
      *
-     * @param ArgumentValue $value
+     * @param ArgumentValue $argumentValue
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $value)
+    public function handleArgument(ArgumentValue $argumentValue): ArgumentValue
     {
-        return $value->setResolver(function ($password) {
+        return $argumentValue->setResolver(function ($password) {
             return bcrypt($password);
         });
     }

--- a/src/Schema/Directives/Args/EqualsFilterDirective.php
+++ b/src/Schema/Directives/Args/EqualsFilterDirective.php
@@ -16,7 +16,7 @@ class EqualsFilterDirective extends BaseDirective implements ArgMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'eq';
     }
@@ -28,7 +28,7 @@ class EqualsFilterDirective extends BaseDirective implements ArgMiddleware
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument)
+    public function handleArgument(ArgumentValue $argument): ArgumentValue
     {
         $arg = $argument->getArgName();
 

--- a/src/Schema/Directives/Args/InFilterDirective.php
+++ b/src/Schema/Directives/Args/InFilterDirective.php
@@ -16,7 +16,7 @@ class InFilterDirective extends BaseDirective implements ArgMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'in';
     }
@@ -28,7 +28,7 @@ class InFilterDirective extends BaseDirective implements ArgMiddleware
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument)
+    public function handleArgument(ArgumentValue $argument): ArgumentValue
     {
         $arg = $argument->getArgName();
 

--- a/src/Schema/Directives/Args/NotEqualsFilterDirective.php
+++ b/src/Schema/Directives/Args/NotEqualsFilterDirective.php
@@ -16,7 +16,7 @@ class NotEqualsFilterDirective extends BaseDirective implements ArgMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'neq';
     }
@@ -28,7 +28,7 @@ class NotEqualsFilterDirective extends BaseDirective implements ArgMiddleware
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument)
+    public function handleArgument(ArgumentValue $argument): ArgumentValue
     {
         $arg = $argument->getArgName();
 

--- a/src/Schema/Directives/Args/NotInFilterDirective.php
+++ b/src/Schema/Directives/Args/NotInFilterDirective.php
@@ -16,7 +16,7 @@ class NotInFilterDirective extends BaseDirective implements ArgMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'notIn';
     }
@@ -28,7 +28,7 @@ class NotInFilterDirective extends BaseDirective implements ArgMiddleware
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument)
+    public function handleArgument(ArgumentValue $argument): ArgumentValue
     {
         $arg = $argument->getArgName();
 

--- a/src/Schema/Directives/Args/RulesDirective.php
+++ b/src/Schema/Directives/Args/RulesDirective.php
@@ -2,21 +2,18 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use GraphQL\Language\AST\ArgumentNode;
-use GraphQL\Language\AST\DirectiveNode;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
-use Nuwave\Lighthouse\Support\Contracts\Directive;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
 
-class RulesDirective extends BaseDirective implements Directive, ArgMiddleware
+class RulesDirective extends BaseDirective implements ArgMiddleware
 {
     /**
      * Name of the directive.
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'rules';
     }
@@ -24,29 +21,23 @@ class RulesDirective extends BaseDirective implements Directive, ArgMiddleware
     /**
      * Resolve the field directive.
      *
-     * @param ArgumentValue $value
+     * @param ArgumentValue $argumentValue
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $value)
+    public function handleArgument(ArgumentValue $argumentValue): ArgumentValue
     {
-        if (in_array($value->getField()->getNodeName(), ['Query', 'Mutation'])) {
-            return $value;
+        if (in_array($argumentValue->getField()->getNodeName(), ['Query', 'Mutation'])) {
+            return $argumentValue;
         }
 
-        $current = $value->getValue();
-        $current['rules'] = array_merge(
-            array_get($value->getArg(), 'rules', []),
+        return $argumentValue->setRules(
             $this->directiveArgValue('apply', [])
-        );
-        $current['messages'] = array_merge(
-            array_get($value->getArg(), 'messages', []),
+        )->setMessages(
             collect($this->directiveArgValue('messages', []))
-                ->mapWithKeys(function ($message, $path) use ($value) {
-                    return [$value->getArgName().".{$path}" => $message];
+                ->mapWithKeys(function (string $message, string $path) use ($argumentValue) {
+                    return [$argumentValue->getArgName().".{$path}" => $message];
                 })->toArray()
         );
-
-        return $value->setValue($current);
     }
 }

--- a/src/Schema/Directives/Args/ScoutDirective.php
+++ b/src/Schema/Directives/Args/ScoutDirective.php
@@ -17,7 +17,7 @@ class ScoutDirective extends BaseDirective implements ArgMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'search';
     }
@@ -29,7 +29,7 @@ class ScoutDirective extends BaseDirective implements ArgMiddleware
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument)
+    public function handleArgument(ArgumentValue $argument): ArgumentValue
     {
         $arg = $argument->getArgName();
 

--- a/src/Schema/Directives/Args/ValidateDirective.php
+++ b/src/Schema/Directives/Args/ValidateDirective.php
@@ -11,14 +11,14 @@ use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
 use Nuwave\Lighthouse\Support\Exceptions\DirectiveException;
 
-class ValidateDirective extends BaseDirective implements ArgMiddleware, FieldMiddleware
+class ValidateDirective extends BaseDirective implements FieldMiddleware
 {
     /**
      * Directive name.
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'validate';
     }
@@ -31,7 +31,7 @@ class ValidateDirective extends BaseDirective implements ArgMiddleware, FieldMid
      * @return FieldValue
      * @throws DirectiveException
      */
-    public function handleField(FieldValue $value)
+    public function handleField(FieldValue $value): FieldValue
     {
         $validator = $this->directiveArgValue('validator');
 
@@ -51,43 +51,10 @@ class ValidateDirective extends BaseDirective implements ArgMiddleware, FieldMid
             $context = array_get($funcArgs, '2');
             $info = array_get($funcArgs, '3');
 
+            // The array keys are named for more convenient retrieval in custom validator classes
             app($validator, compact('root', 'args', 'context', 'info'))->validate();
 
             return call_user_func_array($resolver, $funcArgs);
         });
-    }
-
-    /**
-     * Resolve the field directive.
-     *
-     * @param ArgumentValue $value
-     *
-     * @return ArgumentValue
-     */
-    public function handleArgument(ArgumentValue $value)
-    {
-        // TODO: Rename "getValue" to something more descriptive like "toArray"
-        // and consider using for NodeValue/FieldValue.
-        $current = $value->getValue();
-        $current['rules'] = array_merge(
-            array_get($value->getArg(), 'rules', []),
-            $this->getRules($value->getDirective())
-        );
-
-        return $value->setValue($current);
-    }
-
-    /**
-     * Get array of rules to apply to field.
-     *
-     * @param DirectiveNode $directive
-     *
-     * @return array
-     */
-    protected function getRules(DirectiveNode $directive)
-    {
-        return collect($directive->arguments)->map(function (ArgumentNode $arg) {
-            return $this->argValue($arg);
-        })->collapse()->toArray();
     }
 }

--- a/src/Schema/Directives/Args/WhereBetweenFilterDirective.php
+++ b/src/Schema/Directives/Args/WhereBetweenFilterDirective.php
@@ -16,7 +16,7 @@ class WhereBetweenFilterDirective extends BaseDirective implements ArgMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'whereBetween';
     }
@@ -28,7 +28,7 @@ class WhereBetweenFilterDirective extends BaseDirective implements ArgMiddleware
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument)
+    public function handleArgument(ArgumentValue $argument): ArgumentValue
     {
         return $this->injectKeyedFilter($argument, [
             'resolve' => function ($query, $key, array $args) {

--- a/src/Schema/Directives/Args/WhereFilterDirective.php
+++ b/src/Schema/Directives/Args/WhereFilterDirective.php
@@ -16,7 +16,7 @@ class WhereFilterDirective extends BaseDirective implements ArgMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'where';
     }
@@ -28,7 +28,7 @@ class WhereFilterDirective extends BaseDirective implements ArgMiddleware
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument)
+    public function handleArgument(ArgumentValue $argument): ArgumentValue
     {
         $arg = $argument->getArgName();
 

--- a/src/Schema/Directives/Args/WhereNotBetweenFilterDirective.php
+++ b/src/Schema/Directives/Args/WhereNotBetweenFilterDirective.php
@@ -16,7 +16,7 @@ class WhereNotBetweenFilterDirective extends BaseDirective implements ArgMiddlew
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'whereNotBetween';
     }
@@ -28,7 +28,7 @@ class WhereNotBetweenFilterDirective extends BaseDirective implements ArgMiddlew
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument)
+    public function handleArgument(ArgumentValue $argument): ArgumentValue
     {
         return $this->injectKeyedFilter($argument, [
             'resolve' => function ($query, $key, array $args) {

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -32,7 +32,7 @@ abstract class BaseDirective implements Directive
      *
      * @return $this
      */
-    public function hydrate($definitionNode)
+    public function hydrate($definitionNode): BaseDirective
     {
         $this->definitionNode = $definitionNode;
 
@@ -66,7 +66,7 @@ abstract class BaseDirective implements Directive
      *
      * @return mixed
      */
-    protected function directiveArgValue($name, $default = null, $directive = null)
+    protected function directiveArgValue(string $name, $default = null, $directive = null)
     {
         // Get the definition associated with the class of the directive, unless explicitely given
         $directive = $directive ?? $this->directiveDefinition();
@@ -87,9 +87,9 @@ abstract class BaseDirective implements Directive
     /**
      * @throws DirectiveException
      *
-     * @return mixed|string
+     * @return string
      */
-    protected function getModelClass()
+    protected function getModelClass(): string
     {
         $model = $this->directiveArgValue('model');
 
@@ -119,7 +119,7 @@ abstract class BaseDirective implements Directive
      *
      * @return string
      */
-    protected function namespaceClassName($baseClassName)
+    protected function namespaceClassName(string $baseClassName): string
     {
         $className = $this->associatedNamespace().'\\'.$baseClassName;
 
@@ -136,7 +136,7 @@ abstract class BaseDirective implements Directive
      *
      * @return string
      */
-    protected function associatedNamespace()
+    protected function associatedNamespace(): string
     {
         $namespaceDirective = $this->directiveDefinition(
             (new NamespaceDirective())->name()

--- a/src/Schema/Directives/Fields/AuthDirective.php
+++ b/src/Schema/Directives/Fields/AuthDirective.php
@@ -13,7 +13,7 @@ class AuthDirective extends BaseDirective implements FieldResolver
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'auth';
     }
@@ -25,7 +25,7 @@ class AuthDirective extends BaseDirective implements FieldResolver
      *
      * @return FieldValue
      */
-    public function resolveField(FieldValue $value)
+    public function resolveField(FieldValue $value): FieldValue
     {
         $guard = $this->directiveArgValue('name');
 

--- a/src/Schema/Directives/Fields/BelongsToDirective.php
+++ b/src/Schema/Directives/Fields/BelongsToDirective.php
@@ -14,7 +14,7 @@ class BelongsToDirective extends BaseDirective implements FieldResolver
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'belongsTo';
     }
@@ -26,7 +26,7 @@ class BelongsToDirective extends BaseDirective implements FieldResolver
      *
      * @return FieldValue
      */
-    public function resolveField(FieldValue $value)
+    public function resolveField(FieldValue $value): FieldValue
     {
         $relation = $this->directiveArgValue('relation', $this->definitionNode->name->value);
 

--- a/src/Schema/Directives/Fields/CanDirective.php
+++ b/src/Schema/Directives/Fields/CanDirective.php
@@ -14,7 +14,7 @@ class CanDirective extends BaseDirective implements FieldMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'can';
     }
@@ -26,7 +26,7 @@ class CanDirective extends BaseDirective implements FieldMiddleware
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value)
+    public function handleField(FieldValue $value): FieldValue
     {
         $policies = $this->directiveArgValue('if');
         $model = $this->directiveArgValue('model');

--- a/src/Schema/Directives/Fields/ComplexityDirective.php
+++ b/src/Schema/Directives/Fields/ComplexityDirective.php
@@ -14,7 +14,7 @@ class ComplexityDirective extends BaseDirective implements FieldMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'complexity';
     }
@@ -26,7 +26,7 @@ class ComplexityDirective extends BaseDirective implements FieldMiddleware
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value)
+    public function handleField(FieldValue $value): FieldValue
     {
         $baseClassName = $this->directiveArgValue('class') ?? str_before($this->directiveArgValue('resolver'), '@');
 

--- a/src/Schema/Directives/Fields/CreateDirective.php
+++ b/src/Schema/Directives/Fields/CreateDirective.php
@@ -14,7 +14,7 @@ class CreateDirective extends BaseDirective implements FieldResolver
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'create';
     }
@@ -25,8 +25,9 @@ class CreateDirective extends BaseDirective implements FieldResolver
      * @param FieldValue $value
      *
      * @return FieldValue
+     * @throws DirectiveException
      */
-    public function resolveField(FieldValue $value)
+    public function resolveField(FieldValue $value): FieldValue
     {
         // TODO: create a model registry so we can auto-resolve this.
         $model = $this->directiveArgValue('model');

--- a/src/Schema/Directives/Fields/DeleteDirective.php
+++ b/src/Schema/Directives/Fields/DeleteDirective.php
@@ -19,7 +19,7 @@ class DeleteDirective extends BaseDirective implements FieldResolver
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'delete';
     }
@@ -30,8 +30,9 @@ class DeleteDirective extends BaseDirective implements FieldResolver
      * @param FieldValue $value
      *
      * @return FieldValue
+     * @throws DirectiveException
      */
-    public function resolveField(FieldValue $value)
+    public function resolveField(FieldValue $value): FieldValue
     {
         $idArg = $this->getIDField($value);
         $class = $this->directiveArgValue('model');
@@ -71,7 +72,7 @@ class DeleteDirective extends BaseDirective implements FieldResolver
      *
      * @return bool
      */
-    protected function getIDField(FieldValue $value)
+    protected function getIDField(FieldValue $value): bool
     {
         return collect($value->getField()->arguments)->filter(function ($arg) {
             $type = NodeResolver::resolve($arg->type);

--- a/src/Schema/Directives/Fields/EventDirective.php
+++ b/src/Schema/Directives/Fields/EventDirective.php
@@ -13,7 +13,7 @@ class EventDirective extends BaseDirective implements FieldMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'event';
     }
@@ -26,7 +26,7 @@ class EventDirective extends BaseDirective implements FieldMiddleware
      * @return FieldValue
      * @throws \Nuwave\Lighthouse\Support\Exceptions\DirectiveException
      */
-    public function handleField(FieldValue $value)
+    public function handleField(FieldValue $value): FieldValue
     {
         $eventBaseName = $this->directiveArgValue('fire') ?? $this->directiveArgValue('class');
         $eventClassName = $this->namespaceClassName($eventBaseName);

--- a/src/Schema/Directives/Fields/FieldDirective.php
+++ b/src/Schema/Directives/Fields/FieldDirective.php
@@ -14,7 +14,7 @@ class FieldDirective extends BaseDirective implements FieldResolver
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'field';
     }
@@ -28,7 +28,7 @@ class FieldDirective extends BaseDirective implements FieldResolver
      *
      * @return FieldValue
      */
-    public function resolveField(FieldValue $value)
+    public function resolveField(FieldValue $value): FieldValue
     {
         $baseClassName = $this->directiveArgValue('class')
             ?? str_before($this->directiveArgValue('resolver'), '@');

--- a/src/Schema/Directives/Fields/FindDirective.php
+++ b/src/Schema/Directives/Fields/FindDirective.php
@@ -17,7 +17,7 @@ class FindDirective extends BaseDirective implements FieldResolver
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'find';
     }
@@ -30,7 +30,7 @@ class FindDirective extends BaseDirective implements FieldResolver
      * @return FieldValue
      * @throws DirectiveException
      */
-    public function resolveField(FieldValue $value)
+    public function resolveField(FieldValue $value): FieldValue
     {
         $model = $this->getModelClass();
 

--- a/src/Schema/Directives/Fields/FirstDirective.php
+++ b/src/Schema/Directives/Fields/FirstDirective.php
@@ -14,7 +14,7 @@ class FirstDirective extends BaseDirective implements FieldResolver
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'first';
     }
@@ -27,7 +27,7 @@ class FirstDirective extends BaseDirective implements FieldResolver
      * @return FieldValue
      * @throws \Nuwave\Lighthouse\Support\Exceptions\DirectiveException
      */
-    public function resolveField(FieldValue $value)
+    public function resolveField(FieldValue $value): FieldValue
     {
         $model = $this->getModelClass();
 

--- a/src/Schema/Directives/Fields/GlobalIdDirective.php
+++ b/src/Schema/Directives/Fields/GlobalIdDirective.php
@@ -16,7 +16,7 @@ class GlobalIdDirective extends BaseDirective implements FieldMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'globalId';
     }
@@ -28,7 +28,7 @@ class GlobalIdDirective extends BaseDirective implements FieldMiddleware
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value)
+    public function handleField(FieldValue $value): FieldValue
     {
         $type = $value->getNodeName();
         $resolver = $value->getResolver();

--- a/src/Schema/Directives/Fields/HasManyDirective.php
+++ b/src/Schema/Directives/Fields/HasManyDirective.php
@@ -19,22 +19,26 @@ class HasManyDirective extends PaginationManipulator implements FieldResolver, F
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'hasMany';
     }
 
     /**
-     * @param FieldDefinitionNode      $fieldDefinition
+     * @param FieldDefinitionNode $fieldDefinition
      * @param ObjectTypeDefinitionNode $parentType
-     * @param DocumentAST              $current
-     * @param DocumentAST              $original
-     *
-     * @throws DirectiveException
+     * @param DocumentAST $current
+     * @param DocumentAST $original
      *
      * @return DocumentAST
+     * @throws DirectiveException
      */
-    public function manipulateSchema(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current, DocumentAST $original)
+    public function manipulateSchema(
+        FieldDefinitionNode $fieldDefinition,
+        ObjectTypeDefinitionNode $parentType,
+        DocumentAST $current,
+        DocumentAST $original
+    ): DocumentAST
     {
         $paginationType = $this->getResolverType();
 
@@ -55,8 +59,9 @@ class HasManyDirective extends PaginationManipulator implements FieldResolver, F
      * @param FieldValue $value
      *
      * @return FieldValue
+     * @throws DirectiveException
      */
-    public function resolveField(FieldValue $value)
+    public function resolveField(FieldValue $value): FieldValue
     {
         $relation = $this->directiveArgValue('relation', $value->getFieldName());
         $type = $this->getResolverType();

--- a/src/Schema/Directives/Fields/InjectDirective.php
+++ b/src/Schema/Directives/Fields/InjectDirective.php
@@ -14,7 +14,7 @@ class InjectDirective extends BaseDirective implements FieldMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'inject';
     }
@@ -25,8 +25,9 @@ class InjectDirective extends BaseDirective implements FieldMiddleware
      * @param FieldValue $value
      *
      * @return FieldValue
+     * @throws DirectiveException
      */
-    public function handleField(FieldValue $value)
+    public function handleField(FieldValue $value): FieldValue
     {
         $resolver = $value->getResolver();
         $attr = $this->directiveArgValue('context');

--- a/src/Schema/Directives/Fields/MethodDirective.php
+++ b/src/Schema/Directives/Fields/MethodDirective.php
@@ -14,7 +14,7 @@ class MethodDirective extends BaseDirective implements FieldResolver
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'method';
     }
@@ -26,7 +26,7 @@ class MethodDirective extends BaseDirective implements FieldResolver
      *
      * @return FieldValue
      */
-    public function resolveField(FieldValue $value)
+    public function resolveField(FieldValue $value): FieldValue
     {
         $method = $this->directiveArgValue('name', $this->definitionNode->name->value);
 

--- a/src/Schema/Directives/Fields/MiddlewareDirective.php
+++ b/src/Schema/Directives/Fields/MiddlewareDirective.php
@@ -13,7 +13,7 @@ class MiddlewareDirective extends BaseDirective implements FieldMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'middleware';
     }
@@ -25,7 +25,7 @@ class MiddlewareDirective extends BaseDirective implements FieldMiddleware
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value)
+    public function handleField(FieldValue $value): FieldValue
     {
         $checks = $this->getChecks($value);
 

--- a/src/Schema/Directives/Fields/NamespaceDirective.php
+++ b/src/Schema/Directives/Fields/NamespaceDirective.php
@@ -24,7 +24,7 @@ class NamespaceDirective implements Directive
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'namespace';
     }

--- a/src/Schema/Directives/Fields/PaginateDirective.php
+++ b/src/Schema/Directives/Fields/PaginateDirective.php
@@ -22,7 +22,7 @@ class PaginateDirective extends PaginationManipulator implements FieldResolver, 
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'paginate';
     }
@@ -37,7 +37,12 @@ class PaginateDirective extends PaginationManipulator implements FieldResolver, 
      *
      * @return DocumentAST
      */
-    public function manipulateSchema(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current, DocumentAST $original)
+    public function manipulateSchema(
+        FieldDefinitionNode $fieldDefinition,
+        ObjectTypeDefinitionNode $parentType,
+        DocumentAST $current,
+        DocumentAST $original
+    ): DocumentAST
     {
         switch ($this->getPaginationType()) {
             case self::PAGINATION_TYPE_CONNECTION:
@@ -56,7 +61,7 @@ class PaginateDirective extends PaginationManipulator implements FieldResolver, 
      *
      * @return FieldValue
      */
-    public function resolveField(FieldValue $value)
+    public function resolveField(FieldValue $value): FieldValue
     {
         $paginationType = $this->getPaginationType();
 
@@ -74,7 +79,7 @@ class PaginateDirective extends PaginationManipulator implements FieldResolver, 
      * @return string
      * @throws DirectiveException
      */
-    protected function getPaginationType()
+    protected function getPaginationType(): string
     {
         $paginationType = $this->directiveArgValue('type', self::PAGINATION_TYPE_PAGINATOR);
 
@@ -96,7 +101,7 @@ class PaginateDirective extends PaginationManipulator implements FieldResolver, 
      *
      * @return FieldValue
      */
-    protected function paginatorTypeResolver(FieldValue $value, $model)
+    protected function paginatorTypeResolver(FieldValue $value, string $model): FieldValue
     {
         return $value->setResolver(function ($root, array $args) use ($model) {
             $first = data_get($args, 'count', 15);
@@ -121,7 +126,7 @@ class PaginateDirective extends PaginationManipulator implements FieldResolver, 
      *
      * @return FieldValue
      */
-    protected function connectionTypeResolver(FieldValue $value, $model)
+    protected function connectionTypeResolver(FieldValue $value, string $model): FieldValue
     {
         return $value->setResolver(function ($root, array $args) use ($model, $value) {
             $first = data_get($args, 'first', 15);

--- a/src/Schema/Directives/Fields/PaginationManipulator.php
+++ b/src/Schema/Directives/Fields/PaginationManipulator.php
@@ -5,7 +5,6 @@ namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
-use GraphQL\Language\Parser;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
@@ -88,7 +87,7 @@ abstract class PaginationManipulator extends BaseDirective
         ]);
 
         $fieldDefinition->arguments = ASTHelper::mergeNodeList($fieldDefinition->arguments, $connectionArguments);
-        $fieldDefinition->type = Parser::parseType($connectionTypeName);
+        $fieldDefinition->type = PartialParser::namedType($connectionTypeName);
         $parentType->fields = ASTHelper::mergeNodeList($parentType->fields, [$fieldDefinition]);
 
         $current->setDefinition($connectionType);
@@ -134,7 +133,7 @@ abstract class PaginationManipulator extends BaseDirective
         ]);
 
         $fieldDefinition->arguments = ASTHelper::mergeNodeList($fieldDefinition->arguments, $paginationArguments);
-        $fieldDefinition->type = Parser::parseType($paginatorTypeName);
+        $fieldDefinition->type = PartialParser::namedType($paginatorTypeName);
         $parentType->fields = ASTHelper::mergeNodeList($parentType->fields, [$fieldDefinition]);
 
         $current->setDefinition($paginatorType);

--- a/src/Schema/Directives/Fields/PaginationManipulator.php
+++ b/src/Schema/Directives/Fields/PaginationManipulator.php
@@ -24,10 +24,10 @@ abstract class PaginationManipulator extends BaseDirective
      *
      * @return bool
      */
-    protected function isValidPaginationType($paginationType)
+    protected function isValidPaginationType(string $paginationType): bool
     {
-        return self::PAGINATION_TYPE_PAGINATOR === $paginationType ||
-        self::PAGINATION_TYPE_CONNECTION === $paginationType;
+        return self::PAGINATION_TYPE_PAGINATOR === $paginationType
+            || self::PAGINATION_TYPE_CONNECTION === $paginationType;
     }
 
     /**
@@ -35,7 +35,7 @@ abstract class PaginationManipulator extends BaseDirective
      *
      * @return string
      */
-    protected function convertAliasToPaginationType($paginationType)
+    protected function convertAliasToPaginationType(string $paginationType): string
     {
         if (self::PAGINATION_ALIAS_RELAY === $paginationType) {
             return self::PAGINATION_TYPE_CONNECTION;
@@ -56,7 +56,12 @@ abstract class PaginationManipulator extends BaseDirective
      *
      * @return DocumentAST
      */
-    protected function registerConnection(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current, DocumentAST $original)
+    protected function registerConnection(
+        FieldDefinitionNode $fieldDefinition,
+        ObjectTypeDefinitionNode $parentType,
+        DocumentAST $current,
+        DocumentAST $original
+    ): DocumentAST
     {
         $connectionTypeName = $this->connectionTypeName($fieldDefinition, $parentType);
         $connectionEdgeName = $this->connectionEdgeName($fieldDefinition, $parentType);
@@ -105,7 +110,12 @@ abstract class PaginationManipulator extends BaseDirective
      *
      * @return DocumentAST
      */
-    protected function registerPaginator(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current, DocumentAST $original)
+    protected function registerPaginator(
+        FieldDefinitionNode $fieldDefinition,
+        ObjectTypeDefinitionNode $parentType,
+        DocumentAST $current,
+        DocumentAST $original
+    ): DocumentAST
     {
         $paginatorTypeName = $this->paginatorTypeName($fieldDefinition, $parentType);
         $paginatorFieldClassName = addslashes(PaginatorField::class);
@@ -141,7 +151,7 @@ abstract class PaginationManipulator extends BaseDirective
      *
      * @return string
      */
-    protected function paginatorTypeName(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parent)
+    protected function paginatorTypeName(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parent): string
     {
         return studly_case(
             $this->parentTypeName($parent)
@@ -158,7 +168,7 @@ abstract class PaginationManipulator extends BaseDirective
      *
      * @return string
      */
-    protected function connectionTypeName(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parent)
+    protected function connectionTypeName(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parent): string
     {
         return studly_case(
             $this->parentTypeName($parent)
@@ -175,7 +185,7 @@ abstract class PaginationManipulator extends BaseDirective
      *
      * @return string
      */
-    protected function connectionEdgeName(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parent)
+    protected function connectionEdgeName(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parent): string
     {
         return studly_case(
             $this->parentTypeName($parent)
@@ -189,7 +199,7 @@ abstract class PaginationManipulator extends BaseDirective
      *
      * @return string
      */
-    protected function singularFieldName(FieldDefinitionNode $fieldDefinition)
+    protected function singularFieldName(FieldDefinitionNode $fieldDefinition): string
     {
         return str_singular($fieldDefinition->name->value);
     }
@@ -199,7 +209,7 @@ abstract class PaginationManipulator extends BaseDirective
      *
      * @return string
      */
-    protected function parentTypeName(ObjectTypeDefinitionNode $objectType)
+    protected function parentTypeName(ObjectTypeDefinitionNode $objectType): string
     {
         $name = $objectType->name->value;
 
@@ -213,7 +223,7 @@ abstract class PaginationManipulator extends BaseDirective
      *
      * @return string
      */
-    protected function unpackNodeToString(Node $node)
+    protected function unpackNodeToString(Node $node): string
     {
         if (in_array($node->kind, ['ListType', 'NonNullType', 'FieldDefinition'])) {
             return $this->unpackNodeToString($node->type);

--- a/src/Schema/Directives/Fields/RenameDirective.php
+++ b/src/Schema/Directives/Fields/RenameDirective.php
@@ -14,7 +14,7 @@ class RenameDirective extends BaseDirective implements FieldResolver
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'rename';
     }
@@ -27,7 +27,7 @@ class RenameDirective extends BaseDirective implements FieldResolver
      * @return FieldValue
      * @throws DirectiveException
      */
-    public function resolveField(FieldValue $value)
+    public function resolveField(FieldValue $value): FieldValue
     {
         $attribute = $this->directiveArgValue('attribute');
 

--- a/src/Schema/Directives/Fields/UpdateDirective.php
+++ b/src/Schema/Directives/Fields/UpdateDirective.php
@@ -19,7 +19,7 @@ class UpdateDirective extends BaseDirective implements FieldResolver
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'update';
     }
@@ -32,7 +32,7 @@ class UpdateDirective extends BaseDirective implements FieldResolver
      * @return FieldValue
      * @throws DirectiveException
      */
-    public function resolveField(FieldValue $value)
+    public function resolveField(FieldValue $value): FieldValue
     {
         $idArg = $this->getIDField($value);
         $class = $this->directiveArgValue('model');
@@ -74,7 +74,7 @@ class UpdateDirective extends BaseDirective implements FieldResolver
      *
      * @return bool
      */
-    protected function getIDField(FieldValue $value)
+    protected function getIDField(FieldValue $value): bool
     {
         return collect($value->getField()->arguments)->filter(function ($arg) {
             $type = NodeResolver::resolve($arg->type);

--- a/src/Schema/Directives/Nodes/EnumDirective.php
+++ b/src/Schema/Directives/Nodes/EnumDirective.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Schema\Directives\Nodes;
 
 use GraphQL\Language\AST\EnumValueDefinitionNode;
 use GraphQL\Type\Definition\EnumType;
+use GraphQL\Type\Definition\Type;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
 use Nuwave\Lighthouse\Support\Contracts\NodeResolver;
@@ -15,7 +16,7 @@ class EnumDirective extends BaseDirective implements NodeResolver
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'enum';
     }
@@ -25,9 +26,9 @@ class EnumDirective extends BaseDirective implements NodeResolver
      *
      * @param NodeValue $value
      *
-     * @return \GraphQL\Type\Definition\Type
+     * @return Type
      */
-    public function resolveNode(NodeValue $value)
+    public function resolveNode(NodeValue $value): Type
     {
         return new EnumType([
             'name' => $value->getNodeName(),
@@ -54,7 +55,7 @@ class EnumDirective extends BaseDirective implements NodeResolver
      *
      * @return string
      */
-    protected function safeDescription($description = '')
+    protected function safeDescription(string $description = ''): string
     {
         return trim(str_replace(["\n", "\t"], '', $description));
     }

--- a/src/Schema/Directives/Nodes/GroupDirective.php
+++ b/src/Schema/Directives/Nodes/GroupDirective.php
@@ -29,7 +29,7 @@ class GroupDirective extends BaseDirective implements NodeManipulator
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'group';
     }
@@ -42,8 +42,9 @@ class GroupDirective extends BaseDirective implements NodeManipulator
      * @throws DirectiveException
      *
      * @return DocumentAST
+     * @throws \Nuwave\Lighthouse\Support\Exceptions\DocumentASTException
      */
-    public function manipulateSchema(Node $node, DocumentAST $current, DocumentAST $original)
+    public function manipulateSchema(Node $node, DocumentAST $current, DocumentAST $original): DocumentAST
     {
         $nodeName = $node->name->value;
 
@@ -68,7 +69,7 @@ class GroupDirective extends BaseDirective implements NodeManipulator
      *
      * @return ObjectTypeDefinitionNode
      */
-    protected function setMiddlewareDirectiveOnFields(ObjectTypeDefinitionNode $objectType)
+    protected function setMiddlewareDirectiveOnFields(ObjectTypeDefinitionNode $objectType): ObjectTypeDefinitionNode
     {
         $middlewareValues = $this->directiveArgValue('middleware');
 
@@ -95,7 +96,7 @@ class GroupDirective extends BaseDirective implements NodeManipulator
      *
      * @return ObjectTypeDefinitionNode
      */
-    protected function setNamespaceDirectiveOnFields(ObjectTypeDefinitionNode $objectType)
+    protected function setNamespaceDirectiveOnFields(ObjectTypeDefinitionNode $objectType): ObjectTypeDefinitionNode
     {
         $namespaceValue = $this->directiveArgValue('namespace');
 
@@ -129,7 +130,7 @@ class GroupDirective extends BaseDirective implements NodeManipulator
      *
      * @return DirectiveNode
      */
-    protected function mergeNamespaceOnExistingDirective($namespaceValue, DirectiveNode $directive)
+    protected function mergeNamespaceOnExistingDirective($namespaceValue, DirectiveNode $directive): DirectiveNode
     {
         $namespaces = PartialParser::arguments([
             "field: \"$namespaceValue\"",

--- a/src/Schema/Directives/Nodes/InterfaceDirective.php
+++ b/src/Schema/Directives/Nodes/InterfaceDirective.php
@@ -3,6 +3,7 @@
 namespace Nuwave\Lighthouse\Schema\Directives\Nodes;
 
 use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\Type;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
 use Nuwave\Lighthouse\Support\Contracts\NodeResolver;
@@ -17,7 +18,7 @@ class InterfaceDirective extends BaseDirective implements NodeResolver
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'interface';
     }
@@ -27,16 +28,16 @@ class InterfaceDirective extends BaseDirective implements NodeResolver
      *
      * @param NodeValue $value
      *
-     * @return mixed
+     * @return Type
      */
-    public function resolveNode(NodeValue $value)
+    public function resolveNode(NodeValue $value): Type
     {
         $resolver = $this->directiveArgValue('resolver');
 
         $instance = app(array_get(explode('@', $resolver), '0'));
         $method = array_get(explode('@', $resolver), '1');
 
-        return $value->setType(new InterfaceType([
+        return new InterfaceType([
             'name' => $value->getNodeName(),
             'description' => trim(str_replace("\n", '', $value->getNode()->description)),
             'fields' => function () use ($value) {
@@ -45,6 +46,6 @@ class InterfaceDirective extends BaseDirective implements NodeResolver
             'resolveType' => function ($value) use ($instance, $method) {
                 return call_user_func_array([$instance, $method], [$value]);
             },
-        ]));
+        ]);
     }
 }

--- a/src/Schema/Directives/Nodes/ModelDirective.php
+++ b/src/Schema/Directives/Nodes/ModelDirective.php
@@ -20,7 +20,7 @@ class ModelDirective extends BaseDirective implements NodeMiddleware, NodeManipu
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'model';
     }
@@ -32,7 +32,7 @@ class ModelDirective extends BaseDirective implements NodeMiddleware, NodeManipu
      *
      * @return NodeValue
      */
-    public function handleNode(NodeValue $value)
+    public function handleNode(NodeValue $value): NodeValue
     {
         $modelClassName = $this->getModelClassName($value);
 
@@ -50,7 +50,7 @@ class ModelDirective extends BaseDirective implements NodeMiddleware, NodeManipu
      *
      * @return string
      */
-    protected function getModelClassName(NodeValue $value)
+    protected function getModelClassName(NodeValue $value): string
     {
         $className = $this->directiveArgValue('class');
 
@@ -62,7 +62,7 @@ class ModelDirective extends BaseDirective implements NodeMiddleware, NodeManipu
      *
      * @return string
      */
-    protected function inferModelClassName($nodeName)
+    protected function inferModelClassName(string $nodeName): string
     {
         return config('lighthouse.namespaces.models').'\\'.$nodeName;
     }
@@ -76,7 +76,7 @@ class ModelDirective extends BaseDirective implements NodeMiddleware, NodeManipu
      *
      * @return DocumentAST
      */
-    public function manipulateSchema(Node $node, DocumentAST $current, DocumentAST $original)
+    public function manipulateSchema(Node $node, DocumentAST $current, DocumentAST $original): DocumentAST
     {
         return $this->attachNodeInterfaceToObjectType($node, $current);
     }

--- a/src/Schema/Directives/Nodes/NodeDirective.php
+++ b/src/Schema/Directives/Nodes/NodeDirective.php
@@ -19,7 +19,7 @@ class NodeDirective extends BaseDirective implements NodeMiddleware, NodeManipul
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'node';
     }
@@ -31,7 +31,7 @@ class NodeDirective extends BaseDirective implements NodeMiddleware, NodeManipul
      *
      * @return NodeValue
      */
-    public function handleNode(NodeValue $value)
+    public function handleNode(NodeValue $value): NodeValue
     {
         graphql()->nodes()->node(
             $value->getNodeName(),
@@ -52,7 +52,7 @@ class NodeDirective extends BaseDirective implements NodeMiddleware, NodeManipul
      *
      * @return \Closure
      */
-    protected function getResolver(NodeValue $value, $argKey)
+    protected function getResolver(NodeValue $value, string $argKey): \Closure
     {
         $resolver = $this->directiveArgValue($argKey);
 
@@ -74,13 +74,14 @@ class NodeDirective extends BaseDirective implements NodeMiddleware, NodeManipul
     }
 
     /**
-     * @param Node        $node
+     * @param Node $node
      * @param DocumentAST $current
      * @param DocumentAST $original
      *
      * @return DocumentAST
+     * @throws \Exception
      */
-    public function manipulateSchema(Node $node, DocumentAST $current, DocumentAST $original)
+    public function manipulateSchema(Node $node, DocumentAST $current, DocumentAST $original): DocumentAST
     {
         return $this->attachNodeInterfaceToObjectType($node, $current);
     }

--- a/src/Schema/Directives/Nodes/ScalarDirective.php
+++ b/src/Schema/Directives/Nodes/ScalarDirective.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Nodes;
 
+use GraphQL\Type\Definition\Type;
 use Nuwave\Lighthouse\Schema\Resolvers\ScalarResolver;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
 use Nuwave\Lighthouse\Support\Contracts\NodeResolver;
@@ -14,7 +15,7 @@ class ScalarDirective implements NodeResolver
      * @var string
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'scalar';
     }
@@ -24,10 +25,10 @@ class ScalarDirective implements NodeResolver
      *
      * @param NodeValue $value
      *
-     * @return mixed
+     * @return Type
      */
-    public function resolveNode(NodeValue $value)
+    public function resolveNode(NodeValue $value): Type
     {
-        return ScalarResolver::resolve($value);
+        return ScalarResolver::resolve($value)->getType();
     }
 }

--- a/src/Schema/Directives/Nodes/SecurityDirective.php
+++ b/src/Schema/Directives/Nodes/SecurityDirective.php
@@ -18,7 +18,7 @@ class SecurityDirective extends BaseDirective implements NodeMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'security';
     }
@@ -29,8 +29,9 @@ class SecurityDirective extends BaseDirective implements NodeMiddleware
      * @param NodeValue $value
      *
      * @return NodeValue
+     * @throws DirectiveException
      */
-    public function handleNode(NodeValue $value)
+    public function handleNode(NodeValue $value): NodeValue
     {
         if ('Query' !== $value->getNodeName()) {
             $message = sprintf(
@@ -42,19 +43,17 @@ class SecurityDirective extends BaseDirective implements NodeMiddleware
             throw new DirectiveException($message);
         }
 
-        $this->queryDepth($value);
-        $this->queryComplexity($value);
-        $this->queryIntrospection($value);
+        $this->queryDepth();
+        $this->queryComplexity();
+        $this->queryIntrospection();
 
         return $value;
     }
 
     /**
      * Set the max query complexity.
-     *
-     * @param NodeValue $value
      */
-    protected function queryComplexity(NodeValue $value)
+    protected function queryComplexity()
     {
         $complexity = $this->directiveArgValue('complexity');
 
@@ -67,10 +66,8 @@ class SecurityDirective extends BaseDirective implements NodeMiddleware
 
     /**
      * Set max query depth.
-     *
-     * @param NodeValue $value
      */
-    protected function queryDepth(NodeValue $value)
+    protected function queryDepth()
     {
         $depth = $this->directiveArgValue('depth');
 
@@ -83,10 +80,8 @@ class SecurityDirective extends BaseDirective implements NodeMiddleware
 
     /**
      * Set introspection rule.
-     *
-     * @param NodeValue $value
      */
-    protected function queryIntrospection(NodeValue $value)
+    protected function queryIntrospection()
     {
         $introspection = $this->directiveArgValue('introspection');
 

--- a/src/Schema/Directives/Nodes/UnionDirective.php
+++ b/src/Schema/Directives/Nodes/UnionDirective.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Nodes;
 
+use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
@@ -14,7 +15,7 @@ class UnionDirective extends BaseDirective implements NodeResolver
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'union';
     }
@@ -24,21 +25,21 @@ class UnionDirective extends BaseDirective implements NodeResolver
      *
      * @param NodeValue $value
      *
-     * @return mixed
+     * @return Type
      */
-    public function resolveNode(NodeValue $value)
+    public function resolveNode(NodeValue $value): Type
     {
         $resolver = $this->directiveArgValue('resolver');
 
         $namespace = array_get(explode('@', $resolver), '0');
         $method = array_get(explode('@', $resolver), '1', strtolower($value->getNodeName()));
 
-        return $value->setType(new UnionType([
+        return new UnionType([
             'name' => $value->getNodeName(),
             'description' => trim(str_replace("\n", '', $value->getNode()->description)),
             'types' => function () use ($value) {
                 return collect($value->getNode()->types)->map(function ($type) {
-                    return graphql()->types()->instance($type->name->value);
+                    return graphql()->types()->get($type->name->value);
                 })->filter()->toArray();
             },
             'resolveType' => function ($value) use ($namespace, $method) {
@@ -46,8 +47,8 @@ class UnionDirective extends BaseDirective implements NodeResolver
                     $instance = app($namespace);
                     return call_user_func_array([$instance, $method], [$value]);
                 }
-                return graphql()->types()->instance(last(explode('\\', get_class($value))));
+                return graphql()->types()->get(last(explode('\\', get_class($value))));
             },
-        ]));
+        ]);
     }
 }

--- a/src/Schema/Factories/NodeFactory.php
+++ b/src/Schema/Factories/NodeFactory.php
@@ -36,7 +36,7 @@ class NodeFactory
      * @return Type
      * @throws \Exception
      */
-    public function handle(NodeValue $value)
+    public function handle(NodeValue $value): Type
     {
         $value->setType(
             $this->hasTypeResolver($value)
@@ -53,6 +53,7 @@ class NodeFactory
      * @param NodeValue $value
      *
      * @return bool
+     * @throws \Nuwave\Lighthouse\Support\Exceptions\DirectiveException
      */
     protected function hasTypeResolver(NodeValue $value)
     {
@@ -65,13 +66,13 @@ class NodeFactory
      * @param NodeValue $value
      *
      * @return Type
+     * @throws \Nuwave\Lighthouse\Support\Exceptions\DirectiveException
      */
-    protected function resolveTypeViaDirective(NodeValue $value)
+    protected function resolveTypeViaDirective(NodeValue $value): Type
     {
         return graphql()->directives()
-            ->forNode($value->getNode())
-            ->resolveNode($value)
-            ->getType();
+            ->nodeResolver($value->getNode())
+            ->resolveNode($value);
     }
 
     /**
@@ -82,7 +83,7 @@ class NodeFactory
      * @throws \Exception
      * @return Type
      */
-    protected function resolveType(NodeValue $value)
+    protected function resolveType(NodeValue $value): Type
     {
         // We do not have to consider TypeExtensionNode since they
         // are merged before we get here
@@ -111,7 +112,7 @@ class NodeFactory
      *
      * @return EnumType
      */
-    public function enum(NodeValue $enumNodeValue)
+    public function enum(NodeValue $enumNodeValue): EnumType
     {
         $enumDirective = (new EnumDirective())->hydrate($enumNodeValue->getNode());
 
@@ -125,7 +126,7 @@ class NodeFactory
      *
      * @return ScalarType
      */
-    protected function scalar(NodeValue $value)
+    protected function scalar(NodeValue $value): ScalarType
     {
         return ScalarResolver::resolve($value)->getType();
     }
@@ -137,7 +138,7 @@ class NodeFactory
      *
      * @return InterfaceType
      */
-    protected function interface(NodeValue $value)
+    protected function interface(NodeValue $value): InterfaceType
     {
         return new InterfaceType([
             'name' => $value->getNodeName(),
@@ -152,7 +153,7 @@ class NodeFactory
      *
      * @return ObjectType
      */
-    protected function objectType(NodeValue $value)
+    protected function objectType(NodeValue $value): ObjectType
     {
         return new ObjectType([
             'name' => $value->getNodeName(),
@@ -174,7 +175,7 @@ class NodeFactory
      *
      * @return InputObjectType
      */
-    protected function inputObjectType(NodeValue $value)
+    protected function inputObjectType(NodeValue $value): InputObjectType
     {
         return new InputObjectType([
             'name' => $value->getNodeName(),
@@ -191,7 +192,7 @@ class NodeFactory
      *
      * @return NodeValue
      */
-    protected function applyMiddleware(NodeValue $value)
+    protected function applyMiddleware(NodeValue $value): NodeValue
     {
         return graphql()->directives()->nodeMiddleware($value->getNode())
             ->reduce(function (NodeValue $value, NodeMiddleware $middleware) {

--- a/src/Schema/MiddlewareManager.php
+++ b/src/Schema/MiddlewareManager.php
@@ -29,7 +29,7 @@ class MiddlewareManager
      *
      * @return array
      */
-    public function forRequest($request)
+    public function forRequest(string $request): array
     {
         $document = DocumentAST::fromSource($request);
         $fragments = $document->fragmentDefinitions();
@@ -67,10 +67,8 @@ class MiddlewareManager
      *
      * @param string $name
      * @param array $middleware
-     *
-     * @return void
      */
-    public function registerQuery($name, array $middleware)
+    public function registerQuery(string $name, array $middleware)
     {
         $this->queries = array_merge($this->queries, [$name => $middleware]);
     }
@@ -80,10 +78,8 @@ class MiddlewareManager
      *
      * @param string $name
      * @param array $middleware
-     *
-     * @return void
      */
-    public function registerMutation($name, array $middleware)
+    public function registerMutation(string $name, array $middleware)
     {
         $this->mutations = array_merge($this->mutations, [$name => $middleware]);
     }
@@ -96,7 +92,7 @@ class MiddlewareManager
      *
      * @return array
      */
-    public function operation($operation, array $fields)
+    public function operation(string $operation, array $fields): array
     {
         if ('mutation' === $operation) {
             return array_collapse(array_map(function ($field) {
@@ -118,7 +114,7 @@ class MiddlewareManager
      *
      * @return array
      */
-    public function query($name)
+    public function query(string $name): array
     {
         return array_get($this->queries, $name, []);
     }
@@ -130,7 +126,7 @@ class MiddlewareManager
      *
      * @return array
      */
-    public function mutation($name)
+    public function mutation(string $name): array
     {
         return array_get($this->mutations, $name, []);
     }

--- a/src/Schema/NodeContainer.php
+++ b/src/Schema/NodeContainer.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Schema;
 
 use Closure;
 use GraphQL\Error\Error;
+use GraphQL\Type\Definition\Type;
 use Nuwave\Lighthouse\Support\Traits\HandlesGlobalId;
 
 class NodeContainer
@@ -37,10 +38,8 @@ class NodeContainer
      * @param string  $type
      * @param Closure $resolver
      * @param Closure $resolveType
-     *
-     * @return mixed
      */
-    public function node($type, Closure $resolver, Closure $resolveType)
+    public function node(string $type, Closure $resolver, Closure $resolveType)
     {
         $this->types[$type] = $resolveType;
         $this->nodes[$type] = $resolver;
@@ -51,10 +50,8 @@ class NodeContainer
      *
      * @param string $type
      * @param string $model
-     *
-     * @return void
      */
-    public function model($type, $model)
+    public function model(string $type, string $model)
     {
         $this->models[$model] = $type;
 
@@ -69,8 +66,9 @@ class NodeContainer
      * @param string $globalId
      *
      * @return mixed
+     * @throws Error
      */
-    public function resolve($globalId)
+    public function resolve(string $globalId)
     {
         $type = $this->decodeRelayType($globalId);
 
@@ -88,12 +86,12 @@ class NodeContainer
      *
      * @param mixed $value
      *
-     * @return \GraphQL\Type\Definition\Type
+     * @return Type
      */
-    public function resolveType($value)
+    public function resolveType($value): Type
     {
         if (is_object($value) && isset($this->models[get_class($value)])) {
-            return graphql()->types()->instance($this->models[get_class($value)]);
+            return graphql()->types()->get($this->models[get_class($value)]);
         }
 
         return collect($this->types)
@@ -108,7 +106,7 @@ class NodeContainer
                 $resolver = $item['resolver'];
                 $type = $item['type'];
 
-                return $resolver($value) ? graphql()->types()->instance($type) : $instance;
+                return $resolver($value) ? graphql()->types()->get($type) : $instance;
             });
     }
 }

--- a/src/Schema/Resolvers/EnumResolver.php
+++ b/src/Schema/Resolvers/EnumResolver.php
@@ -20,7 +20,7 @@ class EnumResolver extends AbstractResolver
      *
      * @return EnumType
      */
-    public function generate()
+    public function generate(): EnumType
     {
         $config = [
             'name' => $this->getName(),
@@ -35,7 +35,7 @@ class EnumResolver extends AbstractResolver
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->node->name->value;
     }
@@ -45,7 +45,7 @@ class EnumResolver extends AbstractResolver
      *
      * @return array
      */
-    public function getValues()
+    public function getValues(): array
     {
         return collect($this->node->values)
             ->mapWithKeys(function (EnumValueDefinitionNode $node) {
@@ -60,7 +60,7 @@ class EnumResolver extends AbstractResolver
      *
      * @return string
      */
-    protected function getEnumValueKey(EnumValueDefinitionNode $node)
+    protected function getEnumValueKey(EnumValueDefinitionNode $node): string
     {
         return $node->name->value;
     }
@@ -72,7 +72,7 @@ class EnumResolver extends AbstractResolver
      *
      * @return array
      */
-    protected function parseEnumNode(EnumValueDefinitionNode $node)
+    protected function parseEnumNode(EnumValueDefinitionNode $node): array
     {
         $directive = $this->getDirective($node, 'enum');
 

--- a/src/Schema/Resolvers/FieldTypeResolver.php
+++ b/src/Schema/Resolvers/FieldTypeResolver.php
@@ -18,7 +18,7 @@ class FieldTypeResolver
      *
      * @return FieldValue
      */
-    public static function resolve(FieldValue $value)
+    public static function resolve(FieldValue $value): FieldValue
     {
         return $value->setType(
             (new static())->resolveNodeType($value->getField())
@@ -32,7 +32,7 @@ class FieldTypeResolver
      *
      * @return Type
      */
-    public static function resolveInput(InputValueDefinitionNode $input)
+    public static function resolveInput(InputValueDefinitionNode $input): Type
     {
         return (new static())->resolveNodeType($input);
     }
@@ -44,7 +44,7 @@ class FieldTypeResolver
      *
      * @return Type
      */
-    public static function unpack($type)
+    public static function unpack($type): Type
     {
         return (new static())->unpackNodeType($type);
     }
@@ -92,7 +92,7 @@ class FieldTypeResolver
      *
      * @return Type
      */
-    public function unpackNodeType($type, array $wrappers = [])
+    public function unpackNodeType($type, array $wrappers = []): Type
     {
         $type = is_callable($type) ? $type() : $type;
 
@@ -160,7 +160,7 @@ class FieldTypeResolver
     protected function convertCustomType($name)
     {
         return function () use ($name) {
-            return graphql()->types()->instance($name);
+            return graphql()->types()->get($name);
         };
     }
 }

--- a/src/Schema/Resolvers/NodeResolver.php
+++ b/src/Schema/Resolvers/NodeResolver.php
@@ -12,9 +12,9 @@ class NodeResolver
      *
      * @param mixed $node
      *
-     * @return \GraphQL\Type\Definition\Type
+     * @return Type
      */
-    public static function resolve($node)
+    public static function resolve($node): Type
     {
         return (new static())->fromNode($node);
     }
@@ -89,7 +89,7 @@ class NodeResolver
             case 'String':
                 return Type::string();
             default:
-                return graphql()->types()->instance($node->name->value);
+                return graphql()->types()->get($node->name->value);
         }
     }
 }

--- a/src/Schema/Resolvers/ScalarResolver.php
+++ b/src/Schema/Resolvers/ScalarResolver.php
@@ -20,10 +20,12 @@ class ScalarResolver extends AbstractResolver
      *
      * @return ScalarType
      */
-    public function generate()
+    public function generate(): ScalarType
     {
         $directive = $this->getDirective($this->value->getNode(), 'scalar');
-        $className = $directive ? $this->getClassName($directive) : ucfirst($this->value->getNodeName());
+        $className = $directive
+            ? $this->getClassName($directive)
+            : ucfirst($this->value->getNodeName());
         $namespace = config('lighthouse.namespaces.scalars').'\\'.$className;
 
         return app($namespace);
@@ -36,7 +38,7 @@ class ScalarResolver extends AbstractResolver
      *
      * @return string
      */
-    protected function getClassName(DirectiveNode $directive)
+    protected function getClassName(DirectiveNode $directive): string
     {
         return $this->directiveArgValue(
             $directive,

--- a/src/Schema/Resolvers/ScalarResolver.php
+++ b/src/Schema/Resolvers/ScalarResolver.php
@@ -3,8 +3,9 @@
 namespace Nuwave\Lighthouse\Schema\Resolvers;
 
 use GraphQL\Language\AST\DirectiveNode;
-use GraphQL\Language\AST\ScalarTypeDefinitionNode;
 use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Language\AST\ScalarTypeDefinitionNode;
+use Nuwave\Lighthouse\Support\Exceptions\DirectiveException;
 
 class ScalarResolver extends AbstractResolver
 {
@@ -27,6 +28,18 @@ class ScalarResolver extends AbstractResolver
             ? $this->getClassName($directive)
             : ucfirst($this->value->getNodeName());
         $namespace = config('lighthouse.namespaces.scalars').'\\'.$className;
+
+        if (! class_exists($namespace) && class_exists($className)) {
+            $namespace = $className;
+        } elseif (! class_exists($namespace) && ! class_exists($className)) {
+            $message = sprintf(
+                'Unable to find class [%s] assigned to %s scalar',
+                $className,
+                $this->value->getNodeName()
+            );
+
+            throw new DirectiveException($message);
+        }
 
         return app($namespace);
     }

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -37,7 +37,7 @@ class SchemaBuilder
      *
      * @return Schema
      */
-    public function build($documentAST)
+    public function build(DocumentAST $documentAST): Schema
     {
         $types = $this->convertTypes($documentAST);
         $this->loadRootOperationFields($types);
@@ -85,7 +85,7 @@ class SchemaBuilder
      *
      * @return \Closure
      */
-    protected function isOperationType()
+    protected function isOperationType(): \Closure
     {
         return function (Type $type) {
             return in_array($type->name, ['Query', 'Mutation', 'Subscription']);
@@ -99,7 +99,7 @@ class SchemaBuilder
      *
      * @return Collection
      */
-    public function convertTypes(DocumentAST $document)
+    public function convertTypes(DocumentAST $document): Collection
     {
         return $document->typeDefinitions()
             ->sortBy(function (TypeDefinitionNode $typeDefinition) {
@@ -119,7 +119,7 @@ class SchemaBuilder
      *
      * @return Collection
      */
-    protected function convertDirectives(DocumentAST $document)
+    protected function convertDirectives(DocumentAST $document): Collection
     {
         return $document->directiveDefinitions()->map(function (DirectiveDefinitionNode $directive) {
             return new Directive([

--- a/src/Schema/TypeRegistry.php
+++ b/src/Schema/TypeRegistry.php
@@ -29,9 +29,19 @@ class TypeRegistry
      *
      * @return Type
      */
-    public function instance($typeName)
+    public function get(string $typeName): Type
     {
-        return $this->get($typeName);
+        return $this->types->get($typeName);
+    }
+
+    /**
+     * Register type with registry.
+     *
+     * @param Type $type
+     */
+    public function register(Type $type)
+    {
+        $this->types->put($type->name, $type);
     }
 
     /**
@@ -40,10 +50,11 @@ class TypeRegistry
      * @param string $typeName
      *
      * @return Type
+     * @deprecated in favour of get()
      */
-    public function get($typeName)
+    public function instance(string $typeName): Type
     {
-        return $this->types->get($typeName);
+        return $this->get($typeName);
     }
 
     /**
@@ -55,15 +66,5 @@ class TypeRegistry
     public function type(Type $type)
     {
         $this->register($type);
-    }
-
-    /**
-     * Register type with registry.
-     *
-     * @param Type $type
-     */
-    public function register(Type $type)
-    {
-        $this->types->put($type->name, $type);
     }
 }

--- a/src/Schema/Values/ArgumentValue.php
+++ b/src/Schema/Values/ArgumentValue.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Values;
 
-use GraphQL\Language\AST\DirectiveNode;
 use GraphQL\Language\AST\InputValueDefinitionNode;
 use GraphQL\Type\Definition\Type;
 
@@ -16,38 +15,43 @@ class ArgumentValue
     protected $arg;
 
     /**
-     * Current directive.
-     *
-     * @var DirectiveNode
-     */
-    protected $directive;
-
-    /**
      * Current field.
      *
      * @var FieldValue
      */
     protected $field;
-
-    /**
-     * Current value.
-     *
-     * @var array
-     */
-    protected $value;
-
     /**
      * Set current arg type.
      *
      * @var Type
      */
     protected $type;
+    /**
+     * The resolver function for the arg.
+     *
+     * @var \Closure
+     */
+    protected $resolver;
+
+    /**
+     * Validation rules.
+     *
+     * @var array
+     */
+    protected $rules;
+
+    /**
+     * Messages for the validation rules.
+     *
+     * @var array
+     */
+    protected $messages;
 
     /**
      * Create a new argument value instance.
      *
      * @param FieldValue $field
-     * @param InputValueDefinitionNode   $arg
+     * @param InputValueDefinitionNode $arg
      */
     public function __construct(FieldValue $field, InputValueDefinitionNode $arg)
     {
@@ -56,104 +60,43 @@ class ArgumentValue
     }
 
     /**
-     * Set current directive.
-     *
-     * @param DirectiveNode $directive
-     *
-     * @return self
+     * @return array|null
      */
-    public function setDirective(DirectiveNode $directive)
+    public function getRules()
     {
-        $this->directive = $directive;
+        return $this->rules;
+    }
+
+    /**
+     * @param array $rules
+     *
+     * @return ArgumentValue
+     */
+    public function setRules(array $rules): ArgumentValue
+    {
+        $this->rules = $rules;
 
         return $this;
     }
 
     /**
-     * Set current argument.
-     *
-     * @param InputValueDefinitionNode $arg
-     *
-     * @return self
+     * @return array|null
      */
-    public function setArg(InputValueDefinitionNode $arg)
+    public function getMessages()
     {
-        $this->arg = $arg;
+        return $this->messages;
+    }
+
+    /**
+     * @param array $messages
+     *
+     * @return ArgumentValue
+     */
+    public function setMessages(array $messages): ArgumentValue
+    {
+        $this->messages = $messages;
 
         return $this;
-    }
-
-    /**
-     * Get current argument type.
-     *
-     * @param Type $type
-     *
-     * @return self
-     */
-    public function setType(Type $type)
-    {
-        $this->type = $type;
-
-        $value = $this->getValue();
-        $value['type'] = $type;
-
-        return $this->setValue($value);
-    }
-
-    /**
-     * Set the current value.
-     *
-     * @param array $value
-     *
-     * @return self
-     */
-    public function setValue(array $value)
-    {
-        $this->value = $value;
-
-        return $this;
-    }
-
-    /**
-     * Set directive for middleware.
-     *
-     * @param string $middleware
-     *
-     * @return self
-     */
-    public function setMiddlewareDirective($middleware)
-    {
-        $this->directive = collect($this->arg->directives)
-            ->first(function (DirectiveNode $directive) use ($middleware) {
-                return $directive->name->value === $middleware;
-            });
-
-        return $this;
-    }
-
-    /**
-     * Set a argument resolver.
-     *
-     * @param \Closure $resolver
-     *
-     * @return self
-     */
-    public function setResolver(\Closure $resolver)
-    {
-        $current = $this->getValue();
-        $current['resolve'] = $resolver;
-
-        return $this->setValue($current);
-    }
-
-    /**
-     * Get current argument.
-     *
-     * @return InputValueDefinitionNode
-     */
-    public function getArg()
-    {
-        return $this->arg;
     }
 
     /**
@@ -161,19 +104,9 @@ class ArgumentValue
      *
      * @return FieldValue
      */
-    public function getField()
+    public function getField(): FieldValue
     {
         return $this->field;
-    }
-
-    /**
-     * Get current directive.
-     *
-     * @return DirectiveNode
-     */
-    public function getDirective()
-    {
-        return $this->directive;
     }
 
     /**
@@ -181,19 +114,47 @@ class ArgumentValue
      *
      * @return Type
      */
-    public function getType()
+    public function getType(): Type
     {
         return $this->type;
     }
 
     /**
-     * Get the current value.
+     * Get current argument type.
      *
-     * @return array
+     * @param Type $type
+     *
+     * @return ArgumentValue
      */
-    public function getValue()
+    public function setType(Type $type): ArgumentValue
     {
-        return $this->value;
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * Get the associated resolver function.
+     *
+     * @return \Closure|null
+     */
+    public function getResolver()
+    {
+        return $this->resolver;
+    }
+
+    /**
+     * Set a argument resolver.
+     *
+     * @param \Closure $resolver
+     *
+     * @return ArgumentValue
+     */
+    public function setResolver(\Closure $resolver): ArgumentValue
+    {
+        $this->resolver = $resolver;
+
+        return $this;
     }
 
     /**
@@ -201,8 +162,32 @@ class ArgumentValue
      *
      * @return string
      */
-    public function getArgName()
+    public function getArgName(): string
     {
         return $this->getArg()->name->value;
+    }
+
+    /**
+     * Get current argument.
+     *
+     * @return InputValueDefinitionNode
+     */
+    public function getArg(): InputValueDefinitionNode
+    {
+        return $this->arg;
+    }
+
+    /**
+     * Set current argument.
+     *
+     * @param InputValueDefinitionNode $arg
+     *
+     * @return ArgumentValue
+     */
+    public function setArg(InputValueDefinitionNode $arg): ArgumentValue
+    {
+        $this->arg = $arg;
+
+        return $this;
     }
 }

--- a/src/Schema/Values/NodeValue.php
+++ b/src/Schema/Values/NodeValue.php
@@ -5,7 +5,9 @@ namespace Nuwave\Lighthouse\Schema\Values;
 use GraphQL\Language\AST\DirectiveNode;
 use GraphQL\Language\AST\NamedTypeNode;
 use GraphQL\Language\AST\Node;
+use GraphQL\Language\AST\NodeList;
 use GraphQL\Type\Definition\Type;
+use Illuminate\Support\Collection;
 
 class NodeValue
 {
@@ -52,8 +54,9 @@ class NodeValue
      *
      * @param Node $node
      * @return NodeValue
+     * @deprecated Just use the constructor
      */
-    public static function init(Node $node)
+    public static function init(Node $node): NodeValue
     {
         return new static($node);
     }
@@ -63,9 +66,9 @@ class NodeValue
      *
      * @param Node $node
      *
-     * @return self
+     * @return NodeValue
      */
-    public function setNode(Node $node)
+    public function setNode(Node $node): NodeValue
     {
         $this->node = $node;
 
@@ -77,9 +80,9 @@ class NodeValue
      *
      * @param Type $type
      *
-     * @return self
+     * @return NodeValue
      */
-    public function setType(Type $type)
+    public function setType(Type $type): NodeValue
     {
         $this->type = $type;
 
@@ -90,18 +93,24 @@ class NodeValue
      * Set the current directive.
      *
      * @param DirectiveNode $directive
+     *
+     * @return NodeValue
      */
-    public function setDirective(DirectiveNode $directive)
+    public function setDirective(DirectiveNode $directive): NodeValue
     {
         $this->directive = $directive;
+
+        return $this;
     }
 
     /**
      * Set the current namespace.
      *
      * @param string $namespace
+     *
+     * @return NodeValue
      */
-    public function setNamespace($namespace)
+    public function setNamespace(string $namespace): NodeValue
     {
         $this->namespace = $namespace;
     }
@@ -111,7 +120,7 @@ class NodeValue
      *
      * @return Node
      */
-    public function getNode()
+    public function getNode(): Node
     {
         return $this->node;
     }
@@ -143,7 +152,7 @@ class NodeValue
      *
      * @return string
      */
-    public function getNamespace($class = null)
+    public function getNamespace(string $class = null): string
     {
         return $class ? $this->namespace.'\\'.$class : $this->namespace;
     }
@@ -153,7 +162,7 @@ class NodeValue
      *
      * @return string
      */
-    public function getNodeName()
+    public function getNodeName(): string
     {
         return data_get($this->getNode(), 'name.value');
     }
@@ -161,7 +170,7 @@ class NodeValue
     /**
      * Get fields for node.
      *
-     * @return array
+     * @return NodeList|array
      */
     public function getNodeFields()
     {
@@ -171,9 +180,9 @@ class NodeValue
     /**
      * Get a collection of the names of all interfaces the node has.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
-    public function getInterfaceNames()
+    public function getInterfaceNames(): Collection
     {
         return collect($this->node->interfaces)
             ->map(function (NamedTypeNode $interface) {
@@ -188,7 +197,7 @@ class NodeValue
      *
      * @return bool
      */
-    public function hasInterface($interfaceName)
+    public function hasInterface(string $interfaceName): bool
     {
         return $this->getInterfaceNames()
             ->containsStrict($interfaceName);

--- a/src/Support/Collection.php
+++ b/src/Support/Collection.php
@@ -13,7 +13,10 @@ use Nuwave\Lighthouse\Support\DataLoader\QueryBuilder;
  */
 class Collection
 {
-    public function fetch()
+    /**
+     * @return \Closure
+     */
+    public function fetch(): \Closure
     {
         return function ($relations = null) {
             if (count($this->items) > 0) {
@@ -28,7 +31,10 @@ class Collection
         };
     }
 
-    public function fetchCount()
+    /**
+     * @return \Closure
+     */
+    public function fetchCount(): \Closure
     {
         return function ($relations = null) {
             if (count($this->items) > 0) {
@@ -44,7 +50,10 @@ class Collection
         };
     }
 
-    public function fetchForPage()
+    /**
+     * @return \Closure
+     */
+    public function fetchForPage(): \Closure
     {
         return function ($perPage, $page, $relations) {
             if (count($this->items) > 0) {

--- a/src/Support/Contracts/ArgManipulator.php
+++ b/src/Support/Contracts/ArgManipulator.php
@@ -11,12 +11,17 @@ interface ArgManipulator extends Directive
 {
     /**
      * @param InputValueDefinitionNode $argDefinition
-     * @param FieldDefinitionNode      $fieldDefinition
+     * @param FieldDefinitionNode $fieldDefinition
      * @param ObjectTypeDefinitionNode $parentType
-     * @param DocumentAST              $current
-     * @param DocumentAST              $original
+     * @param DocumentAST $current
+     * @param DocumentAST $original
      *
      * @return DocumentAST
      */
-    public function manipulateSchema(InputValueDefinitionNode $argDefinition, FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current, DocumentAST $original);
+    public function manipulateSchema(
+        InputValueDefinitionNode $argDefinition,
+        FieldDefinitionNode $fieldDefinition,
+        ObjectTypeDefinitionNode $parentType,
+        DocumentAST $current,
+        DocumentAST $original): DocumentAST;
 }

--- a/src/Support/Contracts/ArgManipulator.php
+++ b/src/Support/Contracts/ArgManipulator.php
@@ -23,5 +23,6 @@ interface ArgManipulator extends Directive
         FieldDefinitionNode $fieldDefinition,
         ObjectTypeDefinitionNode $parentType,
         DocumentAST $current,
-        DocumentAST $original): DocumentAST;
+        DocumentAST $original
+    );
 }

--- a/src/Support/Contracts/FieldManipulator.php
+++ b/src/Support/Contracts/FieldManipulator.php
@@ -21,5 +21,5 @@ interface FieldManipulator extends Directive
         ObjectTypeDefinitionNode $parentType,
         DocumentAST $current,
         DocumentAST $original
-    );
+    ): DocumentAST;
 }

--- a/src/Support/Contracts/FieldManipulator.php
+++ b/src/Support/Contracts/FieldManipulator.php
@@ -21,5 +21,5 @@ interface FieldManipulator extends Directive
         ObjectTypeDefinitionNode $parentType,
         DocumentAST $current,
         DocumentAST $original
-    ): DocumentAST;
+    );
 }

--- a/src/Support/Contracts/NodeManipulator.php
+++ b/src/Support/Contracts/NodeManipulator.php
@@ -14,5 +14,5 @@ interface NodeManipulator extends Directive
      *
      * @return DocumentAST
      */
-    public function manipulateSchema(Node $node, DocumentAST $current, DocumentAST $original);
+    public function manipulateSchema(Node $node, DocumentAST $current, DocumentAST $original): DocumentAST;
 }

--- a/src/Support/Contracts/NodeManipulator.php
+++ b/src/Support/Contracts/NodeManipulator.php
@@ -14,5 +14,5 @@ interface NodeManipulator extends Directive
      *
      * @return DocumentAST
      */
-    public function manipulateSchema(Node $node, DocumentAST $current, DocumentAST $original): DocumentAST;
+    public function manipulateSchema(Node $node, DocumentAST $current, DocumentAST $original);
 }

--- a/src/Support/Contracts/NodeResolver.php
+++ b/src/Support/Contracts/NodeResolver.php
@@ -14,5 +14,5 @@ interface NodeResolver extends Directive
      *
      * @return Type
      */
-    public function resolveNode(NodeValue $value): Type;
+    public function resolveNode(NodeValue $value);
 }

--- a/src/Support/Contracts/NodeResolver.php
+++ b/src/Support/Contracts/NodeResolver.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Support\Contracts;
 
+use GraphQL\Type\Definition\Type;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
 
 interface NodeResolver extends Directive
@@ -11,7 +12,7 @@ interface NodeResolver extends Directive
      *
      * @param NodeValue $value
      *
-     * @return \GraphQL\Type\Definition\Type
+     * @return Type
      */
-    public function resolveNode(NodeValue $value);
+    public function resolveNode(NodeValue $value): Type;
 }

--- a/src/Support/Contracts/NodeResolver.php
+++ b/src/Support/Contracts/NodeResolver.php
@@ -14,5 +14,5 @@ interface NodeResolver extends Directive
      *
      * @return Type
      */
-    public function resolveNode(NodeValue $value);
+    public function resolveNode(NodeValue $value): Type;
 }

--- a/src/Support/DataLoader/QueryBuilder.php
+++ b/src/Support/DataLoader/QueryBuilder.php
@@ -24,7 +24,7 @@ class QueryBuilder
      *
      * @return array
      */
-    public function eagerLoadCount(Builder $builder, array $models)
+    public function eagerLoadCount(Builder $builder, array $models): array
     {
         $ids = [];
         $key = $models[0]->getKeyName();
@@ -59,7 +59,7 @@ class QueryBuilder
      *
      * @return array
      */
-    public function eagerLoadRelations(Builder $builder, array $models, $perPage = null, $page = null)
+    public function eagerLoadRelations(Builder $builder, array $models, int $perPage = null, int $page = null): array
     {
         foreach ($builder->getEagerLoads() as $name => $constraints) {
             if (false === strpos($name, '.')) {
@@ -88,7 +88,7 @@ class QueryBuilder
      *
      * @return array
      */
-    protected function loadRelation(Builder $builder, Closure $constraints, array $models, array $options)
+    protected function loadRelation(Builder $builder, Closure $constraints, array $models, array $options): array
     {
         $relation = $builder->getRelation($options['name']);
         $relationQueries = $this->getRelationQueries($builder, $models, $options['name'], $constraints);
@@ -150,7 +150,7 @@ class QueryBuilder
      *
      * @return Relation[]|Collection
      */
-    protected function getRelationQueries(Builder $builder, array $models, $name, Closure $constraints)
+    protected function getRelationQueries(Builder $builder, array $models, $name, Closure $constraints): Collection
     {
         return collect($models)->map(function ($model) use ($builder, $name, $constraints) {
             $relation = $builder->getRelation($name);
@@ -188,7 +188,7 @@ class QueryBuilder
      *
      * @return array
      */
-    protected function hydrate(Model $related, Relation $relation, Collection $results)
+    protected function hydrate(Model $related, Relation $relation, Collection $results): array
     {
         $models = $related->hydrate($results->all(), $related->getConnectionName())->all();
 
@@ -210,7 +210,7 @@ class QueryBuilder
      *
      * @return Collection
      */
-    protected function loadDefaultWith(Collection $collection)
+    protected function loadDefaultWith(Collection $collection): Collection
     {
         if ($collection->isNotEmpty()) {
             $model = $collection->first();

--- a/src/Support/Database/QueryFilter.php
+++ b/src/Support/Database/QueryFilter.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Support\Database;
 
+use Illuminate\Database\Query\Builder;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
 
 class QueryFilter
@@ -18,9 +19,9 @@ class QueryFilter
      *
      * @param ArgumentValue $value
      *
-     * @return self
+     * @return QueryFilter
      */
-    public static function getInstance(ArgumentValue $value)
+    public static function getInstance(ArgumentValue $value): QueryFilter
     {
         $handler = sprintf(
             'query.filter.%s.%s',
@@ -36,10 +37,10 @@ class QueryFilter
     /**
      * Build query with filter(s).
      *
-     * @param \Illuminate\Database\Query\Builder $query
-     * @param array                              $args
+     * @param Builder $query
+     * @param array   $args
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public static function build($query, array $args)
     {
@@ -53,10 +54,10 @@ class QueryFilter
     /**
      * Run query through filter.
      *
-     * @param \Illuminate\Database\Query\Builder $query
-     * @param array                              $args
+     * @param Builder $query
+     * @param array   $args
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function filter($query, array $args = [])
     {
@@ -82,7 +83,7 @@ class QueryFilter
      *
      * @return array
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return $this->filters;
     }
@@ -95,7 +96,7 @@ class QueryFilter
      *
      * @return array|null
      */
-    public function getFilter($key, $default = null)
+    public function getFilter($key, array $default = null)
     {
         return array_get($this->filters, $key, $default);
     }

--- a/src/Support/Facades/GraphQLFacade.php
+++ b/src/Support/Facades/GraphQLFacade.php
@@ -11,7 +11,7 @@ class GraphQLFacade extends Facade
      *
      * @return string
      */
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return 'graphql';
     }

--- a/src/Support/Http/Controllers/GraphQLController.php
+++ b/src/Support/Http/Controllers/GraphQLController.php
@@ -3,6 +3,7 @@
 namespace Nuwave\Lighthouse\Support\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Nuwave\Lighthouse\Schema\Context;
 
@@ -27,12 +28,12 @@ class GraphQLController extends Controller
      *
      * @param Request $request
      *
-     * @return \Illuminate\Http\Response
+     * @return array
      */
-    public function query(Request $request)
+    public function query(Request $request): array
     {
         $query = $request->input('query');
-        $variables = $request->input('variables');
+        $variables = $request->input('variables', []);
 
         if (is_string($variables)) {
             $variables = json_decode($variables, true);

--- a/src/Support/Http/GraphQL/Interfaces/NodeInterface.php
+++ b/src/Support/Http/GraphQL/Interfaces/NodeInterface.php
@@ -11,7 +11,7 @@ class NodeInterface
     /**
      * Resolve node value.
      *
-     * @param string $value
+     * @param mixed $value
      *
      * @return mixed
      */

--- a/src/Support/Http/GraphQL/Queries/NodeQuery.php
+++ b/src/Support/Http/GraphQL/Queries/NodeQuery.php
@@ -14,7 +14,8 @@ class NodeQuery
      * @param mixed $root
      * @param array $args
      *
-     * @return string
+     * @return mixed
+     * @throws \GraphQL\Error\Error
      */
     public function resolve($root, array $args)
     {

--- a/src/Support/Traits/AttachesNodeInterface.php
+++ b/src/Support/Traits/AttachesNodeInterface.php
@@ -17,7 +17,7 @@ trait AttachesNodeInterface
      *
      * @return DocumentAST
      */
-    protected function attachNodeInterfaceToObjectType(ObjectTypeDefinitionNode $objectType, DocumentAST $documentAST)
+    protected function attachNodeInterfaceToObjectType(ObjectTypeDefinitionNode $objectType, DocumentAST $documentAST): DocumentAST
     {
         $objectType->interfaces = array_merge(
             collect($objectType->interfaces)->toArray(),

--- a/src/Support/Traits/AttachesNodeInterface.php
+++ b/src/Support/Traits/AttachesNodeInterface.php
@@ -21,7 +21,7 @@ trait AttachesNodeInterface
     {
         $objectType->interfaces = array_merge(
             collect($objectType->interfaces)->toArray(),
-            [Parser::parseType('Node')]
+            [Parser::parseType('Node', ['noLocation' => true])]
         );
 
         $globalIdFieldName = config('lighthouse.global_id_field', '_id');

--- a/src/Support/Traits/CanFormatError.php
+++ b/src/Support/Traits/CanFormatError.php
@@ -19,7 +19,7 @@ trait CanFormatError
      *
      * @param \Closure $handler
      */
-    public function error($handler)
+    public function error(\Closure $handler)
     {
         $this->errorHandler = $handler;
     }
@@ -31,7 +31,7 @@ trait CanFormatError
      *
      * @return array
      */
-    public function formatError(Error $e)
+    public function formatError(Error $e): array
     {
         $error = ['message' => $e->getMessage()];
         $locations = $e->getLocations();

--- a/src/Support/Traits/CanParseTypes.php
+++ b/src/Support/Traits/CanParseTypes.php
@@ -22,7 +22,7 @@ trait CanParseTypes
      */
     public function parseSchema($schema)
     {
-        return Parser::parse($schema);
+        return Parser::parse($schema, ['noLocation' => true]);
     }
 
     /**

--- a/src/Support/Traits/CreatesPaginators.php
+++ b/src/Support/Traits/CreatesPaginators.php
@@ -50,7 +50,7 @@ trait CreatesPaginators
             })
             ->filter()
             ->each(function ($type) use ($value) {
-                graphql()->types()->type($type);
+                graphql()->types()->get($type);
 
                 if (ends_with($type->name, 'Connection')) {
                     $value->setType($type);
@@ -90,7 +90,7 @@ trait CreatesPaginators
             })
             ->filter()
             ->each(function ($type) use ($value) {
-                graphql()->types()->type($type);
+                graphql()->types()->register($type);
 
                 if (ends_with($type->name, 'Paginator')) {
                     $value->setType($type);

--- a/src/Support/Traits/HandlesGlobalId.php
+++ b/src/Support/Traits/HandlesGlobalId.php
@@ -12,7 +12,7 @@ trait HandlesGlobalId
      *
      * @return string
      */
-    public function encodeGlobalId($type, $id)
+    public function encodeGlobalId(string $type, $id): string
     {
         $resolver = config('lighthouse.globalId.encode');
 
@@ -30,7 +30,7 @@ trait HandlesGlobalId
      *
      * @return array
      */
-    public function decodeGlobalId($id)
+    public function decodeGlobalId(string $id): array
     {
         return explode(':', base64_decode($id));
     }
@@ -42,7 +42,7 @@ trait HandlesGlobalId
      *
      * @return string
      */
-    public function decodeRelayId($id)
+    public function decodeRelayId(string $id): string
     {
         $resolver = config('lighthouse.globalId.decodeId');
 
@@ -62,7 +62,7 @@ trait HandlesGlobalId
      *
      * @return string
      */
-    public function decodeRelayType($id)
+    public function decodeRelayType(string $id): string
     {
         $resolver = config('lighthouse.globalId.decodeType');
 
@@ -82,7 +82,7 @@ trait HandlesGlobalId
      *
      * @return int
      */
-    protected function decodeCursor(array $args)
+    protected function decodeCursor(array $args): int
     {
         $resolver = config('lighthouse.globalId.decodeCursor');
 
@@ -102,7 +102,7 @@ trait HandlesGlobalId
      *
      * @return int
      */
-    protected function getCursorId($cursor)
+    protected function getCursorId(string $cursor): int
     {
         $resolver = config('lighthouse.globalId.getCursorId');
 

--- a/src/Support/Traits/HandlesQueries.php
+++ b/src/Support/Traits/HandlesQueries.php
@@ -20,9 +20,9 @@ trait HandlesQueries
      *
      * @throws DirectiveException
      *
-     * @return mixed|string
+     * @return string
      */
-    public function getModelClass(FieldValue $value)
+    public function getModelClass(FieldValue $value): string
     {
         $model = $this->directiveArgValue(
             $this->fieldDirective($value->getField(), $this->name()),
@@ -54,7 +54,7 @@ trait HandlesQueries
      *
      * @return array
      */
-    protected function getScopes(FieldValue $value)
+    protected function getScopes(FieldValue $value): array
     {
         return $this->directiveArgValue(
             $this->fieldDirective($value->getField(), $this->name()),
@@ -63,13 +63,26 @@ trait HandlesQueries
         );
     }
 
-    public function applyFilters($query, $args)
+    /**
+     * @param $query
+     * @param array $args
+     *
+     * @return mixed
+     */
+    public function applyFilters($query, array $args)
     {
         return $query->when(isset($args['query.filter']), function ($q) use ($args) {
             return QueryFilter::build($q, $args);
         });
     }
 
+    /**
+     * @param $query
+     * @param $args
+     * @param FieldValue $value
+     *
+     * @return mixed
+     */
     public function applyScopes($query, $args, FieldValue $value)
     {
         foreach ($this->getScopes($value) as $scope) {

--- a/src/Support/Traits/HandlesQueryFilter.php
+++ b/src/Support/Traits/HandlesQueryFilter.php
@@ -15,7 +15,7 @@ trait HandlesQueryFilter
      *
      * @return ArgumentValue
      */
-    protected function injectFilter(ArgumentValue $argument, array $filter)
+    protected function injectFilter(ArgumentValue $argument, array $filter): ArgumentValue
     {
         $key = $this->queryFilterKey($argument);
         $query = QueryFilter::getInstance($argument);
@@ -40,7 +40,7 @@ trait HandlesQueryFilter
      *
      * @return ArgumentValue
      */
-    protected function injectKeyedFilter(ArgumentValue $argument, array $filter)
+    protected function injectKeyedFilter(ArgumentValue $argument, array $filter): ArgumentValue
     {
         $key = $this->queryFilterKey($argument);
         $query = QueryFilter::getInstance($argument);
@@ -67,7 +67,7 @@ trait HandlesQueryFilter
      *
      * @return string
      */
-    protected function queryFilterKey(ArgumentValue $argument)
+    protected function queryFilterKey(ArgumentValue $argument): string
     {
         return $this->directiveArgValue(
             'key',

--- a/src/Support/Traits/HandlesTypes.php
+++ b/src/Support/Traits/HandlesTypes.php
@@ -20,7 +20,7 @@ trait HandlesTypes
      *
      * @return bool
      */
-    protected function hasPackedTypes(array $types)
+    protected function hasPackedTypes(array $types): bool
     {
         return collect($types)->reduce(function ($packed, $type) {
             return $packed ?: $this->isTypePacked($type);
@@ -34,7 +34,7 @@ trait HandlesTypes
      *
      * @return bool
      */
-    protected function isTypePacked(Type $type)
+    protected function isTypePacked(Type $type): bool
     {
         if (is_callable(array_get($type->config, 'fields'))) {
             return true;
@@ -111,7 +111,7 @@ trait HandlesTypes
      *
      * @return Type
      */
-    protected function serializeableType(Type $type)
+    protected function serializeableType(Type $type): Type
     {
         $config = $type->config;
 
@@ -142,7 +142,7 @@ trait HandlesTypes
      *
      * @return Type
      */
-    protected function unpackFieldType($type, $wrappers = [])
+    protected function unpackFieldType(Type $type, array $wrappers = []): Type
     {
         if (method_exists($type, 'getWrappedType')) {
             return $this->unpackFieldType(

--- a/src/Support/Traits/IsRelayConnection.php
+++ b/src/Support/Traits/IsRelayConnection.php
@@ -2,6 +2,8 @@
 
 namespace Nuwave\Lighthouse\Support\Traits;
 
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+
 trait IsRelayConnection
 {
     use HandlesGlobalId;
@@ -12,9 +14,9 @@ trait IsRelayConnection
      * @param \Illuminate\Database\Eloquent\Builder $query
      * @param array $args
      *
-     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     * @return LengthAwarePaginator
      */
-    public function scopeRelayConnection($query, array $args)
+    public function scopeRelayConnection($query, array $args): LengthAwarePaginator
     {
         $first = data_get($args, 'first', 15);
         $page = data_get($args, 'page', 1);
@@ -30,9 +32,9 @@ trait IsRelayConnection
      * @param \Illuminate\Database\Eloquent\Builder $query
      * @param array $args
      *
-     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     * @return LengthAwarePaginator
      */
-    public function scopePaginatorConnection($query, array $args)
+    public function scopePaginatorConnection($query, array $args): LengthAwarePaginator
     {
         $first = data_get($args, 'count', 15);
         $page = data_get($args, 'page', 1);

--- a/src/Support/Validator/GraphQLValidator.php
+++ b/src/Support/Validator/GraphQLValidator.php
@@ -2,7 +2,9 @@
 
 namespace Nuwave\Lighthouse\Support\Validator;
 
+use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Validation\Validator;
+use Nuwave\Lighthouse\Schema\Context;
 
 class GraphQLValidator extends Validator
 {
@@ -19,9 +21,9 @@ class GraphQLValidator extends Validator
     /**
      * Get context object.
      *
-     * @return \Nuwave\Lighthouse\Schema\Context
+     * @return Context
      */
-    public function getContext()
+    public function getContext(): Context
     {
         return array_get($this->customAttributes, 'context');
     }
@@ -29,9 +31,9 @@ class GraphQLValidator extends Validator
     /**
      * Get field resolve info.
      *
-     * @return \GraphQL\Type\Definition\ResolveInfo
+     * @return ResolveInfo
      */
-    public function getResolveInfo()
+    public function getResolveInfo(): ResolveInfo
     {
         return array_get($this->customAttributes, 'resolveInfo');
     }

--- a/src/Support/Validator/Validator.php
+++ b/src/Support/Validator/Validator.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Nuwave\Lighthouse\Support\Validator;
 
 use GraphQL\Error\Error;
+use GraphQL\Type\Definition\ResolveInfo;
+use Nuwave\Lighthouse\Schema\Context;
 use Nuwave\Lighthouse\Support\Exceptions\ValidationError;
 
 abstract class Validator
@@ -24,7 +28,7 @@ abstract class Validator
     /**
      * GraphQL Context.
      *
-     * @var \Nuwave\Lighthouse\Schema\Context
+     * @var Context
      */
     protected $context;
 
@@ -40,23 +44,24 @@ abstract class Validator
      *
      * @param mixed                                $root
      * @param array                                $args
-     * @param \Nuwave\Lighthouse\Schema\Context    $context
-     * @param \GraphQL\Type\Definition\ResolveInfo $info
+     * @param Context    $context
+     * @param ResolveInfo $info
      */
-    public function __construct($root, array $args, $context, $info)
+    public function __construct($root, array $args, Context $context, ResolveInfo $info)
     {
         $this->root = $root;
         $this->args = $args;
         $this->context = $context;
         $this->info = $info;
     }
-
+    
     /**
      * Process validator for field.
      *
      * @return bool
+     * @throws Error
      */
-    public function validate()
+    public function validate(): bool
     {
         if (! $this->can()) {
             $this->handleUnauthorized();
@@ -83,7 +88,7 @@ abstract class Validator
      *
      * @return mixed
      */
-    protected function argument($key, $default = null)
+    protected function argument(string $key, $default = null)
     {
         return array_get($this->args, $key, $default);
     }
@@ -93,7 +98,7 @@ abstract class Validator
      *
      * @return array
      */
-    protected function args()
+    protected function args(): array
     {
         return $this->args;
     }
@@ -118,7 +123,7 @@ abstract class Validator
      *
      * @return array
      */
-    protected function messages()
+    protected function messages(): array
     {
         return [];
     }
@@ -128,13 +133,15 @@ abstract class Validator
      *
      * @return bool
      */
-    protected function can()
+    protected function can(): bool
     {
         return true;
     }
-
+    
     /**
      * Handle an unauthorized request.
+     *
+     * @throws Error
      */
     protected function handleUnauthorized()
     {
@@ -146,7 +153,7 @@ abstract class Validator
      *
      * @param \Illuminate\Contracts\Validation\Validator $validator
      */
-    protected function handleInvalid($validator)
+    protected function handleInvalid(\Illuminate\Contracts\Validation\Validator $validator)
     {
         throw with(new ValidationError('validation'))->setValidator($validator);
     }
@@ -156,5 +163,5 @@ abstract class Validator
      *
      * @return array
      */
-    abstract protected function rules();
+    abstract protected function rules(): array;
 }

--- a/src/Support/Validator/ValidatorFactory.php
+++ b/src/Support/Validator/ValidatorFactory.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Support\Validator;
 
+use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Validation\Validator;
 use GraphQL\Type\Definition\ResolveInfo;
 
@@ -10,21 +11,21 @@ class ValidatorFactory
     /**
      * Resolve a new Validator instance.
      *
-     * @param \Illuminate\Contracts\Translation\Translator $translator
-     * @param array                                        $data
-     * @param array                                        $rules
-     * @param array                                        $messages
-     * @param array                                        $customAttributes
+     * @param Translator $translator
+     * @param array      $data
+     * @param array      $rules
+     * @param array      $messages
+     * @param array      $customAttributes
      *
-     * @return \Illuminate\Validation\Validator
+     * @return Validator
      */
     public static function resolve(
-        $translator,
+        Translator $translator,
         array $data,
         array $rules,
         array $messages,
         array $customAttributes
-    ) {
+    ): Validator {
         $resolveInfo = array_get($customAttributes, 'resolveInfo');
 
         return $resolveInfo instanceof ResolveInfo
@@ -42,7 +43,7 @@ class ValidatorFactory
      *
      * @return bool
      */
-    public function requiredWithMutation($attribute, $value, $parameters, $validator)
+    public function requiredWithMutation(string $attribute, $value, array $parameters, GraphQLValidator $validator): bool
     {
         $info = $validator->getResolveInfo();
 

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -6,7 +6,7 @@ if (! function_exists('graphql')) {
      *
      * @return \Nuwave\Lighthouse\GraphQL
      */
-    function graphql()
+    function graphql(): \Nuwave\Lighthouse\GraphQL
     {
         return app('graphql');
     }
@@ -18,7 +18,7 @@ if (! function_exists('auth')) {
      *
      * @return \Illuminate\Auth\AuthManager
      */
-    function auth()
+    function auth(): \Illuminate\Auth\AuthManager
     {
         return app('auth');
     }
@@ -31,7 +31,7 @@ if (! function_exists('schema')) {
      * @return \Nuwave\Lighthouse\Schema\TypeRegistry
      * @deprecated Use graphql()->types() directly in the future
      */
-    function schema()
+    function schema(): \Nuwave\Lighthouse\Schema\TypeRegistry
     {
         return graphql()->types();
     }
@@ -44,7 +44,7 @@ if (! function_exists('directives')) {
      * @return \Nuwave\Lighthouse\Schema\DirectiveRegistry
      * @deprecated Use graphql()->directives() directly in the future
      */
-    function directives()
+    function directives(): \Nuwave\Lighthouse\Schema\DirectiveRegistry
     {
         return graphql()->directives();
     }
@@ -58,7 +58,7 @@ if (! function_exists('config_path')) {
      *
      * @return string
      */
-    function config_path($path = '')
+    function config_path(string $path = ''): string
     {
         return app()->basePath().'/config'.($path ? '/'.$path : $path);
     }
@@ -72,7 +72,7 @@ if (! function_exists('app_path')) {
      *
      * @return string
      */
-    function app_path($path = '')
+    function app_path(string $path = ''): string
     {
         return app()->basePath().'/app'.($path ? '/'.$path : $path);
     }
@@ -86,7 +86,7 @@ if (! function_exists('resolve')) {
      *
      * @return mixed
      */
-    function resolve($name)
+    function resolve(string $name)
     {
         return app($name);
     }

--- a/tests/Integration/Schema/NodeTest.php
+++ b/tests/Integration/Schema/NodeTest.php
@@ -112,7 +112,7 @@ class NodeTest extends DBTestCase
     public function resolveNodeType($value)
     {
         if (is_array($value) && isset($value['name'])) {
-            return graphql()->types()->instance('User');
+            return graphql()->types()->get('User');
         }
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use GraphQL\Language\AST\DocumentNode;
 use GraphQL\Type\Schema;
 use GraphQL\Language\Parser;
 use GraphQL\Executor\ExecutionResult;
@@ -31,7 +32,7 @@ class TestCase extends BaseTestCase
      *
      * @return array
      */
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
             LighthouseServiceProvider::class,
@@ -84,7 +85,7 @@ class TestCase extends BaseTestCase
      *
      * @return \GraphQL\Language\AST\DocumentNode
      */
-    protected function parse($schema)
+    protected function parse(string $schema): DocumentNode
     {
         return Parser::parse($schema);
     }
@@ -96,11 +97,10 @@ class TestCase extends BaseTestCase
      * @param string $query
      * @param bool   $lighthouse
      * @param array  $variables
-     * @param bool   $format
      *
      * @return \GraphQL\Executor\ExecutionResult
      */
-    protected function execute($schema, $query, $lighthouse = false, $variables = [], $format = false): ExecutionResult
+    protected function execute(string $schema, string $query, $lighthouse = false, $variables = []): ExecutionResult
     {
         if ($lighthouse) {
             $addDefaultSchema = file_get_contents(realpath(__DIR__.'/../assets/schema.graphql'));
@@ -120,9 +120,9 @@ class TestCase extends BaseTestCase
      * @param bool   $lighthouse
      * @param array  $variables
      *
-     * @return \GraphQL\Executor\ExecutionResult
+     * @return array
      */
-    protected function executeAndFormat($schema, $query, $lighthouse = false, $variables = [])
+    protected function executeAndFormat(string $schema, string $query, bool $lighthouse = false, array $variables = []): array
     {
         $result = $this->execute($schema, $query, $lighthouse, $variables);
 
@@ -154,7 +154,7 @@ class TestCase extends BaseTestCase
      *
      * @return \GraphQL\Type\Schema
      */
-    protected function buildSchemaWithDefaultQuery($schema): Schema
+    protected function buildSchemaWithDefaultQuery(string $schema): Schema
     {
         return $this->buildSchemaFromString($schema.'
             type Query {

--- a/tests/Unit/Schema/Directives/Nodes/UnionTest.php
+++ b/tests/Unit/Schema/Directives/Nodes/UnionTest.php
@@ -35,7 +35,7 @@ class UnionTest extends TestCase
     {
         $type = isset($value['id']) ? 'User' : 'Employee';
 
-        return graphql()->types()->instance($type);
+        return graphql()->types()->get($type);
     }
 
     protected function schema()

--- a/tests/Unit/Support/Validator/ValidatorTest.php
+++ b/tests/Unit/Support/Validator/ValidatorTest.php
@@ -2,7 +2,10 @@
 
 namespace Tests\Unit\Support\Validator;
 
+use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Http\Request;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
+use Nuwave\Lighthouse\Schema\Context;
 use Nuwave\Lighthouse\Schema\Directives\Args\ValidateDirective;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
@@ -19,7 +22,7 @@ class ValidatorTest extends TestCase
     {
         $this->app->bind('foo.validator', function ($app, $params) {
             return new class($params['root'], $params['args'], $params['context'], $params['info']) extends Validator {
-                protected function rules()
+                protected function rules(): array
                 {
                     return [
                         'foo' => ['min:5'],
@@ -46,7 +49,9 @@ class ValidatorTest extends TestCase
         $this->expectException(ValidationError::class);
         $fieldValue->getResolver()(
             null,
-            ['bar' => 'foo', 'baz' => 1]
+            ['bar' => 'foo', 'baz' => 1],
+            new Context(new Request(), null),
+            new ResolveInfo([])
         );
     }
 }


### PR DESCRIPTION
Because we can depend on PHP 7.0, this enables us to use those features.
I added type hints where they could safely be added - some places require
"mixed" to be set.

In this process, i found & fixed a few minor bugs and also uncovered quite
a lot of cases where the PHPDoc was actually lying. Static type checking
enabled me to find those cases quickly and fix the underlying issues.