### PR TITLE
[Bugfix & Refactor]`eagerLoadCount` cleanup & potential bug fix

### DIFF
--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -5,6 +5,7 @@ namespace Nuwave\Lighthouse\Providers;
 use Illuminate\Support\Str;
 use Nuwave\Lighthouse\GraphQL;
 use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
 use GraphQL\Type\Definition\ResolveInfo;
 use Nuwave\Lighthouse\Schema\NodeRegistry;
@@ -115,8 +116,9 @@ class LighthouseServiceProvider extends ServiceProvider
                     $eagerLoadRelations = [$eagerLoadRelations];
                 }
 
-                $query = $this->first()::withCount($eagerLoadRelations);
-                $this->items = resolve(QueryBuilder::class)->eagerLoadCount($query, $this->items);
+                $queryWithCount = $this->first()::withCount($eagerLoadRelations);
+
+                $this->items = resolve(QueryBuilder::class)->reloadWithBuilder($queryWithCount, $this->items);
             }
 
             return $this;
@@ -127,7 +129,7 @@ class LighthouseServiceProvider extends ServiceProvider
                 if (is_string($eagerLoadRelations)) {
                     $eagerLoadRelations = [$eagerLoadRelations];
                 }
-
+//
                 $this->items = $this->fetchCount($eagerLoadRelations)->items;
                 $query = $this->first()::with($eagerLoadRelations);
                 $this->items = resolve(QueryBuilder::class)

--- a/src/Support/DataLoader/QueryBuilder.php
+++ b/src/Support/DataLoader/QueryBuilder.php
@@ -13,7 +13,10 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 class QueryBuilder
 {
     /**
-     * Eager load count on collection of models.
+     * Reload a collection of models, using a given builder instance.
+     *
+     * This can be used to eagerly load the relations with an additional
+     * clause, such as a count subselect.
      *
      * Thanks to marcus13371337
      * https://github.com/laravel/framework/issues/17845#issuecomment-313701089
@@ -23,7 +26,7 @@ class QueryBuilder
      *
      * @return array
      */
-    public function eagerLoadCount(Builder $builder, array $models): array
+    public function reloadWithBuilder(Builder $builder, array $models): array
     {
         $ids = \array_map(
             function (Model $model) {

--- a/src/Support/DataLoader/QueryBuilder.php
+++ b/src/Support/DataLoader/QueryBuilder.php
@@ -19,21 +19,31 @@ class QueryBuilder
      * https://github.com/laravel/framework/issues/17845#issuecomment-313701089
      *
      * @param Builder $builder
-     * @param array   $models
+     * @param Model[] $models
      *
      * @return array
      */
     public function eagerLoadCount(Builder $builder, array $models): array
     {
-        $ids = \array_map(function (Model $model) {
-            return $model->getKey();
-        }, $models);
+        $ids = \array_map(
+            function (Model $model) {
+                return $model->getKey();
+            },
+            $models
+        );
 
-        $results = $builder->whereKey($ids)->get();
+        $results = $builder
+            ->whereKey($ids)
+            ->get();
 
-        return $results->filter(function (Model $model) use ($ids) {
-            return \in_array($model->getKey(), $ids, true);
-        })->all();
+        return $results
+            ->filter(function (Model $model) use ($ids) {
+                return \in_array(
+                    $model->getKey(),
+                    $ids,
+                    true
+                );
+            })->all();
     }
 
     /**


### PR DESCRIPTION
This piece of code may cause problems because some properties may changes when it was converted to the array by using the `toArray` method. 
In my case, because I'm using the binary UUID for primary key, so the `id` property of model will be converted into a string representation of the binary UUID, so if it `toArray` the model, the `id` will never be the binary UUID anymore.

```php
foreach ($models as $model) {
    if (isset($dictionary[$model->{$key}])) {
        $model->forceFill($dictionary[$model->{$key}]
            ->toArray());
    }
}
```

Also, cleanup the code a bit.