### PR TITLE
[Refactor] Allow setting root path of schema

### DIFF
--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -8,8 +8,8 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Support\Facades\Validator;
-use Nuwave\Lighthouse\Schema\TypeRegistry;
 use Nuwave\Lighthouse\Schema\NodeRegistry;
+use Nuwave\Lighthouse\Schema\TypeRegistry;
 use Nuwave\Lighthouse\Schema\DirectiveRegistry;
 use Nuwave\Lighthouse\Schema\MiddlewareRegistry;
 use Nuwave\Lighthouse\Execution\GraphQLValidator;
@@ -26,15 +26,15 @@ class LighthouseServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->mergeConfigFrom(__DIR__ . '/../../config/config.php', 'lighthouse');
+        $this->mergeConfigFrom(__DIR__.'/../../config/config.php', 'lighthouse');
 
         $this->publishes([
-            __DIR__ . '/../../config/config.php' => config_path('lighthouse.php'),
-            __DIR__ . '/../../assets/default-schema.graphql' => config('lighthouse.schema.register'),
+            __DIR__.'/../../config/config.php' => config_path('lighthouse.php'),
+            __DIR__.'/../../assets/default-schema.graphql' => config('lighthouse.schema.register'),
         ]);
 
         if (config('lighthouse.controller')) {
-            $this->loadRoutesFrom(__DIR__ . '/../Support/Http/routes.php');
+            $this->loadRoutesFrom(__DIR__.'/../Support/Http/routes.php');
         }
 
         $this->registerCollectionMacros();
@@ -72,7 +72,7 @@ class LighthouseServiceProvider extends ServiceProvider
         $this->app->singleton(MiddlewareRegistry::class);
         $this->app->singleton(TypeRegistry::class);
 
-        $this->app->bind(
+        $this->app->singleton(
             SchemaSourceProvider::class,
             function () {
                 return new SchemaStitcher(config('lighthouse.schema.register', ''));
@@ -171,7 +171,7 @@ class LighthouseServiceProvider extends ServiceProvider
                 }
 
                 if (in_array($info->fieldName, $parameters)) {
-                    return !is_null($value);
+                    return ! is_null($value);
                 }
 
                 return true;

--- a/src/Schema/Source/SchemaSourceProvider.php
+++ b/src/Schema/Source/SchemaSourceProvider.php
@@ -3,16 +3,19 @@
 namespace Nuwave\Lighthouse\Schema\Source;
 
 /**
- * Interface SchemaSourceProvider
- * @package Nuwave\Lighthouse\Schema\Source
- *
- * This interface can be implemented to have different methods of providing
- * a schema string. Since the schema is then parsed into an AST and cached,
- * this does not necessarily have to be very performant, e.g. it may be
- * acceptable to download the schema or fetch it from an API.
+ * Interface SchemaSourceProvider.
  */
 interface SchemaSourceProvider
 {
+    /**
+     * Set schema root path.
+     *
+     * @param string $path
+     *
+     * @return SchemaSourceProvider
+     */
+    public function setRootPath(string $path);
+
     /**
      * Provide the schema definition.
      *

--- a/src/Schema/Source/SchemaStitcher.php
+++ b/src/Schema/Source/SchemaStitcher.php
@@ -8,7 +8,7 @@ class SchemaStitcher implements SchemaSourceProvider
      * @var string
      */
     protected $rootSchemaPath;
-    
+
     /**
      * SchemaStitcher constructor.
      *
@@ -18,7 +18,21 @@ class SchemaStitcher implements SchemaSourceProvider
     {
         $this->rootSchemaPath = $rootSchemaPath;
     }
-    
+
+    /**
+     * Set schema root path.
+     *
+     * @param string $path
+     *
+     * @return SchemaSourceProvider
+     */
+    public function setRootPath(string $path): SchemaStitcher
+    {
+        $this->rootSchemaPath = $path;
+
+        return $this;
+    }
+
     /**
      * Stitch together schema documents and return the result as a string.
      *
@@ -28,7 +42,7 @@ class SchemaStitcher implements SchemaSourceProvider
     {
         return self::gatherSchemaImportsRecursively($this->rootSchemaPath);
     }
-    
+
     /**
      * Get the schema, starting from a root schema, following the imports recursively.
      *
@@ -40,13 +54,13 @@ class SchemaStitcher implements SchemaSourceProvider
     {
         // This will throw if no file is found at this location
         return collect(file($path))
-            ->map(function (string $line) use ($path){
-                if(! starts_with(trim($line), '#import ')){
+            ->map(function (string $line) use ($path) {
+                if (! starts_with(trim($line), '#import ')) {
                     return $line;
                 }
 
                 $importFileName = trim(str_after($line, '#import '));
-                $importFilePath = realpath(dirname($path) . '/' . $importFileName);
+                $importFilePath = realpath(dirname($path).'/'.$importFileName);
 
                 return self::gatherSchemaImportsRecursively($importFilePath);
             })->implode('');

--- a/tests/Integration/Schema/Source/SchemaSourceProviderTest.php
+++ b/tests/Integration/Schema/Source/SchemaSourceProviderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Integration\Schema\Source;
+
+use Tests\TestCase;
+use League\Flysystem\Filesystem;
+use League\Flysystem\Adapter\Local;
+use Nuwave\Lighthouse\Schema\Source\SchemaStitcher;
+use Nuwave\Lighthouse\Schema\Source\SchemaSourceProvider;
+
+class SchemaSourceProviderTest extends TestCase
+{
+    const SCHEMA_PATH = __DIR__.'/schema/';
+
+    /**
+     * Set up test case.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $currentDir = new Filesystem(new Local(__DIR__));
+
+        $currentDir->deleteDir('schema');
+        $currentDir->createDir('schema');
+
+        $this->filesystem = new Filesystem(new Local(self::SCHEMA_PATH));
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $currentDir = new Filesystem(new Local(__DIR__));
+
+        $currentDir->deleteDir('schema');
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app->singleton(SchemaSourceProvider::class, function () {
+            return new SchemaStitcher(config('lighthouse.schema.register', ''));
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function itCanSetRootPath()
+    {
+        $this->filesystem->put('foo', 'bar');
+
+        app(SchemaSourceProvider::class)->setRootPath(__DIR__.'/schema/foo');
+
+        $this->assertEquals('bar', app(SchemaSourceProvider::class)->getSchemaString());
+    }
+}

--- a/tests/TestSchemaProvider.php
+++ b/tests/TestSchemaProvider.php
@@ -10,7 +10,7 @@ class TestSchemaProvider implements SchemaSourceProvider
      * @var string
      */
     protected $schema = '';
-    
+
     /**
      * TestSchemaProvider constructor.
      *
@@ -20,12 +20,24 @@ class TestSchemaProvider implements SchemaSourceProvider
     {
         $this->schema = $schema;
     }
-    
+
     /**
      * @return string
      */
     public function getSchemaString(): string
     {
         return $this->schema;
+    }
+
+    /**
+     * Set schema root path.
+     *
+     * @param string $path
+     *
+     * @return SchemaSourceProvider
+     */
+    public function setRootPath(string $path)
+    {
+        return $this;
     }
 }


### PR DESCRIPTION
**Related Issue(s)**

#325

**PR Type**

Refactor

**Changes**

Adds `setRootPath` method to `SchemaSourceProvider` interface to allow users to programmatically change the root path of the schema.

**Breaking changes**

Any user defined implementations of `SchemaSourceProvider` that doesn't currently extend the `SchemaStitcher` will need to add the new method.
