### PR TITLE
[Feat] Extension Manipulate Response

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -72,16 +72,16 @@ class GraphQL
         return collect($requests)->map(function ($request, $index) use ($context, $rootValue) {
             $this->extensionRegistry->batchedQueryDidStart($index);
 
-            $data = $this->executeQuery(
+            $result = $this->executeQuery(
                 array_get($request, 'query', ''),
                 $context,
                 array_get($request, 'variables', []),
                 $rootValue
             );
 
-            $this->extensionRegistry->batchedQueryDidEnd($index);
+            $this->extensionRegistry->batchedQueryDidEnd($result, $index);
 
-            return $data;
+            return $result;
         })->all();
     }
 

--- a/src/Schema/Extensions/ExtensionRegistry.php
+++ b/src/Schema/Extensions/ExtensionRegistry.php
@@ -3,17 +3,25 @@
 namespace Nuwave\Lighthouse\Schema\Extensions;
 
 use Illuminate\Support\Collection;
+use GraphQL\Executor\ExecutionResult;
+use Nuwave\Lighthouse\Support\Pipeline;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 
 class ExtensionRegistry implements \JsonSerializable
 {
-    /**
-     * @var Collection|GraphQLExtension[]
-     */
+    /** @var Pipeline */
+    protected $pipeline;
+
+    /** @var Collection|GraphQLExtension[] */
     protected $extensions;
 
-    public function __construct()
+    /**
+     * @param Pipeline $pipeline
+     */
+    public function __construct(Pipeline $pipeline)
     {
+        $this->pipeline = $pipeline;
+
         $this->extensions = collect(
             config('lighthouse.extensions', [])
         )->mapWithKeys(function (string $extension) {
@@ -80,17 +88,39 @@ class ExtensionRegistry implements \JsonSerializable
     /**
      * Notify all registered extensions that a batched query did end.
      *
-     * @param int $index
+     * @param ExecutionResult $result
+     * @param int             $index
      *
      * @return ExtensionRegistry
      */
-    public function batchedQueryDidEnd($index)
+    public function batchedQueryDidEnd(ExecutionResult $result, $index)
     {
-        $this->extensions->each(function (GraphQLExtension $extension) use ($index) {
-            $extension->batchedQueryDidEnd($index);
-        });
+        $this->extensions->each(
+            function (GraphQLExtension $extension) use ($result, $index) {
+                $extension->batchedQueryDidEnd($result, $index);
+            }
+        );
 
         return $this;
+    }
+
+    /**
+     * Notify all registered extensions that the
+     * response will be sent.
+     *
+     * @param array $response
+     *
+     * @return array
+     */
+    public function willSendResponse(array $response)
+    {
+        return $this->pipeline
+            ->send($response)
+            ->through($this->extensions)
+            ->via('willSendResponse')
+            ->then(function (array $response) {
+                return $response;
+            });
     }
 
     /**

--- a/src/Schema/Extensions/GraphQLExtension.php
+++ b/src/Schema/Extensions/GraphQLExtension.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Schema\Extensions;
 
+use GraphQL\Executor\ExecutionResult;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 
 abstract class GraphQLExtension implements \JsonSerializable
@@ -41,11 +42,25 @@ abstract class GraphQLExtension implements \JsonSerializable
     /**
      * Handle batch request end.
      *
-     * @param int $index
+     * @param ExecutionResult $result
+     * @param int             $index
      */
-    public function batchedQueryDidEnd($index)
+    public function batchedQueryDidEnd(ExecutionResult $result, $index)
     {
         return;
+    }
+
+    /**
+     * Manipulate the GraphQL response.
+     *
+     * @param array    $response
+     * @param \Closure $next
+     *
+     * @return array
+     */
+    public function willSendResponse(array $response, \Closure $next)
+    {
+        return $next($response);
     }
 
     /**

--- a/src/Schema/MiddlewareRegistry.php
+++ b/src/Schema/MiddlewareRegistry.php
@@ -2,9 +2,9 @@
 
 namespace Nuwave\Lighthouse\Schema;
 
+use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Utils\AST;
 use Nuwave\Lighthouse\Execution\QueryAST;
-use GraphQL\Language\AST\OperationDefinitionNode;
 
 class MiddlewareRegistry
 {
@@ -21,7 +21,7 @@ class MiddlewareRegistry
      * @var array
      */
     protected $mutations = [];
-    
+
     /**
      * Handle request.
      *
@@ -33,6 +33,10 @@ class MiddlewareRegistry
      */
     public function forRequest(string $request): array
     {
+        if (empty($request)) {
+            return [];
+        }
+
         $queryAST = QueryAST::fromSource($request);
         $fragments = $queryAST->fragmentDefinitions();
 
@@ -68,7 +72,7 @@ class MiddlewareRegistry
      * Register query middleware.
      *
      * @param string $name
-     * @param array $middleware
+     * @param array  $middleware
      *
      * @return MiddlewareRegistry
      */
@@ -83,7 +87,7 @@ class MiddlewareRegistry
      * Register mutation middleware.
      *
      * @param string $name
-     * @param array $middleware
+     * @param array  $middleware
      *
      * @return MiddlewareRegistry
      */

--- a/tests/Unit/Schema/Extensions/GraphQLExtensionTest.php
+++ b/tests/Unit/Schema/Extensions/GraphQLExtensionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit\Schema\Extensions;
+
+use Tests\TestCase;
+use Nuwave\Lighthouse\Support\Pipeline;
+use Nuwave\Lighthouse\Schema\Extensions\GraphQLExtension;
+use Nuwave\Lighthouse\Schema\Extensions\ExtensionRegistry;
+
+class GraphQLExtensionTest extends TestCase
+{
+    /**
+     * Define environment setup.
+     *
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app->singleton(ExtensionRegistry::class, function () {
+            return new class() extends ExtensionRegistry {
+                public function __construct()
+                {
+                    $this->pipeline = app(\Nuwave\Lighthouse\Support\Pipeline::class);
+                    $this->extensions = collect([GraphQLExtensionTest::getExtension()]);
+                }
+            };
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function itCanManipulateResponseData()
+    {
+        $this->schema = '
+        type Query {
+            foo: String
+        }';
+
+        $json = ['query' => '{ foo }'];
+        $data = $this->postJson('/graphql', $json)->json();
+
+        $this->assertArrayHasKey('meta', $data);
+        $this->assertEquals('data', $data['meta']);
+    }
+
+    /**
+     * @return GraphQLExtension
+     */
+    public static function getExtension(): GraphQLExtension
+    {
+        return new class() extends GraphQLExtension {
+            public static function name()
+            {
+                return 'foo';
+            }
+
+            public function willSendResponse(array $response, \Closure $next)
+            {
+                return $next(array_merge($response, [
+                    'meta' => 'data',
+                ]));
+            }
+
+            public function jsonSerialize()
+            {
+                return [];
+            }
+        };
+    }
+}


### PR DESCRIPTION
**Related Issue(s)**

None, however I ran into an issue w/ persisted queries and needing to manipulate the output before it was sent out to the client.

Additionally, if no query is sent up to the server (as it does with persisted queries) the MiddlewareRegistry would throw an error before GraphQL execution begins. #363 will resolve this issue as well but simply checking to see if the `$request` parameter is empty will prevent an exception from being thrown in the meantime.

**PR Type**

Feature

**Changes**

This PR allows extensions to manipulate the response data prior to being sent down to the client. This keeps the user from having to extend the `GraphQLController` and instead keep all relevant code tucked away in an extension.

**Breaking changes**

None
