### PR TITLE
Fix typo 'compose' => 'composer' in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ giving you full control over your data.
 
 If you have an existing Laravel project, all you really need is two steps:
 
-1. Install via `compose require nuwave/lighthouse`
+1. Install via `composer require nuwave/lighthouse`
 
 2. Define your schema in `routes/graphql/schema.graphql`
 


### PR DESCRIPTION
**Related Issue(s)**

None

**PR Type**

Docs

**Changes**

Adds one missing character :)

**Breaking changes**

None
