### PR TITLE
[FIX] Adjust key in BatchLoader for batched queries

### DIFF
--- a/src/Execution/DataLoader/BatchLoader.php
+++ b/src/Execution/DataLoader/BatchLoader.php
@@ -47,6 +47,11 @@ abstract class BatchLoader
     {
         // The path to the field serves as the unique key for the instance
         $instanceName = static::instanceKey($pathToField);
+        $currentBatchIndex = app('graphql')->currentBatchIndex();
+
+        if (null !== ! $currentBatchIndex) {
+            $instanceName = "batch_{$currentBatchIndex}_{$instanceName}";
+        }
 
         // Only register a new instance if it is not already bound
         $instance = app()->bound($instanceName)

--- a/src/Execution/DataLoader/BatchLoader.php
+++ b/src/Execution/DataLoader/BatchLoader.php
@@ -47,6 +47,9 @@ abstract class BatchLoader
     {
         // The path to the field serves as the unique key for the instance
         $instanceName = static::instanceKey($pathToField);
+
+        // If we are resolving a batched query, we need to assign each
+        // query a uniquely indexed instance
         $currentBatchIndex = app('graphql')->currentBatchIndex();
 
         if (null !== $currentBatchIndex) {

--- a/src/Execution/DataLoader/BatchLoader.php
+++ b/src/Execution/DataLoader/BatchLoader.php
@@ -49,7 +49,7 @@ abstract class BatchLoader
         $instanceName = static::instanceKey($pathToField);
         $currentBatchIndex = app('graphql')->currentBatchIndex();
 
-        if (null !== ! $currentBatchIndex) {
+        if (null !== $currentBatchIndex) {
             $instanceName = "batch_{$currentBatchIndex}_{$instanceName}";
         }
 

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -59,7 +59,8 @@ class GraphQL
     }
 
     /**
-     * Get current batch index.
+     * Returns the index of the current batch if we are resolving
+     * a batched query or `null` if we are resolving a single query.
      *
      * @return int|null
      */

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -41,6 +41,9 @@ class GraphQL
     /** @var Pipeline */
     protected $pipeline;
 
+    /** @var int|null */
+    protected $currentBatchIndex = null;
+
     /**
      * @param ExtensionRegistry    $extensionRegistry
      * @param SchemaBuilder        $schemaBuilder
@@ -56,6 +59,16 @@ class GraphQL
     }
 
     /**
+     * Get current batch index.
+     *
+     * @return int|null
+     */
+    public function currentBatchIndex()
+    {
+        return $this->currentBatchIndex;
+    }
+
+    /**
      * Execute a set of batched queries on the lighthouse schema and return a
      * collection of ExecutionResults.
      *
@@ -68,6 +81,7 @@ class GraphQL
     public function executeBatchedQueries(array $requests, $context = null, $rootValue = null): array
     {
         return collect($requests)->map(function ($request, $index) use ($context, $rootValue) {
+            $this->currentBatchIndex = $index;
             $this->extensionRegistry->batchedQueryDidStart($index);
 
             $result = $this->executeQuery(
@@ -171,9 +185,9 @@ class GraphQL
     protected function getValidationRules(): array
     {
         return [
-            new QueryComplexity(config('lighthouse.security.max_query_complexity', 0)),
-            new QueryDepth(config('lighthouse.security.max_query_depth', 0)),
-            new DisableIntrospection(config('lighthouse.security.disable_introspection', false)),
+            QueryComplexity::class => new QueryComplexity(config('lighthouse.security.max_query_complexity', 0)),
+            QueryDepth::class => new QueryDepth(config('lighthouse.security.max_query_depth', 0)),
+            DisableIntrospection::class => new DisableIntrospection(config('lighthouse.security.disable_introspection', false)),
         ];
     }
 

--- a/tests/Integration/Execution/DataLoader/BatchLoaderTest.php
+++ b/tests/Integration/Execution/DataLoader/BatchLoaderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Integration\Execution\DataLoader;
+
+use Tests\DBTestCase;
+use Tests\Utils\Models\Task;
+use Tests\Utils\Models\User;
+
+class BatchLoaderTest extends DBTestCase
+{
+    /**
+     * @test
+     */
+    public function itCanResolveBatchedFieldsFromBatchedRequests()
+    {
+        $users = factory(User::class, 2)
+            ->create()
+            ->each(function (User $user) {
+                factory(Task::class, 3)->create([
+                    'user_id' => $user->getKey(),
+                ]);
+            });
+
+        $this->schema = '
+        type Task {
+            name: String
+        }
+        type User {
+            name: String
+            email: String
+            tasks: [Task] @hasMany
+        }
+
+        type Query {
+            user(id: ID! @eq): User @find
+        }
+        ';
+
+        $query = '
+        query User($id: ID!) {
+            user(id: $id) {
+                email
+                tasks {
+                    name
+                }
+            }
+        }';
+
+        $batchedQueries = [
+            ['query' => $query, 'variables' => ['id' => $users[0]->getKey()]],
+            ['query' => $query, 'variables' => ['id' => $users[1]->getKey()]],
+        ];
+
+        $data = $this->postJson('/graphql', $batchedQueries)->json();
+        $this->assertCount(2, $data);
+        $this->assertCount(3, array_get($data, '0.data.user.tasks'));
+        $this->assertCount(3, array_get($data, '1.data.user.tasks'));
+    }
+}

--- a/tests/Integration/Execution/DataLoader/BatchLoaderTest.php
+++ b/tests/Integration/Execution/DataLoader/BatchLoaderTest.php
@@ -44,7 +44,8 @@ class BatchLoaderTest extends DBTestCase
                     name
                 }
             }
-        }';
+        }
+        ';
 
         $batchedQueries = [
             ['query' => $query, 'variables' => ['id' => $users[0]->getKey()]],


### PR DESCRIPTION
- [X] Added or updated tests

**Related Issue/Intent**

Currently, if a batched query is sent up to Lighthouse that references the same field the same key will be produced in the `BatchLoader` causing an error (the `key` of any subsequent query will be missing). 

**Changes**

To resolve the issue `Nuwave\Lighthouse\GraphQL` now holds a reference to the `currentBatchIndex`. When set, the `BatchLoader` will prepend the index to the key making the field name unique across multiple queries.

**Breaking changes**

None
