### PR TITLE
itCanPointToScalarClassThroughDirectiveWithoutNamespace

### DIFF
--- a/src/Schema/Factories/NodeFactory.php
+++ b/src/Schema/Factories/NodeFactory.php
@@ -200,10 +200,12 @@ class NodeFactory
         if($directive = ASTHelper::directiveDefinition($scalarDefinition, 'scalar')){
             $className = ASTHelper::directiveArgValue($directive, 'class');
         } else {
-            $className = \namespace_classname($scalarName, [
-                config('lighthouse.namespaces.scalars')
-            ]);
+            $className = $scalarName;
         }
+
+        $className = \namespace_classname($className, [
+            config('lighthouse.namespaces.scalars')
+        ]);
 
         if(!$className){
             throw new \Exception("No class found for the scalar {$scalarName}");

--- a/tests/Unit/Schema/Factories/NodeFactoryTest.php
+++ b/tests/Unit/Schema/Factories/NodeFactoryTest.php
@@ -83,6 +83,20 @@ class NodeFactoryTest extends TestCase
     /**
      * @test
      */
+    public function itCanPointToScalarClassThroughDirectiveWithoutNamespace()
+    {
+        $scalarNode = PartialParser::scalarTypeDefinition('
+        scalar SomeEmail @scalar(class: "Email")
+        ');
+        $scalarType = $this->factory->handle($scalarNode);
+
+        $this->assertInstanceOf(ScalarType::class, $scalarType);
+        $this->assertSame('SomeEmail', $scalarType->name);
+    }
+
+    /**
+     * @test
+     */
     public function itCanTransformInterfaces()
     {
         $interfaceNode = PartialParser::interfaceTypeDefinition('


### PR DESCRIPTION
**Related Issue(s)**

#388

**PR Type**

Bugfix

**Changes**

Add test and fix for pre v2.3 behaviour of `@scalar` directive looking for scalars in the default namespace.