### PR TITLE
[Feat] Context Contract

### DIFF
--- a/src/Execution/ContextFactory.php
+++ b/src/Execution/ContextFactory.php
@@ -18,8 +18,6 @@ class ContextFactory implements CreatesContext
      */
     public function generate(Request $request): GraphQLContext
     {
-        $user = app()->bound('auth') ? auth()->user() : null;
-
-        return new Context($request, $user);
+        return new Context($request, $request->user());
     }
 }

--- a/src/Execution/ContextFactory.php
+++ b/src/Execution/ContextFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Nuwave\Lighthouse\Execution;
+
+use Illuminate\Http\Request;
+use Nuwave\Lighthouse\Schema\Context;
+use Nuwave\Lighthouse\Support\Contracts\CreatesContext;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+
+class ContextFactory implements CreatesContext
+{
+    /**
+     * Generate GraphQL context.
+     *
+     * @param Request $request
+     *
+     * @return GraphQLContext
+     */
+    public function generate(Request $request): GraphQLContext
+    {
+        $user = app()->bound('auth') ? auth()->user() : null;
+
+        return new Context($request, $user);
+    }
+}

--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -8,11 +8,13 @@ use Illuminate\Support\ServiceProvider;
 use GraphQL\Type\Definition\ResolveInfo;
 use Nuwave\Lighthouse\Schema\NodeRegistry;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
+use Nuwave\Lighthouse\Execution\ContextFactory;
 use Nuwave\Lighthouse\Schema\DirectiveRegistry;
 use Nuwave\Lighthouse\Schema\MiddlewareRegistry;
 use Nuwave\Lighthouse\Execution\GraphQLValidator;
 use Nuwave\Lighthouse\Schema\Source\SchemaStitcher;
 use Nuwave\Lighthouse\Schema\Factories\ValueFactory;
+use Nuwave\Lighthouse\Support\Contracts\CreatesContext;
 use Nuwave\Lighthouse\Schema\Source\SchemaSourceProvider;
 use Nuwave\Lighthouse\Schema\Extensions\ExtensionRegistry;
 
@@ -67,6 +69,7 @@ class LighthouseServiceProvider extends ServiceProvider
         $this->app->singleton(NodeRegistry::class);
         $this->app->singleton(MiddlewareRegistry::class);
         $this->app->singleton(TypeRegistry::class);
+        $this->app->singleton(CreatesContext::class, ContextFactory::class);
 
         $this->app->singleton(
             SchemaSourceProvider::class,

--- a/src/Schema/Context.php
+++ b/src/Schema/Context.php
@@ -4,8 +4,9 @@ namespace Nuwave\Lighthouse\Schema;
 
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Auth\Authenticatable as User;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
-class Context
+class Context implements GraphQLContext
 {
     /**
      * Http request.
@@ -26,12 +27,32 @@ class Context
     /**
      * Create new context.
      *
-     * @param Request $request
+     * @param Request   $request
      * @param User|null $user
      */
     public function __construct(Request $request, User $user = null)
     {
         $this->request = $request;
         $this->user = $user;
+    }
+
+    /**
+     * Get instance of authorized user.
+     *
+     * @return User|null
+     */
+    public function user(): User
+    {
+        return $this->user;
+    }
+
+    /**
+     * Get instance of request.
+     *
+     * @return \Illuminate\Http\Request
+     */
+    public function request(): Request
+    {
+        return $this->request;
     }
 }

--- a/src/Schema/Context.php
+++ b/src/Schema/Context.php
@@ -41,7 +41,7 @@ class Context implements GraphQLContext
      *
      * @return User|null
      */
-    public function user(): User
+    public function user()
     {
         return $this->user;
     }

--- a/src/Support/Contracts/CreatesContext.php
+++ b/src/Support/Contracts/CreatesContext.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Nuwave\Lighthouse\Support\Contracts;
+
+use Illuminate\Http\Request;
+
+interface CreatesContext
+{
+    /**
+     * Generate GraphQL context.
+     *
+     * @param Request $request
+     *
+     * @return GraphQLContext
+     */
+    public function generate(Request $request);
+}

--- a/src/Support/Contracts/GraphQLContext.php
+++ b/src/Support/Contracts/GraphQLContext.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Nuwave\Lighthouse\Support\Contracts;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+interface GraphQLContext
+{
+    /**
+     * Get instance of authorized user.
+     *
+     * @return Authenticatable|null
+     */
+    public function user();
+
+    /**
+     * Get instance of request.
+     *
+     * @return \Illuminate\Http\Request
+     */
+    public function request();
+}

--- a/src/Support/Http/Controllers/GraphQLController.php
+++ b/src/Support/Http/Controllers/GraphQLController.php
@@ -2,20 +2,23 @@
 
 namespace Nuwave\Lighthouse\Support\Http\Controllers;
 
-use GraphQL\Executor\ExecutionResult;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Routing\Controller;
 use Nuwave\Lighthouse\GraphQL;
-use Nuwave\Lighthouse\Schema\Context;
-use Nuwave\Lighthouse\Schema\Extensions\ExtensionRegistry;
-use Nuwave\Lighthouse\Schema\Extensions\ExtensionRequest;
+use Illuminate\Routing\Controller;
+use GraphQL\Executor\ExecutionResult;
 use Nuwave\Lighthouse\Schema\MiddlewareRegistry;
+use Nuwave\Lighthouse\Schema\Extensions\ExtensionRequest;
+use Nuwave\Lighthouse\Schema\Extensions\ExtensionRegistry;
+use Nuwave\Lighthouse\Support\Contracts\CreatesContext as Context;
 
 class GraphQLController extends Controller
 {
     /** @var GraphQL */
     protected $graphQL;
+
+    /** @var Context $context */
+    protected $context;
 
     /** @var bool */
     protected $batched = false;
@@ -27,14 +30,17 @@ class GraphQLController extends Controller
      * @param ExtensionRegistry  $extensionRegistry
      * @param MiddlewareRegistry $middlewareRegistry
      * @param GraphQL            $graphQL
+     * @param Context            $context
      */
     public function __construct(
         Request $request,
         ExtensionRegistry $extensionRegistry,
         MiddlewareRegistry $middlewareRegistry,
-        GraphQL $graphQL
+        GraphQL $graphQL,
+        Context $context
     ) {
         $this->graphQL = $graphQL;
+        $this->context = $context;
 
         if ($request->route()) {
             $this->batched = isset($request[0]) && config('lighthouse.batched_queries', true);
@@ -73,13 +79,11 @@ class GraphQLController extends Controller
     public function query(Request $request)
     {
         $debug = config('app.debug') ? config('lighthouse.debug') : false;
-        $user = app()->bound('auth') ? auth()->user() : null;
-        $context = new Context($request, $user);
 
         if ($this->batched) {
             $data = $this->graphQL->executeBatchedQueries(
                 $request->toArray(),
-                $context
+                $this->context->generate($request)
             );
 
             return response(
@@ -97,27 +101,9 @@ class GraphQLController extends Controller
         return response(
             $this->graphQL->executeQuery(
                 $query,
-                new Context($request, $user),
+                $this->context->generate($request),
                 $variables
             )->toArray($debug)
-        );
-    }
-
-    /**
-     * @param Request $request
-     * @param string  $query
-     * @param array   $variables
-     *
-     * @return ExecutionResult
-     */
-    protected function execute(Request $request, string $query, array $variables): ExecutionResult
-    {
-        $user = app()->bound('auth') ? auth()->user() : null;
-
-        return $this->graphQL->executeQuery(
-            $query,
-            new Context($request, $user),
-            $variables
         );
     }
 

--- a/src/Support/Http/Controllers/GraphQLController.php
+++ b/src/Support/Http/Controllers/GraphQLController.php
@@ -8,17 +8,17 @@ use Nuwave\Lighthouse\GraphQL;
 use Illuminate\Routing\Controller;
 use GraphQL\Executor\ExecutionResult;
 use Nuwave\Lighthouse\Schema\MiddlewareRegistry;
+use Nuwave\Lighthouse\Support\Contracts\CreatesContext;
 use Nuwave\Lighthouse\Schema\Extensions\ExtensionRequest;
 use Nuwave\Lighthouse\Schema\Extensions\ExtensionRegistry;
-use Nuwave\Lighthouse\Support\Contracts\CreatesContext as Context;
 
 class GraphQLController extends Controller
 {
     /** @var GraphQL */
     protected $graphQL;
 
-    /** @var Context $context */
-    protected $context;
+    /** @var CreatesContext */
+    protected $createsContext;
 
     /** @var bool */
     protected $batched = false;
@@ -30,17 +30,17 @@ class GraphQLController extends Controller
      * @param ExtensionRegistry  $extensionRegistry
      * @param MiddlewareRegistry $middlewareRegistry
      * @param GraphQL            $graphQL
-     * @param Context            $context
+     * @param CreatesContext     $createsContext
      */
     public function __construct(
         Request $request,
         ExtensionRegistry $extensionRegistry,
         MiddlewareRegistry $middlewareRegistry,
         GraphQL $graphQL,
-        Context $context
+        CreatesContext $createsContext
     ) {
         $this->graphQL = $graphQL;
-        $this->context = $context;
+        $this->createsContext = $createsContext;
 
         if ($request->route()) {
             $this->batched = isset($request[0]) && config('lighthouse.batched_queries', true);
@@ -83,7 +83,7 @@ class GraphQLController extends Controller
         if ($this->batched) {
             $data = $this->graphQL->executeBatchedQueries(
                 $request->toArray(),
-                $this->context->generate($request)
+                $this->createsContext->generate($request)
             );
 
             return response(
@@ -101,7 +101,7 @@ class GraphQLController extends Controller
         return response(
             $this->graphQL->executeQuery(
                 $query,
-                $this->context->generate($request),
+                $this->createsContext->generate($request),
                 $variables
             )->toArray($debug)
         );

--- a/tests/Unit/Schema/Execution/ContextFactoryTest.php
+++ b/tests/Unit/Schema/Execution/ContextFactoryTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Unit\Schema\Execution;
+
+use Tests\TestCase;
+use Illuminate\Http\Request;
+use Illuminate\Foundation\Application;
+use Nuwave\Lighthouse\Support\Contracts\CreatesContext;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+
+class ContextFactoryTest extends TestCase
+{
+    /**
+     * Define environment setup.
+     *
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app->singleton(CreatesContext::class, function () {
+            return new class() implements CreatesContext {
+                public function generate(Request $request)
+                {
+                    return new class($request) implements GraphQLContext {
+                        public function __construct($request)
+                        {
+                            $this->request = $request;
+                        }
+
+                        public function user()
+                        {
+                            return null;
+                        }
+
+                        public function request()
+                        {
+                            return $this->request;
+                        }
+
+                        public function foo()
+                        {
+                            return 'custom.context';
+                        }
+                    };
+                }
+            };
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function itCanGenerateCustomContext()
+    {
+        $resolver = addslashes(self::class).'@resolve';
+        $this->schema = "
+        type Query {
+            context: String @field(resolver:\"{$resolver}\")
+        }";
+        $json = ['query' => '{ context }'];
+
+        $result = $this->postJson('graphql', $json)->json();
+        $execution = [
+            'data' => [
+                'context' => 'custom.context',
+            ],
+        ];
+
+        $this->assertEquals($execution, $result);
+    }
+
+    public function resolve($root, array $args, $context)
+    {
+        return $context->foo();
+    }
+}


### PR DESCRIPTION
**Related Issue(s)**

None

**PR Type**

Feature

**Changes**

Allows users to define their own context by implementing the `CreatesContext` interface. A new `GraphQLContext` interface has also been introduced so a Lighthouse can safely make assumptions about how to get an instance of the original request and authenticated user from the `$context` resolver argument.

**Breaking changes**

None, Lighthouse's default Context will created and injected into resolvers just as it currently is.
