### PR TITLE
Do not try to encode a cursor when the result of a Connection is empty

### DIFF
--- a/src/Schema/Types/ConnectionField.php
+++ b/src/Schema/Types/ConnectionField.php
@@ -31,8 +31,8 @@ class ConnectionField
             'lastPage' => $paginator->lastPage(),
             'hasNextPage' => $paginator->hasMorePages(),
             'hasPreviousPage' => $paginator->currentPage() > 1,
-            'startCursor' => Cursor::encode($paginator->firstItem()),
-            'endCursor' => Cursor::encode($paginator->lastItem()),
+            'startCursor' => $paginator->firstItem() ? Cursor::encode($paginator->firstItem()) : null,
+            'endCursor' => $paginator->lastItem() ? Cursor::encode($paginator->lastItem()) : null,
         ];
     }
 

--- a/src/Schema/Types/ConnectionField.php
+++ b/src/Schema/Types/ConnectionField.php
@@ -31,8 +31,12 @@ class ConnectionField
             'lastPage' => $paginator->lastPage(),
             'hasNextPage' => $paginator->hasMorePages(),
             'hasPreviousPage' => $paginator->currentPage() > 1,
-            'startCursor' => $paginator->firstItem() ? Cursor::encode($paginator->firstItem()) : null,
-            'endCursor' => $paginator->lastItem() ? Cursor::encode($paginator->lastItem()) : null,
+            'startCursor' => $paginator->firstItem()
+                ? Cursor::encode($paginator->firstItem())
+                : null,
+            'endCursor' => $paginator->lastItem()
+                ? Cursor::encode($paginator->lastItem())
+                : null,
         ];
     }
 

--- a/tests/Integration/Schema/Directives/Fields/PaginateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/PaginateDirectiveTest.php
@@ -198,4 +198,60 @@ class PaginateDirectiveTest extends DBTestCase
         $this->assertTrue(array_get($result->data, 'users.pageInfo.hasNextPage'));
         $this->assertCount(5, array_get($result->data, 'users.edges'));
     }
+    
+    /**
+     * @test
+     */
+    public function itQueriesConnectionWithNoData()
+    {
+        $schema = '
+        type User {
+            id: ID!
+            name: String!
+        }
+        
+        type Query {
+            users: [User!]! @paginate(type: "relay")
+        }
+        ';
+
+        $query = '
+        {
+            users(first: 5) {
+                pageInfo {
+                    total
+                    count
+                    currentPage
+                    lastPage
+                    hasNextPage
+                    hasPreviousPage
+                    startCursor
+                    endCursor
+                }
+                edges {
+                    node {
+                        id
+                        name
+                    }
+                }
+            }
+        }
+        ';
+
+        $result = $this->executeQuery($schema, $query);
+        $this->assertSame(
+            [
+                'total' => 0,
+                'count' => 0,
+                'currentPage' => 1 ,
+                'lastPage' => 1,
+                'hasNextPage' => false,
+                'hasPreviousPage' =>false,
+                'startCursor' => null,
+                'endCursor' => null,
+            ],
+            array_get($result->data, 'users.pageInfo')
+        );
+        $this->assertCount(0, array_get($result->data, 'users.edges'));
+    }
 }


### PR DESCRIPTION
**PR Type**

Bugfix

I am getting the following error when the paginator is empty.

```
Argument 1 passed to Nuwave\Lighthouse\Execution\Utils\Cursor::encode() must be of the type integer, null given
```