### PR TITLE
[Refactor] Remove return types on interfaces

### DIFF
--- a/src/Exceptions/RendersErrorsExtensions.php
+++ b/src/Exceptions/RendersErrorsExtensions.php
@@ -18,5 +18,5 @@ interface RendersErrorsExtensions extends ClientAware
      *
      * @return array
      */
-    public function extensionsContent(): array;
+    public function extensionsContent();
 }

--- a/src/Execution/ErrorHandler.php
+++ b/src/Execution/ErrorHandler.php
@@ -12,10 +12,10 @@ interface ErrorHandler
      * Always call $next($error) to keep the Pipeline going. Multiple such Handlers may be registered
      * as an array in the config.
      *
-     * @param Error $error
+     * @param Error    $error
      * @param \Closure $next
      *
      * @return array
      */
-    public static function handle(Error $error, \Closure $next) : array;
+    public static function handle(Error $error, \Closure $next);
 }

--- a/src/Schema/Source/SchemaSourceProvider.php
+++ b/src/Schema/Source/SchemaSourceProvider.php
@@ -3,13 +3,7 @@
 namespace Nuwave\Lighthouse\Schema\Source;
 
 /**
- * Interface SchemaSourceProvider
- * @package Nuwave\Lighthouse\Schema\Source
- *
- * This interface can be implemented to have different methods of providing
- * a schema string. Since the schema is then parsed into an AST and cached,
- * this does not necessarily have to be very performant, e.g. it may be
- * acceptable to download the schema or fetch it from an API.
+ * Interface SchemaSourceProvider.
  */
 interface SchemaSourceProvider
 {
@@ -18,5 +12,5 @@ interface SchemaSourceProvider
      *
      * @return string
      */
-    public function getSchemaString(): string;
+    public function getSchemaString();
 }


### PR DESCRIPTION
**Related Issue(s)**

None

**PR Type**

Refactor

**Changes**

Removes return types on interfaces that may be implemented by the user. This allows the user to choose to add a return type on their implementation rather than forcing them to do so.

**Breaking changes**

None
