### PR TITLE
 Refresh newly created models before returning them

### DIFF
--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -34,6 +34,10 @@ class MutationExecutor
             });
         });
 
+        // Make sure that values that are set through the database insert
+        // are immediately available for return, e.g. default values
+        $model->refresh();
+
         return $model;
     }
 
@@ -73,7 +77,11 @@ class MutationExecutor
     protected static function handleHasManyCreate(Collection $multiValues, HasMany $relation)
     {
         $multiValues->each(function ($singleValues) use ($relation) {
-            self::executeCreate($relation->getModel()->newInstance(), collect($singleValues), $relation);
+            self::executeCreate(
+                $relation->getModel()->newInstance(),
+                collect($singleValues),
+                $relation
+            );
         });
     }
 
@@ -99,18 +107,22 @@ class MutationExecutor
 
         $model = self::saveModelWithBelongsTo($model, $remaining, $parentRelation);
 
-        $hasMany->each(function ($nestedOperations, $relationName) use ($model) {
+        $hasMany->each(function ($nestedOperations, string $relationName) use ($model) {
             /** @var HasMany $relation */
             $relation = $model->{$relationName}();
 
-            collect($nestedOperations)->each(function ($values, $operationKey) use ($relation) {
+            collect($nestedOperations)->each(function ($values, string $operationKey) use ($relation) {
                 if ($operationKey === 'create') {
                     self::handleHasManyCreate(collect($values), $relation);
                 }
 
                 if ($operationKey === 'update') {
                     collect($values)->each(function ($singleValues) use ($relation) {
-                        self::executeUpdate($relation->getModel()->newInstance(), collect($singleValues), $relation);
+                        self::executeUpdate(
+                            $relation->getModel()->newInstance(),
+                            collect($singleValues),
+                            $relation
+                        );
                     });
                 }
 
@@ -144,8 +156,9 @@ class MutationExecutor
      */
     protected static function extractBelongsToArgs(Model $model, Collection $args): Collection
     {
-        return $args->partition(function ($value, $key) use ($model) {
-            return method_exists($model, $key) && ($model->{$key}() instanceof BelongsTo);
+        return $args->partition(function ($value, string $key) use ($model) {
+            return method_exists($model, $key)
+                && ($model->{$key}() instanceof BelongsTo);
         });
     }
 
@@ -179,8 +192,9 @@ class MutationExecutor
      */
     protected static function extractHasManyArgs(Model $model, Collection $args): Collection
     {
-        return $args->partition(function ($value, $key) use ($model) {
-            return method_exists($model, $key) && ($model->{$key}() instanceof HasMany);
+        return $args->partition(function ($value, string $key) use ($model) {
+            return method_exists($model, $key)
+                && ($model->{$key}() instanceof HasMany);
         });
     }
 }

--- a/tests/Integration/Schema/Directives/Fields/CreateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/CreateDirectiveTest.php
@@ -119,4 +119,66 @@ class CreateDirectiveTest extends DBTestCase
         $this->assertSame('foo', Arr::get($result, 'data.createTask.name'));
         $this->assertSame('1', Arr::get($result, 'data.createTask.user.id'));
     }
+
+    /**
+     * @test
+     */
+    public function itCanCreateWithHasMany()
+    {
+        $schema = '
+        type Task {
+            id: ID!
+            name: String!
+        }
+        
+        type User {
+            id: ID!
+            name: String
+            tasks: [Task!]! @hasMany
+        }
+        
+        type Mutation {
+            createUser(input: CreateUserInput!): User @create(flatten: true)
+        }
+        
+        input CreateUserInput {
+            name: String
+            tasks: CreateTaskRelation
+        }
+        
+        input CreateTaskRelation {
+            create: [CreateTaskInput!]
+        }
+        
+        input CreateTaskInput {
+            name: String
+            user: ID
+        }
+        ' . $this->placeholderQuery();
+        $query = '
+        mutation {
+            createUser(input: {
+                name: "foo"
+                tasks: {
+                    create: [{
+                        name: "bar"
+                    }]
+                }
+            }) {
+                id
+                name
+                tasks {
+                    id
+                    name
+                }
+            }
+        }
+        ';
+        $result = $this->execute($schema, $query);
+
+        $this->assertSame('1', Arr::get($result, 'data.createUser.id'));
+        $this->assertSame('foo', Arr::get($result, 'data.createUser.name'));
+        $this->assertSame('1', Arr::get($result, 'data.createUser.tasks.0.id'));
+        $this->assertSame('bar', Arr::get($result, 'data.createUser.tasks.0.name'));
+    }
 }

--- a/tests/Integration/Schema/Directives/Fields/CreateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/CreateDirectiveTest.php
@@ -181,4 +181,35 @@ class CreateDirectiveTest extends DBTestCase
         $this->assertSame('1', Arr::get($result, 'data.createUser.tasks.0.id'));
         $this->assertSame('bar', Arr::get($result, 'data.createUser.tasks.0.name'));
     }
+
+    /**
+     * @test
+     */
+    public function itCreatesAnEntryWithDatabaseDefaultsAndReturnsItImmediately()
+    {
+        $schema = '
+        type Mutation {
+            createTag(name: String): Tag @create
+        }
+        
+        type Tag {
+            name: String!
+            default_string: String!
+        }
+        ' . $this->placeholderQuery();
+        $query = '
+        mutation {
+            createTag(name: "foobar"){
+                name
+                default_string
+            }
+        }
+        ';
+        $result = $this->execute($schema, $query);
+
+        $this->assertSame([
+            'name' => 'foobar',
+            'default_string' => \CreateTestbenchTagsTable::DEFAULT_STRING,
+        ], Arr::get($result, 'data.createTag'));
+    }
 }

--- a/tests/database/migrations/2018_02_28_000002_create_testbench_users_table.php
+++ b/tests/database/migrations/2018_02_28_000002_create_testbench_users_table.php
@@ -13,11 +13,11 @@ class CreateTestbenchUsersTable extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
-            $table->unsignedInteger('company_id');
+            $table->unsignedInteger('company_id')->nullable();
             $table->unsignedInteger('team_id')->nullable();
-            $table->string('name');
-            $table->string('email');
-            $table->string('password');
+            $table->string('name')->nullable();
+            $table->string('email')->nullable();
+            $table->string('password')->nullable();
             $table->timestamps();
         });
     }

--- a/tests/database/migrations/2018_09_30_000006_create_testbench_tags_table.php
+++ b/tests/database/migrations/2018_09_30_000006_create_testbench_tags_table.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Migrations\Migration;
 
 class CreateTestbenchTagsTable extends Migration
 {
+    const DEFAULT_STRING = 'this is the default string';
+
     /**
      * Run the migrations.
      */
@@ -14,6 +16,7 @@ class CreateTestbenchTagsTable extends Migration
         Schema::create('tags', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
+            $table->string('default_string')->default(self::DEFAULT_STRING);
             $table->timestamps();
         });
     }


### PR DESCRIPTION
- [x] Added or updated tests

**Related Issue/Intent**

Resolves #501

**Changes**

Make sure that values that are set through the database insert
are immediately available for return, e.g. default values.

Add a test for creating nested has many relations on the side.

**Breaking changes**

No
