### PR TITLE
Fix for #285 table alias for query

### DIFF
--- a/src/Support/DataLoader/QueryBuilder.php
+++ b/src/Support/DataLoader/QueryBuilder.php
@@ -238,7 +238,7 @@ class QueryBuilder
      *
      * @return string
      */
-    private function tableAlias($name)
+    private function tableAlias(string $name): string
     {
         $table = explode('.',$name);
 

--- a/src/Support/DataLoader/QueryBuilder.php
+++ b/src/Support/DataLoader/QueryBuilder.php
@@ -114,7 +114,7 @@ class QueryBuilder
 
         /** @var \Illuminate\Database\Query\Builder $baseQuery */
         $baseQuery = app('db')->query();
-        $fromExpression = '('.$unitedRelations->toSql().') as '.$baseQuery->grammar->wrap($relatedTable);
+        $fromExpression = '('.$unitedRelations->toSql().') as '.$baseQuery->grammar->wrap($this->tableAlias($relatedTable));
         $results = $baseQuery->select()
             ->from($baseQuery->raw($fromExpression))
             ->setBindings($unitedRelations->getBindings())
@@ -229,5 +229,23 @@ class QueryBuilder
         }
 
         return $collection;
+    }
+    
+    /**
+     * Get alias for a table name.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    private function tableAlias($name)
+    {
+        $table = explode('.',$name);
+
+        if (count($table) > 1) {
+            $name = implode('_', $table);
+        }
+
+        return $name;
     }
 }


### PR DESCRIPTION
**Related Issue(s)**

Dot in table name causing sql error

Resolves #285

**PR Type**

Bugfix

**Changes**

Function returns an alias "schema_table" if table name has a dot, like "schema.table".

