### PR TITLE
Allow using @globalID on args for decoding

### DIFF
--- a/src/Execution/Utils/GlobalId.php
+++ b/src/Execution/Utils/GlobalId.php
@@ -67,22 +67,4 @@ class GlobalId
         list($type, $id) = self::decode($globalID);
         return $type;
     }
-    
-    /**
-     * This function is the resolver for global id fields.
-     *
-     * @param $parentValue
-     * @param $args
-     * @param $context
-     * @param ResolveInfo $resolveInfo
-     *
-     * @return string
-     */
-    public static function resolveIdField($parentValue, $args, $context, ResolveInfo $resolveInfo): string
-    {
-        return self::encode(
-            $resolveInfo->parentType->name,
-            data_get($parentValue, config('lighthouse.global_id_field'))
-        );
-    }
 }

--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -4,11 +4,14 @@ namespace Nuwave\Lighthouse\Schema\AST;
 
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeList;
+use GraphQL\Language\AST\NamedTypeNode;
 use GraphQL\Language\AST\TypeExtensionNode;
 use GraphQL\Language\AST\FieldDefinitionNode;
 use Nuwave\Lighthouse\Schema\DirectiveRegistry;
+use Nuwave\Lighthouse\Exceptions\ParseException;
 use GraphQL\Language\AST\InputValueDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use Nuwave\Lighthouse\Exceptions\DocumentASTException;
 use Nuwave\Lighthouse\Support\Contracts\ArgManipulator;
 use Nuwave\Lighthouse\Support\Contracts\NodeManipulator;
 use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
@@ -18,6 +21,9 @@ class ASTBuilder
 {
     /**
      * @param string $schema
+     *
+     * @throws DocumentASTException
+     * @throws ParseException
      *
      * @return DocumentAST
      */
@@ -34,6 +40,8 @@ class ASTBuilder
         $document = self::applyArgManipulators($document);
 
         $document = self::addPaginationInfoTypes($document);
+        $document = self::addNodeSupport($document);
+
         $document = resolve(ExtensionRegistry::class)->manipulate($document);
 
         return $document;
@@ -52,9 +60,12 @@ class ASTBuilder
             ->reduce(function (DocumentAST $document, Node $node) {
                 $nodeManipulators = resolve(DirectiveRegistry::class)->nodeManipulators($node);
 
-                return $nodeManipulators->reduce(function (DocumentAST $document, NodeManipulator $nodeManipulator) use ($node) {
-                    return $nodeManipulator->manipulateSchema($node, $document);
-                }, $document);
+                return $nodeManipulators->reduce(
+                    function (DocumentAST $document, NodeManipulator $nodeManipulator) use ($node) {
+                        return $nodeManipulator->manipulateSchema($node, $document);
+                    },
+                    $document
+                );
             }, $document);
     }
 
@@ -65,23 +76,25 @@ class ASTBuilder
      */
     protected static function mergeTypeExtensions(DocumentAST $document): DocumentAST
     {
-        $document->objectTypeDefinitions()->each(function (ObjectTypeDefinitionNode $objectType) use ($document) {
-            $name = $objectType->name->value;
+        $document->objectTypeDefinitions()->each(
+            function (ObjectTypeDefinitionNode $objectType) use ($document) {
+                $name = $objectType->name->value;
 
-            $document->typeExtensionDefinitions($name)->reduce(function (
-                ObjectTypeDefinitionNode $relatedObjectType,
-                TypeExtensionNode $typeExtension
-            ) {
-                /** @var NodeList $fields */
-                $fields = $relatedObjectType->fields;
-                $relatedObjectType->fields = $fields->merge($typeExtension->fields);
+                $document->typeExtensionDefinitions($name)->reduce(
+                    function (ObjectTypeDefinitionNode $relatedObjectType, TypeExtensionNode $typeExtension) {
+                        /** @var NodeList $fields */
+                        $fields = $relatedObjectType->fields;
+                        $relatedObjectType->fields = $fields->merge($typeExtension->fields);
 
-                return $relatedObjectType;
-            }, $objectType);
+                        return $relatedObjectType;
+                    },
+                    $objectType
+                );
 
-            // Modify the original document by overwriting the definition with the merged one
-            $document->setDefinition($objectType);
-        });
+                // Modify the original document by overwriting the definition with the merged one
+                $document->setDefinition($objectType);
+            }
+        );
 
         return $document;
     }
@@ -93,24 +106,23 @@ class ASTBuilder
      */
     protected static function applyFieldManipulators(DocumentAST $document): DocumentAST
     {
-        return $document->objectTypeDefinitions()->reduce(function (
-            DocumentAST $document,
-            ObjectTypeDefinitionNode $objectType
-        ) {
-            return collect($objectType->fields)->reduce(function (
-                DocumentAST $document,
-                FieldDefinitionNode $fieldDefinition
-            ) use ($objectType) {
-                $fieldManipulators = resolve(DirectiveRegistry::class)->fieldManipulators($fieldDefinition);
+        return $document->objectTypeDefinitions()->reduce(
+            function (DocumentAST $document, ObjectTypeDefinitionNode $objectType) {
+                return collect($objectType->fields)->reduce(
+                    function (DocumentAST $document, FieldDefinitionNode $fieldDefinition) use ($objectType) {
+                        $fieldManipulators = resolve(DirectiveRegistry::class)->fieldManipulators($fieldDefinition);
 
-                return $fieldManipulators->reduce(function (
-                    DocumentAST $document,
-                    FieldManipulator $fieldManipulator
-                ) use ($fieldDefinition, $objectType) {
-                    return $fieldManipulator->manipulateSchema($fieldDefinition, $objectType, $document);
-                }, $document);
-            }, $document);
-        }, $document);
+                        return $fieldManipulators->reduce(
+                            function (DocumentAST $document, FieldManipulator $fieldManipulator) use ($fieldDefinition, $objectType) {
+                                return $fieldManipulator->manipulateSchema($fieldDefinition, $objectType, $document);
+                            },
+                            $document
+                        );
+                    },
+                    $document);
+            },
+            $document
+        );
     }
 
     /**
@@ -136,17 +148,25 @@ class ASTBuilder
                                     ) {
                                         return $argManipulator->manipulateSchema($argDefinition, $parentField,
                                             $parentType, $document);
-                                    }, $document);
-                            }, $document);
-                    }, $document);
-            }, $document);
+                                    },
+                                    $document
+                                );
+                            },
+                            $document
+                        );
+                    },
+                    $document
+                );
+            },
+            $document
+        );
     }
 
     /**
      * @param DocumentAST $document
      *
-     * @throws \Nuwave\Lighthouse\Exceptions\DocumentASTException
-     * @throws \Nuwave\Lighthouse\Exceptions\ParseException
+     * @throws DocumentASTException
+     * @throws ParseException
      *
      * @return DocumentAST
      */
@@ -209,6 +229,52 @@ class ASTBuilder
         }
         ');
         $document->setDefinition($pageInfo);
+
+        return $document;
+    }
+
+    /**
+     * Inject the node type and a node field into Query.
+     *
+     * @param DocumentAST $document
+     *
+     * @throws ParseException
+     * @throws DocumentASTException
+     *
+     * @return DocumentAST
+     */
+    protected static function addNodeSupport(DocumentAST $document): DocumentAST
+    {
+        $hasTypeImplementingNode = $document->objectTypeDefinitions()
+            ->contains(function (ObjectTypeDefinitionNode $objectType) {
+                return collect($objectType->interfaces)
+                    ->contains(function (NamedTypeNode $interface) {
+                        return 'Node' === $interface->name->value;
+                    });
+            });
+
+        // Only add the node type and node field if a type actually implements them
+        // Otherwise, a validation error is thrown
+        if (! $hasTypeImplementingNode) {
+            return $document;
+        }
+
+        $globalId = config('lighthouse.global_id_field');
+        // Double slashes to escape the slashes in the namespace.
+        $interface = PartialParser::interfaceTypeDefinition(<<<GRAPHQL
+"Node global interface"	
+interface Node @interface(resolveType: "Nuwave\\\Lighthouse\\\Schema\\\NodeRegistry@resolveType") {	
+  "Global identifier that can be used to resolve any Node implementation."
+  $globalId: ID!	
+}	
+GRAPHQL
+);
+        $document->setDefinition($interface);
+
+        $nodeQuery = PartialParser::fieldDefinition(
+            'node(id: ID! @globalId): Node @field(resolver: "Nuwave\\\Lighthouse\\\Schema\\\NodeRegistry@resolve")'
+        );
+        $document->addFieldToQueryType($nodeQuery);
 
         return $document;
     }

--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -236,7 +236,7 @@ class ASTHelper
         );
     
         $globalIdFieldDefinition = PartialParser::fieldDefinition(
-            config('lighthouse.global_id_field') .': ID! @field(resolver: "Nuwave\\\Lighthouse\\\Execution\\\Utils\\\GlobalId@resolveIdField")'
+            config('lighthouse.global_id_field') .': ID! @globalId'
         );
         $objectType->fields = $objectType->fields->merge([$globalIdFieldDefinition]);
         

--- a/src/Schema/Directives/Args/BcryptDirective.php
+++ b/src/Schema/Directives/Args/BcryptDirective.php
@@ -13,23 +13,27 @@ class BcryptDirective extends BaseDirective implements ArgMiddleware
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'bcrypt';
     }
 
     /**
-     * Resolve the field directive.
+     * Apply transformations on the ArgumentValue.
      *
      * @param ArgumentValue $value
      * @param \Closure       $next
      *
      * @return ArgumentValue
      */
-    public function handleArgument(ArgumentValue $value, \Closure $next)
+    public function handleArgument(ArgumentValue $value, \Closure $next): ArgumentValue
     {
-        return $next($value->setResolver(function ($password) {
-            return bcrypt($password);
-        }));
+        return $next(
+            $value->setResolver(
+                function ($password) {
+                    return bcrypt($password);
+                }
+            )
+        );
     }
 }

--- a/src/Schema/NodeRegistry.php
+++ b/src/Schema/NodeRegistry.php
@@ -5,7 +5,6 @@ namespace Nuwave\Lighthouse\Schema;
 use GraphQL\Error\Error;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\ResolveInfo;
-use Nuwave\Lighthouse\Execution\Utils\GlobalId;
 
 class NodeRegistry
 {
@@ -94,8 +93,7 @@ class NodeRegistry
      */
     public function resolve($rootValue, $args, $context, ResolveInfo $resolveInfo)
     {
-        $globalID = $args['id'];
-        list($decodedType, $decodedId) = GlobalId::decode($globalID);
+        list($decodedType, $decodedId) = $args['id'];
 
         // Check if we have a resolver registered for the given type
         if (! $resolver = array_get($this->nodeResolver, $decodedType)) {

--- a/tests/Integration/Schema/NodeInterfaceTest.php
+++ b/tests/Integration/Schema/NodeInterfaceTest.php
@@ -55,7 +55,7 @@ class NodeInterfaceTest extends DBTestCase
             }
         }
         ';
-        $result = $this->executeQuery($schema, $query);
+        $result = $this->execute($schema, $query);
         
         $this->assertSame([
             'first' => [
@@ -66,7 +66,7 @@ class NodeInterfaceTest extends DBTestCase
                 'id' => $secondGlobalId,
                 'name' => $this->testTuples[2]['name'],
             ],
-        ], $result->data);
+        ], $result['data']);
     }
 
     public function resolveNode($id)
@@ -103,13 +103,13 @@ class NodeInterfaceTest extends DBTestCase
             }
         }
         ';
-        $result = $this->executeQuery($schema, $query);
+        $result = $this->execute($schema, $query);
     
         $this->assertSame([
             'node' => [
                 'id' => $globalId,
                 'name' => 'Sepp',
             ],
-        ], $result->data);
+        ], $result['data']);
     }
 }


### PR DESCRIPTION
**Motivation**

Resolves #236

The docs displayed that usage, but it did not actually work.

**Changes**

The `@globalId` can now be used on Arguments to decode a global id. The value that is then passed along
is an array that consists of [$type, $id].

This is used in the definition of the `node` endpoint, that was simplified as a result:
It is now defined in the ASTBuilder again (going back and forth on this one :D ), which in the end
is a cleaner solution that also allows to leverage caching.

Did some formatting cleanups on the go, as i usually do.

**Breaking changes**

Decoding the global ID on fields is now no longer a configurable option. This is because
global IDs are internal, and fields only ever output values, so all they need is encoding.

