### PR TITLE
Fix for #333 - Use connection specified on the model in QueryBuilder

### DIFF
--- a/src/Support/DataLoader/QueryBuilder.php
+++ b/src/Support/DataLoader/QueryBuilder.php
@@ -107,7 +107,7 @@ class QueryBuilder
         // Just get the first of the relations to have an instance available
         $relatedModel = $relationQueries->first()->getModel();
         
-        if($options['paginated']{
+        if($options['paginated']){
             $relationQueries = $relationQueries->map(
                 function (Relation $relation) use ($options) {
                     return $relation->forPage($options['page'], $options['perPage']);

--- a/src/Support/DataLoader/QueryBuilder.php
+++ b/src/Support/DataLoader/QueryBuilder.php
@@ -104,16 +104,16 @@ class QueryBuilder
         $relation = $builder->getRelation($options['name']);
         $relationQueries = $this->getRelationQueries($builder, $models, $options['name'], $constraints);
 
-        $relationQueries = $relationQueries->map(
-            function (Relation $relation) use ($options) {
-                return $relation->when(
-                    $options['paginated'],
-                    function (Builder $query) use ($options) {
-                        return $query->forPage($options['page'], $options['perPage']);
-                    }
-                );
-            }
-        );
+        // Just get the first of the relations to have an instance available
+        $relatedModel = $relationQueries->first()->getModel();
+        
+        if($options['paginated']{
+            $relationQueries = $relationQueries->map(
+                function (Relation $relation) use ($options) {
+                    return $relation->forPage($options['page'], $options['perPage']);
+                }
+            );
+        }
 
         /** @var Builder $unitedRelations */
         $unitedRelations = $relationQueries->reduce(
@@ -124,9 +124,6 @@ class QueryBuilder
             // Use the first query as the initial starting point
             $relationQueries->shift()->getQuery()
         );
-
-        // Just get the first of the relations to have an instance available
-        $relatedModel = $relationQueries->first()->getModel();
         
         // Set the connection of the related model on the database manager and get a Builder instance
         $baseQuery = $this->databaseManager->connection(

--- a/src/Support/DataLoader/QueryBuilder.php
+++ b/src/Support/DataLoader/QueryBuilder.php
@@ -107,6 +107,7 @@ class QueryBuilder
         // Just get the first of the relations to have an instance available
         $relatedModel = $relationQueries->first()->getModel();
         $relatedTable = $relatedModel->getTable();
+        $relatedConnection = $relatedModel->getConnection();
 
         $relationQueries = $relationQueries->map(function (Relation $relation) use ($options) {
             return $relation->when($options['paginated'], function (Builder $query) use ($options) {
@@ -124,7 +125,9 @@ class QueryBuilder
             $relationQueries->shift()->getQuery()
         );
 
-        $baseQuery = $this->databaseManager->query();
+        // Set the connection of the related model on the database manager and get a Builder instance
+        $baseQuery = $this->databaseManager->connection($relatedConnection->getName())->query();
+
         $fromExpression = '('.$unitedRelations->toSql().') as '.$baseQuery->grammar->wrap($this->tableAlias($relatedTable));
         $results = $baseQuery->select()
             ->from($baseQuery->raw($fromExpression))


### PR DESCRIPTION
**Related Issue(s)**

Resolves [#333](https://github.com/nuwave/lighthouse/issues/333)

**PR Type**

Bugfix

**Changes**

Use the connection set on the model when building the query in the QueryBuilder
