### PR TITLE
Parse without location info and serialize effectively

### DIFF
--- a/src/Schema/Directives/Fields/PaginationManipulator.php
+++ b/src/Schema/Directives/Fields/PaginationManipulator.php
@@ -5,7 +5,6 @@ namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
-use GraphQL\Language\Parser;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
@@ -83,7 +82,7 @@ abstract class PaginationManipulator extends BaseDirective
         ]);
 
         $fieldDefinition->arguments = ASTHelper::mergeNodeList($fieldDefinition->arguments, $connectionArguments);
-        $fieldDefinition->type = Parser::parseType($connectionTypeName);
+        $fieldDefinition->type = PartialParser::namedType($connectionTypeName);
         $parentType->fields = ASTHelper::mergeNodeList($parentType->fields, [$fieldDefinition]);
 
         $current->setDefinition($connectionType);
@@ -124,7 +123,7 @@ abstract class PaginationManipulator extends BaseDirective
         ]);
 
         $fieldDefinition->arguments = ASTHelper::mergeNodeList($fieldDefinition->arguments, $paginationArguments);
-        $fieldDefinition->type = Parser::parseType($paginatorTypeName);
+        $fieldDefinition->type = PartialParser::namedType($paginatorTypeName);
         $parentType->fields = ASTHelper::mergeNodeList($parentType->fields, [$fieldDefinition]);
 
         $current->setDefinition($paginatorType);

--- a/src/Support/Traits/AttachesNodeInterface.php
+++ b/src/Support/Traits/AttachesNodeInterface.php
@@ -21,7 +21,7 @@ trait AttachesNodeInterface
     {
         $objectType->interfaces = array_merge(
             collect($objectType->interfaces)->toArray(),
-            [Parser::parseType('Node')]
+            [Parser::parseType('Node', ['noLocation' => true])]
         );
 
         $globalIdFieldName = config('lighthouse.global_id_field', '_id');

--- a/src/Support/Traits/CanParseTypes.php
+++ b/src/Support/Traits/CanParseTypes.php
@@ -22,7 +22,7 @@ trait CanParseTypes
      */
     public function parseSchema($schema)
     {
-        return Parser::parse($schema);
+        return Parser::parse($schema, ['noLocation' => true]);
     }
 
     /**


### PR DESCRIPTION
**PR Type**

Performance optimization

**Changes**

The way the DocumentAST was serialized before was way to costly, as the class
structure of the AST was completely serialized. To improve efficiency,
the location information is left out during parsing and the AST is stored
as an Array.

This is the preferred approach for schema caching as described in http://webonyx.github.io/graphql-php/type-system/type-language/#performance-considerations