### PR TITLE
Throw a helpful error message if the schema is not found

### DIFF
--- a/src/Schema/Source/SchemaStitcher.php
+++ b/src/Schema/Source/SchemaStitcher.php
@@ -2,6 +2,8 @@
 
 namespace Nuwave\Lighthouse\Schema\Source;
 
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+
 class SchemaStitcher implements SchemaSourceProvider
 {
     /**
@@ -24,7 +26,7 @@ class SchemaStitcher implements SchemaSourceProvider
      *
      * @param string $path
      *
-     * @return SchemaSourceProvider
+     * @return SchemaStitcher
      */
     public function setRootPath(string $path): SchemaStitcher
     {
@@ -35,6 +37,8 @@ class SchemaStitcher implements SchemaSourceProvider
 
     /**
      * Stitch together schema documents and return the result as a string.
+     *
+     * @throws FileNotFoundException
      *
      * @return string
      */
@@ -48,26 +52,37 @@ class SchemaStitcher implements SchemaSourceProvider
      *
      * @param string $path
      *
+     * @throws FileNotFoundException
+     *
      * @return string
      */
     protected static function gatherSchemaImportsRecursively(string $path): string
     {
-        // This will throw if no file is found at this location
+        if (! file_exists($path)) {
+            self::throwFileNotFoundException($path);
+        }
+
         return collect(file($path))
             ->map(function (string $line) use ($path) {
                 if (! starts_with(trim($line), '#import ')) {
-                    return rtrim($line, PHP_EOL) . PHP_EOL;
+                    return rtrim($line, PHP_EOL).PHP_EOL;
                 }
 
                 $importFileName = trim(str_after($line, '#import '));
+                $importFilePath = dirname($path).'/'.$importFileName;
 
                 if (! str_contains($importFileName, '*')) {
-                    $importFilePath = realpath(dirname($path).'/'.$importFileName);
+                    $realPath = realpath($importFilePath);
 
-                    return self::gatherSchemaImportsRecursively($importFilePath);
+                    if (! $realPath) {
+                        self::throwFileNotFoundException($importFilePath);
+                    }
+
+                    return self::gatherSchemaImportsRecursively($realPath);
                 }
 
-                $importFilePaths = glob(dirname($path) . '/' . $importFileName);
+                $importFilePaths = glob($importFilePath);
+
                 return collect($importFilePaths)
                     ->map(function ($file) {
                         return self::gatherSchemaImportsRecursively($file);
@@ -75,5 +90,17 @@ class SchemaStitcher implements SchemaSourceProvider
                     ->implode('');
             })
             ->implode('');
+    }
+
+    /**
+     * @param string $path
+     *
+     * @throws FileNotFoundException
+     */
+    protected static function throwFileNotFoundException(string $path)
+    {
+        throw new FileNotFoundException(
+            "Failed to find a GraphQL schema file at {$path}. If you just installed Lighthouse, run php artisan vendor:publish --provider=\"Nuwave\Lighthouse\Providers\LighthouseServiceProvider\" --tag=schema"
+        );
     }
 }

--- a/tests/Unit/Schema/AST/SchemaStitcherTest.php
+++ b/tests/Unit/Schema/AST/SchemaStitcherTest.php
@@ -6,10 +6,11 @@ use PHPUnit\Framework\TestCase;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Adapter\Local;
 use Nuwave\Lighthouse\Schema\Source\SchemaStitcher;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class SchemaStitcherTest extends TestCase
 {
-    const SCHEMA_PATH = __DIR__ . '/schema/';
+    const SCHEMA_PATH = __DIR__.'/schema/';
     const ROOT_SCHEMA_FILENAME = 'root-schema';
 
     /**
@@ -39,13 +40,38 @@ class SchemaStitcherTest extends TestCase
 
     protected function assertSchemaResultIsSame(string $expected)
     {
-        $schema = (new SchemaStitcher(self::SCHEMA_PATH . self::ROOT_SCHEMA_FILENAME))->getSchemaString();
+        $schema = (new SchemaStitcher(self::SCHEMA_PATH.self::ROOT_SCHEMA_FILENAME))->getSchemaString();
         $this->assertSame($expected, $schema);
     }
 
     protected function putRootSchema(string $schema)
     {
         $this->filesystem->put(self::ROOT_SCHEMA_FILENAME, $schema);
+    }
+
+    /**
+     * @test
+     */
+    public function itThrowsIfRootSchemaIsNotFound()
+    {
+        $this->expectException(FileNotFoundException::class);
+        $this->expectExceptionMessageRegExp('/'.self::ROOT_SCHEMA_FILENAME.'/');
+        $this->assertSchemaResultIsSame('');
+    }
+
+    /**
+     * @test
+     */
+    public function itThrowsIfSchemaImportIsNotFound()
+    {
+        $this->expectException(FileNotFoundException::class);
+        $this->expectExceptionMessageRegExp('/does-not-exist.graphql/');
+        $foo = <<<EOT
+#import does-not-exist.graphql
+
+EOT;
+        $this->putRootSchema($foo);
+        $this->assertSchemaResultIsSame($foo);
     }
 
     /**


### PR DESCRIPTION
**Related Issue(s)**

The error message if a schema is not found was pretty cryptic before

![image](https://user-images.githubusercontent.com/12158000/47910964-aa63e680-de94-11e8-8947-632bc4be8e5d.png)


Now it is more clear and gives newcomers a hint on what to do

![image](https://user-images.githubusercontent.com/12158000/47910902-7f799280-de94-11e8-9c86-fa60ff86646d.png)



**PR Type**

Feature

**Changes**

Check if the root schema/imported schemas exist and throw a helpful exception if not.

**Breaking changes**

Nope
