### PR TITLE
Optional parameter before required

### DIFF
--- a/src/Console/stubs/field.stub
+++ b/src/Console/stubs/field.stub
@@ -12,12 +12,12 @@ class DummyClass
      *
      * @param null $rootValue Usually contains the result returned from the parent field. In this case, it is always `null`.
      * @param array $args The arguments that were passed into the field.
-     * @param GraphQLContext|null $context Arbitrary data that is shared between all fields of a single query.
+     * @param GraphQLContext $context Arbitrary data that is shared between all fields of a single query.
      * @param ResolveInfo $resolveInfo Information about the query itself, such as the execution state, the field name, path to the field from the root, and more.
      *
      * @return mixed
      */
-    public function resolve($rootValue, array $args, GraphQLContext $context = null, ResolveInfo $resolveInfo)
+    public function resolve($rootValue, array $args, GraphQLContext $context, ResolveInfo $resolveInfo)
     {
         // TODO implement the resolver
     }


### PR DESCRIPTION
**Related Issue(s)**

This will work unexpectedly if less then 4 arguments will be provided. See also the [example #5](http://php.net/manual/en/functions.arguments.php#functions.arguments.default).

**PR Type**

Reformat

**Changes**

Change the function signature to a valid one.

**Breaking changes**

no
