### PR TITLE
[Fix] Lumen request array access

### DIFF
--- a/src/Support/Http/Controllers/GraphQLController.php
+++ b/src/Support/Http/Controllers/GraphQLController.php
@@ -50,7 +50,7 @@ class GraphQLController extends Controller
      */
     public function query(Request $request)
     {
-        $batched = isset($request[0]) && config('lighthouse.batched_queries', true);
+        $batched = isset($request->toArray()[0]) && config('lighthouse.batched_queries', true);
 
         $this->extensionRegistry->requestDidStart(
             new ExtensionRequest($request, $batched)

--- a/src/Support/Http/Controllers/GraphQLController.php
+++ b/src/Support/Http/Controllers/GraphQLController.php
@@ -50,6 +50,7 @@ class GraphQLController extends Controller
      */
     public function query(Request $request)
     {
+		// If the request is a 0-indexed array, we know we are dealing with a batched query
         $batched = isset($request->toArray()[0]) && config('lighthouse.batched_queries', true);
 
         $this->extensionRegistry->requestDidStart(


### PR DESCRIPTION
**Related Issue(s)**

Resolves #411 

**PR Type**

Bugfix (Lumen)

**Changes**

Converts request object to an array before performing an `isset` on a key.

**Breaking changes**

None