### PR TITLE
Stop bubbling up exceptions docblocks

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,7 +36,118 @@ Just clone the project and run the following in the project root:
 
 ## Code guidelines
 
-Do not use Facades and utilize dependency injection instead. Not every application has them enabled.
+### Laravel feature usage
+
+We strive to be compatible with both Lumen and Laravel.
+
+Do not use Facades and utilize dependency injection instead.
+Not every application has them enabled - Lumen does not use Facades by default.
+
+Prefer direct usage of Illuminate classes instead of helpers.
+
+```php
+# WRONG
+array_get($foo, 'bar');
+
+# CORRECT
+use \Illuminate\Support\Arr;
+Arr::get($foo, 'bar');
+```
+
+### Type definitions
+
+Prefer the strictest possible type annotations wherever possible.
+If known, add additional type information in the PHPDoc.
+
+```php
+/**
+ * We know we get an array of strings here.
+ *
+ * @param string[] $bar
+ * @return string
+ */
+function foo(array $bar): string
+```
+
+For aggregate types such as the commonly used `Collection` class, use
+the generic type hint style. While not officially part of PHPDoc, it is understood
+by PHPStorm and most other editors.
+
+```php
+/**
+ * Hint at the contents of the Collection.
+ *
+ * @return \Illuminate\Support\Collection<string>
+ */
+function foo(): Collection
+```
+
+Use `self` to annotate that a class returns an instance of itself (or its child).
+Use [PHPDoc type hints](http://docs.phpdoc.org/guides/types.html#keywords) to
+differentiate between cases where you return the original object instance and
+other cases where you instantiate a new class.
+
+```php
+<?php
+
+class Foo
+{
+    /**
+     * Some attribute.
+     *
+     * @var string
+     */
+    protected $bar;
+    
+    /**
+     * Use $this for fluent setters when we expect the exact same object back. 
+     *
+     * @param string $bar
+     *
+     * @return $this
+     */
+    public function setBar(string $bar): self
+    {
+        $this->bar = $bar;
+
+        return $this;
+    }
+
+    /**
+     * Use static when you return a new instance.
+     *
+     * @return static
+     */
+    public function duplicate(): self
+    {
+        $instance = new static();
+        $instance->bar = $this->bar;
+
+        return $instance;
+    }
+}
+```
+
+### Annotating Exception Throwing
+
+Only annotate `@throws` for Exceptions that are thrown in the function itself.
+
+```php
+/**
+ * @throws \Exception
+ */
+function foo(){
+  throw Excection();
+}
+
+/**
+ * No need to annotate the Exception here, even though
+ * it is thrown indirectly. 
+ */
+function bar(){
+  foo();
+}
+```
 
 ## Code style
 
@@ -44,8 +155,6 @@ We use [StyleCI](https://styleci.io/) to ensure clean formatting, oriented
 at the Laravel coding style.
 
 Look through some of the code to get a feel for the naming conventions.
-
-Use type hints and return types whenever possible and make sure to include proper **PHPDocs**
 
 Prefer explicit naming and short functions over excessive comments.
 

--- a/src/Execution/DataLoader/ModelRelationFetcher.php
+++ b/src/Execution/DataLoader/ModelRelationFetcher.php
@@ -218,7 +218,7 @@ class ModelRelationFetcher
      * @param string   $relationName
      * @param \Closure $relationConstraints
      *
-     * @return Collection|Relation[]
+     * @return Collection<Relation>
      */
     protected function buildRelationsFromModels(string $relationName, \Closure $relationConstraints): Collection
     {
@@ -285,7 +285,7 @@ class ModelRelationFetcher
     /**
      * This is the name that Eloquent gives to the attribute that contains the count.
      *
-     * @see Illuminate\Database\Eloquent\Concerns\QueriesRelationships->withCount()
+     * @see \Illuminate\Database\Eloquent\Concerns\QueriesRelationships->withCount()
      *
      * @param string $relationName
      *

--- a/src/Execution/DataLoader/ModelRelationFetcher.php
+++ b/src/Execution/DataLoader/ModelRelationFetcher.php
@@ -115,8 +115,6 @@ class ModelRelationFetcher
      * @param int $perPage
      * @param int $page
      *
-     * @throws \Exception
-     *
      * @return ModelRelationFetcher
      */
     public function loadRelationsForPage(int $perPage, int $page = 1): self
@@ -137,8 +135,6 @@ class ModelRelationFetcher
      * @param int      $page
      * @param string   $relationName
      * @param \Closure $relationConstraints
-     *
-     * @throws \Exception
      *
      * @return static
      */
@@ -222,9 +218,7 @@ class ModelRelationFetcher
      * @param string   $relationName
      * @param \Closure $relationConstraints
      *
-     * @throws \Exception
-     *
-     * @return Collection Relation[]
+     * @return Collection|Relation[]
      */
     protected function buildRelationsFromModels(string $relationName, \Closure $relationConstraints): Collection
     {
@@ -262,8 +256,6 @@ class ModelRelationFetcher
      * Load default eager loads.
      *
      * @param EloquentCollection $collection
-     *
-     * @throws \ReflectionException
      *
      * @return static
      */
@@ -397,8 +389,6 @@ class ModelRelationFetcher
      *
      * @param string $relationName
      * @param $relationModels
-     *
-     * @throws \ReflectionException
      */
     protected function hydratePivotRelation(string $relationName, EloquentCollection $relationModels)
     {

--- a/src/Execution/DataLoader/RelationBatchLoader.php
+++ b/src/Execution/DataLoader/RelationBatchLoader.php
@@ -63,8 +63,6 @@ class RelationBatchLoader extends BatchLoader
     /**
      * Resolve the keys.
      *
-     * @throws \Exception
-     *
      * @return array
      */
     public function resolve(): array

--- a/src/Execution/ErrorBuffer.php
+++ b/src/Execution/ErrorBuffer.php
@@ -98,8 +98,6 @@ class ErrorBuffer
      * Flush the errors.
      *
      * @param string $errorMessage
-     *
-     * @throws \Exception
      */
     public function flush(string $errorMessage)
     {

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -93,8 +93,6 @@ class MutationExecutor
      * @param Collection   $args           the corresponding slice of the input arguments for updating this model
      * @param HasMany|null $parentRelation if we are in a nested update, we can use this to associate the new model to its parent
      *
-     * @throws ModelNotFoundException
-     *
      * @return Model
      */
     public static function executeUpdate(Model $model, Collection $args, ?HasMany $parentRelation = null): Model

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class MutationExecutor
 {

--- a/src/Execution/QueryAST.php
+++ b/src/Execution/QueryAST.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Nuwave\Lighthouse\Execution;
 
 use GraphQL\Language\Parser;
-use GraphQL\Error\SyntaxError;
 use GraphQL\Language\AST\Node;
 use Illuminate\Support\Collection;
 use GraphQL\Language\AST\DocumentNode;

--- a/src/Execution/QueryAST.php
+++ b/src/Execution/QueryAST.php
@@ -37,8 +37,6 @@ class QueryAST
      *
      * @param string $schema
      *
-     * @throws SyntaxError
-     *
      * @return QueryAST
      */
     public static function fromSource(string $schema): self

--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -22,8 +22,6 @@ class ASTBuilder
      *
      * @param string $schema
      *
-     * @throws ParseException
-     *
      * @return DocumentAST
      */
     public static function generate(string $schema): DocumentAST
@@ -178,8 +176,6 @@ class ASTBuilder
     /**
      * @param DocumentAST $document
      *
-     * @throws ParseException
-     *
      * @return DocumentAST
      */
     protected static function addPaginationInfoTypes(DocumentAST $document): DocumentAST
@@ -249,8 +245,6 @@ class ASTBuilder
      * Inject the node type and a node field into Query.
      *
      * @param DocumentAST $document
-     *
-     * @throws ParseException
      *
      * @return DocumentAST
      */

--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -5,7 +5,6 @@ namespace Nuwave\Lighthouse\Schema\AST;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NamedTypeNode;
 use GraphQL\Language\AST\FieldDefinitionNode;
-use Nuwave\Lighthouse\Exceptions\ParseException;
 use GraphQL\Language\AST\ObjectTypeExtensionNode;
 use GraphQL\Language\AST\InputValueDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;

--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -50,8 +50,6 @@ class ASTHelper
      * @param bool           $overwriteDuplicates By default this throws if a collision occurs. If
      *                                            this is set to true, the fields of the original list will be overwritten.
      *
-     * @throws DefinitionException
-     *
      * @return NodeList
      */
     public static function mergeUniqueNodeList($original, $addition, bool $overwriteDuplicates = false): NodeList
@@ -99,8 +97,6 @@ class ASTHelper
 
     /**
      * @param Node $definition
-     *
-     * @throws DefinitionException
      *
      * @return string
      */
@@ -285,8 +281,6 @@ class ASTHelper
      *
      * @param ObjectTypeDefinitionNode $objectType
      * @param DocumentAST              $documentAST
-     *
-     * @throws \Exception
      *
      * @return DocumentAST
      */

--- a/src/Schema/AST/PartialParser.php
+++ b/src/Schema/AST/PartialParser.php
@@ -39,8 +39,6 @@ class PartialParser
     /**
      * @param string $definition
      *
-     * @throws ParseException
-     *
      * @return ObjectTypeDefinitionNode
      */
     public static function objectTypeDefinition(string $definition): ObjectTypeDefinitionNode
@@ -53,8 +51,6 @@ class PartialParser
 
     /**
      * @param string $inputValueDefinition
-     *
-     * @throws ParseException
      *
      * @return InputValueDefinitionNode
      */
@@ -81,8 +77,6 @@ class PartialParser
     /**
      * @param string $argumentDefinition
      *
-     * @throws ParseException
-     *
      * @return ArgumentNode
      */
     public static function argument(string $argumentDefinition): ArgumentNode
@@ -108,8 +102,6 @@ class PartialParser
     /**
      * @param string $field
      *
-     * @throws ParseException
-     *
      * @return FieldNode
      */
     public static function field(string $field): FieldNode
@@ -122,8 +114,6 @@ class PartialParser
 
     /**
      * @param string $operation
-     *
-     * @throws ParseException
      *
      * @return OperationDefinitionNode
      */
@@ -138,8 +128,6 @@ class PartialParser
     /**
      * @param string $fieldDefinition
      *
-     * @throws ParseException
-     *
      * @return FieldDefinitionNode
      */
     public static function fieldDefinition(string $fieldDefinition): FieldDefinitionNode
@@ -152,8 +140,6 @@ class PartialParser
 
     /**
      * @param string $directive
-     *
-     * @throws ParseException
      *
      * @return DirectiveNode
      */
@@ -184,8 +170,6 @@ class PartialParser
     /**
      * @param string $directiveDefinition
      *
-     * @throws ParseException
-     *
      * @return DirectiveDefinitionNode
      */
     public static function directiveDefinition(string $directiveDefinition): DirectiveDefinitionNode
@@ -211,8 +195,6 @@ class PartialParser
     /**
      * @param string $interfaceDefinition
      *
-     * @throws ParseException
-     *
      * @return InterfaceTypeDefinitionNode
      */
     public static function interfaceTypeDefinition(string $interfaceDefinition): InterfaceTypeDefinitionNode
@@ -225,8 +207,6 @@ class PartialParser
 
     /**
      * @param string $unionDefinition
-     *
-     * @throws ParseException
      *
      * @return UnionTypeDefinitionNode
      */
@@ -241,8 +221,6 @@ class PartialParser
     /**
      * @param string $inputTypeDefinition
      *
-     * @throws ParseException
-     *
      * @return InputObjectTypeDefinitionNode
      */
     public static function inputObjectTypeDefinition(string $inputTypeDefinition): InputObjectTypeDefinitionNode
@@ -256,8 +234,6 @@ class PartialParser
     /**
      * @param string $scalarDefinition
      *
-     * @throws ParseException
-     *
      * @return ScalarTypeDefinitionNode
      */
     public static function scalarTypeDefinition(string $scalarDefinition): ScalarTypeDefinitionNode
@@ -270,8 +246,6 @@ class PartialParser
 
     /**
      * @param string $enumDefinition
-     *
-     * @throws ParseException
      *
      * @return EnumTypeDefinitionNode
      */

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -11,7 +11,6 @@ use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Language\AST\TypeSystemDefinitionNode;
 use Nuwave\Lighthouse\Support\Contracts\Directive;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
 
 abstract class BaseDirective implements Directive
 {

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -88,9 +88,6 @@ abstract class BaseDirective implements Directive
      *
      * @param string $argumentName
      *
-     * @throws DefinitionException
-     * @throws DirectiveException
-     *
      * @return \Closure
      */
     public function getResolverFromArgument(string $argumentName): \Closure
@@ -106,9 +103,6 @@ abstract class BaseDirective implements Directive
      * Get the model class from the `model` argument of the field.
      *
      * @param string $argumentName The default argument name "model" may be overwritten
-     *
-     * @throws DirectiveException
-     * @throws DefinitionException
      *
      * @return string
      */
@@ -210,8 +204,6 @@ abstract class BaseDirective implements Directive
      * Try adding the default model namespace and ensure the given class is a model.
      *
      * @param string $modelClassCandidate
-     *
-     * @throws DirectiveException
      *
      * @return string
      */

--- a/src/Schema/Directives/Fields/CacheDirective.php
+++ b/src/Schema/Directives/Fields/CacheDirective.php
@@ -29,8 +29,6 @@ class CacheDirective extends BaseDirective implements FieldMiddleware
      * @param FieldValue $value
      * @param \Closure   $next
      *
-     * @throws DirectiveException
-     *
      * @return FieldValue
      */
     public function handleField(FieldValue $value, \Closure $next)

--- a/src/Schema/Directives/Fields/CanDirective.php
+++ b/src/Schema/Directives/Fields/CanDirective.php
@@ -71,8 +71,6 @@ class CanDirective extends BaseDirective implements FieldMiddleware
     /**
      * Get additional arguments that are passed to `Gate::check`.
      *
-     * @throws \Exception
-     *
      * @return array
      */
     protected function getGateArguments(): array

--- a/src/Schema/Directives/Fields/ComplexityDirective.php
+++ b/src/Schema/Directives/Fields/ComplexityDirective.php
@@ -4,8 +4,6 @@ namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
 use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
 

--- a/src/Schema/Directives/Fields/ComplexityDirective.php
+++ b/src/Schema/Directives/Fields/ComplexityDirective.php
@@ -27,9 +27,6 @@ class ComplexityDirective extends BaseDirective implements FieldMiddleware
      * @param FieldValue $fieldValue
      * @param \Closure   $next
      *
-     * @throws DirectiveException
-     * @throws DefinitionException
-     *
      * @return FieldValue
      */
     public function handleField(FieldValue $fieldValue, \Closure $next): FieldValue

--- a/src/Schema/Directives/Fields/EventDirective.php
+++ b/src/Schema/Directives/Fields/EventDirective.php
@@ -24,8 +24,6 @@ class EventDirective extends BaseDirective implements FieldMiddleware
      * @param FieldValue $value
      * @param \Closure    $next
      *
-     * @throws \Nuwave\Lighthouse\Exceptions\DirectiveException
-     *
      * @return FieldValue
      */
     public function handleField(FieldValue $value, \Closure $next)

--- a/src/Schema/Directives/Fields/FieldDirective.php
+++ b/src/Schema/Directives/Fields/FieldDirective.php
@@ -25,9 +25,6 @@ class FieldDirective extends BaseDirective implements FieldResolver
      *
      * @param FieldValue $fieldValue
      *
-     * @throws DirectiveException
-     * @throws DefinitionException
-     *
      * @return FieldValue
      */
     public function resolveField(FieldValue $fieldValue): FieldValue

--- a/src/Schema/Directives/Fields/FieldDirective.php
+++ b/src/Schema/Directives/Fields/FieldDirective.php
@@ -3,8 +3,6 @@
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 

--- a/src/Schema/Directives/Fields/FindDirective.php
+++ b/src/Schema/Directives/Fields/FindDirective.php
@@ -29,9 +29,6 @@ class FindDirective extends BaseDirective implements FieldResolver
      *
      * @param FieldValue $fieldValue
      *
-     * @throws DirectiveException
-     * @throws DefinitionException
-     *
      * @return FieldValue
      */
     public function resolveField(FieldValue $fieldValue): FieldValue

--- a/src/Schema/Directives/Fields/FindDirective.php
+++ b/src/Schema/Directives/Fields/FindDirective.php
@@ -7,8 +7,6 @@ use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Database\Eloquent\Builder;
 use Nuwave\Lighthouse\Execution\QueryFilter;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 

--- a/src/Schema/Directives/Fields/FirstDirective.php
+++ b/src/Schema/Directives/Fields/FirstDirective.php
@@ -27,9 +27,6 @@ class FirstDirective extends BaseDirective implements FieldResolver
      *
      * @param FieldValue $fieldValue
      *
-     * @throws DirectiveException
-     * @throws DefinitionException
-     *
      * @return FieldValue
      */
     public function resolveField(FieldValue $fieldValue): FieldValue

--- a/src/Schema/Directives/Fields/FirstDirective.php
+++ b/src/Schema/Directives/Fields/FirstDirective.php
@@ -5,8 +5,6 @@ namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 use GraphQL\Type\Definition\ResolveInfo;
 use Nuwave\Lighthouse\Execution\QueryFilter;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 

--- a/src/Schema/Directives/Fields/MiddlewareDirective.php
+++ b/src/Schema/Directives/Fields/MiddlewareDirective.php
@@ -15,7 +15,6 @@ use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Illuminate\Routing\MiddlewareNameResolver;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Exceptions\ParseException;
 use GraphQL\Language\AST\ObjectTypeExtensionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;

--- a/src/Schema/Directives/Fields/MiddlewareDirective.php
+++ b/src/Schema/Directives/Fields/MiddlewareDirective.php
@@ -93,8 +93,6 @@ class MiddlewareDirective extends BaseDirective implements FieldMiddleware, Node
      * @param Node $node
      * @param DocumentAST $documentAST
      *
-     * @throws ParseException
-     * @throws DirectiveException
      *
      * @return DocumentAST
      */
@@ -112,7 +110,6 @@ class MiddlewareDirective extends BaseDirective implements FieldMiddleware, Node
      * @param ObjectTypeDefinitionNode|ObjectTypeExtensionNode $objectType
      * @param array $middlewareArgValue
      *
-     * @throws ParseException
      * @throws DirectiveException
      *
      * @return ObjectTypeDefinitionNode|ObjectTypeExtensionNode

--- a/src/Schema/Directives/Fields/PaginateDirective.php
+++ b/src/Schema/Directives/Fields/PaginateDirective.php
@@ -36,8 +36,6 @@ class PaginateDirective extends BaseDirective implements FieldResolver, FieldMan
      * @param ObjectTypeDefinitionNode $parentType
      * @param DocumentAST              $current
      *
-     * @throws \Exception
-     *
      * @return DocumentAST
      */
     public function manipulateSchema(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current): DocumentAST
@@ -56,8 +54,6 @@ class PaginateDirective extends BaseDirective implements FieldResolver, FieldMan
      *
      * @param FieldValue $fieldValue
      *
-     * @throws \Exception
-     *
      * @return FieldValue
      */
     public function resolveField(FieldValue $fieldValue): FieldValue
@@ -72,8 +68,6 @@ class PaginateDirective extends BaseDirective implements FieldResolver, FieldMan
     }
 
     /**
-     * @throws DirectiveException
-     *
      * @return string
      */
     protected function getPaginationType(): string
@@ -87,8 +81,6 @@ class PaginateDirective extends BaseDirective implements FieldResolver, FieldMan
      * Create a paginator resolver.
      *
      * @param FieldValue $value
-     *
-     * @throws \Exception
      *
      * @return FieldValue
      */
@@ -108,8 +100,6 @@ class PaginateDirective extends BaseDirective implements FieldResolver, FieldMan
      * Create a connection resolver.
      *
      * @param FieldValue $value
-     *
-     * @throws \Exception
      *
      * @return FieldValue
      */
@@ -132,9 +122,6 @@ class PaginateDirective extends BaseDirective implements FieldResolver, FieldMan
      * @param array $resolveArgs
      * @param int   $page
      * @param int   $first
-     *
-     * @throws DirectiveException
-     * @throws DefinitionException
      *
      * @return LengthAwarePaginator
      */
@@ -167,7 +154,6 @@ class PaginateDirective extends BaseDirective implements FieldResolver, FieldMan
      * This works differently as in other directives, so we define a seperate function for it.
      *
      * @throws DirectiveException
-     * @throws DefinitionException
      *
      * @return string
      */

--- a/src/Schema/Directives/Fields/PaginateDirective.php
+++ b/src/Schema/Directives/Fields/PaginateDirective.php
@@ -13,7 +13,6 @@ use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Execution\Utils\Pagination;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;

--- a/src/Schema/Directives/Fields/PaginationManipulator.php
+++ b/src/Schema/Directives/Fields/PaginationManipulator.php
@@ -64,10 +64,6 @@ class PaginationManipulator
      * @param DocumentAST              $current
      * @param int|null                 $defaultCount
      *
-     * @throws DefinitionException
-     * @throws DirectiveException
-     * @throws ParseException
-     *
      * @return DocumentAST
      */
     public static function transformToPaginatedField(string $paginationType, FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current, int $defaultCount = null): DocumentAST
@@ -88,9 +84,6 @@ class PaginationManipulator
      * @param ObjectTypeDefinitionNode $parentType
      * @param DocumentAST              $documentAST
      * @param int|null                 $defaultCount
-     *
-     * @throws DefinitionException
-     * @throws ParseException
      *
      * @return DocumentAST
      */
@@ -144,9 +137,6 @@ class PaginationManipulator
      * @param ObjectTypeDefinitionNode $parentType
      * @param DocumentAST              $documentAST
      * @param int|null                 $defaultCount
-     *
-     * @throws DefinitionException
-     * @throws ParseException
      *
      * @return DocumentAST
      */

--- a/src/Schema/Directives/Fields/PaginationManipulator.php
+++ b/src/Schema/Directives/Fields/PaginationManipulator.php
@@ -6,12 +6,10 @@ use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use GraphQL\Language\AST\FieldDefinitionNode;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
-use Nuwave\Lighthouse\Exceptions\ParseException;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Nuwave\Lighthouse\Schema\Types\PaginatorField;
 use Nuwave\Lighthouse\Schema\Types\ConnectionField;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
 
 class PaginationManipulator
 {

--- a/src/Schema/Directives/Fields/RelationDirective.php
+++ b/src/Schema/Directives/Fields/RelationDirective.php
@@ -19,8 +19,6 @@ abstract class RelationDirective extends BaseDirective
      *
      * @param FieldValue $value
      *
-     * @throws \Exception
-     *
      * @return FieldValue
      */
     public function resolveField(FieldValue $value): FieldValue
@@ -44,8 +42,6 @@ abstract class RelationDirective extends BaseDirective
      * @param ObjectTypeDefinitionNode $parentType
      * @param DocumentAST              $current
      *
-     * @throws \Exception
-     *
      * @return DocumentAST
      */
     public function manipulateSchema(FieldDefinitionNode $fieldDefinition, ObjectTypeDefinitionNode $parentType, DocumentAST $current): DocumentAST
@@ -68,8 +64,6 @@ abstract class RelationDirective extends BaseDirective
      * @param array       $args
      * @param null        $context
      * @param ResolveInfo $resolveInfo
-     *
-     * @throws \Exception
      *
      * @return array
      */

--- a/src/Schema/Directives/Nodes/GroupDirective.php
+++ b/src/Schema/Directives/Nodes/GroupDirective.php
@@ -41,8 +41,6 @@ class GroupDirective extends BaseDirective implements NodeManipulator
      * @param Node $node
      * @param DocumentAST $documentAST
      *
-     * @throws \Exception
-     *
      * @return DocumentAST
      */
     public function manipulateSchema(Node $node, DocumentAST $documentAST): DocumentAST
@@ -61,7 +59,7 @@ class GroupDirective extends BaseDirective implements NodeManipulator
     /**
      * @param ObjectTypeDefinitionNode|ObjectTypeExtensionNode $objectType
      *
-     * @throws \Exception
+     * @throws \Nuwave\Lighthouse\Exceptions\DirectiveException
      *
      * @return ObjectTypeDefinitionNode|ObjectTypeExtensionNode
      */

--- a/src/Schema/Directives/Nodes/ModelDirective.php
+++ b/src/Schema/Directives/Nodes/ModelDirective.php
@@ -41,8 +41,6 @@ class ModelDirective extends BaseDirective implements NodeMiddleware, NodeManipu
      * @param NodeValue $value
      * @param \Closure $next
      *
-     * @throws DirectiveException
-     *
      * @return NodeValue
      */
     public function handleNode(NodeValue $value, \Closure $next)
@@ -57,8 +55,6 @@ class ModelDirective extends BaseDirective implements NodeMiddleware, NodeManipu
     /**
      * @param Node $node
      * @param DocumentAST $documentAST
-     *
-     * @throws \Exception
      *
      * @return DocumentAST
      */

--- a/src/Schema/Directives/Nodes/ModelDirective.php
+++ b/src/Schema/Directives/Nodes/ModelDirective.php
@@ -7,7 +7,6 @@ use Nuwave\Lighthouse\Schema\NodeRegistry;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\NodeMiddleware;
 use Nuwave\Lighthouse\Support\Contracts\NodeManipulator;

--- a/src/Schema/Directives/Nodes/NodeDirective.php
+++ b/src/Schema/Directives/Nodes/NodeDirective.php
@@ -42,9 +42,6 @@ class NodeDirective extends BaseDirective implements NodeMiddleware, NodeManipul
      * @param NodeValue $value
      * @param \Closure $next
      *
-     * @throws DirectiveException
-     * @throws DefinitionException
-     *
      * @return NodeValue
      */
     public function handleNode(NodeValue $value, \Closure $next): NodeValue
@@ -62,8 +59,6 @@ class NodeDirective extends BaseDirective implements NodeMiddleware, NodeManipul
     /**
      * @param Node $node
      * @param DocumentAST $documentAST
-     *
-     * @throws \Exception
      *
      * @return DocumentAST
      */

--- a/src/Schema/Directives/Nodes/NodeDirective.php
+++ b/src/Schema/Directives/Nodes/NodeDirective.php
@@ -7,8 +7,6 @@ use Nuwave\Lighthouse\Schema\NodeRegistry;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\NodeMiddleware;
 use Nuwave\Lighthouse\Support\Contracts\NodeManipulator;

--- a/src/Schema/Extensions/DeferExtension.php
+++ b/src/Schema/Extensions/DeferExtension.php
@@ -72,8 +72,6 @@ class DeferExtension extends GraphQLExtension
      *
      * @param DocumentAST $documentAST
      *
-     * @throws \Nuwave\Lighthouse\Exceptions\ParseException
-     *
      * @return DocumentAST
      */
     public function manipulateSchema(DocumentAST $documentAST): DocumentAST

--- a/src/Schema/Extensions/TracingExtension.php
+++ b/src/Schema/Extensions/TracingExtension.php
@@ -45,8 +45,6 @@ class TracingExtension extends GraphQLExtension
      *
      * @param DocumentAST $documentAST
      *
-     * @throws \Nuwave\Lighthouse\Exceptions\ParseException
-     *
      * @return DocumentAST
      */
     public function manipulateSchema(DocumentAST $documentAST): DocumentAST

--- a/src/Schema/Factories/ArgumentFactory.php
+++ b/src/Schema/Factories/ArgumentFactory.php
@@ -12,8 +12,6 @@ class ArgumentFactory
      *
      * @param ArgumentValue $argumentValue
      *
-     * @throws \Exception
-     *
      * @return array
      */
     public function handle(ArgumentValue $argumentValue): array

--- a/src/Schema/Factories/DirectiveFactory.php
+++ b/src/Schema/Factories/DirectiveFactory.php
@@ -78,8 +78,6 @@ class DirectiveFactory
      * @param string                        $directiveName
      * @param TypeSystemDefinitionNode|null $definitionNode
      *
-     * @throws DirectiveException
-     *
      * @return Directive
      */
     public function create(string $directiveName, $definitionNode = null): Directive
@@ -273,8 +271,6 @@ class DirectiveFactory
      *
      * @param TypeDefinitionNode $node
      *
-     * @throws DirectiveException
-     *
      * @return NodeResolver|null
      */
     public function createNodeResolver(TypeDefinitionNode $node): ?NodeResolver
@@ -288,8 +284,6 @@ class DirectiveFactory
      *
      * @param TypeDefinitionNode $typeDefinition
      *
-     * @throws DirectiveException
-     *
      * @return bool
      */
     public function hasNodeResolver(TypeDefinitionNode $typeDefinition): bool
@@ -301,8 +295,6 @@ class DirectiveFactory
      * Check if the given field has a field resolver directive handler assigned to it.
      *
      * @param FieldDefinitionNode $fieldDefinition
-     *
-     * @throws DirectiveException
      *
      * @return bool
      */
@@ -327,8 +319,6 @@ class DirectiveFactory
      * Get handler for field.
      *
      * @param FieldDefinitionNode $field
-     *
-     * @throws DirectiveException
      *
      * @return FieldResolver|null
      */

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -18,7 +18,6 @@ use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use GraphQL\Language\AST\InputValueDefinitionNode;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
 use Nuwave\Lighthouse\Support\Contracts\Directive;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Support\Contracts\ArgDirective;
 use Nuwave\Lighthouse\Support\Contracts\HasErrorBuffer;
 use Nuwave\Lighthouse\Support\Contracts\HasArgumentPath;

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -99,8 +99,6 @@ class FieldFactory
      *
      * @param FieldValue $fieldValue
      *
-     * @throws DirectiveException
-     *
      * @return array Configuration array for a FieldDefinition
      */
     public function handle(FieldValue $fieldValue): array
@@ -469,8 +467,6 @@ class FieldFactory
      * @param array       $args
      * @param mixed       $context
      * @param ResolveInfo $resolveInfo
-     *
-     * @throws \Exception
      */
     protected function validateArgumentsBeforeValidationDirectives($root, array $args, $context, ResolveInfo $resolveInfo)
     {
@@ -507,7 +503,7 @@ class FieldFactory
     }
 
     /**
-     * @throws \Exception
+     * @return void
      */
     protected function flushErrorBufferIfHasErrors()
     {
@@ -523,8 +519,6 @@ class FieldFactory
      * @param array       $args
      * @param mixed       $context
      * @param ResolveInfo $resolveInfo
-     *
-     * @throws \Exception
      */
     protected function handleArgDirectivesAfterValidationDirectives($root, array &$args, $context, ResolveInfo $resolveInfo)
     {

--- a/src/Schema/Factories/NodeFactory.php
+++ b/src/Schema/Factories/NodeFactory.php
@@ -26,7 +26,6 @@ use GraphQL\Language\AST\InputValueDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Language\AST\ScalarTypeDefinitionNode;
 use Nuwave\Lighthouse\Schema\Values\ArgumentValue;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use GraphQL\Language\AST\InputObjectTypeDefinitionNode;

--- a/src/Schema/Factories/NodeFactory.php
+++ b/src/Schema/Factories/NodeFactory.php
@@ -67,9 +67,6 @@ class NodeFactory
      *
      * @param TypeDefinitionNode $definition
      *
-     * @throws DirectiveException
-     * @throws DefinitionException
-     *
      * @return Type
      */
     public function handle(TypeDefinitionNode $definition): Type
@@ -98,8 +95,6 @@ class NodeFactory
      *
      * @param TypeDefinitionNode $definition
      *
-     * @throws DirectiveException
-     *
      * @return bool
      */
     protected function hasTypeResolver(TypeDefinitionNode $definition): bool
@@ -111,8 +106,6 @@ class NodeFactory
      * Use directive resolver to transform type.
      *
      * @param TypeDefinitionNode $definition
-     *
-     * @throws DirectiveException
      *
      * @return Type
      */
@@ -129,9 +122,6 @@ class NodeFactory
      * Transform value to type.
      *
      * @param TypeDefinitionNode $typeDefinition
-     *
-     * @throws DirectiveException
-     * @throws DefinitionException
      *
      * @return Type
      */
@@ -309,9 +299,6 @@ class NodeFactory
     /**
      * @param InterfaceTypeDefinitionNode $interfaceDefinition
      *
-     * @throws DirectiveException
-     * @throws DefinitionException
-     *
      * @return InterfaceType
      */
     protected function resolveInterfaceType(InterfaceTypeDefinitionNode $interfaceDefinition): InterfaceType
@@ -364,9 +351,6 @@ class NodeFactory
 
     /**
      * @param UnionTypeDefinitionNode $unionDefinition
-     *
-     * @throws DirectiveException
-     * @throws DefinitionException
      *
      * @return UnionType
      */

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -14,8 +14,6 @@ use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use GraphQL\Language\AST\DirectiveDefinitionNode;
 use GraphQL\Language\AST\InputValueDefinitionNode;
 use Nuwave\Lighthouse\Schema\Factories\NodeFactory;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\Conversion\DefinitionNodeConverter;
 
 class SchemaBuilder

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -47,9 +47,6 @@ class SchemaBuilder
      *
      * @param DocumentAST $documentAST
      *
-     * @throws DirectiveException
-     * @throws DefinitionException
-     *
      * @return Schema
      */
     public function build($documentAST)

--- a/src/Schema/Source/SchemaStitcher.php
+++ b/src/Schema/Source/SchemaStitcher.php
@@ -39,8 +39,6 @@ class SchemaStitcher implements SchemaSourceProvider
     /**
      * Stitch together schema documents and return the result as a string.
      *
-     * @throws FileNotFoundException
-     *
      * @return string
      */
     public function getSchemaString(): string
@@ -52,8 +50,6 @@ class SchemaStitcher implements SchemaSourceProvider
      * Get the schema, starting from a root schema, following the imports recursively.
      *
      * @param string $path
-     *
-     * @throws FileNotFoundException
      *
      * @return string
      */

--- a/src/Schema/Types/Scalars/Date.php
+++ b/src/Schema/Types/Scalars/Date.php
@@ -36,8 +36,6 @@ class Date extends ScalarType
      *
      * @param mixed $value
      *
-     * @throws Error
-     *
      * @return Carbon
      */
     public function parseValue($value): Carbon

--- a/src/Schema/Types/Scalars/DateTime.php
+++ b/src/Schema/Types/Scalars/DateTime.php
@@ -17,8 +17,6 @@ class DateTime extends ScalarType
      *
      * @param Carbon|string $value
      *
-     * @throws InvariantViolation
-     *
      * @return string
      */
     public function serialize($value): string
@@ -35,8 +33,6 @@ class DateTime extends ScalarType
      * Parse a externally provided variable value into a Carbon instance.
      *
      * @param mixed $value
-     *
-     * @throws Error
      *
      * @return Carbon
      */

--- a/src/Support/Http/Controllers/GraphQLController.php
+++ b/src/Support/Http/Controllers/GraphQLController.php
@@ -54,8 +54,6 @@ class GraphQLController extends Controller
      *
      * @param Request $request
      *
-     * @throws DirectiveException
-     * @throws ParseException
      *
      * @return Response
      */
@@ -81,9 +79,6 @@ class GraphQLController extends Controller
     /**
      * @param Request        $request
      * @param GraphQLContext $context
-     *
-     * @throws DirectiveException
-     * @throws ParseException
      *
      * @return array
      */

--- a/src/Support/Http/Controllers/GraphQLController.php
+++ b/src/Support/Http/Controllers/GraphQLController.php
@@ -7,8 +7,6 @@ use Illuminate\Http\Response;
 use Nuwave\Lighthouse\GraphQL;
 use Illuminate\Routing\Controller;
 use GraphQL\Executor\ExecutionResult;
-use Nuwave\Lighthouse\Exceptions\ParseException;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Support\Contracts\CreatesContext;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLResponse;

--- a/tests/Integration/Support/DataLoader/ModelRelationLoaderPolymorphicTest.php
+++ b/tests/Integration/Support/DataLoader/ModelRelationLoaderPolymorphicTest.php
@@ -28,7 +28,6 @@ class ModelRelationLoaderPolymorphicTest extends DBTestCase
 
     /**
      * @test
-     * @throws \Exception
      */
     public function itGetsPolymorphicRelationship()
     {

--- a/tests/Integration/Support/DataLoader/ModelRelationLoaderTest.php
+++ b/tests/Integration/Support/DataLoader/ModelRelationLoaderTest.php
@@ -26,7 +26,6 @@ class ModelRelationLoaderTest extends DBTestCase
 
     /**
      * @test
-     * @throws \Exception
      */
     public function itCanLoadRelationshipsWithLimitsOnCollection()
     {
@@ -60,7 +59,6 @@ class ModelRelationLoaderTest extends DBTestCase
 
     /**
      * @test
-     * @throws \Exception
      */
     public function itCanPaginateRelationshipOnCollection()
     {
@@ -81,7 +79,6 @@ class ModelRelationLoaderTest extends DBTestCase
 
     /**
      * @test
-     * @throws \Exception
      */
     public function itCanHandleSoftDeletes()
     {


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Added Docs for all relevant versions

**Related Issue/Intent**

None

**Changes**

Stop bubbling up exceptions docblocks
To make it short, a method/function should have a `@throws` docblock **ONLY** if it contains a `throw...` statement.


**Breaking changes**

None