### PR TITLE
Remove prestissimo from Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ matrix:
 before_install:
 - phpenv config-rm xdebug.ini
 - echo "memory_limit=4G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-- composer global require hirak/prestissimo --update-no-dev
 - composer require
   "illuminate/contracts:${LARAVEL}"
   "illuminate/http:${LARAVEL}"


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Added Docs for all relevant versions

**Related Issue/Intent**

<!-- Link to related issues this PR resolves, e.g. "Resolves #236",
or a description of what this PR is trying to achieve. -->
None

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->
Disable prestissimo. This is totally useless as we already cache composer dependencies in Travis.
This can sometimes slow down the build.

This build might take more time just because it was removed, but next one will be as fast as usual

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->
None
