### PR TITLE
Fix paginator total attribute being null with visibility set on models

### DIFF
--- a/src/Support/DataLoader/QueryBuilder.php
+++ b/src/Support/DataLoader/QueryBuilder.php
@@ -40,7 +40,7 @@ class QueryBuilder
 
         foreach ($models as $model) {
             if (isset($dictionary[$model->{ $key }])) {
-                $model->forceFill($dictionary[$model->{ $key }]->toArray());
+                $model->forceFill($dictionary[$model->{ $key }]->getAttributes());
             }
         }
 

--- a/tests/Integration/Support/DataLoader/QueryBuilderTest.php
+++ b/tests/Integration/Support/DataLoader/QueryBuilderTest.php
@@ -75,5 +75,8 @@ class QueryBuilderTest extends DBTestCase
         $this->assertEquals($users[0]->getKey(), $users[0]->tasks[0]->user_id);
         $this->assertEquals($users[1]->getKey(), $users[1]->tasks[0]->user_id);
         $this->assertEquals($users[2]->getKey(), $users[2]->tasks[0]->user_id);
+        $this->assertEquals(4, $users[0]->tasks->total());
+        $this->assertEquals(5, $users[1]->tasks->total());
+        $this->assertEquals(6, $users[2]->tasks->total());
     }
 }

--- a/tests/Utils/Models/Comment.php
+++ b/tests/Utils/Models/Comment.php
@@ -8,5 +8,5 @@ use Illuminate\Database\Eloquent\Model;
 
 class Comment extends Model
 {
-
+    protected $visible = ['id'];
 }

--- a/tests/Utils/Models/Company.php
+++ b/tests/Utils/Models/Company.php
@@ -8,4 +8,6 @@ use Nuwave\Lighthouse\Support\Traits\IsRelayConnection;
 class Company extends Model
 {
     use IsRelayConnection;
+
+    protected $visible = ['id'];
 }

--- a/tests/Utils/Models/Post.php
+++ b/tests/Utils/Models/Post.php
@@ -11,6 +11,8 @@ class Post extends Model
 {
     use Searchable;
 
+    protected $visible = ['id'];
+
     public function comments() {
         return $this->hasMany(Comment::class);
     }

--- a/tests/Utils/Models/Task.php
+++ b/tests/Utils/Models/Task.php
@@ -9,6 +9,8 @@ class Task extends Model
 {
     use IsRelayConnection;
 
+    protected $visible = ['id'];
+
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/tests/Utils/Models/Team.php
+++ b/tests/Utils/Models/Team.php
@@ -6,4 +6,5 @@ use Illuminate\Database\Eloquent\Model;
 
 class Team extends Model
 {
+    protected $visible = ['id'];
 }

--- a/tests/Utils/Models/User.php
+++ b/tests/Utils/Models/User.php
@@ -9,6 +9,8 @@ class User extends Authenticatable
 {
     use IsRelayConnection;
 
+    protected $visible = ['id'];
+
     public function company()
     {
         return $this->belongsTo(Company::class);


### PR DESCRIPTION
**PR Type**

Bugfix

**Changes**

Consider the following schema:

```graphql
type Query {
    me: User @auth
}

type User {
    name: String!
    tasks: [Task!]! @hasMany(type: "paginator")
}

type Task {
    task: String!
}
```

With the following `User` mode:

```php
class User extends Model {
    protected $visible = ['id'];
}
```

And the following query:

```graphql
query {
  me {
    name
    tasks(count: 3) {
      paginatorInfo {
        total
      }
      data {
        task
      }
    }
  }
}
```

This fails with a `InvariantViolation`: `Cannot return null for non-nullable field PaginatorInfo.total.`.

Because `->toArray()` is being used to get all the attributes from the model and re-setting them on the eager loaded model only the `$visible` attributes are taken, while visibility should be ignored here otherwise the `*_count` fields will not be properly copied over.

**Breaking changes**

None, bugfix.
