### PR TITLE
Feature: Middleware Pipeline

### DIFF
--- a/src/Schema/Directives/Args/BcryptDirective.php
+++ b/src/Schema/Directives/Args/BcryptDirective.php
@@ -2,8 +2,9 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
 
 class BcryptDirective extends BaseDirective implements ArgMiddleware
@@ -22,13 +23,14 @@ class BcryptDirective extends BaseDirective implements ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $value
+     * @param Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $value)
+    public function handleArgument(ArgumentValue $value, Closure $next)
     {
-        return $value->setResolver(function ($password) {
+        return $next($value->setResolver(function ($password) {
             return bcrypt($password);
-        });
+        }));
     }
 }

--- a/src/Schema/Directives/Args/EqualsFilterDirective.php
+++ b/src/Schema/Directives/Args/EqualsFilterDirective.php
@@ -2,8 +2,9 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
 use Nuwave\Lighthouse\Support\Traits\HandlesQueryFilter;
 
@@ -25,17 +26,19 @@ class EqualsFilterDirective extends BaseDirective implements ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $argument
+     * @param Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument)
+    public function handleArgument(ArgumentValue $argument, Closure $next)
     {
         $arg = $argument->getArgName();
-
-        return $this->injectFilter($argument, [
+        $argument = $this->injectFilter($argument, [
             'resolve' => function ($query, $key, array $args) use ($arg) {
                 return $query->where($key, array_get($args, $arg));
             },
         ]);
+
+        return $next($argument);
     }
 }

--- a/src/Schema/Directives/Args/InFilterDirective.php
+++ b/src/Schema/Directives/Args/InFilterDirective.php
@@ -2,8 +2,9 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
 use Nuwave\Lighthouse\Support\Traits\HandlesQueryFilter;
 
@@ -25,17 +26,19 @@ class InFilterDirective extends BaseDirective implements ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $argument
+     * @param Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument)
+    public function handleArgument(ArgumentValue $argument, Closure $next)
     {
         $arg = $argument->getArgName();
-
-        return $this->injectFilter($argument, [
+        $argument = $this->injectFilter($argument, [
             'resolve' => function ($query, $key, array $args) use ($arg) {
                 return $query->whereIn($key, array_get($args, $arg));
             },
         ]);
+
+        return $next($argument);
     }
 }

--- a/src/Schema/Directives/Args/NotEqualsFilterDirective.php
+++ b/src/Schema/Directives/Args/NotEqualsFilterDirective.php
@@ -2,8 +2,9 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
 use Nuwave\Lighthouse\Support\Traits\HandlesQueryFilter;
 
@@ -25,17 +26,19 @@ class NotEqualsFilterDirective extends BaseDirective implements ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $argument
+     * @param Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument)
+    public function handleArgument(ArgumentValue $argument, Closure $next)
     {
         $arg = $argument->getArgName();
-
-        return $this->injectFilter($argument, [
+        $argument = $this->injectFilter($argument, [
             'resolve' => function ($query, $key, array $args) use ($arg) {
                 return $query->where($key, '<>', array_get($args, $arg));
             },
         ]);
+
+        return $next($argument);
     }
 }

--- a/src/Schema/Directives/Args/NotInFilterDirective.php
+++ b/src/Schema/Directives/Args/NotInFilterDirective.php
@@ -2,8 +2,9 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
 use Nuwave\Lighthouse\Support\Traits\HandlesQueryFilter;
 
@@ -25,17 +26,20 @@ class NotInFilterDirective extends BaseDirective implements ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $argument
+     * @param Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument)
+    public function handleArgument(ArgumentValue $argument, Closure $next)
     {
         $arg = $argument->getArgName();
 
-        return $this->injectFilter($argument, [
+        $argument = $this->injectFilter($argument, [
             'resolve' => function ($query, $key, array $args) use ($arg) {
                 return $query->whereNotIn($key, array_get($args, $arg));
             },
         ]);
+
+        return $next($argument);
     }
 }

--- a/src/Schema/Directives/Args/RulesDirective.php
+++ b/src/Schema/Directives/Args/RulesDirective.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
+use Closure;
 use GraphQL\Language\AST\ArgumentNode;
 use GraphQL\Language\AST\DirectiveNode;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
@@ -25,10 +26,11 @@ class RulesDirective extends BaseDirective implements Directive, ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $value
+     * @param Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $value)
+    public function handleArgument(ArgumentValue $value, Closure $next)
     {
         if (in_array($value->getField()->getNodeName(), ['Query', 'Mutation'])) {
             return $value;
@@ -47,6 +49,6 @@ class RulesDirective extends BaseDirective implements Directive, ArgMiddleware
                 })->toArray()
         );
 
-        return $value->setValue($current);
+        return $next($value->setValue($current));
     }
 }

--- a/src/Schema/Directives/Args/ScoutDirective.php
+++ b/src/Schema/Directives/Args/ScoutDirective.php
@@ -2,9 +2,10 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
+use Closure;
 use Illuminate\Database\Eloquent\Builder;
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
 use Nuwave\Lighthouse\Support\Traits\HandlesQueryFilter;
 
@@ -26,17 +27,18 @@ class ScoutDirective extends BaseDirective implements ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $argument
+     * @param Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument)
+    public function handleArgument(ArgumentValue $argument, Closure $next)
     {
         $arg = $argument->getArgName();
 
         // Adds within method to specify custom index.
         $within = $this->directiveArgValue('within');
 
-        return $this->injectFilter(
+        $argument = $this->injectFilter(
             $argument, [
                 'resolve' => function (Builder $query, $key, array $args) use ($arg, $within) {
                     $class = get_class($query->getModel());
@@ -51,5 +53,7 @@ class ScoutDirective extends BaseDirective implements ArgMiddleware
                 },
             ]
         );
+
+        return $next($argument);
     }
 }

--- a/src/Schema/Directives/Args/WhereBetweenFilterDirective.php
+++ b/src/Schema/Directives/Args/WhereBetweenFilterDirective.php
@@ -2,8 +2,9 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
 use Nuwave\Lighthouse\Support\Traits\HandlesQueryFilter;
 
@@ -25,12 +26,13 @@ class WhereBetweenFilterDirective extends BaseDirective implements ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $argument
+     * @param Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument)
+    public function handleArgument(ArgumentValue $argument, Closure $next)
     {
-        return $this->injectKeyedFilter($argument, [
+        $argument = $this->injectKeyedFilter($argument, [
             'resolve' => function ($query, $key, array $args) {
                 $between = collect($args['resolveArgs'])->map(function ($arg) use ($args) {
                     return array_get($args, $arg);
@@ -39,5 +41,7 @@ class WhereBetweenFilterDirective extends BaseDirective implements ArgMiddleware
                 return $query->whereBetween($key, $between);
             },
         ]);
+
+        return $next($argument);
     }
 }

--- a/src/Schema/Directives/Args/WhereFilterDirective.php
+++ b/src/Schema/Directives/Args/WhereFilterDirective.php
@@ -2,8 +2,9 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
 use Nuwave\Lighthouse\Support\Traits\HandlesQueryFilter;
 
@@ -25,17 +26,18 @@ class WhereFilterDirective extends BaseDirective implements ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $argument
+     * @param Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument)
+    public function handleArgument(ArgumentValue $argument, Closure $next)
     {
         $arg = $argument->getArgName();
 
         $operator = $this->directiveArgValue('operator', '=');
         $clause = $this->directiveArgValue('clause');
 
-        return $this->injectFilter($argument, [
+        $argument = $this->injectFilter($argument, [
             'resolve' => function ($query, $key, array $args) use ($arg, $operator, $clause) {
                 $value = array_get($args, $arg);
 
@@ -44,5 +46,7 @@ class WhereFilterDirective extends BaseDirective implements ArgMiddleware
                     : $query->where($key, $operator, $value);
             },
         ]);
+
+        return $next($argument);
     }
 }

--- a/src/Schema/Directives/Args/WhereNotBetweenFilterDirective.php
+++ b/src/Schema/Directives/Args/WhereNotBetweenFilterDirective.php
@@ -2,8 +2,9 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
 use Nuwave\Lighthouse\Support\Traits\HandlesQueryFilter;
 
@@ -25,12 +26,13 @@ class WhereNotBetweenFilterDirective extends BaseDirective implements ArgMiddlew
      * Resolve the field directive.
      *
      * @param ArgumentValue $argument
+     * @param Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument)
+    public function handleArgument(ArgumentValue $argument, Closure $next)
     {
-        return $this->injectKeyedFilter($argument, [
+        $argument = $this->injectKeyedFilter($argument, [
             'resolve' => function ($query, $key, array $args) {
                 $between = collect($args['resolveArgs'])->map(function ($arg) use ($args) {
                     return array_get($args, $arg);
@@ -39,5 +41,7 @@ class WhereNotBetweenFilterDirective extends BaseDirective implements ArgMiddlew
                 return $query->whereNotBetween($key, $between);
             },
         ]);
+
+        return $next($argument);
     }
 }

--- a/src/Schema/Directives/Fields/CanDirective.php
+++ b/src/Schema/Directives/Fields/CanDirective.php
@@ -2,9 +2,10 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
+use Closure;
 use GraphQL\Error\Error;
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
 
 class CanDirective extends BaseDirective implements FieldMiddleware
@@ -23,34 +24,35 @@ class CanDirective extends BaseDirective implements FieldMiddleware
      * Resolve the field directive.
      *
      * @param FieldValue $value
+     * @param Closure    $next
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value)
+    public function handleField(FieldValue $value, Closure $next)
     {
         $policies = $this->directiveArgValue('if');
         $model = $this->directiveArgValue('model');
         $resolver = $value->getResolver();
 
-        return $value->setResolver(
+        return $next($value->setResolver(
             function () use ($policies, $resolver, $model) {
                 $args = func_get_args();
                 $model = $model ?: get_class($args[0]);
 
                 $can = collect($policies)->reduce(function ($allowed, $policy) use ($model) {
-                    if (!app('auth')->user()->can($policy, $model)) {
+                    if (! app('auth')->user()->can($policy, $model)) {
                         return false;
                     }
 
                     return $allowed;
                 }, true);
 
-                if (!$can) {
+                if (! $can) {
                     throw new Error('Not authorized to access resource');
                 }
 
                 return call_user_func_array($resolver, $args);
             }
-        );
+        ));
     }
 }

--- a/src/Schema/Directives/Fields/ComplexityDirective.php
+++ b/src/Schema/Directives/Fields/ComplexityDirective.php
@@ -2,8 +2,9 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Closure;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
 use Nuwave\Lighthouse\Support\Exceptions\DirectiveException;
 
@@ -23,30 +24,31 @@ class ComplexityDirective extends BaseDirective implements FieldMiddleware
      * Resolve the field directive.
      *
      * @param FieldValue $value
+     * @param Closure    $next
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value)
+    public function handleField(FieldValue $value, Closure $next)
     {
         $baseClassName = $this->directiveArgValue('class') ?? str_before($this->directiveArgValue('resolver'), '@');
 
         if (empty($baseClassName)) {
-            return $value->setComplexity(function ($childrenComplexity, $args) {
+            return $next($value->setComplexity(function ($childrenComplexity, $args) {
                 $complexity = array_get($args, 'first', array_get($args, 'count', 1));
 
                 return $childrenComplexity * $complexity;
-            });
+            }));
         }
 
         $resolverClass = $this->namespaceClassName($baseClassName);
         $resolverMethod = $this->directiveArgValue('method') ?? str_after($this->directiveArgValue('resolver'), '@');
 
-        if (!method_exists($resolverClass, $resolverMethod)) {
+        if (! method_exists($resolverClass, $resolverMethod)) {
             throw new DirectiveException("Method '{$resolverMethod}' does not exist on class '{$resolverClass}'");
         }
 
-        return $value->setComplexity(function () use ($resolverClass, $resolverMethod) {
+        return $next($value->setComplexity(function () use ($resolverClass, $resolverMethod) {
             return call_user_func_array([app($resolverClass), $resolverMethod], func_get_args());
-        });
+        }));
     }
 }

--- a/src/Schema/Directives/Fields/GlobalIdDirective.php
+++ b/src/Schema/Directives/Fields/GlobalIdDirective.php
@@ -2,10 +2,11 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Closure;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
 use Nuwave\Lighthouse\Support\Traits\HandlesGlobalId;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
 
 class GlobalIdDirective extends BaseDirective implements FieldMiddleware
 {
@@ -25,22 +26,23 @@ class GlobalIdDirective extends BaseDirective implements FieldMiddleware
      * Resolve the field directive.
      *
      * @param FieldValue $value
+     * @param Closure    $next
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value)
+    public function handleField(FieldValue $value, Closure $next)
     {
         $type = $value->getNodeName();
         $resolver = $value->getResolver();
         $process = $this->directiveArgValue('process', 'encode');
 
-        return $value->setResolver(function () use ($resolver, $process, $type) {
+        return $next($value->setResolver(function () use ($resolver, $process, $type) {
             $args = func_get_args();
             $value = call_user_func_array($resolver, $args);
 
             return 'encode' === $process
             ? $this->encodeGlobalId($type, $value)
             : $this->decodeRelayId($value);
-        });
+        }));
     }
 }

--- a/src/Schema/Directives/Fields/MiddlewareDirective.php
+++ b/src/Schema/Directives/Fields/MiddlewareDirective.php
@@ -2,8 +2,9 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Closure;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
 
 class MiddlewareDirective extends BaseDirective implements FieldMiddleware
@@ -22,10 +23,11 @@ class MiddlewareDirective extends BaseDirective implements FieldMiddleware
      * Resolve the field directive.
      *
      * @param FieldValue $value
+     * @param Closure    $next
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value)
+    public function handleField(FieldValue $value, Closure $next)
     {
         $checks = $this->getChecks($value);
 
@@ -43,7 +45,7 @@ class MiddlewareDirective extends BaseDirective implements FieldMiddleware
             }
         }
 
-        return $value;
+        return $next($value);
     }
 
     /**
@@ -55,13 +57,13 @@ class MiddlewareDirective extends BaseDirective implements FieldMiddleware
      */
     protected function getChecks(FieldValue $value)
     {
-        if (!in_array($value->getNodeName(), ['Mutation', 'Query'])) {
+        if (! in_array($value->getNodeName(), ['Mutation', 'Query'])) {
             return null;
         }
 
         $checks = $this->directiveArgValue('checks');
 
-        if (!$checks) {
+        if (! $checks) {
             return null;
         }
 

--- a/src/Schema/Directives/Nodes/ModelDirective.php
+++ b/src/Schema/Directives/Nodes/ModelDirective.php
@@ -2,13 +2,13 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Nodes;
 
-
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Closure;
 use GraphQL\Language\AST\Node;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
-use Nuwave\Lighthouse\Support\Contracts\NodeManipulator;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\NodeMiddleware;
+use Nuwave\Lighthouse\Support\Contracts\NodeManipulator;
 use Nuwave\Lighthouse\Support\Traits\AttachesNodeInterface;
 
 class ModelDirective extends BaseDirective implements NodeMiddleware, NodeManipulator
@@ -29,10 +29,11 @@ class ModelDirective extends BaseDirective implements NodeMiddleware, NodeManipu
      * Handle type construction.
      *
      * @param NodeValue $value
+     * @param Closure   $next
      *
      * @return NodeValue
      */
-    public function handleNode(NodeValue $value)
+    public function handleNode(NodeValue $value, Closure $next)
     {
         $modelClassName = $this->getModelClassName($value);
 
@@ -40,7 +41,7 @@ class ModelDirective extends BaseDirective implements NodeMiddleware, NodeManipu
             $value->getNodeName(), $modelClassName
         );
 
-        return $value;
+        return $next($value);
     }
 
     /**

--- a/src/Schema/Directives/Nodes/NodeDirective.php
+++ b/src/Schema/Directives/Nodes/NodeDirective.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Nodes;
 
+use Closure;
 use GraphQL\Language\AST\Node;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
@@ -28,10 +29,11 @@ class NodeDirective extends BaseDirective implements NodeMiddleware, NodeManipul
      * Handle type construction.
      *
      * @param NodeValue $value
+     * @param Closure   $next
      *
      * @return NodeValue
      */
-    public function handleNode(NodeValue $value)
+    public function handleNode(NodeValue $value, Closure $next)
     {
         graphql()->nodes()->node(
             $value->getNodeName(),
@@ -41,7 +43,7 @@ class NodeDirective extends BaseDirective implements NodeMiddleware, NodeManipul
             $this->getResolver($value, 'typeResolver')
         );
 
-        return $value;
+        return $next($value);
     }
 
     /**

--- a/src/Schema/Directives/Nodes/SecurityDirective.php
+++ b/src/Schema/Directives/Nodes/SecurityDirective.php
@@ -2,12 +2,13 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Nodes;
 
-use GraphQL\Validator\DocumentValidator;
-use GraphQL\Validator\Rules\DisableIntrospection;
-use GraphQL\Validator\Rules\QueryComplexity;
+use Closure;
 use GraphQL\Validator\Rules\QueryDepth;
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use GraphQL\Validator\DocumentValidator;
+use GraphQL\Validator\Rules\QueryComplexity;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
+use GraphQL\Validator\Rules\DisableIntrospection;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\NodeMiddleware;
 use Nuwave\Lighthouse\Support\Exceptions\DirectiveException;
 
@@ -27,10 +28,11 @@ class SecurityDirective extends BaseDirective implements NodeMiddleware
      * Handle node value.
      *
      * @param NodeValue $value
+     * @param Closure   $next
      *
      * @return NodeValue
      */
-    public function handleNode(NodeValue $value)
+    public function handleNode(NodeValue $value, Closure $next)
     {
         if ('Query' !== $value->getNodeName()) {
             $message = sprintf(
@@ -46,7 +48,7 @@ class SecurityDirective extends BaseDirective implements NodeMiddleware
         $this->queryComplexity($value);
         $this->queryIntrospection($value);
 
-        return $value;
+        return $next($value);
     }
 
     /**

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -3,6 +3,7 @@
 namespace Nuwave\Lighthouse\Schema\Factories;
 
 use Illuminate\Support\Collection;
+use Nuwave\Lighthouse\Support\Pipeline;
 use GraphQL\Type\Definition\ResolveInfo;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use GraphQL\Language\AST\InputValueDefinitionNode;
@@ -38,11 +39,13 @@ class FieldFactory
 
         $fieldValue->setResolver($resolverWithValidation);
 
-        $resolverWithMiddleware = graphql()->directives()->fieldMiddleware($fieldValue->getField())
-            ->reduce(function (FieldValue $fieldValue, FieldMiddleware $middleware) {
-                return $middleware->handleField($fieldValue);
-            }, $fieldValue)
-            ->getResolver();
+        $resolverWithMiddleware = app(Pipeline::class)
+            ->send($fieldValue)
+            ->through(directives()->fieldMiddleware($fieldValue->getField()))
+            ->via('handleField')
+            ->then(function (FieldValue $fieldValue) {
+                return $fieldValue;
+            })->getResolver();
 
         // To see what is allowed here, look at the validation rules in
         // GraphQL\Type\Definition\FieldDefinition::getDefinition()

--- a/src/Schema/Factories/NodeFactory.php
+++ b/src/Schema/Factories/NodeFactory.php
@@ -2,27 +2,28 @@
 
 namespace Nuwave\Lighthouse\Schema\Factories;
 
-use GraphQL\Language\AST\EnumTypeDefinitionNode;
-use GraphQL\Language\AST\InputObjectTypeDefinitionNode;
-use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
-use GraphQL\Language\AST\ObjectTypeDefinitionNode;
-use GraphQL\Language\AST\ScalarTypeDefinitionNode;
-use GraphQL\Language\AST\TypeExtensionDefinitionNode as Extension;
-use GraphQL\Type\Definition\Directive;
-use GraphQL\Type\Definition\FieldArgument;
-use GraphQL\Language\AST\UnionTypeDefinitionNode;
+use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\EnumType;
-use GraphQL\Type\Definition\InputObjectType;
-use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ScalarType;
-use GraphQL\Type\Definition\Type;
-use Nuwave\Lighthouse\Schema\Directives\Nodes\EnumDirective;
-use Nuwave\Lighthouse\Schema\Resolvers\NodeResolver;
-use Nuwave\Lighthouse\Schema\Resolvers\ScalarResolver;
+use Nuwave\Lighthouse\Support\Pipeline;
+use GraphQL\Type\Definition\FieldArgument;
+use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\InputObjectType;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
-use Nuwave\Lighthouse\Support\Contracts\NodeMiddleware;
+use GraphQL\Language\AST\EnumTypeDefinitionNode;
+use GraphQL\Language\AST\UnionTypeDefinitionNode;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use GraphQL\Language\AST\ScalarTypeDefinitionNode;
 use Nuwave\Lighthouse\Support\Traits\HandlesTypes;
+use Nuwave\Lighthouse\Schema\Resolvers\NodeResolver;
+use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
+use Nuwave\Lighthouse\Schema\Resolvers\ScalarResolver;
+use GraphQL\Language\AST\InputObjectTypeDefinitionNode;
+use Nuwave\Lighthouse\Support\Contracts\NodeMiddleware;
+use Nuwave\Lighthouse\Schema\Directives\Nodes\EnumDirective;
+use GraphQL\Language\AST\TypeExtensionDefinitionNode as Extension;
 
 class NodeFactory
 {
@@ -33,8 +34,9 @@ class NodeFactory
      *
      * @param NodeValue $value
      *
-     * @return Type
      * @throws \Exception
+     *
+     * @return Type
      */
     public function handle(NodeValue $value)
     {
@@ -80,6 +82,7 @@ class NodeFactory
      * @param NodeValue $value
      *
      * @throws \Exception
+     *
      * @return Type
      */
     protected function resolveType(NodeValue $value)
@@ -193,9 +196,12 @@ class NodeFactory
      */
     protected function applyMiddleware(NodeValue $value)
     {
-        return graphql()->directives()->nodeMiddleware($value->getNode())
-            ->reduce(function (NodeValue $value, NodeMiddleware $middleware) {
-                return $middleware->handleNode($value);
-            }, $value);
+        return app(Pipeline::class)
+            ->send($value)
+            ->through(directives()->nodeMiddleware($value->getNode()))
+            ->via('handleNode')
+            ->then(function (NodeValue $value) {
+                return $value;
+            });
     }
 }

--- a/src/Support/Contracts/ArgMiddleware.php
+++ b/src/Support/Contracts/ArgMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Support\Contracts;
 
+use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
 
 interface ArgMiddleware extends Directive
@@ -10,8 +11,9 @@ interface ArgMiddleware extends Directive
      * Apply transformations on the ArgumentValue.
      *
      * @param ArgumentValue $argument
+     * @param Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument);
+    public function handleArgument(ArgumentValue $argument, Closure $next);
 }

--- a/src/Support/Contracts/FieldMiddleware.php
+++ b/src/Support/Contracts/FieldMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Support\Contracts;
 
+use Closure;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 
 interface FieldMiddleware extends Directive
@@ -10,8 +11,9 @@ interface FieldMiddleware extends Directive
      * Resolve the field directive.
      *
      * @param FieldValue $value
+     * @param Closure    $next
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value);
+    public function handleField(FieldValue $value, Closure $next);
 }

--- a/src/Support/Contracts/NodeMiddleware.php
+++ b/src/Support/Contracts/NodeMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Support\Contracts;
 
+use Closure;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
 
 interface NodeMiddleware extends Directive
@@ -10,8 +11,9 @@ interface NodeMiddleware extends Directive
      * Handle node value.
      *
      * @param NodeValue $value
+     * @param Closure   $next
      *
      * @return NodeValue
      */
-    public function handleNode(NodeValue $value);
+    public function handleNode(NodeValue $value, Closure $next);
 }

--- a/src/Support/Pipeline.php
+++ b/src/Support/Pipeline.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Nuwave\Lighthouse\Support;
+
+use Closure;
+use Illuminate\Support\Collection;
+use Illuminate\Pipeline\Pipeline as BasePipeline;
+
+class Pipeline extends BasePipeline
+{
+    protected $always = null;
+
+    /**
+     * Set the array of pipes.
+     *
+     * @param Collection|array $pipes
+     *
+     * @return self
+     */
+    public function through($pipes)
+    {
+        if ($pipes instanceof \Illuminate\Support\Collection) {
+            $pipes = $pipes->toArray();
+        }
+
+        return parent::through($pipes);
+    }
+
+    /**
+     * Get a Closure that represents a slice of the application onion.
+     *
+     * @return Closure
+     */
+    protected function carry()
+    {
+        return function ($stack, $pipe) {
+            return function ($passable) use ($stack, $pipe) {
+                if (! is_null($this->always)) {
+                    $passable = ($this->always)($passable, $pipe);
+                }
+                $slice = parent::carry();
+
+                $callable = $slice($stack, $pipe);
+
+                return $callable($passable);
+            };
+        };
+    }
+
+    /**
+     * Set always variable.
+     *
+     * @param Closure $always
+     *
+     * @return self
+     */
+    public function always(Closure $always)
+    {
+        $this->always = $always;
+
+        return $this;
+    }
+}

--- a/tests/Unit/Schema/DirectiveRegistryTest.php
+++ b/tests/Unit/Schema/DirectiveRegistryTest.php
@@ -2,15 +2,15 @@
 
 namespace Tests\Unit\Schema;
 
+use Tests\TestCase;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
-use Nuwave\Lighthouse\Schema\Directives\Nodes\ScalarDirective;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\Directive;
-use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
+use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
 use Nuwave\Lighthouse\Support\Exceptions\DirectiveException;
-use Tests\TestCase;
+use Nuwave\Lighthouse\Schema\Directives\Nodes\ScalarDirective;
 
 class DirectiveRegistryTest extends TestCase
 {
@@ -95,8 +95,7 @@ class DirectiveRegistryTest extends TestCase
      */
     public function itCanRegisterDirectivesDirectly()
     {
-        $fooDirective = new class() implements Directive
-        {
+        $fooDirective = new class() implements Directive {
             public function name()
             {
                 return 'foo';
@@ -117,8 +116,7 @@ class DirectiveRegistryTest extends TestCase
         ');
 
         graphql()->directives()->register(
-            new class() extends BaseDirective implements FieldMiddleware
-            {
+            new class() extends BaseDirective implements FieldMiddleware {
                 public function name()
                 {
                     return 'foo';
@@ -129,7 +127,7 @@ class DirectiveRegistryTest extends TestCase
                     return $this->definitionNode;
                 }
 
-                public function handleField(FieldValue $value)
+                public function handleField(FieldValue $value, \Closure $next)
                 {
                 }
             }
@@ -149,14 +147,13 @@ class DirectiveRegistryTest extends TestCase
             foo: String @foo
         ');
 
-        $originalDefinition = new class() implements FieldMiddleware
-        {
+        $originalDefinition = new class() implements FieldMiddleware {
             public function name()
             {
                 return 'foo';
             }
 
-            public function handleField(FieldValue $value)
+            public function handleField(FieldValue $value, \Closure $next)
             {
             }
         };

--- a/tests/Unit/Support/Validator/ValidatorTest.php
+++ b/tests/Unit/Support/Validator/ValidatorTest.php
@@ -2,13 +2,13 @@
 
 namespace Tests\Unit\Support\Validator;
 
-use Nuwave\Lighthouse\Schema\AST\PartialParser;
-use Nuwave\Lighthouse\Schema\Directives\Args\ValidateDirective;
-use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Schema\Values\NodeValue;
-use Nuwave\Lighthouse\Support\Exceptions\ValidationError;
-use Nuwave\Lighthouse\Support\Validator\Validator;
 use Tests\TestCase;
+use Nuwave\Lighthouse\Schema\Values\NodeValue;
+use Nuwave\Lighthouse\Schema\AST\PartialParser;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Support\Validator\Validator;
+use Nuwave\Lighthouse\Support\Exceptions\ValidationError;
+use Nuwave\Lighthouse\Schema\Directives\Args\ValidateDirective;
 
 class ValidatorTest extends TestCase
 {
@@ -41,7 +41,12 @@ class ValidatorTest extends TestCase
             return 'foo';
         });
 
-        (new ValidateDirective())->hydrate($fieldDefinition)->handleField($fieldValue);
+        (new ValidateDirective())->hydrate($fieldDefinition)->handleField(
+            $fieldValue,
+            function ($fieldValue) {
+                return $fieldValue;
+            }
+        );
 
         $this->expectException(ValidationError::class);
         $fieldValue->getResolver()(


### PR DESCRIPTION
### Note: All of this code should be attributed to @olivernybroe and the great work he did on his PR (#118). I [followed up with him](https://github.com/nuwave/lighthouse/commit/788acc04eb77bf7c9dac7704b5bc43b2d54af893#comments) to ensure it was okay to to create this PR on his behalf.

**Changes**

From the original PR notes:

> I have changed Arg directive to use a Laravel Pipeline instead.
This give us the power to actually define if a arg directive should be executed last or if any directive after it should be run also, just like when using Laravel's middlewares.

Originally the value/middleware was intended to be similar to the request/middleware from Laravel. This PR gives us the benefits the middleware pipeline in Laravel provides. There's some additional work to be done on the `FieldResolver` and the generation of Node/Field/Arg values but this provides a great first step.

**Breaking changes**

Any current Node/Field/Arg middleware's handle function(s) will need to pass the value object back into the pipeline for further processing.

For example:

```php
// previous field middleware
public function handleField(FieldValue $value)
{
    return $value->setResolver(function () {
        // ...
    });
}

// new field middleware
public function handleField(FieldValue $value, \Closure $next)
{
    return $next($value->setResolver(function () {
        // ...
    }));
}
```
