### PR TITLE
Change the type annotation for the default field resolver to a nullable GraphQLContext

### DIFF
--- a/src/Console/stubs/field.stub
+++ b/src/Console/stubs/field.stub
@@ -2,8 +2,8 @@
 
 namespace DummyNamespace;
 
-use Nuwave\Lighthouse\Schema\Context;
 use GraphQL\Type\Definition\ResolveInfo;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
 class DummyClass
 {
@@ -12,12 +12,12 @@ class DummyClass
      *
      * @param null $rootValue Usually contains the result returned from the parent field. In this case, it is always `null`.
      * @param array $args The arguments that were passed into the field.
-     * @param Context $context Arbitrary data that is shared between all fields of a single query.
+     * @param GraphQLContext|null $context Arbitrary data that is shared between all fields of a single query.
      * @param ResolveInfo $resolveInfo Information about the query itself, such as the execution state, the field name, path to the field from the root, and more.
      *
      * @return mixed
      */
-    public function resolve($rootValue, array $args, Context $context, ResolveInfo $resolveInfo)
+    public function resolve($rootValue, array $args, GraphQLContext $context = null, ResolveInfo $resolveInfo)
     {
         // TODO implement the resolver
     }


### PR DESCRIPTION
**Related Issue(s)**

Bugfix for #392

**Breaking changes**

No, it un-breaks stuff 😉 
