### PR TITLE
Update default-schema.graphql file

### DIFF
--- a/assets/default-schema.graphql
+++ b/assets/default-schema.graphql
@@ -1,21 +1,21 @@
 type Query {
-    users: [User!]! @paginate(type: "paginator" model: "User")
-    user(id: ID @eq): User @find(model: "User")
+    users: [User!]! @paginate(type: "paginator" model: "App\\User")
+    user(id: ID @eq): User @find(model: "App\\User")
 }
 
 type Mutation {
     createUser(
         name: String @rules(apply: ["required"])
         email: String @rules(apply: ["required", "email", "unique:users,email"])
-    ): User @create(model: "User")
+    ): User @create(model: "App\\User")
     updateUser(
         id: ID @rules(apply: ["required"])
         name: String
         email: String @rules(apply: ["email"])
-    ): User @update(model: "User")
+    ): User @update(model: "App\\User")
     deleteUser(
         id: ID @rules(apply: ["required"])
-    ): User @delete(model: "User")
+    ): User @delete(model: "App\\User")
 }
 
 type User {


### PR DESCRIPTION
Hey,

I think the idea of having a default schema is wonderful. I, however, ran into an issue, which I tried to address with this PR. 

Straight after installation of Lighthouse on a new Laravel install, I was thrilled to test out the default schema Lighthouse generates by default. Laravel immediately threw an error as User model couldn't be found in App\\Models namespace. While I usually keep my models in a Models directory, User is the only one I leave at the default location.

I believe the default installation of a package immediately throwing an error may present a very wrong picture of Lighthouse being non-functional or poorly maintained. I myself have been subscribed to the package updates long enough to know that it definitely isn't the case.

I, therefore, propose the default schema changes the User model location "App\\User" to reflect default Laravel location for User model and avoid the error thrown "on first spin" by a Lighthouse newcomer.

Alternatively, if you choose a different route, I believe it would be beneficial for the interested developers to be made aware of this in the installation/configuration section of the documentation.

Keep up the great work.