### PR TITLE
Add test for recursive relationships

### DIFF
--- a/tests/Integration/Schema/Directives/Fields/HasManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/HasManyDirectiveTest.php
@@ -182,7 +182,7 @@ class HasManyDirectiveTest extends DBTestCase
         }
         ';
 
-        $result = $this->executeQuery($schema, '
+        $result = $this->queryAndReturnResult($schema, '
         { 
             user { 
                 tasks(first: 2) { 
@@ -243,7 +243,7 @@ class HasManyDirectiveTest extends DBTestCase
         }
         ';
 
-        $result = $this->queryAndReturnResult($schema, '
+        $result = $this->executeQuery($schema, '
         { 
             posts {
                 id

--- a/tests/Integration/Schema/Directives/Fields/HasManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/HasManyDirectiveTest.php
@@ -182,7 +182,7 @@ class HasManyDirectiveTest extends DBTestCase
         }
         ';
 
-        $result = $this->queryAndReturnResult($schema, '
+        $result = $this->executeQuery($schema, '
         { 
             user { 
                 tasks(first: 2) { 

--- a/tests/Integration/Schema/Directives/Fields/HasManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/HasManyDirectiveTest.php
@@ -220,7 +220,6 @@ class HasManyDirectiveTest extends DBTestCase
     {
         $post1 = factory(Post::class)->create([
             'id' => 1,
-            'parent_id' => null,
         ]);
 
         $post2 = factory(Post::class)->create([
@@ -248,10 +247,8 @@ class HasManyDirectiveTest extends DBTestCase
         { 
             posts {
                 id
-                
                 parent {
                     id
-                    
                     parent {
                         id
                     }

--- a/tests/Utils/Models/Post.php
+++ b/tests/Utils/Models/Post.php
@@ -22,4 +22,14 @@ class Post extends Model
     {
         return $this->belongsTo(Task::class);
     }
+
+    public function parent() : BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+
+    public function children() : HasMany
+    {
+        return $this->hasMany(Post::class);
+    }
 }

--- a/tests/database/factories/PostFactory.php
+++ b/tests/database/factories/PostFactory.php
@@ -15,5 +15,8 @@ $factory->define(Post::class, function (Faker $faker) {
         'task_id' => function () {
             return factory(Task::class)->create()->getKey();
         },
+        'parent_id' => function() {
+            return factory(Post::class)->create(['parent_id' => null]);
+        }
     ];
 });

--- a/tests/database/factories/PostFactory.php
+++ b/tests/database/factories/PostFactory.php
@@ -15,8 +15,6 @@ $factory->define(Post::class, function (Faker $faker) {
         'task_id' => function () {
             return factory(Task::class)->create()->getKey();
         },
-        'parent_id' => function() {
-            return factory(Post::class)->create(['parent_id' => null]);
-        }
+        'parent_id' => null
     ];
 });

--- a/tests/database/migrations/2018_02_28_000004_create_testbench_posts_table.php
+++ b/tests/database/migrations/2018_02_28_000004_create_testbench_posts_table.php
@@ -17,7 +17,14 @@ class CreateTestbenchPostsTable extends Migration
             $table->string('body');
             $table->unsignedInteger('user_id');
             $table->unsignedInteger('task_id');
+            $table->unsignedInteger('parent_id')->nullable();
             $table->timestamps();
+        });
+
+        Schema::table('posts', function(Blueprint $table) {
+            $table->foreign('parent_id')
+                ->references('id')
+                ->on('posts');
         });
     }
 


### PR DESCRIPTION
**Related Issue(s)**

Currently, when querying recursive relationships, relationships in the second recursion become null. 
As discussed in the Slack channel, this is a WIP PR that currently adds a failing test that demonstrates this behaviour.

**PR Type**

Probably a bugfix, maybe a feature?


**Changes**

Support recursive relationships.

**Breaking changes**

As far as I am aware, there are no breaking changes unless someone relies on the "second layer parent is null" behaviour.
