### PR TITLE
Add support for a default count value for paginators

### DIFF
--- a/src/Execution/DataLoader/RelationBatchLoader.php
+++ b/src/Execution/DataLoader/RelationBatchLoader.php
@@ -34,11 +34,11 @@ class RelationBatchLoader extends BatchLoader
      * @var string|null
      */
     protected $paginationType;
-    
+
     /**
-     * @param string $relationName
-     * @param array $args
-     * @param array $scopes
+     * @param string      $relationName
+     * @param array       $args
+     * @param array       $scopes
      * @param string|null $paginationType
      */
     public function __construct(string $relationName, array $args, array $scopes, string $paginationType = null)
@@ -48,7 +48,7 @@ class RelationBatchLoader extends BatchLoader
         $this->scopes = $scopes;
         $this->paginationType = $paginationType;
     }
-    
+
     /**
      * Resolve the keys.
      *
@@ -59,31 +59,35 @@ class RelationBatchLoader extends BatchLoader
     public function resolve(): array
     {
         $modelRelationFetcher = $this->getRelationFetcher();
-    
+
         switch ($this->paginationType) {
             case PaginationManipulator::PAGINATION_TYPE_CONNECTION:
                 // first is an required argument
                 $first = $this->args['first'];
                 $after = Cursor::decode($this->args);
                 $currentPage = Pagination::calculateCurrentPage($first, $after);
-            
+
                 $modelRelationFetcher->loadRelationsForPage($first, $currentPage);
                 break;
             case PaginationManipulator::PAGINATION_TYPE_PAGINATOR:
                 // count must be set so we can safely get it like this
                 $count = $this->args['count'];
                 $page = array_get($this->args, 'page', 1);
-            
+
+                if ($count instanceof \GraphQL\Language\AST\IntValueNode) {
+                    $count = $count->value;
+                }
+
                 $modelRelationFetcher->loadRelationsForPage($count, $page);
                 break;
             default:
                 $modelRelationFetcher->loadRelations();
                 break;
         }
-    
+
         return $modelRelationFetcher->getRelationDictionary($this->relationName);
     }
-    
+
     /**
      * @return ModelRelationFetcher
      */
@@ -93,11 +97,12 @@ class RelationBatchLoader extends BatchLoader
             $this->getParentModels(),
             [$this->relationName => function ($query) {
                 $query = QueryUtils::applyScopes($query, $this->args, $this->scopes);
+
                 return QueryUtils::applyFilters($query, $this->args);
             }]
         );
     }
-    
+
     /**
      * Get the parents from the keys that are present on the BatchLoader.
      *

--- a/src/Execution/DataLoader/RelationBatchLoader.php
+++ b/src/Execution/DataLoader/RelationBatchLoader.php
@@ -65,6 +65,11 @@ class RelationBatchLoader extends BatchLoader
                 // first is an required argument
                 $first = $this->args['first'];
                 $after = Cursor::decode($this->args);
+
+                if ($first instanceof \GraphQL\Language\AST\IntValueNode) {
+                    $first = $first->value;
+                }
+
                 $currentPage = Pagination::calculateCurrentPage($first, $after);
 
                 $modelRelationFetcher->loadRelationsForPage($first, $currentPage);

--- a/src/Schema/Directives/Fields/PaginateDirective.php
+++ b/src/Schema/Directives/Fields/PaginateDirective.php
@@ -2,21 +2,21 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use GraphQL\Language\AST\FieldDefinitionNode;
-use GraphQL\Language\AST\ObjectTypeDefinitionNode;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Model;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Execution\QueryUtils;
-use Nuwave\Lighthouse\Execution\Utils\Cursor;
-use Nuwave\Lighthouse\Execution\Utils\Pagination;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
+use GraphQL\Language\AST\FieldDefinitionNode;
+use Nuwave\Lighthouse\Execution\Utils\Cursor;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
+use Nuwave\Lighthouse\Execution\Utils\Pagination;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use Nuwave\Lighthouse\Exceptions\DirectiveException;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
 
 class PaginateDirective extends BaseDirective implements FieldResolver, FieldManipulator
 {

--- a/src/Schema/Directives/Fields/PaginateDirective.php
+++ b/src/Schema/Directives/Fields/PaginateDirective.php
@@ -2,21 +2,21 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
+use GraphQL\Language\AST\FieldDefinitionNode;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Model;
-use Nuwave\Lighthouse\Schema\AST\ASTHelper;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Execution\QueryUtils;
 use Nuwave\Lighthouse\Execution\Utils\Cursor;
-use GraphQL\Language\AST\FieldDefinitionNode;
-use Nuwave\Lighthouse\Schema\AST\DocumentAST;
-use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Execution\Utils\Pagination;
-use GraphQL\Language\AST\ObjectTypeDefinitionNode;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Schema\AST\ASTHelper;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
-use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 
 class PaginateDirective extends BaseDirective implements FieldResolver, FieldManipulator
 {
@@ -45,7 +45,8 @@ class PaginateDirective extends BaseDirective implements FieldResolver, FieldMan
             $this->getPaginationType(),
             $fieldDefinition,
             $parentType,
-            $current
+            $current,
+            $this->directiveArgValue('defaultCount')
         );
     }
 
@@ -96,6 +97,10 @@ class PaginateDirective extends BaseDirective implements FieldResolver, FieldMan
             function ($root, array $args) {
                 $first = $args['count'];
                 $page = array_get($args, 'page', 1);
+
+                if ($first instanceof \GraphQL\Language\AST\IntValueNode) {
+                    $first = $first->value;
+                }
 
                 return $this->getPaginatedResults(\func_get_args(), $page, $first);
             }
@@ -172,7 +177,7 @@ class PaginateDirective extends BaseDirective implements FieldResolver, FieldMan
         $model = $this->directiveArgValue('model');
 
         // Fallback to using information from the schema definition as the model name
-        if ( ! $model) {
+        if (! $model) {
             $model = ASTHelper::getFieldTypeName($this->definitionNode);
 
             // Cut the added type suffix to get the base model class name

--- a/src/Schema/Directives/Fields/PaginationManipulator.php
+++ b/src/Schema/Directives/Fields/PaginationManipulator.php
@@ -2,16 +2,16 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use GraphQL\Language\AST\FieldDefinitionNode;
-use GraphQL\Language\AST\ObjectTypeDefinitionNode;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
-use Nuwave\Lighthouse\Exceptions\ParseException;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
+use GraphQL\Language\AST\FieldDefinitionNode;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
-use Nuwave\Lighthouse\Schema\Types\ConnectionField;
+use Nuwave\Lighthouse\Exceptions\ParseException;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Nuwave\Lighthouse\Schema\Types\PaginatorField;
+use Nuwave\Lighthouse\Schema\Types\ConnectionField;
+use Nuwave\Lighthouse\Exceptions\DirectiveException;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
 
 class PaginationManipulator
 {

--- a/src/Schema/Directives/Fields/PaginationManipulator.php
+++ b/src/Schema/Directives/Fields/PaginationManipulator.php
@@ -2,27 +2,27 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use GraphQL\Language\AST\FieldDefinitionNode;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Exceptions\DirectiveException;
+use Nuwave\Lighthouse\Exceptions\ParseException;
+use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
-use Nuwave\Lighthouse\Exceptions\ParseException;
-use GraphQL\Language\AST\ObjectTypeDefinitionNode;
-use Nuwave\Lighthouse\Schema\Types\PaginatorField;
 use Nuwave\Lighthouse\Schema\Types\ConnectionField;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Schema\Types\PaginatorField;
 
 class PaginationManipulator
 {
     // The default is offset-based pagination
     const PAGINATION_TYPE_PAGINATOR = 'paginator';
     const PAGINATION_ALIAS_DEFAULT = 'default';
-    
+
     // Those are both aliases for a Connection style pagination
     const PAGINATION_TYPE_CONNECTION = 'connection';
     const PAGINATION_ALIAS_RELAY = 'relay';
-    
+
     /**
      * Apply possible aliases and throw if the given pagination type is invalid.
      *
@@ -37,18 +37,18 @@ class PaginationManipulator
         if (self::PAGINATION_ALIAS_RELAY === $paginationType) {
             return self::PAGINATION_TYPE_CONNECTION;
         }
-        
+
         if (self::PAGINATION_ALIAS_DEFAULT === $paginationType) {
             return self::PAGINATION_TYPE_PAGINATOR;
         }
-        
-        if(in_array($paginationType, [
+
+        if (in_array($paginationType, [
             self::PAGINATION_TYPE_PAGINATOR,
-            self::PAGINATION_TYPE_CONNECTION
-        ])){
+            self::PAGINATION_TYPE_CONNECTION,
+        ])) {
             return $paginationType;
         }
-        
+
         throw new DirectiveException("Found invalid pagination type: {$paginationType}");
     }
 
@@ -58,10 +58,11 @@ class PaginationManipulator
      * This makes either an offset-based Paginator or a cursor-based Connection.
      * The types in between are automatically generated and applied to the schema.
      *
-     * @param string $paginationType
-     * @param FieldDefinitionNode $fieldDefinition
+     * @param string                   $paginationType
+     * @param FieldDefinitionNode      $fieldDefinition
      * @param ObjectTypeDefinitionNode $parentType
-     * @param DocumentAST $current
+     * @param DocumentAST              $current
+     * @param int|null                 $defaultCount
      *
      * @throws DefinitionException
      * @throws DirectiveException
@@ -69,23 +70,23 @@ class PaginationManipulator
      *
      * @return DocumentAST
      */
-    public static function transformToPaginatedField(string $paginationType, FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current): DocumentAST
+    public static function transformToPaginatedField(string $paginationType, FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current, int $defaultCount = null): DocumentAST
     {
         switch (self::assertValidPaginationType($paginationType)) {
             case PaginationManipulator::PAGINATION_TYPE_CONNECTION:
                 return PaginationManipulator::registerConnection($fieldDefinition, $parentType, $current);
             case PaginationManipulator::PAGINATION_TYPE_PAGINATOR:
             default:
-                return PaginationManipulator::registerPaginator($fieldDefinition, $parentType, $current);
+                return PaginationManipulator::registerPaginator($fieldDefinition, $parentType, $current, $defaultCount);
         }
     }
 
     /**
      * Register connection w/ schema.
      *
-     * @param FieldDefinitionNode $fieldDefinition
+     * @param FieldDefinitionNode      $fieldDefinition
      * @param ObjectTypeDefinitionNode $parentType
-     * @param DocumentAST $documentAST
+     * @param DocumentAST              $documentAST
      *
      * @throws DefinitionException
      * @throws ParseException
@@ -132,16 +133,17 @@ class PaginationManipulator
     /**
      * Register paginator w/ schema.
      *
-     * @param FieldDefinitionNode $fieldDefinition
+     * @param FieldDefinitionNode      $fieldDefinition
      * @param ObjectTypeDefinitionNode $parentType
-     * @param DocumentAST $documentAST
+     * @param DocumentAST              $documentAST
+     * @param int|null                 $defaultCount
      *
      * @throws DefinitionException
      * @throws ParseException
      *
      * @return DocumentAST
      */
-    public static function registerPaginator(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $documentAST): DocumentAST
+    public static function registerPaginator(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $documentAST, int $defaultCount = null): DocumentAST
     {
         $fieldTypeName = ASTHelper::getFieldTypeName($fieldDefinition);
         $paginatorTypeName = "{$fieldTypeName}Paginator";
@@ -154,10 +156,16 @@ class PaginationManipulator
             }
         ");
 
-        $paginationArguments = PartialParser::inputValueDefinitions([
+        $inputValueDefinitions = [
             'count: Int!',
             'page: Int',
-        ]);
+        ];
+
+        if ($defaultCount) {
+            $inputValueDefinitions[0] = "count: Int = {$defaultCount}";
+        }
+
+        $paginationArguments = PartialParser::inputValueDefinitions($inputValueDefinitions);
 
         $fieldDefinition->arguments = ASTHelper::mergeNodeList($fieldDefinition->arguments, $paginationArguments);
         $fieldDefinition->type = PartialParser::namedType($paginatorTypeName);

--- a/src/Schema/Directives/Fields/PaginationManipulator.php
+++ b/src/Schema/Directives/Fields/PaginationManipulator.php
@@ -160,7 +160,7 @@ class PaginationManipulator
             ? "count: Int = {$defaultCount}"
             : 'count: Int!';
 
-        $paginationArguments = [
+        $inputValueDefinitions = [
             $countArgument,
             'page: Int',
         ];

--- a/src/Schema/Directives/Fields/PaginationManipulator.php
+++ b/src/Schema/Directives/Fields/PaginationManipulator.php
@@ -156,14 +156,14 @@ class PaginationManipulator
             }
         ");
 
-        $inputValueDefinitions = [
-            'count: Int!',
+        $countArgument = $defaultCount
+            ? "count: Int = {$defaultCount}"
+            : 'count: Int!';
+
+        $paginationArguments = [
+            $countArgument,
             'page: Int',
         ];
-
-        if ($defaultCount) {
-            $inputValueDefinitions[0] = "count: Int = {$defaultCount}";
-        }
 
         $paginationArguments = PartialParser::inputValueDefinitions($inputValueDefinitions);
 

--- a/src/Schema/Directives/Fields/RelationDirective.php
+++ b/src/Schema/Directives/Fields/RelationDirective.php
@@ -2,15 +2,15 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use GraphQL\Language\AST\FieldDefinitionNode;
-use GraphQL\Language\AST\ObjectTypeDefinitionNode;
-use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Database\Eloquent\Model;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Language\AST\FieldDefinitionNode;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Execution\DataLoader\BatchLoader;
 use Nuwave\Lighthouse\Execution\DataLoader\RelationBatchLoader;
-use Nuwave\Lighthouse\Schema\AST\DocumentAST;
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
-use Nuwave\Lighthouse\Schema\Values\FieldValue;
 
 abstract class RelationDirective extends BaseDirective
 {

--- a/src/Schema/Directives/Fields/RelationDirective.php
+++ b/src/Schema/Directives/Fields/RelationDirective.php
@@ -2,15 +2,15 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use Illuminate\Database\Eloquent\Model;
-use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Language\AST\FieldDefinitionNode;
-use Nuwave\Lighthouse\Schema\AST\DocumentAST;
-use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Database\Eloquent\Model;
 use Nuwave\Lighthouse\Execution\DataLoader\BatchLoader;
 use Nuwave\Lighthouse\Execution\DataLoader\RelationBatchLoader;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
 
 abstract class RelationDirective extends BaseDirective
 {
@@ -19,8 +19,9 @@ abstract class RelationDirective extends BaseDirective
      *
      * @param FieldValue $value
      *
-     * @return FieldValue
      * @throws \Exception
+     *
+     * @return FieldValue
      */
     public function resolveField(FieldValue $value): FieldValue
     {
@@ -37,11 +38,11 @@ abstract class RelationDirective extends BaseDirective
             }
         );
     }
-    
+
     /**
-     * @param FieldDefinitionNode $fieldDefinition
+     * @param FieldDefinitionNode      $fieldDefinition
      * @param ObjectTypeDefinitionNode $parentType
-     * @param DocumentAST $current
+     * @param DocumentAST              $current
      *
      * @throws \Exception
      *
@@ -50,20 +51,22 @@ abstract class RelationDirective extends BaseDirective
     public function manipulateSchema(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current): DocumentAST
     {
         $paginationType = $this->directiveArgValue('type');
-        
+
         // We default to not changing the field if no pagination type is set explicitly.
         // This makes sense for relations, as there should not be too many entries.
-        if(! $paginationType) {
+        if (! $paginationType) {
             return $current;
         }
-        
-        return PaginationManipulator::transformToPaginatedField($paginationType, $fieldDefinition, $parentType, $current);
+
+        $defaultCount = $this->directiveArgValue('defaultCount');
+
+        return PaginationManipulator::transformToPaginatedField($paginationType, $fieldDefinition, $parentType, $current, $defaultCount);
     }
-    
+
     /**
-     * @param Model $parent
-     * @param array $args
-     * @param null $context
+     * @param Model       $parent
+     * @param array       $args
+     * @param null        $context
      * @param ResolveInfo $resolveInfo
      *
      * @throws \Exception
@@ -72,16 +75,16 @@ abstract class RelationDirective extends BaseDirective
      */
     protected function getLoaderConstructorArguments(Model $parent, array $args, $context, ResolveInfo $resolveInfo): array
     {
-        $constructorArgs =  [
+        $constructorArgs = [
             'scopes' => $this->directiveArgValue('scopes', []),
             'args' => $args,
             'relationName' => $this->directiveArgValue('relation', $this->definitionNode->name->value),
         ];
-        
-        if($paginationType = $this->directiveArgValue('type')){
+
+        if ($paginationType = $this->directiveArgValue('type')) {
             $constructorArgs += ['paginationType' => PaginationManipulator::assertValidPaginationType($paginationType)];
         }
-        
+
         return $constructorArgs;
     }
 }

--- a/tests/Integration/Schema/Directives/Fields/HasManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/HasManyDirectiveTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Integration\Schema\Directives\Fields;
 
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Post;
 use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
+use Nuwave\Lighthouse\Exceptions\DirectiveException;
 
 class HasManyDirectiveTest extends DBTestCase
 {

--- a/tests/Integration/Schema/Directives/Fields/HasManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/HasManyDirectiveTest.php
@@ -246,6 +246,46 @@ class HasManyDirectiveTest extends DBTestCase
     /**
      * @test
      */
+    public function itCanQueryHasManyRelayConnectionWithADefaultCount()
+    {
+        $schema = '
+        type User {
+            tasks: [Task!]! @hasMany(type: "relay", defaultCount: 2)
+        }
+        
+        type Task {
+            id: Int!
+        }
+        
+        type Query {
+            user: User @auth
+        }
+        ';
+
+        $result = $this->executeQuery($schema, '
+        {
+            user {
+                tasks {
+                    pageInfo {
+                        hasNextPage
+                    }
+                    edges {
+                        node {
+                            id
+                        }
+                    }
+                }
+            }
+        }
+        ');
+
+        $this->assertTrue(array_get($result->data, 'user.tasks.pageInfo.hasNextPage'));
+        $this->assertCount(2, array_get($result->data, 'user.tasks.edges'));
+    }
+
+    /**
+     * @test
+     */
     public function itCanQueryHasManyNestedRelationships()
     {
         $schema = '

--- a/tests/Integration/Schema/Directives/Fields/HasManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/HasManyDirectiveTest.php
@@ -169,17 +169,12 @@ class HasManyDirectiveTest extends DBTestCase
         $schema = '
         type User {
             tasks: [Task!]! @hasMany(type: "paginator", defaultCount: 2)
-            posts: [Post!]! @hasMany(type: "paginator", defaultCount: 2)
         }
         
         type Task {
             id: Int!
         }
-        
-        type Post {
-            id: Int!
-        }
-        
+
         type Query {
             user: User @auth
         }

--- a/tests/Integration/Schema/Directives/Fields/PaginateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/PaginateDirectiveTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Integration\Schema\Directives\Fields;
 
-use Tests\DBTestCase;
-use Tests\Utils\Models\Post;
-use Tests\Utils\Models\User;
-use Tests\Utils\Models\Comment;
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Database\Eloquent\Builder;
+use Tests\DBTestCase;
+use Tests\Utils\Models\Comment;
+use Tests\Utils\Models\Post;
+use Tests\Utils\Models\User;
 
 class PaginateDirectiveTest extends DBTestCase
 {
@@ -243,10 +243,10 @@ class PaginateDirectiveTest extends DBTestCase
             [
                 'total' => 0,
                 'count' => 0,
-                'currentPage' => 1 ,
+                'currentPage' => 1,
                 'lastPage' => 1,
                 'hasNextPage' => false,
-                'hasPreviousPage' =>false,
+                'hasPreviousPage' => false,
                 'startCursor' => null,
                 'endCursor' => null,
             ],
@@ -323,7 +323,7 @@ class PaginateDirectiveTest extends DBTestCase
         extend type Query @group {
             users: [User!]! @paginate(model: "User")
         }
-        ' . $this->placeholderQuery();
+        '.$this->placeholderQuery();
 
         $query = '
         {
@@ -339,5 +339,43 @@ class PaginateDirectiveTest extends DBTestCase
         $result = $this->executeQuery($schema, $query);
 
         $this->assertCount(1, array_get($result->data, 'users.data'));
+    }
+
+    /** @test */
+    public function itCanHaveADefaultPaginationCount()
+    {
+        factory(User::class, 10)->create();
+
+        $schema = '
+        type User {
+            id: ID!
+            name: String!
+        }
+        
+        type Query {
+            users: [User!]! @paginate(defaultCount: 5)
+        }
+        ';
+
+        $query = '
+        {
+            users {
+                paginatorInfo {
+                    count
+                    total
+                    currentPage
+                }
+                data {
+                    id
+                    name
+                }
+            }
+        }
+        ';
+
+        $result = $this->executeQuery($schema, $query);
+        $this->assertEquals(5, array_get($result->data, 'users.paginatorInfo.count'));
+        $this->assertEquals(10, array_get($result->data, 'users.paginatorInfo.total'));
+        $this->assertCount(5, array_get($result->data, 'users.data'));
     }
 }

--- a/tests/Integration/Schema/Directives/Fields/PaginateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/PaginateDirectiveTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Integration\Schema\Directives\Fields;
 
-use GraphQL\Type\Definition\ResolveInfo;
-use Illuminate\Database\Eloquent\Builder;
 use Tests\DBTestCase;
-use Tests\Utils\Models\Comment;
 use Tests\Utils\Models\Post;
 use Tests\Utils\Models\User;
+use Tests\Utils\Models\Comment;
+use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Database\Eloquent\Builder;
 
 class PaginateDirectiveTest extends DBTestCase
 {


### PR DESCRIPTION
Resolves #426

The `@hasMany` and `@paginator` directives now support an additional argument `defaultCount` that sets a default value for the generated field argument `count`.

```graphql
type Query {
  posts: [Post!]! @paginate(defaultCount: 20)
}
```

This allows the API consumer to omit the count when requesting a paginated list of fields.

```graphql
{
  posts {
    data {
      id
      name
    }
  }
}
```