### PR TITLE
Fix coverage generation in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,12 @@ matrix:
   - php: 7.2
     env: LARAVEL='5.7.*' PHPUNIT='^7.0'
   include:
-  - php: 7.2
+  - php: 7.1
     env: LARAVEL='5.7.*' PHPUNIT='^7.0' COVERAGE=1
   fast_finish: true
 
 before_install:
+- phpenv config-rm xdebug.ini
 - echo "memory_limit=4G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 - composer global require hirak/prestissimo --update-no-dev
 - composer require
@@ -52,7 +53,7 @@ install:
 
 script:
 - if [[ $COVERAGE = 1 ]]; then
-    phpunit --coverage-clover=coverage.xml;
+    phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml;
   else
     phpunit --colors=always --verbose;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ matrix:
   fast_finish: true
 
 before_install:
-- phpenv config-rm xdebug.ini
 - echo "memory_limit=4G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 - composer global require hirak/prestissimo --update-no-dev
 - composer require

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
 
 script:
 - if [[ $COVERAGE = 1 ]]; then
-    phpdbg -qrr vendor/bin/phpunit --colors=always --verbose --coverage-text --coverage-clover=coverage.xml;
+    phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml;
   else
     phpunit --colors=always --verbose;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
 
 script:
 - if [[ $COVERAGE = 1 ]]; then
-    phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml;
+    vendor/bin/phpunit --coverage-clover=coverage.xml;
   else
     phpunit --colors=always --verbose;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
 
 script:
 - if [[ $COVERAGE = 1 ]]; then
-    vendor/bin/phpunit --coverage-clover=coverage.xml;
+    phpunit --coverage-clover=coverage.xml;
   else
     phpunit --colors=always --verbose;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,16 @@ env:
 
 matrix:
   exclude:
+  # Laravel > 5.6 requires PHP 7.1
   - php: 7.0
     env: LARAVEL='5.6.*' PHPUNIT='^7.0'
   - php: 7.0
     env: LARAVEL='5.7.*' PHPUNIT='^7.0'
-  - php: 7.2
+  # This is run with coverage instead
+  - php: 7.1
     env: LARAVEL='5.7.*' PHPUNIT='^7.0'
   include:
+  # Generating coverage on 7.1, as 7.2 does segfault, switch back eventually
   - php: 7.1
     env: LARAVEL='5.7.*' PHPUNIT='^7.0' COVERAGE=1
   fast_finish: true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,15 +27,4 @@
             </exclude>
         </whitelist>
     </filter>
-    <logging>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <php>
-        <!-- Strong Password Generator (https://strongpasswordgenerator.com/) -->
-        <env name="APP_KEY" value="O4JYm19Y7qXbllmw5zng88a4MlUmW0uq"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite" /> -->
-    </php>
 </phpunit>


### PR DESCRIPTION
We have to generate the coverage report in PHP 7.1, as PHP 7.2 is currently bugged and causes segmentation faults when running PHPUnit with coverage.