### PR TITLE
[WIP] Apollo Engine Tracing

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -3,19 +3,20 @@
 namespace Nuwave\Lighthouse;
 
 use GraphQL\Deferred;
-use GraphQL\Executor\ExecutionResult;
-use GraphQL\GraphQL as GraphQLBase;
 use GraphQL\Type\Schema;
+use GraphQL\GraphQL as GraphQLBase;
+use GraphQL\Executor\ExecutionResult;
 use Illuminate\Support\Facades\Cache;
+use Nuwave\Lighthouse\Schema\TypeRegistry;
+use Nuwave\Lighthouse\Schema\NodeContainer;
+use Nuwave\Lighthouse\Schema\SchemaBuilder;
 use Nuwave\Lighthouse\Schema\AST\ASTBuilder;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\DirectiveRegistry;
 use Nuwave\Lighthouse\Schema\MiddlewareManager;
-use Nuwave\Lighthouse\Schema\NodeContainer;
-use Nuwave\Lighthouse\Schema\SchemaBuilder;
-use Nuwave\Lighthouse\Schema\Source\SchemaSourceProvider;
-use Nuwave\Lighthouse\Schema\TypeRegistry;
 use Nuwave\Lighthouse\Support\Traits\CanFormatError;
+use Nuwave\Lighthouse\Schema\Source\SchemaSourceProvider;
+use Nuwave\Lighthouse\Schema\Extensions\ExtensionRegistry;
 
 class GraphQL
 {
@@ -50,6 +51,13 @@ class GraphQL
     protected $middleware;
 
     /**
+     * Extension registry.
+     *
+     * @var ExtensionRegistry
+     */
+    protected $extensions;
+
+    /**
      * GraphQL Schema.
      *
      * @var Schema
@@ -70,17 +78,20 @@ class GraphQL
      * @param TypeRegistry      $types
      * @param MiddlewareManager $middleware
      * @param NodeContainer     $nodes
+     * @param ExtensionRegistry $extensions
      */
     public function __construct(
         DirectiveRegistry $directives,
         TypeRegistry $types,
         MiddlewareManager $middleware,
-        NodeContainer $nodes
+        NodeContainer $nodes,
+        ExtensionRegistry $extensions
     ) {
         $this->directives = $directives;
         $this->types = $types;
         $this->middleware = $middleware;
         $this->nodes = $nodes;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -272,5 +283,15 @@ class GraphQL
     public function nodes(): NodeContainer
     {
         return $this->nodes;
+    }
+
+    /**
+     * Get instance of extension registry.
+     *
+     * @return ExtensionRegistry
+     */
+    public function extensions(): ExtensionRegistry
+    {
+        return $this->extensions;
     }
 }

--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -2,16 +2,17 @@
 
 namespace Nuwave\Lighthouse\Providers;
 
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Nuwave\Lighthouse\GraphQL;
-use Nuwave\Lighthouse\Schema\Factories\ValueFactory;
-use Nuwave\Lighthouse\Schema\Source\SchemaSourceProvider;
+use Illuminate\Support\Collection;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Validator;
 use Nuwave\Lighthouse\Schema\Source\SchemaStitcher;
-use Nuwave\Lighthouse\Support\Collection as LighthouseCollection;
+use Nuwave\Lighthouse\Schema\Factories\ValueFactory;
+use Nuwave\Lighthouse\Schema\Extensions\TraceExtension;
+use Nuwave\Lighthouse\Schema\Source\SchemaSourceProvider;
 use Nuwave\Lighthouse\Support\Validator\ValidatorFactory;
+use Nuwave\Lighthouse\Support\Collection as LighthouseCollection;
 
 class LighthouseServiceProvider extends ServiceProvider
 {
@@ -32,6 +33,7 @@ class LighthouseServiceProvider extends ServiceProvider
 
         $this->registerMacros();
         $this->registerValidator();
+        $this->registerExtensions();
     }
 
     /**
@@ -107,5 +109,17 @@ class LighthouseServiceProvider extends ServiceProvider
         });
 
         Validator::extendImplicit('required_with_mutation', ValidatorFactory::class.'@requiredWithMutation');
+    }
+
+    /**
+     * Register extensions w/ registry.
+     */
+    public function registerExtensions()
+    {
+        $this->app->singleton(TraceExtension::class);
+
+        graphql()->extensions()->registerMany([
+            $this->app->get(TraceExtension::class),
+        ]);
     }
 }

--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -2,16 +2,17 @@
 
 namespace Nuwave\Lighthouse\Schema\AST;
 
-use GraphQL\Language\AST\FieldDefinitionNode;
-use GraphQL\Language\AST\InputValueDefinitionNode;
-use GraphQL\Language\AST\NamedTypeNode;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeList;
+use GraphQL\Language\AST\NamedTypeNode;
+use GraphQL\Language\AST\FieldDefinitionNode;
+use GraphQL\Language\AST\InputValueDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Language\AST\TypeExtensionDefinitionNode;
 use Nuwave\Lighthouse\Support\Contracts\ArgManipulator;
-use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
 use Nuwave\Lighthouse\Support\Contracts\NodeManipulator;
+use Nuwave\Lighthouse\Schema\Extensions\GraphQLExtension;
+use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
 
 class ASTBuilder
 {
@@ -33,6 +34,7 @@ class ASTBuilder
         $document = self::applyArgManipulators($document);
 
         $document = self::addNodeSupport($document);
+        $document = self::applyExtensions($document);
 
         return $document;
     }
@@ -67,6 +69,11 @@ class ASTBuilder
             }, $document);
     }
 
+    /**
+     * @param DocumentAST $document
+     *
+     * @return DocumentAST
+     */
     protected static function mergeTypeExtensions(DocumentAST $document)
     {
         $document->objectTypeDefinitions()->each(function (ObjectTypeDefinitionNode $objectType) use ($document) {
@@ -170,11 +177,13 @@ class ASTBuilder
      */
     protected static function addNodeSupport(DocumentAST $document)
     {
-        $hasTypeImplementingNode = $document->objectTypeDefinitions()->contains(function (ObjectTypeDefinitionNode $objectType) {
-            return collect($objectType->interfaces)->contains(function (NamedTypeNode $interface) {
-                return 'Node' === $interface->name->value;
+        $hasTypeImplementingNode = $document->objectTypeDefinitions()
+            ->contains(function (ObjectTypeDefinitionNode $objectType) {
+                return collect($objectType->interfaces)
+                    ->contains(function (NamedTypeNode $interface) {
+                        return 'Node' === $interface->name->value;
+                    });
             });
-        });
 
         // Only add the node type and node field if a type actually implements them
         // Otherwise, a validation error is thrown
@@ -198,5 +207,25 @@ class ASTBuilder
         $document->addFieldToQueryType($nodeQuery);
 
         return $document;
+    }
+
+    /**
+     * @param DocumentAST $document
+     *
+     * @return DocumentAST
+     */
+    protected static function applyExtensions(DocumentAST $document)
+    {
+        $originalDocument = $document;
+
+        return graphql()
+            ->extensions()
+            ->active()
+            ->reduce(function (
+                DocumentAST $document,
+                GraphQLExtension $extension
+            ) use ($originalDocument) {
+                return $extension->manipulateSchema($document, $originalDocument);
+            }, $document);
     }
 }

--- a/src/Schema/Directives/Fields/TraceDirective.php
+++ b/src/Schema/Directives/Fields/TraceDirective.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Directives\Fields;
+
+use GraphQL\Type\Definition\ResolveInfo;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Nuwave\Lighthouse\Schema\Extensions\TraceExtension;
+use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
+
+class TraceDirective extends BaseDirective implements FieldMiddleware
+{
+    /**
+     * Name of the directive.
+     *
+     * @return string
+     */
+    public function name()
+    {
+        return 'trace';
+    }
+
+    /**
+     * Resolve the field directive.
+     *
+     * @param FieldValue $value
+     * @param \Closure   $next
+     *
+     * @return FieldValue
+     */
+    public function handleField(FieldValue $value, \Closure $next)
+    {
+        $value = $next($value);
+        $resolver = $value->getResolver();
+
+        return $value->setResolver(function ($root, $args, $context, ResolveInfo $info) use ($resolver) {
+            $start = now();
+            $result = call_user_func($resolver, $root, $args, $context, $info);
+
+            app(TraceExtension::class)->record($info, $start, now());
+
+            return $result;
+        });
+    }
+}

--- a/src/Schema/Directives/Fields/TraceDirective.php
+++ b/src/Schema/Directives/Fields/TraceDirective.php
@@ -39,9 +39,9 @@ class TraceDirective extends BaseDirective implements FieldMiddleware
 
             ($result instanceof \GraphQL\Deferred)
                 ? $result->then(function (&$items) use ($info, $start) {
-                    app(TraceExtension::class)->record($info, $start);
+                    app(TraceExtension::class)->record($info, $start, now());
                 })
-                : app(TraceExtension::class)->record($info, $start);
+                : app(TraceExtension::class)->record($info, $start, now());
 
             return $result;
         });

--- a/src/Schema/Directives/Fields/TraceDirective.php
+++ b/src/Schema/Directives/Fields/TraceDirective.php
@@ -37,7 +37,11 @@ class TraceDirective extends BaseDirective implements FieldMiddleware
             $start = now();
             $result = call_user_func($resolver, $root, $args, $context, $info);
 
-            app(TraceExtension::class)->record($info, $start, now());
+            ($result instanceof \GraphQL\Deferred)
+                ? $result->then(function (&$items) use ($info, $start) {
+                    app(TraceExtension::class)->record($info, $start);
+                })
+                : app(TraceExtension::class)->record($info, $start);
 
             return $result;
         });

--- a/src/Schema/Extensions/ExtensionRegistry.php
+++ b/src/Schema/Extensions/ExtensionRegistry.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Extensions;
+
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+
+class ExtensionRegistry
+{
+    /**
+     * @var \Illuminate\Support\Collection
+     */
+    protected $extensions;
+
+    /**
+     * Create instance of extension registry.
+     */
+    public function __construct()
+    {
+        $this->extensions = collect();
+    }
+
+    /**
+     * Register graphql extension.
+     *
+     * @param GraphQLExtension $extension
+     */
+    public function register(GraphQLExtension $extension)
+    {
+        $this->extensions->put($extension->name(), $extension);
+    }
+
+    /**
+     * Register graphql extensions.
+     *
+     * @param array $extensions
+     */
+    public function registerMany($extensions)
+    {
+        foreach ($extensions as $extension) {
+            $this->register($extension);
+        }
+    }
+
+    /**
+     * Get extension.
+     *
+     * @param name $name
+     *
+     * @return GraphQLExtension|null
+     */
+    public function get($name)
+    {
+        return $this->extensions->get($name);
+    }
+
+    /**
+     * Get active extensions.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function active()
+    {
+        return $this->extensions->only(
+            config('lighthouse.extensions', [])
+        );
+    }
+
+    /**
+     * Process formatted data.
+     *
+     * @return array
+     */
+    public function format()
+    {
+        return $this->extensions
+            ->only(config('lighthouse.extensions', []))
+            ->mapWithKeys(function (GraphQLExtension $extension) {
+                return [$extension->name() => $extension->format()];
+            })
+            ->toArray();
+    }
+}

--- a/src/Schema/Extensions/ExtensionRegistry.php
+++ b/src/Schema/Extensions/ExtensionRegistry.php
@@ -2,8 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Extensions;
 
-use Nuwave\Lighthouse\Schema\AST\DocumentAST;
-
 class ExtensionRegistry
 {
     /**
@@ -60,9 +58,13 @@ class ExtensionRegistry
      */
     public function active()
     {
-        return $this->extensions->only(
-            config('lighthouse.extensions', [])
-        );
+        $extensions = config('lighthouse.extensions', []);
+
+        if (is_string($extensions)) {
+            $extensions = explode(',', $extensions);
+        }
+
+        return $this->extensions->only($extensions);
     }
 
     /**

--- a/src/Schema/Extensions/ExtensionRegistry.php
+++ b/src/Schema/Extensions/ExtensionRegistry.php
@@ -66,16 +66,28 @@ class ExtensionRegistry
     }
 
     /**
-     * Process formatted data.
+     * Handle request start.
+     *
+     * @param ExtensionRequest $request
+     */
+    public function requestDidStart(ExtensionRequest $request)
+    {
+        $this->active()->each(function (GraphQLExtension $extension) use ($request) {
+            $extension->requestDidStart($request);
+        });
+    }
+
+    /**
+     * Get output for all extensions.
      *
      * @return array
      */
-    public function format()
+    public function toArray()
     {
         return $this->extensions
             ->only(config('lighthouse.extensions', []))
             ->mapWithKeys(function (GraphQLExtension $extension) {
-                return [$extension->name() => $extension->format()];
+                return [$extension->name() => $extension->toArray()];
             })
             ->toArray();
     }

--- a/src/Schema/Extensions/ExtensionRegistry.php
+++ b/src/Schema/Extensions/ExtensionRegistry.php
@@ -86,8 +86,7 @@ class ExtensionRegistry
      */
     public function toArray()
     {
-        return $this->extensions
-            ->only(config('lighthouse.extensions', []))
+        return $this->active()
             ->mapWithKeys(function (GraphQLExtension $extension) {
                 return [$extension->name() => $extension->toArray()];
             })

--- a/src/Schema/Extensions/ExtensionRequest.php
+++ b/src/Schema/Extensions/ExtensionRequest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Extensions;
+
+class ExtensionRequest
+{
+    /**
+     * @var \Illuminate\Http\Request
+     */
+    protected $request;
+
+    /**
+     * @var string
+     */
+    protected $queryString;
+
+    /**
+     * @var string
+     */
+    protected $operationName;
+
+    /**
+     * @var array
+     */
+    protected $variables;
+
+    /**
+     * Create instance of extension request.
+     *
+     * @param array $options
+     */
+    public function __construct(array $options)
+    {
+        $this->request = array_get($options, 'request');
+        $this->queryString = array_get($options, 'query_string');
+        $this->operationName = array_get($options, 'operationName');
+        $this->variables = array_get($options, 'variables');
+    }
+
+    /**
+     * Get request instance.
+     *
+     * @return \Illuminate\Http\Request
+     */
+    public function request()
+    {
+        return $this->request;
+    }
+
+    /**
+     * Get GraphQL query string.
+     *
+     * @return string
+     */
+    public function queryString()
+    {
+        return $this->queryString;
+    }
+
+    /**
+     * Get request operation name.
+     *
+     * @return string
+     */
+    public function operationName()
+    {
+        return $this->operationName;
+    }
+
+    /**
+     * Get request variables.
+     *
+     * @return array
+     */
+    public function variables()
+    {
+        return $this->variables;
+    }
+
+    /**
+     * GraphQL schema.
+     *
+     * @return \GraphQL\Type\Schema
+     */
+    public function schema()
+    {
+        return $this->schema;
+    }
+}

--- a/src/Schema/Extensions/GraphQLExtension.php
+++ b/src/Schema/Extensions/GraphQLExtension.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Extensions;
+
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+
+abstract class GraphQLExtension implements \JsonSerializable
+{
+    /**
+     * Manipulate the schema.
+     *
+     * @param DocumentAST $current
+     * @param DocumentAST $original
+     *
+     * @return DocumentAST
+     */
+    public function manipulateSchema(DocumentAST $current, DocumentAST $original)
+    {
+        return $current;
+    }
+
+    /**
+     * Specify data which should be serialized to JSON.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Extension name.
+     *
+     * @return string
+     */
+    abstract public function name();
+
+    /**
+     * Format extension output.
+     *
+     * @return array
+     */
+    abstract public function toArray();
+}

--- a/src/Schema/Extensions/GraphQLExtension.php
+++ b/src/Schema/Extensions/GraphQLExtension.php
@@ -20,6 +20,16 @@ abstract class GraphQLExtension implements \JsonSerializable
     }
 
     /**
+     * Handle request start.
+     *
+     * @param ExtensionRequest $request
+     */
+    public function requestDidStart(ExtensionRequest $request)
+    {
+        return;
+    }
+
+    /**
      * Specify data which should be serialized to JSON.
      *
      * @return array

--- a/src/Schema/Extensions/TraceExtension.php
+++ b/src/Schema/Extensions/TraceExtension.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Extensions;
+
+use Carbon\Carbon;
+use GraphQL\Language\AST\NodeList;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Language\AST\FieldDefinitionNode;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+use Nuwave\Lighthouse\Schema\AST\PartialParser;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+
+class TraceExtension extends GraphQLExtension
+{
+    /**
+     * Trace entries.
+     *
+     * @var \Illuminate\Support\Collection
+     */
+    protected $resolvers;
+
+    /**
+     * Create instance of trace extension.
+     */
+    public function __construct()
+    {
+        $this->resolvers = collect();
+    }
+
+    /**
+     * Extension name.
+     *
+     * @return string
+     */
+    public function name()
+    {
+        return 'trace';
+    }
+
+    /**
+     * Manipulate the schema.
+     *
+     * @param DocumentAST $current
+     * @param DocumentAST $original
+     *
+     * @return DocumentAST
+     */
+    public function manipulateSchema(DocumentAST $current, DocumentAST $original)
+    {
+        $trace = PartialParser::directive('@trace');
+
+        return $current->typeDefinitions()
+            ->reduce(function (DocumentAST $document, ObjectTypeDefinitionNode $objectType) use ($trace) {
+                if (! data_get($objectType, 'name.value')) {
+                    return $document;
+                }
+
+                $objectType->fields = new NodeList(collect($objectType->fields)
+                    ->map(function (FieldDefinitionNode $field) use ($trace) {
+                        $field->directives = $field->directives->merge([$trace]);
+
+                        return $field;
+                    })->all());
+
+                $document->setDefinition($objectType);
+
+                return $document;
+            }, $current);
+    }
+
+    /**
+     * Record resolver execution time.
+     *
+     * @param ResolveInfo $info
+     * @param Carbon      $start
+     * @param Carbon      $end
+     */
+    public function record(ResolveInfo $info, Carbon $start, Carbon $end)
+    {
+        $duration = $end->micro - $start->micro;
+
+        $this->resolvers->push([
+            'path' => $info->path,
+            'parentType' => $info->parentType->name,
+            'fieldName' => $info->fieldName,
+            'duration' => $duration,
+        ]);
+    }
+
+    /**
+     * Format extension output.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->resolvers->toArray();
+    }
+}

--- a/tests/Integration/GraphQLTest.php
+++ b/tests/Integration/GraphQLTest.php
@@ -2,15 +2,15 @@
 
 namespace Tests\Integration;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class GraphQLTest extends DBTestCase
 {
     use RefreshDatabase;
-    
+
     protected $schema = '
     type User {
         id: ID!
@@ -97,6 +97,7 @@ class GraphQLTest extends DBTestCase
                     })->toArray(),
                 ],
             ],
+            'extensions' => [],
         ];
 
         $this->assertEquals($expected, $data);
@@ -130,6 +131,7 @@ class GraphQLTest extends DBTestCase
                     })->toArray(),
                 ],
             ],
+            'extensions' => [],
         ];
 
         $this->assertEquals($expected, $data);
@@ -152,7 +154,7 @@ class GraphQLTest extends DBTestCase
         }
         ';
 
-        $uri = 'graphql?' . http_build_query(['query' => $query]);
+        $uri = 'graphql?'.http_build_query(['query' => $query]);
 
         $data = $this->getJson($uri)->json();
 
@@ -165,6 +167,7 @@ class GraphQLTest extends DBTestCase
                     })->toArray(),
                 ],
             ],
+            'extensions' => [],
         ];
 
         $this->assertEquals($expected, $data);

--- a/tests/Unit/GraphQLTest.php
+++ b/tests/Unit/GraphQLTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit;
 
-use GraphQL\Type\Schema;
 use Tests\TestCase;
+use GraphQL\Type\Schema;
 
 class GraphQLTest extends TestCase
 {
@@ -17,17 +17,17 @@ class GraphQLTest extends TestCase
         user: User! @field(class: "Tests\\\Unit\\\GraphQLTest" method: "user")
     }
     ';
-    
+
     /**
      * @test
      */
     public function itCanBuildGraphQLSchema()
     {
         $schema = graphql()->buildSchema();
-        
+
         $this->assertInstanceOf(Schema::class, $schema);
     }
-    
+
     /**
      * @test
      */
@@ -42,7 +42,7 @@ class GraphQLTest extends TestCase
             }
         }
         ';
-        
+
         $expected = [
             'data' => [
                 'user' => [
@@ -51,11 +51,12 @@ class GraphQLTest extends TestCase
                     'updated_at' => now()->format('Y-m-d'),
                 ],
             ],
+            'extensions' => [],
         ];
-        
+
         $this->assertEquals($expected, graphql()->execute($query));
     }
-    
+
     public function user($root, array $args, $context, $info)
     {
         return [

--- a/tests/Unit/Schema/Extensions/TraceExtensionTest.php
+++ b/tests/Unit/Schema/Extensions/TraceExtensionTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit\Schema\Extensions;
+
+use Tests\TestCase;
+use Nuwave\Lighthouse\Schema\Extensions\TraceExtension;
+
+class TraceExtensionTest extends TestCase
+{
+    /**
+     * Define environment setup.
+     *
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('lighthouse.extensions', ['trace']);
+    }
+
+    /**
+     * @test
+     */
+    public function itCanAddTraceExtensionMetaToResult()
+    {
+        $resolver = addslashes(self::class).'@resolve';
+
+        $schema = "
+        type Query {
+            foo: String @field(resolver: \"{$resolver}\")
+        }";
+
+        $result = $this->execute($schema, '{ foo }', true);
+        dd(app(TraceExtension::class)->toArray());
+    }
+
+    public function resolve()
+    {
+        usleep(20000); // 20 milliseconds
+        return 'bar';
+    }
+}

--- a/tests/Unit/Schema/Extensions/TraceExtensionTest.php
+++ b/tests/Unit/Schema/Extensions/TraceExtensionTest.php
@@ -16,7 +16,7 @@ class TraceExtensionTest extends TestCase
     {
         parent::getEnvironmentSetUp($app);
 
-        $app['config']->set('lighthouse.extensions', ['trace']);
+        $app['config']->set('lighthouse.extensions', ['tracing']);
     }
 
     /**
@@ -32,7 +32,8 @@ class TraceExtensionTest extends TestCase
         }";
 
         $result = $this->execute($schema, '{ foo }', true);
-        dd(app(TraceExtension::class)->toArray());
+        $this->assertArrayHasKey('tracing', $result->extensions);
+        $this->assertArrayHasKey('resolvers', $result->extensions['tracing']);
     }
 
     public function resolve()

--- a/tests/Unit/Schema/Extensions/TraceExtensionTest.php
+++ b/tests/Unit/Schema/Extensions/TraceExtensionTest.php
@@ -28,12 +28,12 @@ class TraceExtensionTest extends TestCase
 
         $schema = "
         type Query {
-            foo: String @field(resolver: \"{$resolver}\")
+            foo: String! @field(resolver: \"{$resolver}\")
         }";
 
         $result = $this->execute($schema, '{ foo }', true);
         $this->assertArrayHasKey('tracing', $result->extensions);
-        $this->assertArrayHasKey('resolvers', $result->extensions['tracing']);
+        $this->assertArrayHasKey('resolvers', $result->extensions['tracing']['execution']);
     }
 
     public function resolve()


### PR DESCRIPTION
**Related Issue(s)**

#98 

**PR Type**

Feature

**Changes**

This PR introduces [Apollo Engine Tracing](https://www.apollographql.com/docs/engine/performance.html#trace) (it also works w/ [Prisma's Playground](https://github.com/prismagraphql/graphql-playground)) as well as a draft for implementing [extensions](https://github.com/apollographql/apollo-server/tree/master/packages/graphql-extensions). A new `extensions` config option will be added which accepts an array of extensions to activate.

```php
// lighthouse.php
return [
    // ...
    'extensions' => ['tracing']
];
```

*Note: The `GraphqlExtension` and `ExtensionRegistry` were only introduced in this PR to get basic functionality working. A PR is already in progress to build out the API*

**Breaking changes**

None