### PR TITLE
Capitalize the class name in generator commands

### DIFF
--- a/src/Console/InterfaceCommand.php
+++ b/src/Console/InterfaceCommand.php
@@ -2,9 +2,7 @@
 
 namespace Nuwave\Lighthouse\Console;
 
-use Illuminate\Console\GeneratorCommand;
-
-class InterfaceCommand extends GeneratorCommand
+class InterfaceCommand extends LighthouseGeneratorCommand
 {
     /**
      * The name of the console command.

--- a/src/Console/LighthouseGeneratorCommand.php
+++ b/src/Console/LighthouseGeneratorCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Nuwave\Lighthouse\Console;
+
+use Illuminate\Console\GeneratorCommand;
+
+/**
+ * This class can be removed if/when https://github.com/laravel/framework/pull/26176 is merged.
+ */
+abstract class LighthouseGeneratorCommand extends GeneratorCommand
+{
+    /**
+     * Get the desired class name from the input.
+     *
+     * @return string
+     */
+    protected function getNameInput()
+    {
+        return ucfirst(trim($this->argument('name')));
+    }
+}

--- a/src/Console/MutationCommand.php
+++ b/src/Console/MutationCommand.php
@@ -2,9 +2,7 @@
 
 namespace Nuwave\Lighthouse\Console;
 
-use Illuminate\Console\GeneratorCommand;
-
-class MutationCommand extends GeneratorCommand
+class MutationCommand extends LighthouseGeneratorCommand
 {
     /**
      * The name of the console command.

--- a/src/Console/QueryCommand.php
+++ b/src/Console/QueryCommand.php
@@ -2,9 +2,7 @@
 
 namespace Nuwave\Lighthouse\Console;
 
-use Illuminate\Console\GeneratorCommand;
-
-class QueryCommand extends GeneratorCommand
+class QueryCommand extends LighthouseGeneratorCommand
 {
     /**
      * The name of the console command.

--- a/src/Console/ScalarCommand.php
+++ b/src/Console/ScalarCommand.php
@@ -2,9 +2,7 @@
 
 namespace Nuwave\Lighthouse\Console;
 
-use Illuminate\Console\GeneratorCommand;
-
-class ScalarCommand extends GeneratorCommand
+class ScalarCommand extends LighthouseGeneratorCommand
 {
     /**
      * The name of the console command.

--- a/src/Console/UnionCommand.php
+++ b/src/Console/UnionCommand.php
@@ -2,9 +2,7 @@
 
 namespace Nuwave\Lighthouse\Console;
 
-use Illuminate\Console\GeneratorCommand;
-
-class UnionCommand extends GeneratorCommand
+class UnionCommand extends LighthouseGeneratorCommand
 {
     /**
      * The name of the console command.


### PR DESCRIPTION
**Related Issue(s)**

This class can be removed if/when https://github.com/laravel/framework/pull/26176 is merged.

**Changes**

This prevents users of the field generator commands that copy-and-paste the field definitions from accidentally creating a lowercased class.

**Breaking changes**

No