### PR TITLE
Being able to set injected value with dot notation deeper

### DIFF
--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -476,15 +476,23 @@ type Mutation {
   createPost(title: String!, content: String!): Post
     @create
     @inject(context: "user.id", name: "user_id")
-
-  createTask(input: CreateTaskInput!): Task
-    @create
-    @inject(context: "user.id", name: "input.user_id")
 }
 ```
 
 This is useful to ensure that the authenticated user's `id` is
 automatically used for creating new models and can not be manipulated.
+
+If you are using an Input Object as an argument, you can use dot notation to
+set a nested argument.
+
+
+```graphql
+type Mutation {
+  createTask(input: CreateTaskInput!): Task
+    @create
+    @inject(context: "user.id", name: "input.user_id")
+}
+```
 
 ## @interface
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -476,6 +476,10 @@ type Mutation {
   createPost(title: String!, content: String!): Post
     @create
     @inject(context: "user.id", name: "user_id")
+
+  createTask(input: CreateTaskInput!): Task
+    @create
+    @inject(context: "user.id", name: "input.user_id")
 }
 ```
 

--- a/src/Schema/Directives/Fields/InjectDirective.php
+++ b/src/Schema/Directives/Fields/InjectDirective.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
+use Illuminate\Support\Arr;
 use GraphQL\Type\Definition\ResolveInfo;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;
@@ -53,7 +54,7 @@ class InjectDirective extends BaseDirective implements FieldMiddleware
                 use ($contextAttributeName, $argumentName, $previousResolvers) {
                     return $previousResolvers(
                         $rootValue,
-                        array_add($args, $argumentName,data_get($context, $contextAttributeName)),
+                        Arr::add($args, $argumentName,data_get($context, $contextAttributeName)),
                         $context,
                         $resolveInfo
                     );

--- a/src/Schema/Directives/Fields/InjectDirective.php
+++ b/src/Schema/Directives/Fields/InjectDirective.php
@@ -53,7 +53,7 @@ class InjectDirective extends BaseDirective implements FieldMiddleware
                 use ($contextAttributeName, $argumentName, $previousResolvers) {
                     return $previousResolvers(
                         $rootValue,
-                        $args + [$argumentName => data_get($context, $contextAttributeName)],
+                        array_add($args, $argumentName,data_get($context, $contextAttributeName)),
                         $context,
                         $resolveInfo
                     );

--- a/tests/Integration/Schema/Directives/Fields/InjectDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/InjectDirectiveTest.php
@@ -55,6 +55,4 @@ class InjectDirectiveTest extends DBTestCase
         $this->assertSame('foo', Arr::get($result, 'data.createTask.name'));
         $this->assertSame('1', Arr::get($result, 'data.createTask.user.id'));
     }
-
-
 }

--- a/tests/Integration/Schema/Directives/Fields/InjectDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/InjectDirectiveTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Integration\Schema\Directives\Fields;
+
+use Tests\DBTestCase;
+use Illuminate\Support\Arr;
+use Tests\Utils\Models\User;
+
+class InjectDirectiveTest extends DBTestCase
+{
+    /**
+     * @test
+     */
+    public function itCanCreateFromInputObjectWithDeepInjection()
+    {
+        $user = factory(User::class)->create();
+        $this->be($user);
+
+        $schema = '
+        type Task {
+            id: ID!
+            name: String!
+            user: User @belongsTo
+        }
+        
+        type User {
+            id: ID
+        }
+        
+        type Mutation {
+            createTask(input: CreateTaskInput!): Task @create(flatten: true) @inject(context: "user.id", name: "input.user_id")
+        }
+        
+        input CreateTaskInput {
+            name: String
+        }
+        ' . $this->placeholderQuery();
+        $query = '
+        mutation {
+            createTask(input: {
+                name: "foo"
+            }) {
+                id
+                name
+                user {
+                    id
+                }
+            }
+        }
+        ';
+        $this->schema = $schema;
+        $result = $this->queryViaHttp($query);
+
+        $this->assertSame('1', Arr::get($result, 'data.createTask.id'));
+        $this->assertSame('foo', Arr::get($result, 'data.createTask.name'));
+        $this->assertSame('1', Arr::get($result, 'data.createTask.user.id'));
+    }
+
+
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions

**Related Issue/Intent**

Allows inject with dot notation. For example if using input object. This allows to do as follows:
`type Mutation {
  createPost($input: CreateObjectInput!): Post
    @create
    @inject(context: "user.id", name: "input.user_id")
}`


