### PR TITLE
Get the model class for the directives in the same way for all directives

### DIFF
--- a/src/Schema/Directives/Fields/CanDirective.php
+++ b/src/Schema/Directives/Fields/CanDirective.php
@@ -31,13 +31,12 @@ class CanDirective extends BaseDirective implements FieldMiddleware
     public function handleField(FieldValue $value, Closure $next)
     {
         $policies = $this->directiveArgValue('if');
-        $model = $this->directiveArgValue('model');
         $resolver = $value->getResolver();
 
         return $next($value->setResolver(
-            function () use ($policies, $resolver, $model) {
+            function () use ($policies, $resolver) {
                 $args = func_get_args();
-                $model = $model ?: get_class($args[0]);
+                $model = $this->getModelClass() ?: get_class($args[0]);
 
                 $can = collect($policies)->reduce(function ($allowed, $policy) use ($model) {
                     if (! app('auth')->user()->can($policy, $model)) {

--- a/src/Schema/Directives/Fields/CreateDirective.php
+++ b/src/Schema/Directives/Fields/CreateDirective.php
@@ -28,19 +28,8 @@ class CreateDirective extends BaseDirective implements FieldResolver
      */
     public function resolveField(FieldValue $value)
     {
-        // TODO: create a model registry so we can auto-resolve this.
-        $model = $this->directiveArgValue('model');
-
-        if (!$model) {
-            throw new DirectiveException(sprintf(
-                'The `create` directive on %s [%s] must have a `model` argument',
-                $value->getNodeName(),
-                $value->getFieldName()
-            ));
-        }
-
-        return $value->setResolver(function ($root, array $args) use ($model) {
-            return $model::create($args);
+        return $value->setResolver(function ($root, array $args){
+            return $this->getModelClass()::create($args);
         });
     }
 }

--- a/src/Schema/Directives/Fields/DeleteDirective.php
+++ b/src/Schema/Directives/Fields/DeleteDirective.php
@@ -34,16 +34,8 @@ class DeleteDirective extends BaseDirective implements FieldResolver
     public function resolveField(FieldValue $value)
     {
         $idArg = $this->getIDField($value);
-        $class = $this->directiveArgValue('model');
         $globalId = $this->directiveArgValue('globalId', false);
 
-        if (!$class) {
-            throw new DirectiveException(sprintf(
-                'The `delete` directive on %s [%s] must have a `model` argument',
-                $value->getNodeName(),
-                $value->getFieldName()
-            ));
-        }
 
         if (!$idArg) {
             new DirectiveException(sprintf(
@@ -52,9 +44,9 @@ class DeleteDirective extends BaseDirective implements FieldResolver
             ));
         }
 
-        return $value->setResolver(function ($root, array $args) use ($class, $idArg, $globalId) {
+        return $value->setResolver(function ($root, array $args) use ($idArg, $globalId) {
             $id = $globalId ? $this->decodeGlobalId(array_get($args, $idArg))[1] : array_get($args, $idArg);
-            $model = $class::find($id);
+            $model = $this->getModelClass()::find($id);
 
             if ($model) {
                 $model->delete();

--- a/src/Schema/Directives/Fields/UpdateDirective.php
+++ b/src/Schema/Directives/Fields/UpdateDirective.php
@@ -35,16 +35,7 @@ class UpdateDirective extends BaseDirective implements FieldResolver
     public function resolveField(FieldValue $value)
     {
         $idArg = $this->getIDField($value);
-        $class = $this->directiveArgValue('model');
         $globalId = $this->directiveArgValue('globalId', false);
-
-        if (!$class) {
-            throw new DirectiveException(sprintf(
-                'The `update` directive on %s [%s] must have a `model` argument',
-                $value->getNodeName(),
-                $value->getFieldName()
-            ));
-        }
 
         if (!$idArg) {
             new DirectiveException(sprintf(
@@ -53,9 +44,10 @@ class UpdateDirective extends BaseDirective implements FieldResolver
             ));
         }
 
-        return $value->setResolver(function ($root, array $args) use ($class, $idArg, $globalId) {
+        return $value->setResolver(function ($root, array $args) use ($idArg, $globalId) {
             $id = $globalId ? $this->decodeGlobalId(array_get($args, $idArg))[1] : array_get($args, $idArg);
-            $model = $class::find($id);
+            
+            $model = $this->getModelClass()::find($id);
 
             if ($model) {
                 $attributes = collect($args)->except([$idArg])->toArray();


### PR DESCRIPTION
**Related Issue(s)**

Previously, the configuration option for the Model namespace was not considered in
a bunch of cases.

**PR Type**

Bugfix

**Changes**

The common method for getting a model is now reused in all applicable places, thus unifying
the behaviour that a user can expect when referencing models in directives.

**Breaking changes**

Apart from some really far fetched edge cases, no. Should a user reference a model like

	@create(model: "App\\Foo")

this would now reference `App\Models\App\Foo` if it exists.
