### PR TITLE
Change now()-helper to Carbon::now()

### DIFF
--- a/src/Schema/Directives/Fields/CacheDirective.php
+++ b/src/Schema/Directives/Fields/CacheDirective.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
+use Carbon\Carbon;
 use GraphQL\Language\AST\DirectiveNode;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
 use Nuwave\Lighthouse\Schema\Values\CacheValue;
@@ -57,7 +58,7 @@ class CacheDirective extends BaseDirective implements FieldMiddleware
 
             $useTags = $this->useTags();
             $cacheExp = $maxAge
-                ? now()->addSeconds($maxAge)
+                ? Carbon::now()->addSeconds($maxAge)
                 : null;
             $cacheKey = $cacheValue->getKey();
             $cacheTags = $cacheValue->getTags();

--- a/src/Schema/Directives/Fields/TracingDirective.php
+++ b/src/Schema/Directives/Fields/TracingDirective.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
+use Carbon\Carbon;
 use GraphQL\Type\Definition\ResolveInfo;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
@@ -41,14 +42,14 @@ class TracingDirective extends BaseDirective implements FieldMiddleware
             /** @var TracingExtension $tracingExtension */
             $tracingExtension = $extensionRegistry->get(TracingExtension::name());
 
-            $start = now();
+            $start = Carbon::now();
             $result = $resolver($root, $args, $context, $info);
 
             ($result instanceof \GraphQL\Deferred)
                 ? $result->then(function (&$items) use ($info, $start, $tracingExtension) {
-                    $tracingExtension->record($info, $start, now());
+                    $tracingExtension->record($info, $start, Carbon::now());
                 })
-                : $tracingExtension->record($info, $start, now());
+                : $tracingExtension->record($info, $start, Carbon::now());
 
             return $result;
         });

--- a/src/Schema/Extensions/TracingExtension.php
+++ b/src/Schema/Extensions/TracingExtension.php
@@ -69,7 +69,7 @@ class TracingExtension extends GraphQLExtension
      */
     public function requestDidStart(ExtensionRequest $request): TracingExtension
     {
-        $this->requestStart = now();
+        $this->requestStart = Carbon::now();
 
         return $this;
     }
@@ -113,7 +113,7 @@ class TracingExtension extends GraphQLExtension
      */
     public function jsonSerialize(): array
     {
-        $end = now();
+        $end = Carbon::now();
         $duration = abs(($end->micro - $this->requestStart->micro) * 1000);
 
         return [


### PR DESCRIPTION
**Related Issue(s)**

Lumen doesn't have a now()-helper as Laravel does so this enables Lumen to use cache and tracing.

**PR Type**

Bugfix (Lumen)

**Changes**

Changed now() to Carbon::now()

**Breaking changes**

None
