### PR TITLE
Server Side Caching

### DIFF
--- a/src/Schema/Directives/CacheDirective.php
+++ b/src/Schema/Directives/CacheDirective.php
@@ -38,6 +38,10 @@ class CacheDirective extends BaseDirective implements FieldMiddleware
         $resolver = $value->getResolver();
         $maxAge = $this->directiveArgValue('maxAge');
 
+        if (true === $this->directiveArgValue('private')) {
+            $value->isPrivateCache(true);
+        }
+
         return $value->setResolver(function () use ($value, $resolver, $maxAge) {
             $arguments = func_get_args();
             /** @var \Illuminate\Support\Facades\Cache $cache */

--- a/src/Schema/Factories/ValueFactory.php
+++ b/src/Schema/Factories/ValueFactory.php
@@ -4,10 +4,10 @@ namespace Nuwave\Lighthouse\Schema\Factories;
 
 use Closure;
 use GraphQL\Language\AST\TypeDefinitionNode;
-use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
+use Nuwave\Lighthouse\Schema\Values\NodeValue;
 use Nuwave\Lighthouse\Schema\Values\CacheValue;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Schema\Values\NodeValue;
+use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
 
 class ValueFactory
 {
@@ -142,36 +142,12 @@ class ValueFactory
     /**
      * Create cache value for field.
      *
-     * @param FieldValue  $fieldValue
-     * @param mixed       $rootValue
-     * @param array       $args
-     * @param mixed       $context
-     * @param ResolveInfo $resolveInfo
+     * @param array $arguments
      */
-    public function cache(
-        $fieldValue,
-        $rootValue,
-        $args,
-        $context,
-        $resolveInfo
-    ) {
-        if ($this->cache) {
-            return call_user_func(
-                $this->cache,
-                $fieldValue,
-                $rootValue,
-                $args,
-                $context,
-                $resolveInfo
-            );
-        }
-
-        return new CacheValue(
-            $fieldValue,
-            $rootValue,
-            $args,
-            $context,
-            $resolveInfo
-        );
+    public function cache(array $arguments)
+    {
+        return $this->cache
+            ? call_user_func($this->cache, $arguments)
+            : new CacheValue($arguments);
     }
 }

--- a/src/Schema/Factories/ValueFactory.php
+++ b/src/Schema/Factories/ValueFactory.php
@@ -4,10 +4,10 @@ namespace Nuwave\Lighthouse\Schema\Factories;
 
 use Closure;
 use GraphQL\Language\AST\TypeDefinitionNode;
-use Nuwave\Lighthouse\Schema\Values\NodeValue;
-use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use GraphQL\Language\AST\InputValueDefinitionNode;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
+use Nuwave\Lighthouse\Schema\Values\CacheValue;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Schema\Values\NodeValue;
 
 class ValueFactory
 {
@@ -31,6 +31,13 @@ class ValueFactory
      * @var Closure
      */
     protected $arg;
+
+    /**
+     * Cache value resolver.
+     *
+     * @var Closure
+     */
+    protected $cache;
 
     /**
      * Set node value instance resolver.
@@ -70,6 +77,20 @@ class ValueFactory
     public function argResolver(Closure $resolver)
     {
         $this->arg = $resolver;
+
+        return $this;
+    }
+
+    /**
+     * Set cache value instance resolver.
+     *
+     * @param Closure $resolver
+     *
+     * @return self
+     */
+    public function cacheResolver(Closure $resolver)
+    {
+        return $this->cache = $resolver;
 
         return $this;
     }
@@ -116,5 +137,41 @@ class ValueFactory
         return $this->arg
             ? call_user_func($this->arg, $fieldValue, $arg)
             : new ArgumentValue($fieldValue, $arg);
+    }
+
+    /**
+     * Create cache value for field.
+     *
+     * @param FieldValue  $fieldValue
+     * @param mixed       $rootValue
+     * @param array       $args
+     * @param mixed       $context
+     * @param ResolveInfo $resolveInfo
+     */
+    public function cache(
+        $fieldValue,
+        $rootValue,
+        $args,
+        $context,
+        $resolveInfo
+    ) {
+        if ($this->cache) {
+            return call_user_func(
+                $this->cache,
+                $fieldValue,
+                $rootValue,
+                $args,
+                $context,
+                $resolveInfo
+            );
+        }
+
+        return new CacheValue(
+            $fieldValue,
+            $rootValue,
+            $args,
+            $context,
+            $resolveInfo
+        );
     }
 }

--- a/src/Schema/Values/CacheValue.php
+++ b/src/Schema/Values/CacheValue.php
@@ -99,8 +99,8 @@ class CacheValue
         $fieldTag = collect([
             'graphql',
             strtolower($this->fieldValue->getNodeName()),
-            $this->resolveInfo->fieldName,
             $this->fieldKey,
+            $this->resolveInfo->fieldName,
         ])->filter()->values()->implode(':');
 
         return [$typeTag, $fieldTag];

--- a/src/Schema/Values/CacheValue.php
+++ b/src/Schema/Values/CacheValue.php
@@ -90,13 +90,20 @@ class CacheValue
      */
     public function getTags()
     {
+        $typeTag = collect([
+            'graphql',
+            strtolower($this->fieldValue->getNodeName()),
+            $this->fieldKey,
+        ])->filter()->values()->implode(':');
+
         $fieldTag = collect([
+            'graphql',
             strtolower($this->fieldValue->getNodeName()),
             $this->resolveInfo->fieldName,
             $this->fieldKey,
         ])->filter()->values()->implode(':');
 
-        return ['graphql', $fieldTag];
+        return [$typeTag, $fieldTag];
     }
 
     /**

--- a/src/Schema/Values/CacheValue.php
+++ b/src/Schema/Values/CacheValue.php
@@ -68,15 +68,17 @@ class CacheValue
      */
     public function getKey()
     {
+        $private = $this->fieldValue->isPrivateCache();
         $argKeys = $this->argKeys();
 
-        return sprintf(
-            '%s:%s:%s%s',
+        return $this->implode([
+            $private ? 'auth' : null,
+            $private ? auth()->user()->getKey() : null,
             strtolower($this->resolveInfo->parentType->name),
             $this->fieldKey,
             strtolower($this->resolveInfo->fieldName),
-            $argKeys->isNotEmpty() ? ':'.$argKeys->implode(':') : null
-        );
+            $argKeys->isNotEmpty() ? $argKeys->implode(':') : null,
+        ]);
     }
 
     /**
@@ -90,18 +92,18 @@ class CacheValue
      */
     public function getTags()
     {
-        $typeTag = collect([
+        $typeTag = $this->implode([
             'graphql',
             strtolower($this->fieldValue->getNodeName()),
             $this->fieldKey,
-        ])->filter()->values()->implode(':');
+        ]);
 
-        $fieldTag = collect([
+        $fieldTag = $this->implode([
             'graphql',
             strtolower($this->fieldValue->getNodeName()),
             $this->fieldKey,
             $this->resolveInfo->fieldName,
-        ])->filter()->values()->implode(':');
+        ]);
 
         return [$typeTag, $fieldTag];
     }
@@ -132,5 +134,19 @@ class CacheValue
         if ($cacheFieldKey) {
             $this->fieldKey = data_get($this->rootValue, $cacheFieldKey);
         }
+    }
+
+    /**
+     * Implode value to create string.
+     *
+     * @param array $items
+     *
+     * @return string
+     */
+    protected function implode($items)
+    {
+        return collect($items)->filter()
+            ->values()
+            ->implode(':');
     }
 }

--- a/src/Schema/Values/CacheValue.php
+++ b/src/Schema/Values/CacheValue.php
@@ -37,24 +37,23 @@ class CacheValue
     protected $fieldKey;
 
     /**
-     * @param FieldValue  $fieldValue
-     * @param mixed       $rootValue
-     * @param array       $args
-     * @param mixed       $context
-     * @param ResolveInfo $resolveInfo
+     * @var bool
      */
-    public function __construct(
-        $fieldValue,
-        $rootValue,
-        $args,
-        $context,
-        $resolveInfo
-    ) {
-        $this->fieldValue = $fieldValue;
-        $this->rootValue = $rootValue;
-        $this->args = $args;
-        $this->context = $context;
-        $this->resolveInfo = $resolveInfo;
+    protected $privateCache;
+
+    /**
+     * Create instance of cache value.
+     *
+     * @param array $arguments
+     */
+    public function __construct(array $arguments = [])
+    {
+        $this->fieldValue = array_get($arguments, 'field_value');
+        $this->rootValue = array_get($arguments, 'root');
+        $this->args = array_get($arguments, 'args');
+        $this->context = array_get($arguments, 'context');
+        $this->resolveInfo = array_get($arguments, 'resolve_info');
+        $this->privateCache = array_get($arguments, 'private_cache');
 
         $this->setFieldKey();
     }
@@ -68,12 +67,11 @@ class CacheValue
      */
     public function getKey()
     {
-        $private = $this->fieldValue->isPrivateCache();
         $argKeys = $this->argKeys();
 
         return $this->implode([
-            $private ? 'auth' : null,
-            $private ? auth()->user()->getKey() : null,
+            $this->privateCache ? 'auth' : null,
+            $this->privateCache ? auth()->user()->getKey() : null,
             strtolower($this->resolveInfo->parentType->name),
             $this->fieldKey,
             strtolower($this->resolveInfo->fieldName),
@@ -129,6 +127,10 @@ class CacheValue
      */
     protected function setFieldKey()
     {
+        if (! $this->fieldValue || ! $this->rootValue) {
+            return null;
+        }
+
         $cacheFieldKey = $this->fieldValue->getNode()->getCacheKey();
 
         if ($cacheFieldKey) {

--- a/src/Schema/Values/CacheValue.php
+++ b/src/Schema/Values/CacheValue.php
@@ -53,6 +53,22 @@ class CacheValue
     }
 
     /**
+     * Convert input arguments to keys.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function argKeys()
+    {
+        return collect($this->args)
+            ->sortKeys()
+            ->map(function ($value, $key) {
+                $keyValue = is_array($value) ? json_encode($value, true) : $value;
+
+                return "{$key}:{$keyValue}";
+            });
+    }
+
+    /**
      * Resolve key from root value.
      *
      * @param string $key
@@ -63,12 +79,14 @@ class CacheValue
     {
         $cacheFieldKey = $this->fieldValue->getNode()->getCacheKey();
         $key = $cacheFieldKey ? data_get($this->rootValue, $cacheFieldKey) : null;
+        $argKeys = $this->argKeys();
 
         return sprintf(
-            '%s:%s:%s',
+            '%s:%s:%s%s',
             strtolower($this->fieldValue->getNodeName()),
             $key,
-            strtolower($this->fieldValue->getFieldName())
+            strtolower($this->fieldValue->getFieldName()),
+            $argKeys->isNotEmpty() ? ':'.$argKeys->implode(':') : null
         );
     }
 }

--- a/src/Schema/Values/CacheValue.php
+++ b/src/Schema/Values/CacheValue.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Values;
+
+use GraphQL\Type\Definition\ResolveInfo;
+
+class CacheValue
+{
+    /**
+     * @var FieldValue
+     */
+    protected $fieldValue;
+
+    /**
+     * @var mixed
+     */
+    protected $rootValue;
+
+    /**
+     * @var array
+     */
+    protected $args;
+
+    /**
+     * @var mixed
+     */
+    protected $context;
+
+    /**
+     * @var ResolveInfo
+     */
+    protected $resolveInfo;
+
+    /**
+     * @param FieldValue  $fieldValue
+     * @param mixed       $rootValue
+     * @param array       $args
+     * @param mixed       $context
+     * @param ResolveInfo $resolveInfo
+     */
+    public function __construct(
+        $fieldValue,
+        $rootValue,
+        $args,
+        $context,
+        $resolveInfo
+    ) {
+        $this->fieldValue = $fieldValue;
+        $this->rootValue = $rootValue;
+        $this->args = $args;
+        $this->context = $context;
+        $this->resolveInfo = $resolveInfo;
+    }
+
+    /**
+     * Resolve key from root value.
+     *
+     * @param string $key
+     *
+     * @return mixed
+     */
+    public function getKey()
+    {
+        $cacheFieldKey = $this->fieldValue->getNode()->getCacheKey();
+        $key = $cacheFieldKey ? data_get($this->rootValue, $cacheFieldKey) : null;
+
+        return sprintf(
+            '%s:%s:%s',
+            strtolower($this->fieldValue->getNodeName()),
+            $key,
+            strtolower($this->fieldValue->getFieldName())
+        );
+    }
+}

--- a/src/Schema/Values/FieldValue.php
+++ b/src/Schema/Values/FieldValue.php
@@ -50,6 +50,13 @@ class FieldValue
     protected $complexity;
 
     /**
+     * Cache key should be private.
+     *
+     * @var bool
+     */
+    protected $privateCache = false;
+
+    /**
      * Additional args to inject into resolver.
      *
      * @var array
@@ -224,6 +231,22 @@ class FieldValue
     public function getComplexity()
     {
         return $this->complexity;
+    }
+
+    /**
+     * Get private cache flag.
+     *
+     * @return FieldValue|bool
+     */
+    public function isPrivateCache($flag = null)
+    {
+        if (null === $flag) {
+            return $this->privateCache;
+        }
+
+        $this->privateCache = $flag;
+
+        return $this;
     }
 
     /**

--- a/src/Schema/Values/FieldValue.php
+++ b/src/Schema/Values/FieldValue.php
@@ -4,7 +4,6 @@ namespace Nuwave\Lighthouse\Schema\Values;
 
 use GraphQL\Type\Definition\Type;
 use GraphQL\Language\AST\FieldDefinitionNode;
-use Nuwave\Lighthouse\Schema\Values\FieldValue;
 
 class FieldValue
 {

--- a/src/Schema/Values/NodeValue.php
+++ b/src/Schema/Values/NodeValue.php
@@ -2,10 +2,10 @@
 
 namespace Nuwave\Lighthouse\Schema\Values;
 
-use GraphQL\Language\AST\DirectiveNode;
-use GraphQL\Language\AST\NamedTypeNode;
 use GraphQL\Language\AST\Node;
 use GraphQL\Type\Definition\Type;
+use GraphQL\Language\AST\DirectiveNode;
+use GraphQL\Language\AST\NamedTypeNode;
 
 class NodeValue
 {
@@ -38,6 +38,13 @@ class NodeValue
     protected $namespace;
 
     /**
+     * Cache key for node.
+     *
+     * @var string
+     */
+    protected $cacheKey;
+
+    /**
      * Create new instance of node value.
      *
      * @param Node $node
@@ -51,6 +58,7 @@ class NodeValue
      * Create new instance of node value.
      *
      * @param Node $node
+     *
      * @return NodeValue
      */
     public static function init(Node $node)
@@ -104,6 +112,16 @@ class NodeValue
     public function setNamespace($namespace)
     {
         $this->namespace = $namespace;
+    }
+
+    /**
+     * Set node cache key.
+     *
+     * @param string $key
+     */
+    public function setCacheKey($key)
+    {
+        $this->cacheKey = $key;
     }
 
     /**
@@ -179,6 +197,16 @@ class NodeValue
             ->map(function (NamedTypeNode $interface) {
                 return $interface->name->value;
             });
+    }
+
+    /**
+     * Get node's cache key.
+     *
+     * @return string|null
+     */
+    public function getCacheKey()
+    {
+        return $this->cacheKey;
     }
 
     /**

--- a/tests/Integration/Schema/Directives/CacheDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/CacheDirectiveTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Integration\Schema\Directives;
+
+use GraphQL\Deferred;
+use Tests\DBTestCase;
+use Tests\Utils\Models\Post;
+use Tests\Utils\Models\User;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class CacheDirectiveTest extends DBTestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     */
+    public function itCanStoreResolverResultInCache()
+    {
+        $resolver = addslashes(self::class).'@resolve';
+        $schema = "
+        type User {
+            id: ID!
+            name: String @cache
+        }
+        type Query {
+            user: User @field(resolver: \"{$resolver}\")
+        }";
+
+        $result = $this->execute($schema, '{ user { name } }');
+        $this->assertEquals('foobar', array_get($result->data, 'user.name'));
+        $this->assertEquals('foobar', app('cache')->get('user:1:name'));
+    }
+
+    /**
+     * @test
+     */
+    public function itCanStorePaginateResolverInCache()
+    {
+        factory(User::class, 5)->create();
+
+        $schema = '
+        type User {
+            id: ID!
+            name: String!
+        }
+        type Query {
+            users: [User] @paginate(type: "paginator", model: "User") @cache
+        }';
+
+        $query = '{
+            users(count: 5) {
+                data {
+                    id
+                    name
+                }
+            }
+        }';
+
+        $this->execute($schema, $query, true);
+
+        $result = app('cache')->get('query::users');
+
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
+        $this->assertCount(5, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function itCanCacheHasManyResolver()
+    {
+        $user = factory(User::class)->create();
+
+        factory(Post::class, 3)->create([
+            'user_id' => $user->getKey(),
+        ]);
+
+        $schema = '
+        type Post {
+            id: ID!
+            title: String
+        }
+        type User {
+            id: ID!
+            name: String!
+            posts: [Post] @hasMany(type: "paginator") @cache
+        }
+        type Query {
+            user(id: ID! @eq): User @find(model: "User")
+        }';
+
+        $query = '{
+            user(id: '.$user->getKey().') {
+                id
+                name
+                posts(count: 3) {
+                    data {
+                        title
+                    }
+                }
+            }
+        }';
+
+        $this->execute($schema, $query, true);
+
+        $posts = app('cache')->get("user:{$user->getKey()}:posts");
+        $this->assertInstanceOf(LengthAwarePaginator::class, $posts);
+        $this->assertCount(3, $posts);
+    }
+
+    public function resolve()
+    {
+        return [
+            'id' => 1,
+            'name' => 'foobar',
+        ];
+    }
+}

--- a/tests/Integration/Schema/Directives/CacheDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/CacheDirectiveTest.php
@@ -60,7 +60,7 @@ class CacheDirectiveTest extends DBTestCase
 
         $this->execute($schema, $query, true);
 
-        $result = app('cache')->get('query::users');
+        $result = app('cache')->get('query::users:count:5');
 
         $this->assertInstanceOf(LengthAwarePaginator::class, $result);
         $this->assertCount(5, $result);
@@ -105,7 +105,7 @@ class CacheDirectiveTest extends DBTestCase
 
         $this->execute($schema, $query, true);
 
-        $posts = app('cache')->get("user:{$user->getKey()}:posts");
+        $posts = app('cache')->get("user:{$user->getKey()}:posts:count:3");
         $this->assertInstanceOf(LengthAwarePaginator::class, $posts);
         $this->assertCount(3, $posts);
     }

--- a/tests/Integration/Schema/Directives/CacheDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/CacheDirectiveTest.php
@@ -171,8 +171,8 @@ class CacheDirectiveTest extends DBTestCase
 
         /** @var ValueFactory $valueFactory */
         $valueFactory = app(ValueFactory::class);
-        $valueFactory->cacheResolver(function (...$args) {
-            return new class(...$args) extends CacheValue {
+        $valueFactory->cacheResolver(function ($arguments) {
+            return new class($arguments) extends CacheValue {
                 public function getKey()
                 {
                     return 'foo';

--- a/tests/Integration/Schema/Directives/Fields/PaginateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/PaginateDirectiveTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Integration\Schema\Directives\Fields;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\DBTestCase;
-use Tests\Utils\Models\Comment;
 use Tests\Utils\Models\Post;
 use Tests\Utils\Models\User;
+use Tests\Utils\Models\Comment;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class PaginateDirectiveTest extends DBTestCase
 {
@@ -26,8 +26,7 @@ class PaginateDirectiveTest extends DBTestCase
         }
         type Query {
             users: [User!]! @paginate(type: "paginator" model: "User")
-        }
-        ';
+        }';
 
         $query = '{
             users(count: 5) {


### PR DESCRIPTION
**PR Type**

New Feature

**Changes**

This PR introduces a new `@cache` directive to cache resolved fields using Laravel's built in cache management. The directive accepts two optional arguments. `maxAge` will set the amount of seconds the value(s) should stay in cache. `private` will prepend the authenticated user's id to the cache key and should be used on fields that provide different output depending on the authenticated user. The cache key also takes arguments into consideration so queries on the same field but different input arguments (i.e., `users(page:1)` vs `users(page:2)`) are handled appropriately.

Usage example:

```graphql
# schema
type Query {
    users: [User] @paginate(...) @cache(maxAge: 60)
}

# query
{
    users(count: 5) {
        # ...
    }
}
```

*This will store the first 5 users in cache for 1 minute.*

The cache key is generated by the `CacheValue` class. You can choose to extend this class and use your own implementation if you wish to generate the cache key differently.

```php
class MyServiceProvider extends ServiceProvider
{
    public function boot()
    {
        // register a custom cache value object.
        app(ValueFactory::class)->cacheResolver(function (...$args) {
            return new MyCacheValue(...$args);
        });
    }
}
```

**Breaking changes**

None
