### PR TITLE
add DateTime scalar to default schema

### DIFF
--- a/assets/default-schema.graphql
+++ b/assets/default-schema.graphql
@@ -1,3 +1,5 @@
+scalar DateTime @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\DateTime")
+
 type Query {
     users: [User!]! @paginate(type: "paginator" model: "App\\User")
     user(id: ID @eq): User @find(model: "App\\User")


### PR DESCRIPTION
Thanks for wonderful library. I love it.

I encountered the following error when I first installed this library.

```js
{
  "message": "Can only create NonNull of a Nullable GraphQLType but got: null",
  "exception": "GraphQL\\Error\\InvariantViolation",
  "file": "/var/www/html/vendor/webonyx/graphql-php/src/Type/Definition/NonNull.php",
  "line": 25,
  "trace": [
    {
      "file": "/var/www/html/vendor/webonyx/graphql-php/src/Type/Definition/Type.php",
      "line": 88,
      "function": "__construct",
      "class": "GraphQL\\Type\\Definition\\NonNull",
      "type": "->"
    },
    // ....
}
```

**PR Type**

Docs

**Changes**

After I import `DateTime` scalar on the top of `routes/graphql/schema.graphql` the error has gone.

```gql
scalar DateTime @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\DateTime")
```

referring the Doc: https://lighthouse-php.netlify.com/docs/schema-scalars.html

Is there better solution or did I failed to install properly?

Thanks,