### PR TITLE
Rename the ScoutDirective to SearchDirective to match its actual name

### DIFF
--- a/src/Schema/Directives/Args/SearchDirective.php
+++ b/src/Schema/Directives/Args/SearchDirective.php
@@ -8,7 +8,7 @@ use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgMiddleware;
 use Nuwave\Lighthouse\Support\Traits\HandlesQueryFilter;
 
-class ScoutDirective extends BaseDirective implements ArgMiddleware
+class SearchDirective extends BaseDirective implements ArgMiddleware
 {
     use HandlesQueryFilter;
 

--- a/tests/Integration/Schema/Directives/Args/SearchDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Args/SearchDirectiveTest.php
@@ -1,23 +1,16 @@
 <?php
 
-
 namespace Tests\Integration\Schema\Directives\Args;
 
-
-use Illuminate\Foundation\Testing\RefreshDatabase;
-
-use Laravel\Scout\Builder;
-use Laravel\Scout\EngineManager;
-use Laravel\Scout\Engines\Engine;
-use Laravel\Scout\Engines\NullEngine;
 use Mockery;
 use Mockery\Mock;
 use Tests\DBTestCase;
-use Tests\Utils\Models\Comment;
 use Tests\Utils\Models\Post;
-use Tests\Utils\Models\User;
+use Laravel\Scout\EngineManager;
+use Laravel\Scout\Engines\NullEngine;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
-class ScoutDirectiveTest extends DBTestCase
+class SearchDirectiveTest extends DBTestCase
 {
     use RefreshDatabase;
 
@@ -27,25 +20,9 @@ class ScoutDirectiveTest extends DBTestCase
     /** @var Mock */
     protected $engine;
 
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->engineManager = Mockery::mock();
-        $this->engine = Mockery::mock(NullEngine::class)->makePartial();
-
-        $this->app->singleton(EngineManager::class, function ($app) {
-            return $this->engineManager;
-        });
-
-        $this->engineManager->shouldReceive('engine')
-            ->andReturn($this->engine);
-    }
-
-
     /** @test */
     public function canSearch()
     {
-
         $postA = factory(Post::class)->create([
             'title' => 'great title'
         ]);
@@ -86,7 +63,6 @@ class ScoutDirectiveTest extends DBTestCase
     /** @test */
     public function canSearchWithCustomIndex()
     {
-
         $postA = factory(Post::class)->create([
             'title' => 'great title'
         ]);
@@ -100,10 +76,10 @@ class ScoutDirectiveTest extends DBTestCase
         $this->engine->shouldReceive("map")->andReturn(collect([$postA, $postB]))->once();
 
         $this->engine->shouldReceive('paginate')->with(
-                Mockery::on(function ($argument) {
-                    return $argument->index == "my.index";
-                }), Mockery::any(), Mockery::any()
-            )
+            Mockery::on(function ($argument) {
+                return $argument->index == "my.index";
+            }), Mockery::any(), Mockery::any()
+        )
             ->andReturn(collect([$postA, $postB]))
             ->once();
 
@@ -132,4 +108,17 @@ class ScoutDirectiveTest extends DBTestCase
         $this->assertEquals($postB->id, $result->data['posts']['data'][1]['id']);
     }
 
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->engineManager = Mockery::mock();
+        $this->engine = Mockery::mock(NullEngine::class)->makePartial();
+
+        $this->app->singleton(EngineManager::class, function ($app) {
+            return $this->engineManager;
+        });
+
+        $this->engineManager->shouldReceive('engine')
+            ->andReturn($this->engine);
+    }
 }


### PR DESCRIPTION
**Related Issue(s)**

Resolves #226

**PR Type**

Refactor

**Breaking changes**

Nope, as usage of the directive stays the same
