### PR TITLE
Do not append default namespace before the configured namespace

### DIFF
--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -156,7 +156,7 @@ abstract class BaseDirective implements Directive
 
         $modelWithDefaultNamespace = config('lighthouse.namespaces.models').'\\'.$model;
         if(class_exists($modelWithDefaultNamespace)){
-            return $model;
+            return $modelWithDefaultNamespace;
         }
 
         return $this->namespaceClassName($model);

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -100,11 +100,11 @@ abstract class BaseDirective implements Directive
     {
         // The resolver is expected to contain a class and a method name, seperated by an @ symbol
         // e.g. App\My\Class@methodName
-        $resolverArgument = $this->directiveArgValue($argumentName);
+        $resolverArgumentFragments = explode('@', $this->directiveArgValue($argumentName));
 
         $baseClassName =
             $this->directiveArgValue('class')
-            ?? str_before($resolverArgument, '@');
+            ?? $resolverArgumentFragments[0];
 
         if (empty($baseClassName)) {
             // If a default is given, simply return it
@@ -119,7 +119,7 @@ abstract class BaseDirective implements Directive
         $resolverClass = $this->namespaceClassName($baseClassName);
         $resolverMethod =
             $this->directiveArgValue('method')
-            ?? str_after($resolverArgument, '@')
+            ?? $resolverArgumentFragments[1]
             ?? 'resolve';
 
         if (! method_exists($resolverClass, $resolverMethod)) {

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -146,15 +146,16 @@ abstract class BaseDirective implements Directive
                 .$this->name().'directive on '.$this->definitionNode->name->value);
         }
 
-        if (! class_exists($model)) {
-            $model = config('lighthouse.namespaces.models').'\\'.$model;
+        if(class_exists($model)){
+            return $model;
         }
 
-        if (! class_exists($model)) {
-            $model = $this->namespaceClassName($model);
+        $modelWithDefaultNamespace = config('lighthouse.namespaces.models').'\\'.$model;
+        if(class_exists($modelWithDefaultNamespace)){
+            return $model;
         }
 
-        return $model;
+        return $this->namespaceClassName($model);
     }
 
     /**
@@ -186,7 +187,7 @@ abstract class BaseDirective implements Directive
     protected function associatedNamespace(): string
     {
         $namespaceDirective = $this->directiveDefinition(
-            (new NamespaceDirective())->name()
+            (new NamespaceDirective)->name()
         );
 
         return $namespaceDirective


### PR DESCRIPTION
**Related Issue(s)**

Supersedes #298 

**PR Type**

Bugfix + Refactor

**Changes**

Before, the code always prepended the default model namespace and then added on the
extra namespace. Now, each one of those fallbacks is tried seperately.

**Breaking changes**

Nope
