### PR TITLE
Update Context.php

### DIFF
--- a/src/Schema/Context.php
+++ b/src/Schema/Context.php
@@ -3,7 +3,7 @@
 namespace Nuwave\Lighthouse\Schema;
 
 use Illuminate\Http\Request;
-use Illuminate\Foundation\Auth\User;
+use Illuminate\Contracts\Auth\Authenticatable as User;
 
 class Context
 {


### PR DESCRIPTION
**Related Issue(s)**

#295 

**PR Type**

Bug fix

**Changes**

This PR typehints the `Illuminate\Contracts\Auth\Authenticatable` contract instead of `Illuminate\Foundation\Auth\User` into the Context constructor. This should make it agnostic between Laravel and Lumen, as Lumen doesn't include the `Illuminate\Foundation\Auth\User` class.

**Breaking changes**

None foreseen