### PR TITLE
Enable usage of the default field namespace for @complexity

### DIFF
--- a/tests/Utils/Queries/Foo.php
+++ b/tests/Utils/Queries/Foo.php
@@ -32,4 +32,9 @@ class Foo
     {
         return self::THE_ANSWER;
     }
+
+    public function complexity(): int
+    {
+        return self::THE_ANSWER;
+    }
 }


### PR DESCRIPTION
**PR Type**

Feature

**Changes**

The default namespace resolution for `@complexity` now works just like `@field`.
This makes them more consistent.

**Breaking changes**

Nope
