### PR TITLE
Prevent name conflict between argument names and non-relation methods when executing nested mutations

### DIFF
--- a/docs/master/guides/relationships.md
+++ b/docs/master/guides/relationships.md
@@ -144,8 +144,31 @@ class Post extends Model
 Lighthouse allows you to create, update or delete your relationships in
 a single mutation.
 
-By default all mutations are wrapped in a database transaction, so if any of the nested
-operations fail, the whole mutation is aborted and no changes are written to the database.
+You have to define return types on your relationship methods so that Lighthouse
+can detect them.
+
+```php
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Post extends Model 
+{
+    // WORKS
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    // DOES NOT WORK
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);        
+    }
+}
+```
+
+By default, all mutations are wrapped in a database transaction.
+If any of the nested operations fail, the whole mutation is aborted
+and no changes are written to the database.
 You can change this setting [in the configuration](../getting-started/configuration.md).
 
 ### Belongs To

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -155,9 +155,9 @@ class MutationExecutor
      *   ]
      * ]
      *
-     * @param Model $model
+     * @param Model      $model
      * @param Collection $args
-     * @param string $relationClass
+     * @param string     $relationClass
      *
      * @return Collection
      */
@@ -167,15 +167,20 @@ class MutationExecutor
         return $args->partition(function ($value, string $key) use ($model, $relationClass) {
             $reflection = new \ReflectionClass($model);
 
-            if(! $reflection->hasMethod($key)) return false;
+            if(! $reflection->hasMethod($key)){
+                return false;
+            }
 
-            $relationMethodClass = $reflection->getMethod($key)->class;
-            $modelClass = $reflection->getName();
+            $relationMethodCandidate = $model->getMethod($key);
+            if(!$returnType = $relationMethodCandidate->getReturnType()){
+                return false;
+            }
 
-            // Means the method is native
-            if($relationMethodClass !== $modelClass) return false;
+            if(! $returnType instanceof \ReflectionNamedType){
+                return false;
+            }
 
-            return ($model->{$key}() instanceof $relationClass);
+            return $returnType->getName() === $relationClass;
         });
     }
 }

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -20,7 +20,8 @@ class MutationExecutor
      */
     public static function executeCreate(Model $model, Collection $args, HasMany $parentRelation = null): Model
     {
-        list($hasMany, $remaining) = self::partitionArgsByRelationType($model, $args, HasMany::class);
+        $reflection = new \ReflectionClass($model);
+        list($hasMany, $remaining) = self::partitionArgsByRelationType($reflection, $args, HasMany::class);
 
         $model = self::saveModelWithBelongsTo($model, $remaining, $parentRelation);
 
@@ -47,7 +48,8 @@ class MutationExecutor
      */
     protected static function saveModelWithBelongsTo(Model $model, Collection $remaining, HasMany $parentRelation = null): Model
     {
-        list($belongsTo, $remaining) = self::partitionArgsByRelationType($model, $remaining,BelongsTo::class);
+        $reflection = new \ReflectionClass($model);
+        list($belongsTo, $remaining) = self::partitionArgsByRelationType($reflection, $remaining,BelongsTo::class);
 
         // Use all the remaining attributes and fill the model
         $model->fill(
@@ -100,7 +102,8 @@ class MutationExecutor
 
         $model = $model->newQuery()->findOrFail($id);
 
-        list($hasMany, $remaining) = self::partitionArgsByRelationType($model, $args, HasMany::class);
+        $reflection = new \ReflectionClass($model);
+        list($hasMany, $remaining) = self::partitionArgsByRelationType($reflection, $args, HasMany::class);
 
         $model = self::saveModelWithBelongsTo($model, $remaining, $parentRelation);
 
@@ -155,19 +158,16 @@ class MutationExecutor
      *   ]
      * ]
      *
-     * @param Model      $model
-     * @param Collection $args
-     * @param string     $relationClass
+     * @param \ReflectionClass $model
+     * @param Collection       $args
+     * @param string           $relationClass
      *
      * @return Collection
      */
-    protected static function partitionArgsByRelationType(Model $model, Collection $args, string $relationClass): Collection
+    protected static function partitionArgsByRelationType(\ReflectionClass $model, Collection $args, string $relationClass): Collection
     {
-
         return $args->partition(function ($value, string $key) use ($model, $relationClass) {
-            $reflection = new \ReflectionClass($model);
-
-            if(! $reflection->hasMethod($key)){
+            if(! $model->hasMethod($key)){
                 return false;
             }
 

--- a/tests/Integration/Schema/Directives/Fields/CreateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/CreateDirectiveTest.php
@@ -351,6 +351,7 @@ class CreateDirectiveTest extends DBTestCase
         type Task {
             id: ID!
             name: String!
+            guard: String
         }
         
         type User {
@@ -375,7 +376,6 @@ class CreateDirectiveTest extends DBTestCase
         input CreateTaskInput {
             name: String
             guard: String
-            delete: Boolean
         }
         '.$this->placeholderQuery();
         $query = '
@@ -385,9 +385,7 @@ class CreateDirectiveTest extends DBTestCase
                 tasks: {
                     create: [{
                         name: "Uniq"
-                        delete: true
                         guard: "api"
-                        
                     }]
                 }
             }) {
@@ -396,13 +394,14 @@ class CreateDirectiveTest extends DBTestCase
                 tasks {
                     id
                     name
+                    guard
                 }
             }
         }
         ';
         $result = $this->execute($schema, $query);
-
+        print_r($result);
         $this->assertSame('api', Arr::get($result, 'data.createUser.tasks.0.guard'));
-        $this->assertSame(true, Arr::get($result, 'data.createUser.tasks.0.delete'));
+
     }
 }

--- a/tests/Integration/Schema/Directives/Fields/CreateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/CreateDirectiveTest.php
@@ -340,4 +340,69 @@ class CreateDirectiveTest extends DBTestCase
             $this->assertCount(2, User::all());
         }
     }
+
+    /**
+     * @test
+     */
+    public function itDoesNotFailWhenPropertyNameMatchesModelsNativeMethods()
+    {
+
+        $schema = '
+        type Task {
+            id: ID!
+            name: String!
+        }
+        
+        type User {
+            id: ID!
+            name: String
+            tasks: [Task!]! @hasMany
+        }
+        
+        type Mutation {
+            createUser(input: CreateUserInput!): User @create(flatten: true)
+        }
+        
+        input CreateUserInput {
+            name: String
+            tasks: CreateTaskRelation
+        }
+        
+        input CreateTaskRelation {
+            create: [CreateTaskInput!]
+        }
+        
+        input CreateTaskInput {
+            name: String
+            guard: String
+            delete: Boolean
+        }
+        '.$this->placeholderQuery();
+        $query = '
+        mutation {
+            createUser(input: {
+                name: "foo"
+                tasks: {
+                    create: [{
+                        name: "Uniq"
+                        delete: true
+                        guard: "api"
+                        
+                    }]
+                }
+            }) {
+                id
+                name
+                tasks {
+                    id
+                    name
+                }
+            }
+        }
+        ';
+        $result = $this->execute($schema, $query);
+
+        $this->assertSame('api', Arr::get($result, 'data.createUser.tasks.0.guard'));
+        $this->assertSame(true, Arr::get($result, 'data.createUser.tasks.0.delete'));
+    }
 }

--- a/tests/Integration/Schema/Directives/Fields/CreateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/CreateDirectiveTest.php
@@ -400,7 +400,7 @@ class CreateDirectiveTest extends DBTestCase
         }
         ';
         $result = $this->execute($schema, $query);
-        print_r($result);
+
         $this->assertSame('api', Arr::get($result, 'data.createUser.tasks.0.guard'));
 
     }

--- a/tests/database/migrations/2018_02_28_000003_create_testbench_tasks_table.php
+++ b/tests/database/migrations/2018_02_28_000003_create_testbench_tasks_table.php
@@ -17,7 +17,6 @@ class CreateTestbenchTasksTable extends Migration
             $table->string('name')->unique();
             // Properties which collide with native model method names
             $table->string('guard')->nullable();
-            $table->boolean('delete')->nullable();
             // -------------------------------------------------------
             $table->timestamps();
             $table->softDeletes();

--- a/tests/database/migrations/2018_02_28_000003_create_testbench_tasks_table.php
+++ b/tests/database/migrations/2018_02_28_000003_create_testbench_tasks_table.php
@@ -15,6 +15,10 @@ class CreateTestbenchTasksTable extends Migration
             $table->increments('id');
             $table->unsignedInteger('user_id');
             $table->string('name')->unique();
+            // Properties which collide with native model method names
+            $table->string('guard')->nullable();
+            $table->boolean('delete')->nullable();
+            // -------------------------------------------------------
             $table->timestamps();
             $table->softDeletes();
         });


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated docs

**Related Issue/Intent**

Resolves #507

**Changes**

Detect relationships when executing nested mutations by using reflection instead of calling the methods and examining the result.

This prevents non-relationship methods from being called, which may lead to errors and/or side effects.

**Breaking Changes**

Users are required to define the return type of a relationship method in their Eloquent Model for the detection to work.