### PR TITLE
remove fromRaw from compatibility

### DIFF
--- a/src/Support/DataLoader/QueryBuilder.php
+++ b/src/Support/DataLoader/QueryBuilder.php
@@ -115,10 +115,10 @@ class QueryBuilder
         /** @var \Illuminate\Database\Query\Builder $baseQuery */
         $baseQuery = app('db')->query();
         $fromExpression = '('.$unitedRelations->toSql().') as '.$baseQuery->grammar->wrap($relatedTable);
-        $results = $baseQuery->select()->fromRaw(
-            $fromExpression,
-            $unitedRelations->getBindings()
-        )->get();
+        $results = $baseQuery->select()
+            ->from($baseQuery->raw($fromExpression))
+            ->setBindings($unitedRelations->getBindings())
+            ->get();
 
         $hydrated = $this->hydrate($relatedModel, $relation, $results);
         $collection = $this->loadDefaultWith($relatedModel->newCollection($hydrated));


### PR DESCRIPTION
**Related Issue(s)**

#204 

**PR Type**

Compatibility Fix

**Changes**

Laravel v5.4 doesn't have `fromRaw` so this PR tweaks the `QueryBuilder` to use the `from` and `setBindings` methods available in older versions of Laravel.

**Breaking changes**

None
