### PR TITLE
[WIP] [Refactor] Remove original DocumentAST parameters

### DIFF
--- a/src/Schema/Directives/Fields/PaginateDirective.php
+++ b/src/Schema/Directives/Fields/PaginateDirective.php
@@ -2,16 +2,16 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use GraphQL\Language\AST\FieldDefinitionNode;
-use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Illuminate\Pagination\Paginator;
 use Nuwave\Lighthouse\Execution\QueryUtils;
+use GraphQL\Language\AST\FieldDefinitionNode;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
-use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Support\Traits\HandlesGlobalId;
+use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
+use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
 
 class PaginateDirective extends PaginationManipulator implements FieldResolver, FieldManipulator
 {
@@ -31,21 +31,20 @@ class PaginateDirective extends PaginationManipulator implements FieldResolver, 
      * @param FieldDefinitionNode      $fieldDefinition
      * @param ObjectTypeDefinitionNode $parentType
      * @param DocumentAST              $current
-     * @param DocumentAST              $original
      *
      * @throws \Exception
      *
      * @return DocumentAST
      */
-    public function manipulateSchema(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current, DocumentAST $original)
+    public function manipulateSchema(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current)
     {
         switch ($this->getPaginationType()) {
             case self::PAGINATION_TYPE_CONNECTION:
-                return $this->registerConnection($fieldDefinition, $parentType, $current, $original);
+                return $this->registerConnection($fieldDefinition, $parentType, $current);
             case self::PAGINATION_TYPE_PAGINATOR:
-                return $this->registerPaginator($fieldDefinition, $parentType, $current, $original);
+                return $this->registerPaginator($fieldDefinition, $parentType, $current);
             default:
-                return $this->registerPaginator($fieldDefinition, $parentType, $current, $original);
+                return $this->registerPaginator($fieldDefinition, $parentType, $current);
         }
     }
 
@@ -75,15 +74,16 @@ class PaginateDirective extends PaginationManipulator implements FieldResolver, 
     }
 
     /**
-     * @return string
      * @throws DirectiveException
+     *
+     * @return string
      */
     protected function getPaginationType()
     {
         $paginationType = $this->directiveArgValue('type', self::PAGINATION_TYPE_PAGINATOR);
 
         $paginationType = $this->convertAliasToPaginationType($paginationType);
-        if (!$this->isValidPaginationType($paginationType)) {
+        if (! $this->isValidPaginationType($paginationType)) {
             $fieldName = $this->fieldDefinition->name->value;
             $directiveName = self::name();
             throw new DirectiveException("'$paginationType' is not a valid pagination type. Field: '$fieldName', Directive: '$directiveName'");
@@ -96,7 +96,7 @@ class PaginateDirective extends PaginationManipulator implements FieldResolver, 
      * Create a paginator resolver.
      *
      * @param FieldValue $value
-     * @param string $model
+     * @param string     $model
      *
      * @return FieldValue
      */

--- a/src/Schema/Directives/Fields/PaginationManipulator.php
+++ b/src/Schema/Directives/Fields/PaginationManipulator.php
@@ -2,15 +2,15 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\Node;
-use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
+use GraphQL\Language\AST\FieldDefinitionNode;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
-use Nuwave\Lighthouse\Schema\Types\ConnectionField;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Nuwave\Lighthouse\Schema\Types\PaginatorField;
+use Nuwave\Lighthouse\Schema\Types\ConnectionField;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 
 abstract class PaginationManipulator extends BaseDirective
 {
@@ -49,13 +49,12 @@ abstract class PaginationManipulator extends BaseDirective
      * @param FieldDefinitionNode      $fieldDefinition
      * @param ObjectTypeDefinitionNode $parentType
      * @param DocumentAST              $current
-     * @param DocumentAST              $original
      *
      * @throws \Exception
      *
      * @return DocumentAST
      */
-    protected function registerConnection(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current, DocumentAST $original)
+    protected function registerConnection(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current)
     {
         $connectionTypeName = $this->connectionTypeName($fieldDefinition, $parentType);
         $connectionEdgeName = $this->connectionEdgeName($fieldDefinition, $parentType);
@@ -98,13 +97,12 @@ abstract class PaginationManipulator extends BaseDirective
      * @param FieldDefinitionNode      $fieldDefinition
      * @param ObjectTypeDefinitionNode $parentType
      * @param DocumentAST              $current
-     * @param DocumentAST              $original
      *
      * @throws \Exception
      *
      * @return DocumentAST
      */
-    protected function registerPaginator(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current, DocumentAST $original)
+    protected function registerPaginator(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current)
     {
         $paginatorTypeName = $this->paginatorTypeName($fieldDefinition, $parentType);
         $paginatorFieldClassName = addslashes(PaginatorField::class);
@@ -135,7 +133,7 @@ abstract class PaginationManipulator extends BaseDirective
     /**
      * Get paginator type name.
      *
-     * @param FieldDefinitionNode $fieldDefinition
+     * @param FieldDefinitionNode      $fieldDefinition
      * @param ObjectTypeDefinitionNode $parent
      *
      * @return string
@@ -144,15 +142,15 @@ abstract class PaginationManipulator extends BaseDirective
     {
         return studly_case(
             $this->parentTypeName($parent)
-            . $this->singularFieldName($fieldDefinition)
-            . '_Paginator'
+            .$this->singularFieldName($fieldDefinition)
+            .'_Paginator'
         );
     }
 
     /**
      * Get connection type name.
      *
-     * @param FieldDefinitionNode $fieldDefinition
+     * @param FieldDefinitionNode      $fieldDefinition
      * @param ObjectTypeDefinitionNode $parent
      *
      * @return string
@@ -161,15 +159,15 @@ abstract class PaginationManipulator extends BaseDirective
     {
         return studly_case(
             $this->parentTypeName($parent)
-            . $this->singularFieldName($fieldDefinition)
-            . '_Connection'
+            .$this->singularFieldName($fieldDefinition)
+            .'_Connection'
         );
     }
 
     /**
      * Get connection edge name.
      *
-     * @param FieldDefinitionNode $fieldDefinition
+     * @param FieldDefinitionNode      $fieldDefinition
      * @param ObjectTypeDefinitionNode $parent
      *
      * @return string
@@ -178,8 +176,8 @@ abstract class PaginationManipulator extends BaseDirective
     {
         return studly_case(
             $this->parentTypeName($parent)
-            . $this->singularFieldName($fieldDefinition)
-            . '_Edge'
+            .$this->singularFieldName($fieldDefinition)
+            .'_Edge'
         );
     }
 
@@ -202,7 +200,7 @@ abstract class PaginationManipulator extends BaseDirective
     {
         $name = $objectType->name->value;
 
-        return 'Query' === $name ? '' : $name . '_';
+        return 'Query' === $name ? '' : $name.'_';
     }
 
     /**

--- a/src/Schema/Directives/Nodes/GroupDirective.php
+++ b/src/Schema/Directives/Nodes/GroupDirective.php
@@ -5,14 +5,14 @@ namespace Nuwave\Lighthouse\Schema\Directives\Nodes;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeList;
 use GraphQL\Language\AST\DirectiveNode;
-use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use GraphQL\Language\AST\FieldDefinitionNode;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
 use GraphQL\Language\AST\ObjectTypeExtensionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\NodeManipulator;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Schema\Directives\Fields\NamespaceDirective;
 
 /**
@@ -36,19 +36,18 @@ class GroupDirective extends BaseDirective implements NodeManipulator
     }
 
     /**
-     * @param Node $node
+     * @param Node        $node
      * @param DocumentAST $current
-     * @param DocumentAST $original
      *
      * @throws DirectiveException
      *
      * @return DocumentAST
      */
-    public function manipulateSchema(Node $node, DocumentAST $current, DocumentAST $original)
+    public function manipulateSchema(Node $node, DocumentAST $current)
     {
         $nodeName = $node->name->value;
 
-        if (!in_array($nodeName, ['Query', 'Mutation'])) {
+        if (! in_array($nodeName, ['Query', 'Mutation'])) {
             $message = "The group directive can only be placed on a Query or Mutation [$nodeName]";
 
             throw new DirectiveException($message);
@@ -73,11 +72,11 @@ class GroupDirective extends BaseDirective implements NodeManipulator
     {
         $middlewareValues = $this->directiveArgValue('middleware');
 
-        if (!$middlewareValues) {
+        if (! $middlewareValues) {
             return $objectType;
         }
 
-        $middlewareValues = '["' . implode('", "', $middlewareValues) . '"]';
+        $middlewareValues = '["'.implode('", "', $middlewareValues).'"]';
         $middlewareDirective = PartialParser::directive("@middleware(checks: $middlewareValues)");
 
         $objectType->fields = new NodeList(collect($objectType->fields)->map(function (FieldDefinitionNode $fieldDefinition) use ($middlewareDirective) {
@@ -100,11 +99,11 @@ class GroupDirective extends BaseDirective implements NodeManipulator
     {
         $namespaceValue = $this->directiveArgValue('namespace');
 
-        if (!$namespaceValue) {
+        if (! $namespaceValue) {
             return $objectType;
         }
 
-        if (!is_string($namespaceValue)) {
+        if (! is_string($namespaceValue)) {
             throw new DirectiveException('The value of the namespace directive on has to be a string');
         }
 
@@ -125,7 +124,7 @@ class GroupDirective extends BaseDirective implements NodeManipulator
     }
 
     /**
-     * @param string $namespaceValue
+     * @param string        $namespaceValue
      * @param DirectiveNode $directive
      *
      * @return DirectiveNode

--- a/src/Schema/Directives/Nodes/ModelDirective.php
+++ b/src/Schema/Directives/Nodes/ModelDirective.php
@@ -29,7 +29,7 @@ class ModelDirective extends BaseDirective implements NodeMiddleware, NodeManipu
      * Handle type construction.
      *
      * @param NodeValue $value
-     * @param \Closure   $next
+     * @param \Closure  $next
      *
      * @return NodeValue
      */
@@ -71,13 +71,12 @@ class ModelDirective extends BaseDirective implements NodeMiddleware, NodeManipu
     /**
      * @param Node        $node
      * @param DocumentAST $current
-     * @param DocumentAST $original
      *
      * @throws \Exception
      *
      * @return DocumentAST
      */
-    public function manipulateSchema(Node $node, DocumentAST $current, DocumentAST $original)
+    public function manipulateSchema(Node $node, DocumentAST $current)
     {
         return $this->attachNodeInterfaceToObjectType($node, $current);
     }

--- a/src/Schema/Directives/Nodes/NodeDirective.php
+++ b/src/Schema/Directives/Nodes/NodeDirective.php
@@ -30,7 +30,7 @@ class NodeDirective extends BaseDirective implements NodeMiddleware, NodeManipul
      * Handle type construction.
      *
      * @param NodeValue $value
-     * @param \Closure $next
+     * @param \Closure  $next
      *
      * @return NodeValue
      */
@@ -65,15 +65,14 @@ class NodeDirective extends BaseDirective implements NodeMiddleware, NodeManipul
     }
 
     /**
-     * @param Node $node
+     * @param Node        $node
      * @param DocumentAST $current
-     * @param DocumentAST $original
      *
      * @throws \Exception
      *
      * @return DocumentAST
      */
-    public function manipulateSchema(Node $node, DocumentAST $current, DocumentAST $original)
+    public function manipulateSchema(Node $node, DocumentAST $current)
     {
         return $this->attachNodeInterfaceToObjectType($node, $current);
     }

--- a/src/Support/Contracts/ArgManipulator.php
+++ b/src/Support/Contracts/ArgManipulator.php
@@ -3,9 +3,9 @@
 namespace Nuwave\Lighthouse\Support\Contracts;
 
 use GraphQL\Language\AST\FieldDefinitionNode;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use GraphQL\Language\AST\InputValueDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
-use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 
 interface ArgManipulator extends Directive
 {
@@ -14,9 +14,8 @@ interface ArgManipulator extends Directive
      * @param FieldDefinitionNode      $fieldDefinition
      * @param ObjectTypeDefinitionNode $parentType
      * @param DocumentAST              $current
-     * @param DocumentAST              $original
      *
      * @return DocumentAST
      */
-    public function manipulateSchema(InputValueDefinitionNode $argDefinition, FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current, DocumentAST $original);
+    public function manipulateSchema(InputValueDefinitionNode $argDefinition, FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current);
 }

--- a/src/Support/Contracts/FieldManipulator.php
+++ b/src/Support/Contracts/FieldManipulator.php
@@ -3,8 +3,8 @@
 namespace Nuwave\Lighthouse\Support\Contracts;
 
 use GraphQL\Language\AST\FieldDefinitionNode;
-use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 
 interface FieldManipulator extends Directive
 {
@@ -12,14 +12,12 @@ interface FieldManipulator extends Directive
      * @param FieldDefinitionNode      $fieldDefinition
      * @param ObjectTypeDefinitionNode $parentType
      * @param DocumentAST              $current
-     * @param DocumentAST              $original
      *
      * @return DocumentAST
      */
     public function manipulateSchema(
         FieldDefinitionNode $fieldDefinition,
         ObjectTypeDefinitionNode $parentType,
-        DocumentAST $current,
-        DocumentAST $original
+        DocumentAST $current
     );
 }

--- a/src/Support/Contracts/NodeManipulator.php
+++ b/src/Support/Contracts/NodeManipulator.php
@@ -10,9 +10,8 @@ interface NodeManipulator extends Directive
     /**
      * @param Node        $node
      * @param DocumentAST $current
-     * @param DocumentAST $original
      *
      * @return DocumentAST
      */
-    public function manipulateSchema(Node $node, DocumentAST $current, DocumentAST $original);
+    public function manipulateSchema(Node $node, DocumentAST $current);
 }


### PR DESCRIPTION
**Related Issue(s)**

None

**PR Type**

Refactor/Bug

**Changes**

The `$original` DocumentAST is currently pointing to the same reference as the `$current` DocumentAST so it's not actually holding a reference to a "copy" of the original document. Since it's not currently being used anywhere in the codebase (and wouldn't be correct if it was), it's being removed to shorten up the function signature.

**Breaking changes**

Yes, however it's currently a bug. To update, the user simply needs to remove this parameter from their function signature.
