### PR TITLE
[Refactoring] Add `getResolver` method to `BaseDirective` class

### DIFF
--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -118,8 +118,8 @@ class FieldFactory
     {
         return function ($obj, array $args, $context = null, $info = null) use ($fieldName, $rootOperationType) {
             $class = config("lighthouse.namespaces.{$rootOperationType}").'\\'.studly_case($fieldName);
-
-            return (new $class($obj, $args, $context, $info))->resolve();
+            
+            return app($class)->resolve($obj, $args, $context, $info);
         };
     }
 


### PR DESCRIPTION
There are some potential usages of the business logic for `getResolver` from an argument around multiple places. 

For reusability, extracting the business logic into a single method would be better.

The only change is that if a method was not provided, fallback to the `resolve` method instead.

Also, I'm planning to extend the `paginate` directive, and I found I have to get the resolver too. So to preventing repeat my self, I made this PR.