### PR TITLE
Make the `load` and `tryRegisterClassName` to public method in `DirectiveRegistry` class

### DIFF
--- a/src/Schema/DirectiveRegistry.php
+++ b/src/Schema/DirectiveRegistry.php
@@ -52,7 +52,7 @@ class DirectiveRegistry
      * @param array|string $paths
      * @param null         $namespace
      */
-    protected function load($paths, $namespace = null)
+    public function load($paths, $namespace = null)
     {
         $paths = collect($paths)
             ->unique()
@@ -90,7 +90,7 @@ class DirectiveRegistry
      *
      * @throws \ReflectionException
      */
-    protected function tryRegisterClassName($className)
+    public function tryRegisterClassName($className)
     {
         $reflection = new \ReflectionClass($className);
 


### PR DESCRIPTION
I'm creating a package for Lighthouse, so I have to load my directives into the `DirectiveRegistry`, but I don't want to repeat myself…  so does other developers I think.