### PR TITLE
[Bug fix]PartialParser can not parse `argument`

### DIFF
--- a/src/Schema/AST/PartialParser.php
+++ b/src/Schema/AST/PartialParser.php
@@ -83,12 +83,12 @@ class PartialParser
      *
      * @throws ParseException
      *
-     * @return NodeList
+     * @return ArgumentNode
      */
-    public static function argument(string $argumentDefinition): NodeList
+    public static function argument(string $argumentDefinition): ArgumentNode
     {
         return self::getFirstAndValidateType(
-            self::field("field($argumentDefinition): String")->arguments,
+            self::field("field($argumentDefinition)")->arguments,
             ArgumentNode::class
         );
     }

--- a/tests/Unit/Schema/AST/PartialParserTest.php
+++ b/tests/Unit/Schema/AST/PartialParserTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Schema\AST;
 
+use GraphQL\Language\AST\ArgumentNode;
 use Tests\TestCase;
 use GraphQL\Error\SyntaxError;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
@@ -57,15 +58,18 @@ class PartialParserTest extends TestCase
 
     public function testParsesObjectTypesArray()
     {
-        $objectTypes = PartialParser::objectTypeDefinitions(['
+        $objectTypes = PartialParser::objectTypeDefinitions([
+            '
         type Foo {
             foo: String
         }
-        ', '
+        ',
+            '
         type Bar {
             bar: Int
         }
-        ']);
+        '
+        ]);
 
         $this->assertCount(2, $objectTypes);
         $this->assertInstanceOf(ObjectTypeDefinitionNode::class, $objectTypes[0]);
@@ -75,21 +79,25 @@ class PartialParserTest extends TestCase
     public function testThrowsOnInvalidTypeInObjectTypesArray()
     {
         $this->expectException(ParseException::class);
-        PartialParser::objectTypeDefinitions(['
+        PartialParser::objectTypeDefinitions([
+            '
         type Foo {
             foo: String
         }
-        ', '
+        ',
+            '
         interface Bar {
             bar: Int
         }
-        ']);
+        '
+        ]);
     }
 
     public function testThrowsOnMultipleDefinitionsInArrayItem()
     {
         $this->expectException(ParseException::class);
-        PartialParser::objectTypeDefinitions(['
+        PartialParser::objectTypeDefinitions([
+            '
         type Foo {
             foo: String
         }
@@ -97,7 +105,8 @@ class PartialParserTest extends TestCase
         type Bar {
             bar: Int
         }
-        ']);
+        '
+        ]);
     }
 
     public function testParseOperationDefinition()
@@ -110,5 +119,18 @@ class PartialParserTest extends TestCase
             }
         ')
         );
+    }
+
+    public function testParseArgument()
+    {
+        $argumentNode = PartialParser::argument('key: "value"');
+
+        $this->assertInstanceOf(
+            ArgumentNode::class,
+            $argumentNode
+        );
+        
+        $this->assertEquals('key', $argumentNode->name->value);
+        $this->assertEquals('value', $argumentNode->value->value);
     }
 }

--- a/tests/Unit/Schema/AST/PartialParserTest.php
+++ b/tests/Unit/Schema/AST/PartialParserTest.php
@@ -2,13 +2,13 @@
 
 namespace Tests\Unit\Schema\AST;
 
-use GraphQL\Language\AST\ArgumentNode;
 use Tests\TestCase;
 use GraphQL\Error\SyntaxError;
+use GraphQL\Language\AST\ArgumentNode;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
+use Nuwave\Lighthouse\Exceptions\ParseException;
 use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
-use Nuwave\Lighthouse\Exceptions\ParseException;
 
 class PartialParserTest extends TestCase
 {
@@ -58,18 +58,15 @@ class PartialParserTest extends TestCase
 
     public function testParsesObjectTypesArray()
     {
-        $objectTypes = PartialParser::objectTypeDefinitions([
-            '
+        $objectTypes = PartialParser::objectTypeDefinitions(['
         type Foo {
             foo: String
         }
-        ',
-            '
+        ', '
         type Bar {
             bar: Int
         }
-        '
-        ]);
+        ']);
 
         $this->assertCount(2, $objectTypes);
         $this->assertInstanceOf(ObjectTypeDefinitionNode::class, $objectTypes[0]);
@@ -79,25 +76,21 @@ class PartialParserTest extends TestCase
     public function testThrowsOnInvalidTypeInObjectTypesArray()
     {
         $this->expectException(ParseException::class);
-        PartialParser::objectTypeDefinitions([
-            '
+        PartialParser::objectTypeDefinitions(['
         type Foo {
             foo: String
         }
-        ',
-            '
+        ', '
         interface Bar {
             bar: Int
         }
-        '
-        ]);
+        ']);
     }
 
     public function testThrowsOnMultipleDefinitionsInArrayItem()
     {
         $this->expectException(ParseException::class);
-        PartialParser::objectTypeDefinitions([
-            '
+        PartialParser::objectTypeDefinitions(['
         type Foo {
             foo: String
         }
@@ -105,8 +98,7 @@ class PartialParserTest extends TestCase
         type Bar {
             bar: Int
         }
-        '
-        ]);
+        ']);
     }
 
     public function testParseOperationDefinition()
@@ -129,7 +121,7 @@ class PartialParserTest extends TestCase
             ArgumentNode::class,
             $argumentNode
         );
-        
+
         $this->assertEquals('key', $argumentNode->name->value);
         $this->assertEquals('value', $argumentNode->value->value);
     }


### PR DESCRIPTION
A quick bug fix for PartialParser.