### PR TITLE
Default to field name if no explicit value is given for an ENUM

### DIFF
--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -174,16 +174,15 @@ class ASTHelper
             : $default;
     }
 
-
     /**
      * Get argument's value.
      *
-     * @param Node  $arg
+     * @param ArgumentNode $arg
      * @param mixed $default
      *
      * @return mixed
      */
-    public static function argValue(Node $arg, $default = null)
+    public static function argValue(ArgumentNode $arg, $default = null)
     {
         $valueNode = $arg->value;
 
@@ -191,25 +190,9 @@ class ASTHelper
             return $default;
         }
 
-        if ($valueNode instanceof ListValueNode) {
-            return collect($valueNode->values)
-                ->map(function (ValueNode $valueNode) {
-                    return $valueNode->value;
-                })
-                ->toArray();
-        }
-
-        if ($valueNode instanceof ObjectValueNode) {
-            return collect($valueNode->fields)
-                ->mapWithKeys(function (ObjectFieldNode $field) {
-                    return [$field->name->value => self::argValue($field)];
-                })
-                ->toArray();
-        }
-
-        return $valueNode->value;
+        return AST::valueFromASTUntyped($valueNode);
     }
-    
+
     /**
      * This can be at most one directive, since directives can only be used once per location.
      *

--- a/src/Schema/Factories/NodeFactory.php
+++ b/src/Schema/Factories/NodeFactory.php
@@ -172,14 +172,13 @@ class NodeFactory
                 ->mapWithKeys(function (EnumValueDefinitionNode $field) {
                     // Get the directive that is defined on the field itself
                     $directive = ASTHelper::directiveDefinition( $field, 'enum');
-                
-                    if (!$directive) {
-                        return [];
-                    }
-                
+
                     return [
                         $field->name->value => [
-                            'value' => ASTHelper::directiveArgValue($directive, 'value'),
+                            // If no explicit value is given, we default to the field name
+                            'value' => $directive
+                                ? ASTHelper::directiveArgValue($directive, 'value')
+                                : $field->name->value,
                             'description' => data_get($field->description, 'value'),
                         ]
                     ];

--- a/tests/Unit/Schema/Factories/NodeFactoryTest.php
+++ b/tests/Unit/Schema/Factories/NodeFactoryTest.php
@@ -9,7 +9,6 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\InputObjectType;
-use Nuwave\Lighthouse\Schema\Values\NodeValue;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
 use Nuwave\Lighthouse\Schema\Factories\NodeFactory;
 
@@ -35,21 +34,37 @@ class NodeFactoryTest extends TestCase
     /**
      * @test
      */
-    public function itCanTransformEnums()
+    public function itSetsEnumValueThroughDirective()
     {
         $enumNode = PartialParser::enumTypeDefinition('
         enum Role {
-            "Company administrator."
-            ADMIN @enum(value:"admin")
-
-            "Company employee."
-            EMPLOYEE @enum(value:"employee")
+            ADMIN @enum(value: 123)
         }
         ');
+        /** @var EnumType $type */
         $type = $this->factory->handle($enumNode);
 
         $this->assertInstanceOf(EnumType::class, $type);
         $this->assertSame('Role', $type->name);
+        $this->assertSame(123, $type->getValue('ADMIN')->value);
+    }
+
+    /**
+     * @test
+     */
+    public function itDefaultsEnumValueToItsName()
+    {
+        $enumNode = PartialParser::enumTypeDefinition('
+        enum Role {
+            EMPLOYEE
+        }
+        ');
+        /** @var EnumType $type */
+        $type = $this->factory->handle($enumNode);
+
+        $this->assertInstanceOf(EnumType::class, $type);
+        $this->assertSame('Role', $type->name);
+        $this->assertSame('EMPLOYEE', $type->getValue('EMPLOYEE')->value);
     }
 
     /**

--- a/tests/Unit/Schema/SchemaBuilderTest.php
+++ b/tests/Unit/Schema/SchemaBuilderTest.php
@@ -60,10 +60,10 @@ class SchemaBuilderTest extends TestCase
         "Role description"
         enum Role {
             "Company administrator."
-            admin @enum(value:"admin")
+            ADMIN @enum(value:"admin")
 
             "Company employee."
-            employee @enum(value:"employee")
+            EMPLOYEE @enum(value:"employee")
         }
         ');
     
@@ -74,7 +74,7 @@ class SchemaBuilderTest extends TestCase
     
         $enumValues = $enum->getValues();
         $this->assertCount(2, $enumValues);
-        $this->assertSame('Company administrator.', $enum->getValue('admin')->description);
+        $this->assertSame('Company administrator.', $enum->getValue('ADMIN')->description);
     }
 
     /**


### PR DESCRIPTION
**Related Issue(s)**

This simplifies enum definitions that are just string values.

**PR Type**

Feature/Bugfix

**Changes**

Previously, you always had to define a value for enums. This is generally fine, but
leads to unnecessarily verbose code when your enum is composed of strings:

```graphql
enum Role {
  ADMIN @enum(value: "ADMIN")
}
```

If the internal value of the enum is the same as the field name, `@enum` can be omitted:

```graphql
enum Role {
  ADMIN
}
```

**Bugfix**

During testing, i also discovered a bug where literal values defined via `@enum` were
not always converted to the correct type.

```graphql
enum Role {
  ADMIN @enum(value: 1)
}
```

Lead to an internal value of `string('1')`. Now it correctly parses it to a `int(1)`
This did not cause problems for most users because of PHP's type juggling, but could
have broken if someone uses `declare(strict_types: 1)`.

It is fixed now.

**Breaking changes**

Nope
