### PR TITLE
Simplify the type hints for Closure to \Closure

### DIFF
--- a/src/Schema/Directives/Args/BcryptDirective.php
+++ b/src/Schema/Directives/Args/BcryptDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
@@ -23,11 +22,11 @@ class BcryptDirective extends BaseDirective implements ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $value
-     * @param Closure       $next
+     * @param \Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $value, Closure $next)
+    public function handleArgument(ArgumentValue $value, \Closure $next)
     {
         return $next($value->setResolver(function ($password) {
             return bcrypt($password);

--- a/src/Schema/Directives/Args/EqualsFilterDirective.php
+++ b/src/Schema/Directives/Args/EqualsFilterDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
@@ -26,11 +25,11 @@ class EqualsFilterDirective extends BaseDirective implements ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $argument
-     * @param Closure       $next
+     * @param \Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument, Closure $next)
+    public function handleArgument(ArgumentValue $argument, \Closure $next)
     {
         $arg = $argument->getArgName();
         $argument = $this->injectFilter($argument, [

--- a/src/Schema/Directives/Args/InFilterDirective.php
+++ b/src/Schema/Directives/Args/InFilterDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
@@ -26,11 +25,11 @@ class InFilterDirective extends BaseDirective implements ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $argument
-     * @param Closure       $next
+     * @param \Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument, Closure $next)
+    public function handleArgument(ArgumentValue $argument, \Closure $next)
     {
         $arg = $argument->getArgName();
         $argument = $this->injectFilter($argument, [

--- a/src/Schema/Directives/Args/NotEqualsFilterDirective.php
+++ b/src/Schema/Directives/Args/NotEqualsFilterDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
@@ -26,11 +25,11 @@ class NotEqualsFilterDirective extends BaseDirective implements ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $argument
-     * @param Closure       $next
+     * @param \Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument, Closure $next)
+    public function handleArgument(ArgumentValue $argument, \Closure $next)
     {
         $arg = $argument->getArgName();
         $argument = $this->injectFilter($argument, [

--- a/src/Schema/Directives/Args/NotInFilterDirective.php
+++ b/src/Schema/Directives/Args/NotInFilterDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
@@ -26,11 +25,11 @@ class NotInFilterDirective extends BaseDirective implements ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $argument
-     * @param Closure       $next
+     * @param \Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument, Closure $next)
+    public function handleArgument(ArgumentValue $argument, \Closure $next)
     {
         $arg = $argument->getArgName();
 

--- a/src/Schema/Directives/Args/RulesDirective.php
+++ b/src/Schema/Directives/Args/RulesDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Closure;
 use GraphQL\Language\AST\ArgumentNode;
 use GraphQL\Language\AST\DirectiveNode;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
@@ -26,11 +25,11 @@ class RulesDirective extends BaseDirective implements Directive, ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $value
-     * @param Closure       $next
+     * @param \Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $value, Closure $next)
+    public function handleArgument(ArgumentValue $value, \Closure $next)
     {
         if (in_array($value->getField()->getNodeName(), ['Query', 'Mutation'])) {
             return $value;

--- a/src/Schema/Directives/Args/ScoutDirective.php
+++ b/src/Schema/Directives/Args/ScoutDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
@@ -27,11 +26,11 @@ class ScoutDirective extends BaseDirective implements ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $argument
-     * @param Closure       $next
+     * @param \Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument, Closure $next)
+    public function handleArgument(ArgumentValue $argument, \Closure $next)
     {
         $arg = $argument->getArgName();
 

--- a/src/Schema/Directives/Args/ValidateDirective.php
+++ b/src/Schema/Directives/Args/ValidateDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Closure;
 use GraphQL\Language\AST\ArgumentNode;
 use GraphQL\Language\AST\DirectiveNode;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
@@ -28,13 +27,13 @@ class ValidateDirective extends BaseDirective implements ArgMiddleware, FieldMid
      * Resolve the field directive.
      *
      * @param FieldValue $value
-     * @param Closure    $next
+     * @param \Closure    $next
      *
      * @throws DirectiveException
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value, Closure $next)
+    public function handleField(FieldValue $value, \Closure $next)
     {
         $validator = $this->directiveArgValue('validator');
 
@@ -64,11 +63,11 @@ class ValidateDirective extends BaseDirective implements ArgMiddleware, FieldMid
      * Resolve the field directive.
      *
      * @param ArgumentValue $value
-     * @param Closure       $next
+     * @param \Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $value, Closure $next)
+    public function handleArgument(ArgumentValue $value, \Closure $next)
     {
         // TODO: Rename "getValue" to something more descriptive like "toArray"
         // and consider using for NodeValue/FieldValue.

--- a/src/Schema/Directives/Args/WhereBetweenFilterDirective.php
+++ b/src/Schema/Directives/Args/WhereBetweenFilterDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
@@ -26,11 +25,11 @@ class WhereBetweenFilterDirective extends BaseDirective implements ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $argument
-     * @param Closure       $next
+     * @param \Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument, Closure $next)
+    public function handleArgument(ArgumentValue $argument, \Closure $next)
     {
         $argument = $this->injectKeyedFilter($argument, [
             'resolve' => function ($query, $key, array $args) {

--- a/src/Schema/Directives/Args/WhereFilterDirective.php
+++ b/src/Schema/Directives/Args/WhereFilterDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
@@ -26,11 +25,11 @@ class WhereFilterDirective extends BaseDirective implements ArgMiddleware
      * Resolve the field directive.
      *
      * @param ArgumentValue $argument
-     * @param Closure       $next
+     * @param \Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument, Closure $next)
+    public function handleArgument(ArgumentValue $argument, \Closure $next)
     {
         $arg = $argument->getArgName();
 

--- a/src/Schema/Directives/Args/WhereNotBetweenFilterDirective.php
+++ b/src/Schema/Directives/Args/WhereNotBetweenFilterDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
-use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
@@ -26,11 +25,11 @@ class WhereNotBetweenFilterDirective extends BaseDirective implements ArgMiddlew
      * Resolve the field directive.
      *
      * @param ArgumentValue $argument
-     * @param Closure       $next
+     * @param \Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument, Closure $next)
+    public function handleArgument(ArgumentValue $argument, \Closure $next)
     {
         $argument = $this->injectKeyedFilter($argument, [
             'resolve' => function ($query, $key, array $args) {

--- a/src/Schema/Directives/Fields/CanDirective.php
+++ b/src/Schema/Directives/Fields/CanDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use Closure;
 use GraphQL\Error\Error;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
@@ -24,11 +23,11 @@ class CanDirective extends BaseDirective implements FieldMiddleware
      * Resolve the field directive.
      *
      * @param FieldValue $value
-     * @param Closure    $next
+     * @param \Closure    $next
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value, Closure $next)
+    public function handleField(FieldValue $value, \Closure $next)
     {
         $policies = $this->directiveArgValue('if');
         $model = $this->directiveArgValue('model');

--- a/src/Schema/Directives/Fields/ComplexityDirective.php
+++ b/src/Schema/Directives/Fields/ComplexityDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use Closure;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
@@ -24,11 +23,11 @@ class ComplexityDirective extends BaseDirective implements FieldMiddleware
      * Resolve the field directive.
      *
      * @param FieldValue $value
-     * @param Closure    $next
+     * @param \Closure    $next
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value, Closure $next)
+    public function handleField(FieldValue $value, \Closure $next)
     {
         $baseClassName = $this->directiveArgValue('class') ?? str_before($this->directiveArgValue('resolver'), '@');
 

--- a/src/Schema/Directives/Fields/EventDirective.php
+++ b/src/Schema/Directives/Fields/EventDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use Closure;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
@@ -23,13 +22,13 @@ class EventDirective extends BaseDirective implements FieldMiddleware
      * Resolve the field directive.
      *
      * @param FieldValue $value
-     * @param Closure    $next
+     * @param \Closure    $next
      *
      * @throws \Nuwave\Lighthouse\Support\Exceptions\DirectiveException
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value, Closure $next)
+    public function handleField(FieldValue $value, \Closure $next)
     {
         $eventBaseName = $this->directiveArgValue('fire') ?? $this->directiveArgValue('class');
         $eventClassName = $this->namespaceClassName($eventBaseName);

--- a/src/Schema/Directives/Fields/GlobalIdDirective.php
+++ b/src/Schema/Directives/Fields/GlobalIdDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use Closure;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Traits\HandlesGlobalId;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
@@ -26,11 +25,11 @@ class GlobalIdDirective extends BaseDirective implements FieldMiddleware
      * Resolve the field directive.
      *
      * @param FieldValue $value
-     * @param Closure    $next
+     * @param \Closure    $next
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value, Closure $next)
+    public function handleField(FieldValue $value, \Closure $next)
     {
         $type = $value->getNodeName();
         $resolver = $value->getResolver();

--- a/src/Schema/Directives/Fields/InjectDirective.php
+++ b/src/Schema/Directives/Fields/InjectDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use Closure;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
@@ -24,11 +23,11 @@ class InjectDirective extends BaseDirective implements FieldMiddleware
      * Resolve the field directive.
      *
      * @param FieldValue $value
-     * @param Closure    $next
+     * @param \Closure    $next
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value, Closure $next)
+    public function handleField(FieldValue $value, \Closure $next)
     {
         $resolver = $value->getResolver();
         $attr = $this->directiveArgValue('context');

--- a/src/Schema/Directives/Fields/MiddlewareDirective.php
+++ b/src/Schema/Directives/Fields/MiddlewareDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use Closure;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
@@ -23,11 +22,11 @@ class MiddlewareDirective extends BaseDirective implements FieldMiddleware
      * Resolve the field directive.
      *
      * @param FieldValue $value
-     * @param Closure    $next
+     * @param \Closure    $next
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value, Closure $next)
+    public function handleField(FieldValue $value, \Closure $next)
     {
         $checks = $this->getChecks($value);
 

--- a/src/Schema/Directives/Nodes/ModelDirective.php
+++ b/src/Schema/Directives/Nodes/ModelDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Nodes;
 
-use Closure;
 use GraphQL\Language\AST\Node;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
@@ -29,11 +28,11 @@ class ModelDirective extends BaseDirective implements NodeMiddleware, NodeManipu
      * Handle type construction.
      *
      * @param NodeValue $value
-     * @param Closure   $next
+     * @param \Closure   $next
      *
      * @return NodeValue
      */
-    public function handleNode(NodeValue $value, Closure $next)
+    public function handleNode(NodeValue $value, \Closure $next)
     {
         $modelClassName = $this->getModelClassName($value);
 

--- a/src/Schema/Directives/Nodes/NodeDirective.php
+++ b/src/Schema/Directives/Nodes/NodeDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Nodes;
 
-use Closure;
 use GraphQL\Language\AST\Node;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
@@ -29,11 +28,11 @@ class NodeDirective extends BaseDirective implements NodeMiddleware, NodeManipul
      * Handle type construction.
      *
      * @param NodeValue $value
-     * @param Closure   $next
+     * @param \Closure   $next
      *
      * @return NodeValue
      */
-    public function handleNode(NodeValue $value, Closure $next)
+    public function handleNode(NodeValue $value, \Closure $next)
     {
         graphql()->nodes()->node(
             $value->getNodeName(),

--- a/src/Schema/Directives/Nodes/SecurityDirective.php
+++ b/src/Schema/Directives/Nodes/SecurityDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Nodes;
 
-use Closure;
 use GraphQL\Validator\Rules\QueryDepth;
 use GraphQL\Validator\DocumentValidator;
 use GraphQL\Validator\Rules\QueryComplexity;
@@ -28,11 +27,11 @@ class SecurityDirective extends BaseDirective implements NodeMiddleware
      * Handle node value.
      *
      * @param NodeValue $value
-     * @param Closure   $next
+     * @param \Closure   $next
      *
      * @return NodeValue
      */
-    public function handleNode(NodeValue $value, Closure $next)
+    public function handleNode(NodeValue $value, \Closure $next)
     {
         if ('Query' !== $value->getNodeName()) {
             $message = sprintf(

--- a/src/Schema/Factories/ValueFactory.php
+++ b/src/Schema/Factories/ValueFactory.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Factories;
 
-use Closure;
 use GraphQL\Language\AST\TypeDefinitionNode;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
@@ -14,28 +13,28 @@ class ValueFactory
     /**
      * Node value resolver.
      *
-     * @var Closure
+     * @var \Closure
      */
     protected $node;
 
     /**
      * Field value resolver.
      *
-     * @var Closure
+     * @var\Closure
      */
     protected $field;
 
     /**
      * Argument value resolver.
      *
-     * @var Closure
+     * @var\Closure
      */
     protected $arg;
 
     /**
      * Set node value instance resolver.
      *
-     * @param Closure $resolver
+     * @param\Closure $resolver
      *
      * @return self
      */
@@ -49,7 +48,7 @@ class ValueFactory
     /**
      * Set field value instance resolver.
      *
-     * @param Closure $resolver
+     * @param\Closure $resolver
      *
      * @return self
      */
@@ -63,7 +62,7 @@ class ValueFactory
     /**
      * Set arg value instance resolver.
      *
-     * @param Closure $resolver
+     * @param\Closure $resolver
      *
      * @return self
      */

--- a/src/Schema/Factories/ValueFactory.php
+++ b/src/Schema/Factories/ValueFactory.php
@@ -20,25 +20,25 @@ class ValueFactory
     /**
      * Field value resolver.
      *
-     * @var\Closure
+     * @var \Closure
      */
     protected $field;
 
     /**
      * Argument value resolver.
      *
-     * @var\Closure
+     * @var \Closure
      */
     protected $arg;
 
     /**
      * Set node value instance resolver.
      *
-     * @param\Closure $resolver
+     * @param \Closure $resolver
      *
      * @return self
      */
-    public function nodeResolver(Closure $resolver)
+    public function nodeResolver(\Closure $resolver)
     {
         $this->node = $resolver;
 
@@ -48,11 +48,11 @@ class ValueFactory
     /**
      * Set field value instance resolver.
      *
-     * @param\Closure $resolver
+     * @param \Closure $resolver
      *
      * @return self
      */
-    public function fieldResolver(Closure $resolver)
+    public function fieldResolver(\Closure $resolver)
     {
         $this->field = $resolver;
 
@@ -62,11 +62,11 @@ class ValueFactory
     /**
      * Set arg value instance resolver.
      *
-     * @param\Closure $resolver
+     * @param \Closure $resolver
      *
      * @return self
      */
-    public function argResolver(Closure $resolver)
+    public function argResolver(\Closure $resolver)
     {
         $this->arg = $resolver;
 

--- a/src/Schema/NodeContainer.php
+++ b/src/Schema/NodeContainer.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema;
 
-use Closure;
 use GraphQL\Error\Error;
 use Nuwave\Lighthouse\Support\Traits\HandlesGlobalId;
 
@@ -35,12 +34,12 @@ class NodeContainer
      * Store resolver for node.
      *
      * @param string  $type
-     * @param Closure $resolver
-     * @param Closure $resolveType
+     * @param \Closure $resolver
+     * @param \Closure $resolveType
      *
      * @return mixed
      */
-    public function node($type, Closure $resolver, Closure $resolveType)
+    public function node($type, \Closure $resolver, \Closure $resolveType)
     {
         $this->types[$type] = $resolveType;
         $this->nodes[$type] = $resolver;

--- a/src/Schema/Resolvers/FieldResolver.php
+++ b/src/Schema/Resolvers/FieldResolver.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Resolvers;
 
-use Closure;
 use GraphQL\Language\AST\FieldDefinitionNode;
 
 abstract class FieldResolver
@@ -17,7 +16,7 @@ abstract class FieldResolver
     /**
      * Field resolver.
      *
-     * @var Closure
+     * @var \Closure
      */
     protected $resolver;
 
@@ -25,9 +24,9 @@ abstract class FieldResolver
      * Create a new instance of field resolver.
      *
      * @param FieldDefinitionNode $field
-     * @param Closure|null        $resolver
+     * @param \Closure|null        $resolver
      */
-    public function __construct(FieldDefinitionNode $field, Closure $resolver = null)
+    public function __construct(FieldDefinitionNode $field, \Closure $resolver = null)
     {
         $this->field = $field;
         $this->resolver = $resolver;
@@ -37,11 +36,11 @@ abstract class FieldResolver
      * Resolve field type from field.
      *
      * @param FieldDefinitionNode $field
-     * @param Closure|null        $resolver
+     * @param \Closure|null        $resolver
      *
      * @return array
      */
-    public static function resolve(FieldDefinitionNode $field, Closure $resolver = null)
+    public static function resolve(FieldDefinitionNode $field, \Closure $resolver = null)
     {
         $instance = new static($field, $resolver);
 

--- a/src/Support/Contracts/ArgMiddleware.php
+++ b/src/Support/Contracts/ArgMiddleware.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Support\Contracts;
 
-use Closure;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
 
 interface ArgMiddleware extends Directive
@@ -11,9 +10,9 @@ interface ArgMiddleware extends Directive
      * Apply transformations on the ArgumentValue.
      *
      * @param ArgumentValue $argument
-     * @param Closure       $next
+     * @param \Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $argument, Closure $next);
+    public function handleArgument(ArgumentValue $argument, \Closure $next);
 }

--- a/src/Support/Contracts/FieldMiddleware.php
+++ b/src/Support/Contracts/FieldMiddleware.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Support\Contracts;
 
-use Closure;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 
 interface FieldMiddleware extends Directive
@@ -11,9 +10,9 @@ interface FieldMiddleware extends Directive
      * Resolve the field directive.
      *
      * @param FieldValue $value
-     * @param Closure    $next
+     * @param \Closure    $next
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value, Closure $next);
+    public function handleField(FieldValue $value, \Closure $next);
 }

--- a/src/Support/Contracts/NodeMiddleware.php
+++ b/src/Support/Contracts/NodeMiddleware.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Support\Contracts;
 
-use Closure;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
 
 interface NodeMiddleware extends Directive
@@ -11,9 +10,9 @@ interface NodeMiddleware extends Directive
      * Handle node value.
      *
      * @param NodeValue $value
-     * @param Closure   $next
+     * @param \Closure   $next
      *
      * @return NodeValue
      */
-    public function handleNode(NodeValue $value, Closure $next);
+    public function handleNode(NodeValue $value, \Closure $next);
 }

--- a/src/Support/DataLoader/QueryBuilder.php
+++ b/src/Support/DataLoader/QueryBuilder.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Support\DataLoader;
 
-use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -80,7 +79,7 @@ class QueryBuilder
      * Eagerly load the relationship on a set of models.
      *
      * @param Builder $builder
-     * @param Closure $constraints
+     * @param \Closure $constraints
      * @param array   $models
      * @param array   $options
      *
@@ -88,7 +87,7 @@ class QueryBuilder
      *
      * @return array
      */
-    protected function loadRelation(Builder $builder, Closure $constraints, array $models, array $options)
+    protected function loadRelation(Builder $builder, \Closure $constraints, array $models, array $options)
     {
         $relation = $builder->getRelation($options['name']);
         $relationQueries = $this->getRelationQueries($builder, $models, $options['name'], $constraints);
@@ -146,11 +145,11 @@ class QueryBuilder
      * @param Builder $builder
      * @param array   $models
      * @param string  $name
-     * @param Closure $constraints
+     * @param \Closure $constraints
      *
      * @return Relation[]|Collection
      */
-    protected function getRelationQueries(Builder $builder, array $models, $name, Closure $constraints)
+    protected function getRelationQueries(Builder $builder, array $models, $name, \Closure $constraints)
     {
         return collect($models)->map(function ($model) use ($builder, $name, $constraints) {
             $relation = $builder->getRelation($name);

--- a/src/Support/Pipeline.php
+++ b/src/Support/Pipeline.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Support;
 
-use Closure;
 use Illuminate\Support\Collection;
 use Illuminate\Pipeline\Pipeline as BasePipeline;
 
@@ -27,9 +26,9 @@ class Pipeline extends BasePipeline
     }
 
     /**
-     * Get a Closure that represents a slice of the application onion.
+     * Get a \Closure that represents a slice of the application onion.
      *
-     * @return Closure
+     * @return \Closure
      */
     protected function carry()
     {
@@ -50,7 +49,7 @@ class Pipeline extends BasePipeline
     /**
      * Set always variable.
      *
-     * @param Closure $always
+     * @param \Closure $always
      *
      * @return self
      */

--- a/src/Support/Pipeline.php
+++ b/src/Support/Pipeline.php
@@ -53,7 +53,7 @@ class Pipeline extends BasePipeline
      *
      * @return self
      */
-    public function always(Closure $always)
+    public function always(\Closure $always)
     {
         $this->always = $always;
 


### PR DESCRIPTION
This makes it very obvious, which kind of Closure is reffered to when reading
the code and allows us to omit the use statement at the top of the file.

As we are using opis/closure, this change should make the distinction clear.

**PR Type**

Refactor