### PR TITLE
Add a description for the default DateTime scalar

### DIFF
--- a/src/Schema/Types/Scalars/DateTime.php
+++ b/src/Schema/Types/Scalars/DateTime.php
@@ -12,6 +12,8 @@ class DateTime extends ScalarType
 {
     public $name = 'DateTime';
 
+    public $description = 'A date string with format Y-m-d H:i:s. Example: "2018-01-01 13:00:00"';
+
     public function serialize($value)
     {
         return $value->toAtomString();


### PR DESCRIPTION
**Related Issue(s)**

None

**PR Type**

Bugfix

**Changes**

When using the scalar DateTime type in your schema, no description pops up when using introspection. When someone views the docs they will not be able to see which format is returned. 

**Breaking changes**

None
