### PR TITLE
Multiple paginators on same type

### DIFF
--- a/tests/Integration/Schema/Directives/Fields/HasManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/HasManyDirectiveTest.php
@@ -90,6 +90,7 @@ class HasManyDirectiveTest extends DBTestCase
         type User {
             tasks: [Task!]! @hasMany(type: "paginator")
             posts: [Post!]! @hasMany(type: "paginator")
+            posts2: [Post!]! @hasMany(type: "paginator")
         }
         
         type Task {

--- a/tests/Integration/Schema/Directives/Fields/PaginateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/PaginateDirectiveTest.php
@@ -26,6 +26,7 @@ class PaginateDirectiveTest extends DBTestCase
         
         type Query {
             users: [User!]! @paginate
+            users2: [User!]! @paginate
         }
         ';
 


### PR DESCRIPTION
**Related Issue(s)**

Resolves #357 

**PR Type**

Bugfix

**Changes**

When use `@paginate` and `@hasMany` directives (and thus `PaginatorManipulator`), if there is another type defined with the same name, it throws an exception.
This PR handles it and, if the type is already defined, does what we have been doing before (previously to the PR #348) 

**Breaking changes**

None unless a developer has extended to `PaginatorManipulator` (since some function's definitions has changed)
