### PR TITLE
Add getRoothPath to SchemaStitcher

### DIFF
--- a/src/Schema/Source/SchemaSourceProvider.php
+++ b/src/Schema/Source/SchemaSourceProvider.php
@@ -17,6 +17,13 @@ interface SchemaSourceProvider
     public function setRootPath(string $path);
 
     /**
+     * Get schema root path.
+     *
+     * @return string
+     */
+    public function getRootPath();
+
+    /**
      * Provide the schema definition.
      *
      * @return string

--- a/src/Schema/Source/SchemaStitcher.php
+++ b/src/Schema/Source/SchemaStitcher.php
@@ -34,6 +34,14 @@ class SchemaStitcher implements SchemaSourceProvider
     }
 
     /**
+     * @return string
+     */
+    public function getRootPath(): string
+    {
+        return $this->rootSchemaPath;
+    }
+
+    /**
      * Stitch together schema documents and return the result as a string.
      *
      * @return string

--- a/src/Schema/Source/SchemaStitcher.php
+++ b/src/Schema/Source/SchemaStitcher.php
@@ -24,7 +24,7 @@ class SchemaStitcher implements SchemaSourceProvider
      *
      * @param string $path
      *
-     * @return SchemaSourceProvider
+     * @return SchemaStitcher
      */
     public function setRootPath(string $path): SchemaStitcher
     {

--- a/tests/Integration/Schema/Source/SchemaSourceProviderTest.php
+++ b/tests/Integration/Schema/Source/SchemaSourceProviderTest.php
@@ -59,4 +59,12 @@ class SchemaSourceProviderTest extends TestCase
 
         $this->assertEquals('bar', app(SchemaSourceProvider::class)->getSchemaString());
     }
+
+    /**
+     * @test
+     */
+    public function itCanGetRootPath()
+    {
+        $this->assertEquals('/var/www/vendor/orchestra/testbench-core/src/Concerns/../../laravel/routes/graphql/schema.graphql', app(SchemaSourceProvider::class)->getRootPath());
+    }
 }

--- a/tests/TestSchemaProvider.php
+++ b/tests/TestSchemaProvider.php
@@ -40,4 +40,14 @@ class TestSchemaProvider implements SchemaSourceProvider
     {
         return $this;
     }
+
+    /**
+     * Get schema root path.
+     *
+     * @return string
+     */
+    public function getRootPath()
+    {
+        return '';
+    }
 }


### PR DESCRIPTION
**Related Issue(s)**

None

**PR Type**

Feature

**Changes**

Our Lighthouse Utils plugin overwrites the schema root path to generate a new schema. I have upgraded the plugin to work with 2.3 and was happy to see a setter was introduced to do this, so I don't have to do it through the config. I still need to retrieve the original schema path before overwriting it, so it would be even better if I could also retrieve it without having to go through the config. 
Also see: https://github.com/deInternetJongens/Lighthouse-Utils/blob/develop/src/Generators/SchemaGenerator.php#L165

**Breaking changes**

Not that I know of
