### PR TITLE
Resolve default namespaces for Queries and Mutations.

### DIFF
--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -103,7 +103,12 @@ abstract class BaseDirective implements Directive
             throw new DirectiveException("Directive '{$this->name()}' must have an argument '{$argumentName}' with 'ClassName@methodName'");
         }
 
-        $className = $this->namespaceClassName($argumentParts[0]);
+        $className = $this->namespaceClassName($argumentParts[0], [
+            config('lighthouse.namespaces.models'),
+            config('lighthouse.namespaces.mutations'),
+            config('lighthouse.namespaces.queries')
+        ]);
+
         $methodName = $argumentParts[1];
 
         if (! method_exists($className, $methodName)) {

--- a/tests/Unit/Schema/Directives/Nodes/GroupDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/Nodes/GroupDirectiveTest.php
@@ -70,4 +70,63 @@ class GroupDirectiveTest extends TestCase
         $this->assertEquals('foo', $middleware[0]);
         $this->assertEquals('bar', $middleware[1]);
     }
+
+    /**
+     * @test
+     */
+    public function itHandlesDefaultNamespacesForMutations()
+    {
+        $schema = '
+        type Query {
+            dummy: Int
+        }
+
+        type Mutation {
+            dummy: Int
+        }
+        
+        extend type Mutation {
+            foo: String @field(resolver: "FooMutation@bar")
+        }
+        ';
+
+        $mutation = '        
+        mutation{
+            foo
+        }        
+        ';
+        
+        $result = $this->executeQuery($schema, $mutation);
+        $this->assertEquals('bar', $result->data['foo']);
+    }
+
+    /**
+     * @test
+     */
+    public function itHandlesDefaultNamespacesForQueries()
+    {
+        $schema = '
+        type Query {
+            dummy: Int
+        }
+
+        type Mutation {
+            dummy: Int
+        }
+        
+        extend type Query {
+            foo: String @field(resolver: "FooQuery@bar")
+        }
+        ';
+
+        $query = '                
+        query{
+            foo
+        }        
+        ';
+        
+        $result = $this->executeQuery($schema, $query);
+
+        $this->assertEquals('bar', $result->data['foo']);
+    }
 }

--- a/tests/Unit/Schema/SchemaBuilderTest.php
+++ b/tests/Unit/Schema/SchemaBuilderTest.php
@@ -22,7 +22,7 @@ class SchemaBuilderTest extends TestCase
 
         $app['config']->set(
             'lighthouse.namespaces.queries',
-            'Tests\\Utils\\Mutations'
+            'Tests\\Utils\\Queries'
         );
 
         $app['config']->set(

--- a/tests/Utils/Mutations/FooMutation.php
+++ b/tests/Utils/Mutations/FooMutation.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Utils\Mutations;
+
+use GraphQL\Type\Definition\ResolveInfo;
+
+class FooMutation
+{
+  public function bar($root, array $args, $context, ResolveInfo $resolve)
+  {
+    return 'bar';
+  }
+}
+

--- a/tests/Utils/Queries/FooQuery.php
+++ b/tests/Utils/Queries/FooQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Utils\Queries;
+
+use GraphQL\Type\Definition\ResolveInfo;
+
+class FooQuery
+{
+  public function bar($root, array $args, $context, ResolveInfo $resolve)
+  {
+    return 'bar';
+  }
+}
+


### PR DESCRIPTION
**Related Issue(s)**

Resolves/improves #384 

**PR Type**

Improvement

**Changes**

This is a improvement about how default namespaces are handled by fields.

Configs in `lighthouse.php` allow us to define default namespaces for Models, Queries, Mutations ... 
But, when using a custom resolver  it does not use "default namespaces" configs to resolve the class namespaces.

WITHOUT this PR we must set fullpath for namespace on `@group` or `@field `directive. Otherwise a `class not found` is thrown.

```graphql
extend type Mutation{
  updateUser(name: String) @field(resolver: "App\\Http\\GraphQL\\Mutations\\UserMutation@update")
}
```
```graphql
extend type Mutation @group(namespace:  "App\\Http\\GraphQL\\Mutations"){
  updateUser(name: String) @field(resolver: "UserMutation@update")
}
```



WITH this PR we can simple do this

```graphql
extend type Mutation{
  updateUser(name: String) @field(resolver: "UserMutation@update")
}
```


**Breaking changes**

There is no breaking changes.
