### PR TITLE
[fix] errors when publishing assets

### DIFF
--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -21,11 +21,12 @@ class LighthouseServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->mergeConfigFrom(__DIR__.'/../../config/config.php', 'lighthouse');
         $this->publishes([
             __DIR__.'/../../config/config.php' => config_path('lighthouse.php'),
             __DIR__.'/../../assets/default-schema.graphql' => config('lighthouse.schema.register'),
         ]);
-        $this->mergeConfigFrom(__DIR__.'/../../config/config.php', 'lighthouse');
+
 
         if (config('lighthouse.controller')) {
             $this->loadRoutesFrom(__DIR__.'/../Support/Http/routes.php');


### PR DESCRIPTION
**PR Type**

Bugfix

**Changes**

Error occurs when firing `php artisan vendor:publish --provider="Nuwave\Lighthouse\Providers\LighthouseServiceProvider"`. 

You should place `$this->mergeConfigFrom ` before `config('lighthouse.schema.register') `,otherwise `config('lighthouse.schema.register')` returns null which can give rise to php execution error.