### PR TITLE
Allow publishing the schema and config seperately

### DIFF
--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -28,8 +28,11 @@ class LighthouseServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__.'/../../config/config.php' => config_path('lighthouse.php'),
+        ], 'config');
+
+        $this->publishes([
             __DIR__.'/../../assets/default-schema.graphql' => config('lighthouse.schema.register'),
-        ]);
+        ], 'schema');
 
         if (config('lighthouse.controller')) {
             $this->loadRoutesFrom(__DIR__.'/../Support/Http/routes.php');


### PR DESCRIPTION
Just tested this in a local project, everything works as before. This gives the option to

	php artisan vendor:publish --provider="Nuwave\Lighthouse\Providers\LighthouseServiceProvider" --tag=schema

or

	php artisan vendor:publish --provider="Nuwave\Lighthouse\Providers\LighthouseServiceProvider" --tag=config

to publish only the parts of the assets that you want