### PR TITLE
Align resolver signature with `@field` directive

### DIFF
--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -118,8 +118,8 @@ class FieldFactory
     {
         return function ($obj, array $args, $context = null, $info = null) use ($fieldName, $rootOperationType) {
             $class = config("lighthouse.namespaces.{$rootOperationType}").'\\'.studly_case($fieldName);
-
-            return (new $class($obj, $args, $context, $info))->resolve();
+            
+            return app($class)->resolve($obj, $args, $context, $info);
         };
     }
 


### PR DESCRIPTION
The signature for default resolver is not aligned with `@field` directive's.
For more consistency, I would like to recommend make this little change.