### PR TITLE
Fix default config for `disable_introspection`

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -1,5 +1,7 @@
 <?php
 
+use GraphQL\Validator\Rules\DisableIntrospection;
+
 return [
     
     /*
@@ -105,7 +107,7 @@ return [
     'security' => [
         'max_query_complexity' => 0,
         'max_query_depth' => 0,
-        'disable_introspection' => 0,
+        'disable_introspection' => DisableIntrospection::DISABLED,
     ],
 
      /*

--- a/config/config.php
+++ b/config/config.php
@@ -105,7 +105,7 @@ return [
     'security' => [
         'max_query_complexity' => 0,
         'max_query_depth' => 0,
-        'disable_introspection' => false,
+        'disable_introspection' => 0,
     ],
 
      /*


### PR DESCRIPTION
Internally `graphql-php` use strict checks for this so we need `0` instead of `false`.