### PR TITLE
Prevent duplicate type extension nodes and duplicate fields

### DIFF
--- a/src/Exceptions/DefinitionException.php
+++ b/src/Exceptions/DefinitionException.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Nuwave\Lighthouse\Exceptions;
+
+use Exception;
+use GraphQL\Error\ClientAware;
+
+class DefinitionException extends Exception implements ClientAware
+{
+    /**
+     * Returns true when exception message is safe to be displayed to a client.
+     *
+     * @api
+     * @return bool
+     */
+    public function isClientSafe()
+    {
+        return false;
+    }
+
+    /**
+     * Returns string describing a category of the error.
+     *
+     * Value "graphql" is reserved for errors produced by query parsing or validation, do not use it.
+     *
+     * @api
+     * @return string
+     */
+    public function getCategory()
+    {
+        return 'schema';
+    }
+}

--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -17,6 +17,7 @@ use GraphQL\Language\AST\ObjectValueNode;
 use GraphQL\Language\AST\NonNullTypeNode;
 use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\Directives\Fields\NamespaceDirective;
 
 class ASTHelper
@@ -32,7 +33,7 @@ class ASTHelper
      * Remove this method (and possibly the entire class) once it is resolved.
      *
      * @param NodeList|array $original
-     * @param array          $addition
+     * @param NodeList|array $addition
      *
      * @return NodeList
      */
@@ -46,32 +47,42 @@ class ASTHelper
     }
 
     /**
-     * This function will merge two lists uniquely by name. Fields will
-     * be removed from the original list if the name exists in both lists.
+     * This function will merge two lists uniquely by name.
      *
      * @param NodeList|array $original
-     * @param array          $addition
+     * @param NodeList|array $addition
+     * @param bool $overwriteDuplicates By default this throws if a collision occurs. If
+     * this is set to true, the fields of the original list will be overwritten.
+     *
+     * @throws DefinitionException
      *
      * @return NodeList
      */
-    public static function mergeUniqueNodeList($original, $addition): NodeList
+    public static function mergeUniqueNodeList($original, $addition, bool $overwriteDuplicates = false): NodeList
     {
-        $newFields = collect($addition)
+        $newNames = collect($addition)
             ->pluck('name.value')
             ->filter()
             ->all();
         
-        $filteredList = collect($original)
-            ->filter(function ($field) use ($newFields) {
-                return ! in_array(
-                    data_get($field, 'name.value'),
-                    $newFields
+        $remainingDefinitions = collect($original)
+            ->reject(function ($definition) use ($newNames, $overwriteDuplicates) {
+                $oldName = $definition->name->value;
+                $collisionOccured = in_array(
+                    $oldName,
+                    $newNames
                 );
+
+                if($collisionOccured && ! $overwriteDuplicates){
+                    throw new DefinitionException("Duplicate definition {$oldName} found when merging.");
+                }
+
+                return $collisionOccured;
             })
             ->values()
             ->all();
 
-        return self::mergeNodeList($filteredList, $addition);
+        return self::mergeNodeList($remainingDefinitions, $addition);
     }
 
     /**

--- a/src/Schema/AST/DocumentAST.php
+++ b/src/Schema/AST/DocumentAST.php
@@ -299,7 +299,9 @@ class DocumentAST implements \Serializable
     public function setDefinition(DefinitionNode $newDefinition): DocumentAST
     {
         if($newDefinition instanceof TypeExtensionNode){
-            $this->typeExtensions->push($newDefinition);
+            if(!$this->typeExtensions->search($newDefinition, true)) {
+                $this->typeExtensions->push($newDefinition);
+            }
         } else {
             $this->definitionMap->put(
                 $newDefinition->name->value,

--- a/src/Schema/AST/DocumentAST.php
+++ b/src/Schema/AST/DocumentAST.php
@@ -299,7 +299,7 @@ class DocumentAST implements \Serializable
     public function setDefinition(DefinitionNode $newDefinition): DocumentAST
     {
         if($newDefinition instanceof TypeExtensionNode){
-            if(!$this->typeExtensions->search($newDefinition, true)) {
+            if(! $this->typeExtensions->search($newDefinition, true)) {
                 $this->typeExtensions->push($newDefinition);
             }
         } else {

--- a/tests/Integration/Schema/Directives/Fields/PaginateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/PaginateDirectiveTest.php
@@ -306,4 +306,42 @@ class PaginateDirectiveTest extends DBTestCase
         );
         $this->assertCount(0, array_get($result->data, 'users.data'));
     }
+
+    /**
+     * @test
+     */
+    public function itPaginatesWhenDefinedInTypeExtension()
+    {
+        factory(User::class, 2)->create();
+
+        $schema = '
+        type User {
+            id: ID!
+            name: String!
+        }
+
+        type Query {
+            dummy: Int
+        }
+
+        extend type Query @group {
+            users: [User!]! @paginate(model: "User")
+        }
+        ';
+
+        $query = '
+        {
+            users(count: 1) {
+                data {
+                    id
+                    name
+                }
+            }
+        }
+        ';
+
+        $result = $this->executeQuery($schema, $query);
+
+        $this->assertCount(1, array_get($result->data, 'users.data'));
+    }
 }

--- a/tests/Unit/Schema/AST/ASTBuilderTest.php
+++ b/tests/Unit/Schema/AST/ASTBuilderTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Schema\AST;
 
 use Tests\TestCase;
 use Nuwave\Lighthouse\Schema\AST\ASTBuilder;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
 
 class ASTBuilderTest extends TestCase
 {
@@ -32,5 +33,22 @@ class ASTBuilderTest extends TestCase
                 ->queryTypeDefinition()
                 ->fields
         );
+    }
+
+    /**
+     * @test
+     */
+    public function itDoesNotAllowDuplicateFieldsOnTypeExtensions()
+    {
+        $this->expectException(DefinitionException::class);
+        ASTBuilder::generate('
+        type Query {
+            foo: String
+        }
+        
+        extend type Query {
+            foo: Int
+        }
+        ');
     }
 }

--- a/tests/Unit/Schema/AST/DocumentASTTest.php
+++ b/tests/Unit/Schema/AST/DocumentASTTest.php
@@ -63,6 +63,32 @@ class DocumentASTTest extends TestCase
             $documentAST->mutationTypeDefinition()
         );
     }
+
+    /**
+     * @test
+     */
+    public function itOverwritesDefinitionWithSameName()
+    {
+        $documentAST = DocumentAST::fromSource('
+        type Query {
+            foo: Int
+        }
+        ');
+
+        $objectType = PartialParser::objectTypeDefinition('
+        type Query {
+            bar: Int
+        }
+        ');
+
+        $documentAST->setDefinition($objectType);
+
+        $this->assertSame(
+            'bar',
+            $documentAST->queryTypeDefinition()->fields[0]->name->value
+        );
+    }
+
     /**
      * @test
      */

--- a/tests/Unit/Schema/Directives/Fields/InjectDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/Fields/InjectDirectiveTest.php
@@ -12,6 +12,8 @@ class InjectDirectiveTest extends DBTestCase
      */
     public function itCanInjectDataFromContextIntoArgs()
     {
+        $user = factory(User::class)->create();
+        $this->be($user);
 
         $schema = $this->buildSchemaFromString('
         type User {

--- a/tests/Unit/Schema/Directives/Fields/InjectDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/Fields/InjectDirectiveTest.php
@@ -12,8 +12,6 @@ class InjectDirectiveTest extends DBTestCase
      */
     public function itCanInjectDataFromContextIntoArgs()
     {
-        $user = factory(User::class)->create();
-        $this->be($user);
 
         $schema = $this->buildSchemaFromString('
         type User {
@@ -36,8 +34,48 @@ class InjectDirectiveTest extends DBTestCase
         $this->postJson('graphql',['query' => $query]);
     }
 
+    /**
+     * @test
+     */
+    public function itCanCreateQueryPaginatorsInGroup()
+    {
+        factory(User::class, 2)->create();
+
+        $schema = '
+        type User {
+            id: ID!
+            name: String!
+        }
+
+        type Query {
+            dummy: Int
+        }
+
+        extend type Query @group {
+            users: [User!]! @paginate(model: "User")
+        }
+        ';
+
+        $query = '
+        {
+            users(count: 1) {
+                data {
+                    id
+                    name
+                }
+            }
+        }
+        ';
+
+        $result = $this->executeQuery($schema, $query);
+
+
+        $this->assertCount(1, array_get($result->data, 'users.data'));
+    }
+
     public function resolveUser($root, $args)
     {
         $this->assertSame(1, $args['user_id']);
     }
+
 }

--- a/tests/Unit/Schema/Directives/Fields/PaginateDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/Fields/PaginateDirectiveTest.php
@@ -65,4 +65,37 @@ class PaginateDirectiveTest extends TestCase
             $typeMap
         );
     }
+
+    /**
+     * @test
+     */
+    public function itRegistersPaginatorFromTypeExtensionField()
+    {
+        $schema = $this->buildSchemaFromString('
+        type User {
+            id: ID!
+            name: String!
+        }
+
+        type Query {
+            dummy: Int
+        }
+
+        extend type Query @group {
+            users: [User!]! @paginate
+        }
+        ');
+        $typeMap = $schema->getTypeMap();
+
+        $this->assertArrayHasKey(
+            'UserPaginator',
+            $typeMap
+        );
+
+        // See https://github.com/nuwave/lighthouse/issues/387
+        $this->assertArrayNotHasKey(
+            'UserPaginatorPaginator',
+            $typeMap
+        );
+    }
 }


### PR DESCRIPTION
**Related Issue(s)**

Resolves #387 

**PR Type**

Bugfix

**Changes**

Prevent type extension nodes to be added more than once.

I added the unit test that was added by @jbbr and it passes with the provided fix

# Edit by @spawnia

**Breaking Changes**

The ASTBuilder now throws when merging type extensions that define duplicate fields. Whereas this might cause failures for some users, it uncovers behaviour that was previously bugged. It now fails early instead of adding a hard to find bug, so i think it is a strict improvement over the previous behaviour.