### PR TITLE
[Enhancement] Add a `clearCache` method to enable clear document AST cache

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -197,6 +197,19 @@ class GraphQL
     }
 
     /**
+     * Clear the documentAST cache.
+     *
+     * @return GraphQL
+     */
+    public function clearCache(): self
+    {
+        $this->documentAST = null;
+        Cache::forget(config('lighthouse.cache.key'));
+
+        return $this;
+    }
+
+    /**
      * Return an instance of a BatchLoader for a specific field.
      *
      * @param string $loaderClass


### PR DESCRIPTION
Currently we can only clear the cache from artisan command.
This PR adds a `clearCache` method to enable clear document AST cache programmatically.