### PR TITLE
Force value to array to be able to filter as array

### DIFF
--- a/src/Support/DataLoader/QueryBuilder.php
+++ b/src/Support/DataLoader/QueryBuilder.php
@@ -247,7 +247,7 @@ class QueryBuilder
             $reflection = new ReflectionClass($model);
             $withProperty = $reflection->getProperty('with');
             $withProperty->setAccessible(true);
-            $with = array_filter($withProperty->getValue($model), function ($relation) use ($model) {
+            $with = array_filter((array) $withProperty->getValue($model), function ($relation) use ($model) {
                 return ! $model->relationLoaded($relation);
             });
 


### PR DESCRIPTION
**Related Issue(s)**
Resolves #346

**PR Type**
BugFix

**Changes**
Force casts `$with` to array to be able to `array_filter`. Casting a string to an array always returns a new array with the string as single value.
```PHP
$with = 'title';
$withAsArray = (array) $with; // becomes  ['title']
```

demo: https://3v4l.org/IgPlq

**Breaking changes**
- none