### PR TITLE
Allow deleting multiple models via @delete

### DIFF
--- a/src/Schema/Directives/Fields/DeleteDirective.php
+++ b/src/Schema/Directives/Fields/DeleteDirective.php
@@ -2,13 +2,15 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use GraphQL\Type\Definition\IDType;
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
-use Nuwave\Lighthouse\Schema\Resolvers\NodeResolver;
+use GraphQL\Language\AST\NodeKind;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
+use GraphQL\Language\AST\InputValueDefinitionNode;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Support\Traits\HandlesGlobalId;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 
 class DeleteDirective extends BaseDirective implements FieldResolver
 {
@@ -29,49 +31,58 @@ class DeleteDirective extends BaseDirective implements FieldResolver
      *
      * @param FieldValue $value
      *
+     * @throws DirectiveException
+     *
      * @return FieldValue
      */
     public function resolveField(FieldValue $value)
     {
-        $idArg = $this->getIDField($value);
-        $globalId = $this->directiveArgValue('globalId', false);
+        return $value->setResolver(function ($root, array $args) {
+            $argumentDefinition = $this->getSingleArgumentDefinition();
 
+            if(NodeKind::NON_NULL_TYPE !== $argumentDefinition->type->kind){
+                throw new DirectiveException(
+                    "The @delete directive requires the field {$this->definitionNode->name->value} to have a NonNull argument. Mark it with !"
+                );
+            }
 
-        if (!$idArg) {
-            new DirectiveException(sprintf(
-                'The `delete` requires that you have an `ID` field on %s',
-                $value->getNodeName()
-            ));
-        }
+            $idOrIds = reset($args);
+            if($this->directiveArgValue('globalId', false)){
+                // At this point we know the type is at least wrapped in a NonNull type, so we go one deeper
+                if(NodeKind::LIST_TYPE === $argumentDefinition->type->type->kind){
+                    $idOrIds = array_map([$this, 'decodeRelayId'], $idOrIds);
+                } else {
+                    $idOrIds = $this->decodeRelayId($idOrIds);
+                }
+            }
 
-        return $value->setResolver(function ($root, array $args) use ($idArg, $globalId) {
-            $id = $globalId ? $this->decodeGlobalId(array_get($args, $idArg))[1] : array_get($args, $idArg);
-            $model = $this->getModelClass()::find($id);
+            $modelClass = $this->getModelClass();
+            $model = $modelClass::find($idOrIds);
 
-            if ($model) {
+            if (!$model) {
+                return null;
+            }
+
+            if($model instanceof Model){
                 $model->delete();
+            }
+
+            if($model instanceof Collection){
+                $modelClass::destroy($idOrIds);
             }
 
             return $model;
         });
     }
 
-    /**
-     * Check if field has an ID argument.
-     *
-     * @param FieldValue $value
-     *
-     * @return bool
-     */
-    protected function getIDField(FieldValue $value)
+    protected function getSingleArgumentDefinition(): InputValueDefinitionNode
     {
-        return collect($value->getField()->arguments)->filter(function ($arg) {
-            $type = NodeResolver::resolve($arg->type);
-            $type = method_exists($type, 'getWrappedType') ? $type->getWrappedType() : $type;
+        if (1 !== count($this->definitionNode->arguments)) {
+            throw new DirectiveException(
+                "The @delete directive requires the field {$this->definitionNode->name->value} to only contain a single argument."
+            );
+        }
 
-            return $type instanceof IDType;
-        })->map(function ($arg) {
-            return $arg->name->value;
-        })->first();
+        return $this->definitionNode->arguments[0];
     }
 }


### PR DESCRIPTION
The DeleteDirective previously checked if an Argument with the ID type is defined on the field.
This check is both expensive and can easily go wrong, e.g if the user wants a different data type
or if they provide another argument.

The argument to the field can either be a single ID, or a list of IDs.
If the defined argument is a ListType, the returned value is a collection of models.

**PR Type**

Feature

**Breaking changes**

The field that `@delete` is defined on must contain exactly one NonNull argument.
Multiple or no arguments do not make sense and have not worked before, so the only
possible breakage will be that the user will have to mark the argument as required.
I put a descriptive Exception in the directive to notify the user.
