### PR TITLE
Allow schema import via glob in SchemaStitcher

### DIFF
--- a/src/Schema/Source/SchemaStitcher.php
+++ b/src/Schema/Source/SchemaStitcher.php
@@ -60,9 +60,18 @@ class SchemaStitcher implements SchemaSourceProvider
                 }
 
                 $importFileName = trim(str_after($line, '#import '));
-                $importFilePath = realpath(dirname($path).'/'.$importFileName);
 
-                return self::gatherSchemaImportsRecursively($importFilePath);
+                if (! str_contains($importFileName, '*')) {
+                    $importFilePath = realpath(dirname($path).'/'.$importFileName);
+
+                    return self::gatherSchemaImportsRecursively($importFilePath);
+                }
+
+                $importFilePaths = glob(dirname($path) . '/' . $importFileName);
+                return collect($importFilePaths)
+                    ->map(function ($file) {
+                        return self::gatherSchemaImportsRecursively($file);
+                    })->implode('');
             })->implode('');
     }
 }

--- a/src/Schema/Source/SchemaStitcher.php
+++ b/src/Schema/Source/SchemaStitcher.php
@@ -73,6 +73,7 @@ class SchemaStitcher implements SchemaSourceProvider
                         return self::gatherSchemaImportsRecursively($file);
                     })
                     ->implode('');
-            })->implode('');
+            })
+            ->implode('');
     }
 }

--- a/src/Schema/Source/SchemaStitcher.php
+++ b/src/Schema/Source/SchemaStitcher.php
@@ -71,7 +71,8 @@ class SchemaStitcher implements SchemaSourceProvider
                 return collect($importFilePaths)
                     ->map(function ($file) {
                         return self::gatherSchemaImportsRecursively($file);
-                    })->implode('');
+                    })
+                    ->implode('');
             })->implode('');
     }
 }

--- a/tests/Unit/Schema/AST/SchemaStitcherTest.php
+++ b/tests/Unit/Schema/AST/SchemaStitcherTest.php
@@ -172,4 +172,37 @@ EOT
 EOT
         );
     }
+
+    /**
+     * @test
+     */
+    public function itImportsViaGlob()
+    {
+        $this->putRootSchema(<<<EOT
+foo
+#import subdir/*.graphql
+
+EOT
+        );
+
+        $this->filesystem->createDir('subdir');
+        $this->filesystem->put('subdir/bar.graphql', <<<EOT
+bar
+
+EOT
+        );
+        $this->filesystem->put('subdir/other.graphql', <<<EOT
+other
+
+EOT
+        );
+
+        $this->assertSchemaResultIsSame(<<<EOT
+foo
+bar
+other
+
+EOT
+        );
+    }
 }


### PR DESCRIPTION
**Related Issue(s)**

Resolves #314 

**PR Type**

Feature

**Changes**

If the file name to import has a wildcard, it loads via `glob`.

**Breaking changes**

No breaking changes.
