### PR TITLE
Introduce the HasOneDirective and the HasOneLoader, improve BatchLoader semantics

### DIFF
--- a/src/Schema/Directives/Fields/BelongsToDirective.php
+++ b/src/Schema/Directives/Fields/BelongsToDirective.php
@@ -2,8 +2,10 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Illuminate\Database\Eloquent\Model;
+use GraphQL\Type\Definition\ResolveInfo;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 use Nuwave\Lighthouse\Support\DataLoader\Loaders\BelongsToLoader;
 
@@ -28,14 +30,19 @@ class BelongsToDirective extends BaseDirective implements FieldResolver
      */
     public function resolveField(FieldValue $value)
     {
-        $relation = $this->directiveArgValue('relation', $this->definitionNode->name->value);
+        return $value->setResolver(function (Model $parent, array $args, $context = null, ResolveInfo $resolveInfo){
+            $relation = $this->directiveArgValue('relation', $this->definitionNode->name->value);
 
-        return $value->setResolver(function ($root, array $args, $context = null, $info = null) use ($relation) {
-            return graphql()->batch(BelongsToLoader::class, $root->getKey(), [
-                'relation' => $relation,
-                'root' => $root,
-                'args' => $args,
-            ], BelongsToLoader::key($root, $relation, $info));
+            /** @var BelongsToLoader $belongsToLoader */
+            $belongsToLoader = graphql()->batchLoader(
+                BelongsToLoader::class,
+                $resolveInfo->path,
+                ['relation' => $relation, 'resolveArgs' => $args]
+            );
+
+            return $belongsToLoader->load($parent->getKey(), [
+                'parent' => $parent
+            ]);
         });
     }
 }

--- a/src/Schema/Directives/Fields/HasOneDirective.php
+++ b/src/Schema/Directives/Fields/HasOneDirective.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Directives\Fields;
+
+use Illuminate\Database\Eloquent\Model;
+use GraphQL\Type\Definition\ResolveInfo;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Nuwave\Lighthouse\Support\DataLoader\Loaders\HasOneLoader;
+
+class HasOneDirective extends BaseDirective implements FieldResolver
+{
+    /**
+     * Name of the directive.
+     *
+     * @return string
+     */
+    public function name()
+    {
+        return 'hasOne';
+    }
+
+    /**
+     * Resolve the field directive.
+     *
+     * @param FieldValue $value
+     *
+     * @return FieldValue
+     */
+    public function resolveField(FieldValue $value)
+    {
+        return $value->setResolver(
+            function (Model $parent, array $resolveArgs, $context = null, ResolveInfo $resolveInfo = null) {
+                /** @var HasOneLoader $hasOneLoader */
+                $hasOneLoader = graphql()->batchLoader(
+                    HasOneLoader::class,
+                    $resolveInfo->path,
+                    [
+                        'relation' => $this->directiveArgValue('relation', $this->definitionNode->name->value),
+                        'resolveArgs' => $resolveArgs,
+                        'scopes' => $this->directiveArgValue('scopes', []),
+                    ]
+                );
+
+                return $hasOneLoader->load($parent->getKey(), ['parent' => $parent]);
+            }
+        );
+    }
+}

--- a/tests/Integration/Schema/Directives/Fields/BelongsToTest.php
+++ b/tests/Integration/Schema/Directives/Fields/BelongsToTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Integration\Schema\Directives\Fields;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\DBTestCase;
-use Tests\Utils\Models\Company;
-use Tests\Utils\Models\Team;
 use Tests\Utils\Models\User;
+use Tests\Utils\Models\Team;
+use Tests\Utils\Models\Company;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class BelongsToTest extends DBTestCase
 {
@@ -59,9 +59,11 @@ class BelongsToTest extends DBTestCase
         type Company {
             name: String!
         }
+        
         type User {
             company: Company @belongsTo
         }
+        
         type Query {
             user: User @auth
         }

--- a/tests/Integration/Schema/Directives/Fields/HasOneDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/HasOneDirectiveTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Integration\Schema\Directives\Fields;
+
+use Tests\DBTestCase;
+use Tests\Utils\Models\Post;
+use Tests\Utils\Models\Task;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class HasOneDirectiveTest extends DBTestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     */
+    public function itCanQueryHasOneRelationship()
+    {
+        // Task with id 1, no post
+        factory(Task::class)->create();
+        // Creates a task with id 2 and assigns it to this post
+        factory(Post::class)->create();
+
+        $schema = '
+        type Post {
+            id: Int
+        }
+        
+        type Task {
+            post: Post @hasOne
+        }
+        
+        type Query {
+            tasks: [Task!]! @all
+        }
+        ';
+
+        $result = $this->execute($schema, '
+        {
+            tasks {
+                post {
+                    id
+                }
+            }
+        }
+        ');
+
+        $this->assertSame(
+            [
+                'tasks' => [
+                    ['post' => null],
+                    ['post' => ['id' => 1]],
+                ],
+            ],
+            $result['data']
+        );
+    }
+}

--- a/tests/Integration/Schema/Directives/Nodes/UnionDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Nodes/UnionDirectiveTest.php
@@ -18,7 +18,10 @@ class UnionDirectiveTest extends DBTestCase
     public function itCanResolveUnionTypes()
     {
         // This creates a user with it
-        factory(Post::class)->create();
+        factory(Post::class)->create(
+            // Prevent creating more users through nested factory
+            ['task_id' => 1]
+        );
 
         $schema = '
         union Stuff @union(resolver: "' . addslashes(self::class) . '@resolveType") =

--- a/tests/Utils/Models/Post.php
+++ b/tests/Utils/Models/Post.php
@@ -5,6 +5,7 @@ namespace Tests\Utils\Models;
 use Laravel\Scout\Searchable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Post extends Model
 {
@@ -15,5 +16,10 @@ class Post extends Model
     public function comments(): HasMany
     {
         return $this->hasMany(Comment::class);
+    }
+
+    public function task(): BelongsTo
+    {
+        return $this->belongsTo(Task::class);
     }
 }

--- a/tests/Utils/Models/Task.php
+++ b/tests/Utils/Models/Task.php
@@ -4,6 +4,7 @@ namespace Tests\Utils\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Nuwave\Lighthouse\Support\Traits\IsRelayConnection;
 
@@ -16,5 +17,10 @@ class Task extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function post(): HasOne
+    {
+        return $this->hasOne(Post::class);
     }
 }

--- a/tests/database/factories/PostFactory.php
+++ b/tests/database/factories/PostFactory.php
@@ -1,6 +1,7 @@
 <?php
 
 use Tests\Utils\Models\Post;
+use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
 use Faker\Generator as Faker;
 
@@ -10,6 +11,9 @@ $factory->define(Post::class, function (Faker $faker) {
         'body' => $faker->sentence,
         'user_id' => function () {
             return factory(User::class)->create()->getKey();
+        },
+        'task_id' => function () {
+            return factory(Task::class)->create()->getKey();
         },
     ];
 });

--- a/tests/database/migrations/2018_02_28_000004_create_testbench_posts_table.php
+++ b/tests/database/migrations/2018_02_28_000004_create_testbench_posts_table.php
@@ -16,6 +16,7 @@ class CreateTestbenchPostsTable extends Migration
             $table->string('title');
             $table->string('body');
             $table->unsignedInteger('user_id');
+            $table->unsignedInteger('task_id');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
**Related Issue(s)**

Resolves #276

**PR Type**

Feature

**Changes**

- Add test case and scenario for a HasOne relationship
- BatchLoader classes are now initialized with a set of immutable params
- Avoid unnecessary steps inbetween for performance & code clarity
- Loaders now indicate clearly what they require as a one-off config and what is required for each field instance

**Breaking changes**

For users that do not reach into internals, nothing changes. Existing directives continue to work as before.

- The API for the BatchLoader abstract class changed so additional Loader implementations have to adapt. `resolve()` is now expected to return a keyed array of results.
- `graphql()->batch()` was changed to `graphql()->batchLoader()` and is now only responsible for returning a unique BatchLoader instance.
