### PR TITLE
Pass operationName through executeQuery function, fixes #241

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -168,7 +168,8 @@ class GraphQL
             $query,
             $rootValue,
             $context,
-            $variables
+            $variables,
+            request()->input('operationName')
         );
 
         $result->extensions = $this->extensions->toArray();

--- a/tests/Unit/GraphQLTest.php
+++ b/tests/Unit/GraphQLTest.php
@@ -57,6 +57,39 @@ class GraphQLTest extends TestCase
         $this->assertEquals($expected, graphql()->execute($query));
     }
 
+    /**
+     * @test
+     */
+    public function itCanExecuteQueryWithNamedOperation()
+    {
+        $query = '
+        query User {
+            user {
+                id
+                created_at
+                updated_at
+            }
+        }
+        query userOnlyId {
+            user {
+                id
+            }
+        }
+        ';
+        request()->merge(['operationName' => 'userOnlyId']);
+
+        $expected = [
+            'data' => [
+                'user' => [
+                    'id' => 1,
+                ],
+            ],
+            'extensions' => [],
+        ];
+
+        $this->assertEquals($expected, graphql()->execute($query));
+    }
+
     public function user($root, array $args, $context, $info)
     {
         return [


### PR DESCRIPTION
**Related Issue(s)**

#241 


**PR Type**

Bugfix

**Changes**

Adds support for 'named operations in GraphQL Playground / GraphiQL. As described in #241 

**Breaking changes**

Not that I know, Laravel defaults to null so it should still work when it was not passed.
