### PR TITLE
[Bugfix]Add new line to the end of the imported file

### DIFF
--- a/src/Schema/Source/SchemaStitcher.php
+++ b/src/Schema/Source/SchemaStitcher.php
@@ -56,7 +56,7 @@ class SchemaStitcher implements SchemaSourceProvider
         return collect(file($path))
             ->map(function (string $line) use ($path) {
                 if (! starts_with(trim($line), '#import ')) {
-                    return $line;
+                    return trim($line, PHP_EOL) . PHP_EOL;
                 }
 
                 $importFileName = trim(str_after($line, '#import '));
@@ -72,8 +72,8 @@ class SchemaStitcher implements SchemaSourceProvider
                     ->map(function ($file) {
                         return self::gatherSchemaImportsRecursively($file);
                     })
-                    ->implode('') . "\n";
+                    ->implode('');
             })
-            ->implode('') . "\n";
+            ->implode('');
     }
 }

--- a/src/Schema/Source/SchemaStitcher.php
+++ b/src/Schema/Source/SchemaStitcher.php
@@ -72,8 +72,8 @@ class SchemaStitcher implements SchemaSourceProvider
                     ->map(function ($file) {
                         return self::gatherSchemaImportsRecursively($file);
                     })
-                    ->implode('');
+                    ->implode('') . "\n";
             })
-            ->implode('');
+            ->implode('') . "\n";
     }
 }

--- a/src/Schema/Source/SchemaStitcher.php
+++ b/src/Schema/Source/SchemaStitcher.php
@@ -56,7 +56,7 @@ class SchemaStitcher implements SchemaSourceProvider
         return collect(file($path))
             ->map(function (string $line) use ($path) {
                 if (! starts_with(trim($line), '#import ')) {
-                    return trim($line, PHP_EOL) . PHP_EOL;
+                    return rtrim($line, PHP_EOL) . PHP_EOL;
                 }
 
                 $importFileName = trim(str_after($line, '#import '));

--- a/tests/Integration/Schema/Source/SchemaSourceProviderTest.php
+++ b/tests/Integration/Schema/Source/SchemaSourceProviderTest.php
@@ -57,6 +57,6 @@ class SchemaSourceProviderTest extends TestCase
 
         app(SchemaSourceProvider::class)->setRootPath(__DIR__.'/schema/foo');
 
-        $this->assertEquals('bar', app(SchemaSourceProvider::class)->getSchemaString());
+        $this->assertEquals('bar' . PHP_EOL, app(SchemaSourceProvider::class)->getSchemaString());
     }
 }

--- a/tests/Unit/Schema/AST/SchemaStitcherTest.php
+++ b/tests/Unit/Schema/AST/SchemaStitcherTest.php
@@ -214,11 +214,16 @@ EOT
         $this->putRootSchema(<<<EOT
 foo
 #import bar
+#import foobar
 EOT
         );
 
         $this->filesystem->put('bar', <<<EOT
 bar
+EOT
+        );
+
+        $this->filesystem->put('foobar', <<<EOT
 foobar
 EOT
         );

--- a/tests/Unit/Schema/AST/SchemaStitcherTest.php
+++ b/tests/Unit/Schema/AST/SchemaStitcherTest.php
@@ -205,4 +205,30 @@ other
 EOT
         );
     }
+
+    /**
+     * @test
+     */
+    public function itAddsNewlineToTheEndOfImportedFile()
+    {
+        $this->putRootSchema(<<<EOT
+foo
+#import bar
+EOT
+        );
+
+        $this->filesystem->put('bar', <<<EOT
+bar
+foobar
+EOT
+        );
+
+        $this->assertSchemaResultIsSame(<<<EOT
+foo
+bar
+foobar
+
+EOT
+        );
+    }
 }


### PR DESCRIPTION
The issue occurs when:

imported file 1
```graphql
union Account = User | Admin
```

imported file 2
```graphql
scalar Email
```

results this:
```graphql
union Account = User | Adminscalar Email
```

which will cause a syntax error.

Adding new line to the end of the imported file can solve this problem.