### PR TITLE
Allow passing a custom builder to @paginate instead of a model

### DIFF
--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -115,6 +115,21 @@ class ASTHelper
     }
 
     /**
+     * Does the given directive have an argument of the given name?
+     *
+     * @param DirectiveNode $directiveDefinition
+     * @param string $name
+     *
+     * @return bool
+     */
+    public static function directiveHasArgument(DirectiveNode $directiveDefinition, string $name): bool
+    {
+        return collect($directiveDefinition->arguments)->contains(function(ArgumentNode $argumentNode) use ($name){
+            return $argumentNode->name->value === $name;
+        });
+    }
+
+    /**
      * @param DirectiveNode $directive
      * @param string $name
      * @param mixed|null $default

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -3,13 +3,12 @@
 namespace Nuwave\Lighthouse\Schema\Directives;
 
 use GraphQL\Language\AST\DirectiveNode;
-use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use GraphQL\Language\AST\FieldDefinitionNode;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Language\AST\TypeSystemDefinitionNode;
 use Nuwave\Lighthouse\Support\Contracts\Directive;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;
-use Nuwave\Lighthouse\Schema\Directives\Fields\NamespaceDirective;
 
 abstract class BaseDirective implements Directive
 {
@@ -56,55 +55,54 @@ abstract class BaseDirective implements Directive
      */
     protected function directiveArgValue(string $name, $default = null)
     {
-        if (! $directive = $this->directiveDefinition()) {
-            return $default;
-        }
-
-        return ASTHelper::directiveArgValue($directive, $name, $default);
+        return ASTHelper::directiveArgValue($this->directiveDefinition(), $name, $default);
     }
-    
+
     /**
-     * Get the resolver that is specified in the current directive.
+     * Does the current directive have an argument with the given name?
      *
-     * @param \Closure $defaultResolver Add in a default resolver to return if no resolver class is given.
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function directiveHasArgument(string $name): bool
+    {
+        return ASTHelper::directiveHasArgument($this->directiveDefinition(), $name);
+    }
+
+    /**
+     * Get a Closure that is defined through an argument on the directive.
+     *
      * @param string $argumentName If the name of the directive argument is not "resolver" you may overwrite it.
      *
      * @throws DirectiveException
      *
      * @return \Closure
      */
-    public function getResolver(\Closure $defaultResolver = null, string $argumentName = 'resolver'): \Closure
+    public function getMethodArgument(string $argumentName): \Closure
     {
-        // The resolver is expected to contain a class and a method name, seperated by an @ symbol
+        // A method argument is expected to contain a class and a method name, seperated by an @ symbol
         // e.g. App\My\Class@methodName
-        $resolverArgumentFragments = explode('@', $this->directiveArgValue($argumentName));
+        $argumentParts = explode('@', $this->directiveArgValue($argumentName));
 
-        $baseClassName =
-            $this->directiveArgValue('class')
-            ?? $resolverArgumentFragments[0];
-
-        if (empty($baseClassName)) {
-            // If a default is given, simply return it
-            if($defaultResolver){
-                return $defaultResolver;
-            }
-            
-            throw new DirectiveException("Directive '{$this->name()}' must have a resolver class specified.");
-        }
-        
-        $resolverClass = $this->namespaceClassName($baseClassName);
-        $resolverMethod =
-            $this->directiveArgValue('method')
-            ?? $resolverArgumentFragments[1]
-            ?? 'resolve';
-
-        if (! method_exists($resolverClass, $resolverMethod)) {
-            throw new DirectiveException("Method '{$resolverMethod}' does not exist on class '{$resolverClass}'");
+        if (
+            count($argumentParts) !== 2
+            || empty($argumentParts[0])
+            || empty($argumentParts[1])
+        ){
+            throw new DirectiveException("Directive '{$this->name()}' must have an argument '{$argumentName}' with 'ClassName@methodName'");
         }
 
-        return \Closure::fromCallable([app($resolverClass), $resolverMethod]);
+        $className = $this->namespaceClassName($argumentParts[0]);
+        $methodName = $argumentParts[1];
+
+        if (! method_exists($className, $methodName)) {
+            throw new DirectiveException("Method '{$methodName}' does not exist on class '{$className}'");
+        }
+
+        return \Closure::fromCallable([resolve($className), $methodName]);
     }
-    
+
     /**
      * Get the model class from the `model` argument of the field.
      *
@@ -137,7 +135,7 @@ abstract class BaseDirective implements Directive
             config('lighthouse.namespaces.models')
         ]);
     }
-    
+
     /**
      *
      * @param string $classCandidate
@@ -151,11 +149,11 @@ abstract class BaseDirective implements Directive
     {
         // Always try the explicitly set namespace first
         \array_unshift($namespacesToTry, ASTHelper::getNamespaceForDirective($this->definitionNode, static::name()));
-        
+
         if(!$className = \namespace_classname($classCandidate, $namespacesToTry)){
             throw new DirectiveException("No class '$classCandidate' was found for directive '{$this->name()}'");
         };
-        
+
         return $className;
     }
 }

--- a/src/Schema/Directives/Fields/ComplexityDirective.php
+++ b/src/Schema/Directives/Fields/ComplexityDirective.php
@@ -14,7 +14,7 @@ class ComplexityDirective extends BaseDirective implements FieldMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'complexity';
     }
@@ -29,18 +29,18 @@ class ComplexityDirective extends BaseDirective implements FieldMiddleware
      *
      * @return FieldValue
      */
-    public function handleField(FieldValue $value, \Closure $next)
+    public function handleField(FieldValue $value, \Closure $next): FieldValue
     {
-        $complexityResolver = $this->getResolver(
-            function ($childrenComplexity, $args) {
-                $complexity = array_get($args, 'first', array_get($args, 'count', 1));
-
-                return $childrenComplexity * $complexity;
-            }
-        );
-        
         return $next(
-            $value->setComplexity($complexityResolver)
+            $value->setComplexity(
+                $this->directiveHasArgument('resolver')
+                ? $this->getMethodArgument('resolver')
+                : function ($childrenComplexity, $args) {
+                    $complexity = array_get($args, 'first', array_get($args, 'count', 1));
+
+                    return $childrenComplexity * $complexity;
+                }
+            )
         );
     }
 }

--- a/src/Schema/Directives/Nodes/NodeDirective.php
+++ b/src/Schema/Directives/Nodes/NodeDirective.php
@@ -30,7 +30,7 @@ class NodeDirective extends BaseDirective implements NodeMiddleware, NodeManipul
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'node';
     }
@@ -45,13 +45,13 @@ class NodeDirective extends BaseDirective implements NodeMiddleware, NodeManipul
      *
      * @return NodeValue
      */
-    public function handleNode(NodeValue $value, \Closure $next)
+    public function handleNode(NodeValue $value, \Closure $next): NodeValue
     {
         $typeName = $value->getNodeName();
         
         $this->nodeRegistry->registerNode(
             $typeName,
-            $this->getResolver()
+            $this->getMethodArgument('resolver')
         );
 
         return $next($value);
@@ -65,7 +65,7 @@ class NodeDirective extends BaseDirective implements NodeMiddleware, NodeManipul
      *
      * @return DocumentAST
      */
-    public function manipulateSchema(Node $node, DocumentAST $documentAST)
+    public function manipulateSchema(Node $node, DocumentAST $documentAST): DocumentAST
     {
         return ASTHelper::attachNodeInterfaceToObjectType($node, $documentAST);
     }

--- a/src/Schema/Factories/NodeFactory.php
+++ b/src/Schema/Factories/NodeFactory.php
@@ -85,6 +85,8 @@ class NodeFactory
      *
      * @param NodeValue $value
      *
+     * @throws DirectiveException
+     *
      * @return bool
      */
     protected function hasTypeResolver(NodeValue $value): bool
@@ -243,7 +245,16 @@ class NodeFactory
     
         $interfaceDefinition = $interfaceNodeValue->getNode();
         if($directive = ASTHelper::directiveDefinition('interface', $interfaceDefinition)){
-            $typeResolver = (new InterfaceDirective)->hydrate($interfaceDefinition)->getResolver();
+            $interfaceDirective = (new InterfaceDirective)->hydrate($interfaceDefinition);
+
+            if($interfaceDirective->directiveHasArgument('resolveType')){
+                $typeResolver = $interfaceDirective->getMethodArgument('resolveType');
+            } else {
+                /**
+                 * @deprecated in v3 this will only be available as the argument resolveType
+                 */
+                $typeResolver = $interfaceDirective->getMethodArgument('resolver');
+            }
         } else {
             $interfaceClass = \namespace_classname($nodeName, [
                 config('lighthouse.namespaces.interfaces')
@@ -275,7 +286,16 @@ class NodeFactory
     
         $unionDefinition = $value->getNode();
         if($directive = ASTHelper::directiveDefinition('union', $unionDefinition)){
-            $typeResolver = (new UnionDirective)->hydrate($unionDefinition)->getResolver();
+            $unionDirective = (new UnionDirective)->hydrate($unionDefinition);
+
+            if($unionDirective->directiveHasArgument('resolveType')){
+                $typeResolver = $unionDirective->getMethodArgument('resolveType');
+            } else {
+                /**
+                 * @deprecated in v3 this will only be available as the argument resolveType
+                 */
+                $typeResolver = $unionDirective->getMethodArgument('resolver');
+            }
         } else {
             $unionClass = \namespace_classname($nodeName, [
                 config('lighthouse.namespaces.unions')

--- a/tests/Unit/Schema/Directives/Fields/FieldDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/Fields/FieldDirectiveTest.php
@@ -9,6 +9,7 @@ class FieldDirectiveTest extends TestCase
 {
     /**
      * @test
+     * @deprecated this option of defining field resolvers will be removed in v3
      */
     public function itCanResolveFieldWithAssignedClass()
     {
@@ -54,7 +55,7 @@ class FieldDirectiveTest extends TestCase
     {
         $schema = '
         type Query {
-            bar: String! @field(class:"Tests\\\Utils\\\Resolvers\\\Foo" method: "baz" args:["foo.baz"])
+            bar: String! @field(resolver: "Tests\\\Utils\\\Resolvers\\\Foo@baz" args:["foo.baz"])
         }
         ';
         $query = '
@@ -70,12 +71,12 @@ class FieldDirectiveTest extends TestCase
     /**
      * @test
      */
-    public function itThrowsAnErrorIfNoClassIsDefined()
+    public function itThrowsAnErrorOnlyOnePartIsDefined()
     {
         $this->expectException(DirectiveException::class);
         $schema = '
         type Query {
-            bar: String! @field(method: "bar")
+            bar: String! @field(resolver: "bar")
         }
         ';
         $query = '
@@ -89,12 +90,12 @@ class FieldDirectiveTest extends TestCase
     /**
      * @test
      */
-    public function itThrowsAnErrorIfNoMethodIsDefined()
+    public function itThrowsAnErrorIfOnePartIsEmpty()
     {
         $this->expectException(DirectiveException::class);
         $schema = '
         type Query {
-            bar: String! @field(class: "Foo\\\Bar")
+            bar: String! @field(class: "Foo\\\Bar@")
         }
         ';
         $query = '

--- a/tests/Unit/Schema/Directives/Fields/PaginateDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/Fields/PaginateDirectiveTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Schema\Directives\Fields;
 
 use Tests\TestCase;
+use GraphQL\Type\Definition\FieldDefinition;
 
 class PaginateDirectiveTest extends TestCase
 {
@@ -17,16 +18,19 @@ class PaginateDirectiveTest extends TestCase
         $this->assertEquals($connection, $relay);
     }
 
-    protected function getConnectionQueryField($type)
+    protected function getConnectionQueryField(string $type): FieldDefinition
     {
-        return $this->buildSchemaFromString("
-        type Users {
-            name: String
-        }
-        
-        type Query {
-            users: [User!]! @paginate(type: \"$type\" model: \"User\")
-        }
-        ")->getQueryType()->getField('users');
+        return $this
+            ->buildSchemaFromString("
+            type Users {
+                name: String
+            }
+            
+            type Query {
+                users: [User!]! @paginate(type: \"$type\" model: \"User\")
+            }
+            ")
+            ->getQueryType()
+            ->getField('users');
     }
 }


### PR DESCRIPTION
Supersedes #302

This enables the user to use the complex logic that is within the @paginate directive
with a completely custom query.

- Add 'builder' argument to @paginate
- Add test that verifies a custom builder can be called

**Deprecation**

Deprecate alternate way of defining a field resolver through class/method

**Breaking changes''

Fail hard if no valid resolver argument was found but an argument for specifying such
was given. This might cause some users to get Errors, but in a good way - since it means
their previous definition did not work.

They can then either fix the directive argument or simply omit it to use the default, if possible.

**Refactor**

- Refactor BaseDirective->getResolver() to a more general getMethodArgument that contains
less magic and is more composable
- Add directiveHasArgument method to both BaseDirective and ASTHelper
- Refactor existing classes to use the new methods
- More types