### PR TITLE
Add ScalarDirective back in and tests that show how Scalars and Unions can still use custom classes and resolvers

### DIFF
--- a/src/Schema/Directives/Nodes/ScalarDirective.php
+++ b/src/Schema/Directives/Nodes/ScalarDirective.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Directives\Nodes;
+
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+
+class ScalarDirective extends BaseDirective
+{
+    /**
+     * Name of the directive.
+     *
+     * @return string
+     */
+    public function name()
+    {
+        return 'scalar';
+    }
+}

--- a/src/Schema/Factories/NodeFactory.php
+++ b/src/Schema/Factories/NodeFactory.php
@@ -176,10 +176,15 @@ class NodeFactory
     protected function resolveScalarType(NodeValue $scalarNodeValue): ScalarType
     {
         $nodeName = $scalarNodeValue->getNodeName();
-        $className = \namespace_classname($nodeName, [
-            config('lighthouse.namespaces.scalars')
-        ]);
-        
+
+        if($directive = ASTHelper::directiveDefinition('scalar', $scalarNodeValue->getNode())){
+            $className = ASTHelper::directiveArgValue($directive, 'class');
+        } else {
+            $className = \namespace_classname($nodeName, [
+                config('lighthouse.namespaces.scalars')
+            ]);
+        }
+
         if(!$className){
             throw new \Exception("No class found for the scalar {$nodeName}");
         }

--- a/tests/Integration/Schema/Types/UnionTest.php
+++ b/tests/Integration/Schema/Types/UnionTest.php
@@ -43,19 +43,24 @@ class UnionTest extends DBTestCase
     {
         return [
             // This uses the default type resolver
-            $this->schema(''),
+            $this->schema(false),
             // This scenario requires a custom resolver, since the types User and Post do not match
-            $this->schema('Custom'),
+            $this->schema(true),
         ];
     }
     
-    public function schema(string $prefix): array
+    public function schema(bool $withCustomTypeResolver): array
     {
         $fieldResolver = addslashes(self::class). '@fetchResults';
 
+        $prefix = $withCustomTypeResolver ? 'Custom' : '';
+        $customResolver = $withCustomTypeResolver
+            ? '@union(resolver: "Tests\\\\Utils\\\\Unions\\\\CustomStuff@resolveType")'
+            : '';
+
         return [
             "
-            union {$prefix}Stuff = {$prefix}User | {$prefix}Post
+            union Stuff {$customResolver} = {$prefix}User | {$prefix}Post
             
             type {$prefix}User {
                 name: String!
@@ -66,7 +71,7 @@ class UnionTest extends DBTestCase
             }
             
             type Query {
-                stuff: [{$prefix}Stuff!]! @field(resolver: \"$fieldResolver\")
+                stuff: [Stuff!]! @field(resolver: \"$fieldResolver\")
             }
             ",
             "

--- a/tests/Unit/Schema/Factories/NodeFactoryTest.php
+++ b/tests/Unit/Schema/Factories/NodeFactoryTest.php
@@ -69,6 +69,20 @@ class NodeFactoryTest extends TestCase
     /**
      * @test
      */
+    public function itCanPointToScalarClassThroughDirective()
+    {
+        $scalarNode = PartialParser::scalarTypeDefinition('
+        scalar DateTime @scalar(class: "Nuwave\\\Lighthouse\\\Schema\\\Types\\\Scalars\\\DateTime")
+        ');
+        $scalarType = $this->factory->handle(new NodeValue($scalarNode));
+
+        $this->assertInstanceOf(ScalarType::class, $scalarType);
+        $this->assertSame('DateTime', $scalarType->name);
+    }
+
+    /**
+     * @test
+     */
     public function itCanTransformInterfaces()
     {
         $interfaceNode = PartialParser::interfaceTypeDefinition('


### PR DESCRIPTION
Also, the InterfaceTest shows how Interfaces can use custom type resolvers as well.

**Related Issue(s)**

#321 

**PR Type**

Regression Fix, Tests