### PR TITLE
[Enhancement] Add `resolver` argument to paginate directive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "source": "https://github.com/nuwave/lighthouse"
     },
     "require": {
-        "php" : ">= 7.0",
+        "php" : ">= 7.1",
         "ext-json": "*",
         "illuminate/contracts": "^5.4",
         "illuminate/http": "^5.4",

--- a/src/Schema/Directives/Fields/PaginateDirective.php
+++ b/src/Schema/Directives/Fields/PaginateDirective.php
@@ -2,16 +2,21 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Illuminate\Pagination\Paginator;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Nuwave\Lighthouse\Schema\Context;
 use Nuwave\Lighthouse\Execution\QueryUtils;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
-use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Support\Traits\HandlesGlobalId;
+use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
+use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
+use Nuwave\Lighthouse\Exceptions\DirectiveException;
+
 
 class PaginateDirective extends PaginationManipulator implements FieldResolver, FieldManipulator
 {
@@ -22,22 +27,23 @@ class PaginateDirective extends PaginationManipulator implements FieldResolver, 
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'paginate';
     }
 
     /**
-     * @param FieldDefinitionNode      $fieldDefinition
+     * @param FieldDefinitionNode $fieldDefinition
      * @param ObjectTypeDefinitionNode $parentType
-     * @param DocumentAST              $current
-     * @param DocumentAST              $original
+     * @param DocumentAST $current
+     * @param DocumentAST $original
      *
      * @throws \Exception
+     * @throws DirectiveException
      *
      * @return DocumentAST
      */
-    public function manipulateSchema(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current, DocumentAST $original)
+    public function manipulateSchema(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current, DocumentAST $original): DocumentAST
     {
         switch ($this->getPaginationType()) {
             case self::PAGINATION_TYPE_CONNECTION:
@@ -50,42 +56,18 @@ class PaginateDirective extends PaginationManipulator implements FieldResolver, 
     }
 
     /**
-     * Resolve the field directive.
-     *
-     * @param FieldValue $value
-     *
      * @throws DirectiveException
      *
-     * @return FieldValue
-     */
-    public function resolveField(FieldValue $value)
-    {
-        $paginationType = $this->getPaginationType();
-
-        $model = $this->getModelClass();
-
-        switch ($paginationType) {
-            case self::PAGINATION_TYPE_CONNECTION:
-                return $this->connectionTypeResolver($value, $model);
-            case self::PAGINATION_TYPE_PAGINATOR:
-                return $this->paginatorTypeResolver($value, $model);
-            default:
-                return $this->paginatorTypeResolver($value, $model);
-        }
-    }
-
-    /**
      * @return string
-     * @throws DirectiveException
      */
-    protected function getPaginationType()
+    protected function getPaginationType(): string
     {
         $paginationType = $this->directiveArgValue('type', self::PAGINATION_TYPE_PAGINATOR);
 
         $paginationType = $this->convertAliasToPaginationType($paginationType);
         if (!$this->isValidPaginationType($paginationType)) {
-            $fieldName = $this->fieldDefinition->name->value;
-            $directiveName = self::name();
+            $fieldName = $this->definitionNode->name->value;
+            $directiveName = $this->name();
             throw new DirectiveException("'$paginationType' is not a valid pagination type. Field: '$fieldName', Directive: '$directiveName'");
         }
 
@@ -93,53 +75,117 @@ class PaginateDirective extends PaginationManipulator implements FieldResolver, 
     }
 
     /**
-     * Create a paginator resolver.
+     * Resolve the field directive.
      *
      * @param FieldValue $value
-     * @param string $model
+     *
+     * @throws \Exception
+     * @throws DirectiveException
      *
      * @return FieldValue
      */
-    protected function paginatorTypeResolver(FieldValue $value, $model)
+    public function resolveField(FieldValue $value): FieldValue
     {
-        return $value->setResolver(function ($root, array $args) use ($model) {
-            $first = data_get($args, 'count', 15);
-            $page = data_get($args, 'page', 1);
+        $paginationType = $this->getPaginationType();
+        $resolver = null;
+        $modelClass = null;
 
-            $query = QueryUtils::applyFilters($model::query(), $args);
-            $query = QueryUtils::applyScopes($query, $args, $this->directiveArgValue('scopes', []));
+        try {
+            $resolver = $this->getResolver();
+        } catch (DirectiveException $e) {
+            $modelClass = $this->getModelClass();
+        }
 
-            Paginator::currentPageResolver(function () use ($page) {
-                return $page;
-            });
-
-            return $query->paginate($first);
-        });
+        switch ($paginationType) {
+            case self::PAGINATION_TYPE_CONNECTION:
+                return $this->connectionTypeResolver($value, $resolver, $modelClass);
+            case self::PAGINATION_TYPE_PAGINATOR:
+                return $this->paginatorTypeResolver($value, $resolver, $modelClass);
+            default:
+                return $this->paginatorTypeResolver($value, $resolver, $modelClass);
+        }
     }
 
     /**
      * Create a connection resolver.
      *
      * @param FieldValue $value
-     * @param string     $model
+     * @param \Closure|null $resolver
+     * @param null|string $modelClass
      *
      * @return FieldValue
      */
-    protected function connectionTypeResolver(FieldValue $value, $model)
+    protected function connectionTypeResolver(FieldValue $value, ?\Closure $resolver, ?string $modelClass): FieldValue
     {
-        return $value->setResolver(function ($root, array $args) use ($model, $value) {
+        return $value->setResolver(function ($root, array $args, Context $context, ResolveInfo $info) use ($resolver, $modelClass) {
             $first = data_get($args, 'first', 15);
             $after = $this->decodeCursor($args);
             $page = $first && $after ? floor(($first + $after) / $first) : 1;
 
-            $query = QueryUtils::applyFilters($model::query(), $args);
-            $query = QueryUtils::applyScopes($query, $args, $this->directiveArgValue('scopes', []));
+            $this->setCurrentPageResolver($page);
 
-            Paginator::currentPageResolver(function () use ($page) {
-                return $page;
-            });
-
-            return $query->paginate($first);
+            return $this->getPaginator($first, $resolver, $modelClass, \func_get_args());
         });
+    }
+
+    /**
+     * Create a paginator resolver.
+     *
+     * @param FieldValue $value
+     * @param \Closure|null $resolver
+     * @param null|string $modelClass
+     *
+     * @return FieldValue
+     */
+    protected function paginatorTypeResolver(FieldValue $value, ?\Closure $resolver, ?string $modelClass): FieldValue
+    {
+        return $value->setResolver(function ($root, array $args, Context $context, ResolveInfo $info) use ($resolver, $modelClass) {
+            $count = data_get($args, 'count', 15);
+            $page = data_get($args, 'page', 1);
+
+            $this->setCurrentPageResolver($page);
+
+            return $this->getPaginator($count, $resolver, $modelClass, \func_get_args());
+        });
+    }
+
+    /**
+     * Set the current page to the given page number.
+     *
+     * @param int $page
+     */
+    protected function setCurrentPageResolver(int $page): void
+    {
+        Paginator::currentPageResolver(function () use ($page) {
+            return $page;
+        });
+    }
+
+    /**
+     * @param int $perPage
+     * @param \Closure|null $resolver
+     * @param null|string $modelClass
+     * @param array $resolverArgs
+     *
+     * @throws DirectiveException
+     *
+     * @return LengthAwarePaginator
+     */
+    protected function getPaginator(int $perPage, ?\Closure $resolver, ?string $modelClass, array $resolverArgs): LengthAwarePaginator
+    {
+        if ($resolver) {
+            $query = \call_user_func_array($resolver, $resolverArgs);
+            if ( ! ($query instanceof Builder)) {
+                throw new DirectiveException('The returned value of paginate resolver must be an instance of ' . Builder::class);
+            }
+        } else {
+            $query = $modelClass::query();
+        }
+
+        $args = $resolverArgs[1];
+        $query = QueryUtils::applyFilters($query, $args);
+        $query = QueryUtils::applyScopes($query, $args, $this->directiveArgValue('scopes', []));
+
+        return $query->paginate($perPage);
     }
 }


### PR DESCRIPTION
## Summary
* Update PHP to 7.1 (to use more strict type hinting)
* Add PHP native return type
* Add `resolver` argument to allow user define their own resolver for the field

## The `resolver` argument
See the discussions at #290 

This PR allows user to define their own resolver instead of the default `model` solution.

The purpose is clear:  **Increasing the flexibility**.

In real world, chances are that user would like to have their own query conditions to filter the result set.

Below is a real example of mine:

```graphql
type Query {
    users(query: QueryCondition): [User!]!  @paginate(type: "paginator" resolver:"App\\GraphQL\\Queries\\Users") @middleware(checks: ["auth:api"])
}

input QueryCondition {
    conditions: [Condition!]!
    relation: Relation = "AND"
    order: Order
    orderby: String
}

input Condition {
    key: String!
    value: String!
    operator: Operator!
}

enum Order {
    ASC @enum(value: "ASC")
    DESC @enum(value: "DESC")
}

enum Relation {
    AND @enum(value: "AND")
    OR @enum(value: "OR")
}

enum Operator {
    IN @enum(value: "IN")
    NOT_IN @enum(value: "NOT IN")
    EQUALS @enum(value: "=")
    NOT_EQUALS @enum(value: "!=")
    LIKE @enum(value: "LIKE")
    NOT_LIKE @enum(value: "NOT LIKE")
    GREATER_THAN @enum(value: ">")
    GREATER_THAN_OR_EQUAL @enum(value: ">=")
    LESS_THAN @enum(value: "<")
    LESS_THAN_OR_EQUAL @enum(value: "<=")
}
```

In `Users::resolve` simply return an instance of `Illuminate\Database\Eloquent\Builder`.
```php
namespace App\GraphQL\Queries;

use App\Models\User;
use Illuminate\Database\Eloquent\Builder;

class Users
{
    public function resolve($root, array $args): Builder
    {
        $eloquentBuilder = User::query();

        // query how ever you like ...

        return $eloquentBuilder;
    }
}
```


As you can see, this way, the API consumer can specify the query throw the `query` variable themselves, which can bring massive flexibility to the client side.