### PR TITLE
Enable using the GraphQL endpoint via GET by default

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -21,7 +21,7 @@ return [
     | This setting controls if GET requests to the GraphQL endpoint are allowed.
     |
     */
-    'route_enable_get' => false,
+    'route_enable_get' => true,
     
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
I do not see any harm in defaulting this to `true`, it will avoid a
very common issue among new users of Lighthouse.

**Related Issue(s)**

#202 

**PR Type**

Config change

**Breaking changes**

Nope, the config can easily be changed back
