### PR TITLE
[FIX] Query Parsing

### DIFF
--- a/tests/Utils/Models/Task.php
+++ b/tests/Utils/Models/Task.php
@@ -3,11 +3,12 @@
 namespace Tests\Utils\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Nuwave\Lighthouse\Support\Traits\IsRelayConnection;
 
 class Task extends Model
 {
-    use IsRelayConnection;
+    use IsRelayConnection, SoftDeletes;
 
     public function user()
     {

--- a/tests/database/migrations/2018_02_28_000003_create_testbench_tasks_table.php
+++ b/tests/database/migrations/2018_02_28_000003_create_testbench_tasks_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 class CreateTestbenchTasksTable extends Migration
 {
@@ -16,6 +16,7 @@ class CreateTestbenchTasksTable extends Migration
             $table->unsignedInteger('user_id');
             $table->string('name');
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 


### PR DESCRIPTION
**PR Type**

Bugfix

**Changes**

Not sure if this is Laravel related (seems to be) but when using the `fromSub` function on a Query Builder it strips out the soft delete check from the first query, thus breaking soft deletes used in the `@hasMany` or `@belongsTo` directives.

**Breaking changes**

None
