### PR TITLE
`BaseDirective` class enhancements

### DIFF
--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives;
 
+use Closure;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\ValueNode;
 use GraphQL\Language\AST\ArgumentNode;
@@ -89,14 +90,14 @@ abstract class BaseDirective implements Directive
     /**
      * Get the resolver that is specified in the current directive.
      *
-     * @param \Closure $defaultResolver Add in a default resolver to return if no resolver class is given.
+     * @param Closure $defaultResolver Add in a default resolver to return if no resolver class is given.
      * @param string $argumentName If the name of the directive argument is not "resolver" you may overwrite it.
      *
      * @throws DirectiveException
      *
-     * @return \Closure
+     * @return Closure
      */
-    protected function getResolver(\Closure $defaultResolver = null, string $argumentName = 'resolver'): \Closure
+    protected function getResolver(Closure $defaultResolver = null, string $argumentName = 'resolver'): Closure
     {
         $baseClassName =
             $this->directiveArgValue('class')
@@ -122,7 +123,7 @@ abstract class BaseDirective implements Directive
             throw new DirectiveException("Method '{$resolverMethod}' does not exist on class '{$resolverClass}'");
         }
 
-        return \Closure::fromCallable([app($resolverClass), $resolverMethod]);
+        return Closure::fromCallable([app($resolverClass), $resolverMethod]);
     }
 
     /**

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -99,27 +99,29 @@ abstract class BaseDirective implements Directive
      */
     protected function getResolver(Closure $defaultResolver = null, string $argumentName = 'resolver'): Closure
     {
+        $resolverFragments = explode('@', $this->directiveArgValue($argumentName) ?? '');
+
         $baseClassName =
             $this->directiveArgValue('class')
-            ?? str_before($this->directiveArgValue($argumentName), '@');
+            ?? $resolverFragments[0];
 
         if (empty($baseClassName)) {
             // If a default is given, simply return it
-            if($defaultResolver){
+            if ($defaultResolver) {
                 return $defaultResolver;
             }
-            
+
             $directiveName = $this->name();
             throw new DirectiveException("Directive '{$directiveName}' must have a resolver class specified.");
         }
-        
+
         $resolverClass = $this->namespaceClassName($baseClassName);
         $resolverMethod =
             $this->directiveArgValue('method')
-            ?? str_after($this->directiveArgValue($argumentName), '@')
+            ?? $resolverFragments[1]
             ?? 'resolve';
 
-        if (! method_exists($resolverClass, $resolverMethod)) {
+        if ( ! method_exists($resolverClass, $resolverMethod)) {
             throw new DirectiveException("Method '{$resolverMethod}' does not exist on class '{$resolverClass}'");
         }
 


### PR DESCRIPTION
Just made some enhancements to the `BaseDirective` class.

[75fae5e](https://github.com/nuwave/lighthouse/pull/298/commits/75fae5eeba1577e4c01db17f7d83cd0277766885) `str_after($this->directiveArgValue($argumentName), '@')` won't work as expected if the resolver method was not given.

For example 
```graphql
@field(resolver: "App\Models\User")
``` 
won't fallback to `App\Models\User@resolve`.
Instead, simply using the `explode` function, which also gives more simplicity.

------------------

[37bd724](https://github.com/nuwave/lighthouse/pull/298/commits/37bd7240b0ef43632fa528e0c9549062ce312357) Add more flexibility to `getModelClass` method, and uniform the Exception to be thrown.

#### Added `field name` as a fallback
For example:

```graphql
type Query {
    users: [User!]! @paginate(type: "paginator" model: "User")
}
```
You can omit the `model: "User"` part now,
because the field name `users` will be transformed into `Namespace/For/Model/User`,
and if it is a valid class, use it as the model class instead.

The fallback priority would be:
1. `model` argument
2. `model` argument + namespace
3. `field return type` + namespace
4. `field name(converted to singular form)` + namespace

#### Uniformed the Exception
Restrict the Exception to only the `DirectiveException` to clarify where the issue came from.
