### PR TITLE
Deprecate instance method in favor of get

### DIFF
--- a/src/Schema/Directives/Nodes/UnionDirective.php
+++ b/src/Schema/Directives/Nodes/UnionDirective.php
@@ -38,7 +38,7 @@ class UnionDirective extends BaseDirective implements NodeResolver
             'description' => trim(str_replace("\n", '', $value->getNode()->description)),
             'types' => function () use ($value) {
                 return collect($value->getNode()->types)->map(function ($type) {
-                    return graphql()->types()->instance($type->name->value);
+                    return graphql()->types()->get($type->name->value);
                 })->filter()->toArray();
             },
             'resolveType' => function ($value) use ($namespace, $method) {
@@ -46,7 +46,7 @@ class UnionDirective extends BaseDirective implements NodeResolver
                     $instance = app($namespace);
                     return call_user_func_array([$instance, $method], [$value]);
                 }
-                return graphql()->types()->instance(last(explode('\\', get_class($value))));
+                return graphql()->types()->get(last(explode('\\', get_class($value))));
             },
         ]));
     }

--- a/src/Schema/NodeContainer.php
+++ b/src/Schema/NodeContainer.php
@@ -92,7 +92,7 @@ class NodeContainer
     public function resolveType($value)
     {
         if (is_object($value) && isset($this->models[get_class($value)])) {
-            return graphql()->types()->instance($this->models[get_class($value)]);
+            return graphql()->types()->get($this->models[get_class($value)]);
         }
 
         return collect($this->types)
@@ -107,7 +107,7 @@ class NodeContainer
                 $resolver = $item['resolver'];
                 $type = $item['type'];
 
-                return $resolver($value) ? graphql()->types()->instance($type) : $instance;
+                return $resolver($value) ? graphql()->types()->get($type) : $instance;
             });
     }
 }

--- a/src/Schema/Resolvers/FieldTypeResolver.php
+++ b/src/Schema/Resolvers/FieldTypeResolver.php
@@ -160,7 +160,7 @@ class FieldTypeResolver
     protected function convertCustomType($name)
     {
         return function () use ($name) {
-            return graphql()->types()->instance($name);
+            return graphql()->types()->get($name);
         };
     }
 }

--- a/src/Schema/Resolvers/NodeResolver.php
+++ b/src/Schema/Resolvers/NodeResolver.php
@@ -89,7 +89,7 @@ class NodeResolver
             case 'String':
                 return Type::string();
             default:
-                return graphql()->types()->instance($node->name->value);
+                return graphql()->types()->get($node->name->value);
         }
     }
 }

--- a/src/Schema/TypeRegistry.php
+++ b/src/Schema/TypeRegistry.php
@@ -28,6 +28,7 @@ class TypeRegistry
      * @param string $typeName
      *
      * @return Type
+     * @deprecated in favour of get
      */
     public function instance($typeName)
     {

--- a/tests/Integration/Schema/NodeTest.php
+++ b/tests/Integration/Schema/NodeTest.php
@@ -112,7 +112,7 @@ class NodeTest extends DBTestCase
     public function resolveNodeType($value)
     {
         if (is_array($value) && isset($value['name'])) {
-            return graphql()->types()->instance('User');
+            return graphql()->types()->get('User');
         }
     }
 }

--- a/tests/Unit/Schema/Directives/Nodes/UnionTest.php
+++ b/tests/Unit/Schema/Directives/Nodes/UnionTest.php
@@ -35,7 +35,7 @@ class UnionTest extends TestCase
     {
         $type = isset($value['id']) ? 'User' : 'Employee';
 
-        return graphql()->types()->instance($type);
+        return graphql()->types()->get($type);
     }
 
     protected function schema()


### PR DESCRIPTION
This makes it so the TypeRegistry has a smaller public API and a more
intuitive method name, get() and register() are pretty standard for a registry.

**PR Type**

Refactor

**Breaking changes**

Nope, but the deprecated method will be removed in v3
