### PR TITLE
Treat subscriptions just like other fields

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,4 @@ services:
   php:
     image: spawnia/php7.1-fpm:dev-1.3.1
     volumes:
-      - ./:/var/www
-    environment:
-      - APP_ENV=local
-      - APP_DEBUG=true
-      - APP_KEY=base64:w+nUc1ZQlOX4JI4PfIp1TZORaju1JfAxnsJ0SLT1A+4=
+    - ./:/var/www

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -959,13 +959,16 @@ type Query {
 
 ## @subscription
 
-Declare a [class](../extensions/subscriptions.md#the-subscription-class) to handle the broadcasting of a subscription to clients.
+Declare a class to handle the broadcasting of a subscription to clients.
+
+If you follow the default naming conventions for [defining subscription fields]([class](../extensions/subscriptions.md#defining-fields) )
+you do not need this directive. It is only useful if you need to override the default namespace.
 
 ```graphql
 type Subscription {
     postUpdated(author: ID!): Post
         @subscription(
-            class: "App\\GraphQL\\Subscriptions\\PostUpdatedSubscription"
+            class: "App\\GraphQL\\Blog\\PostUpdatedSubscription"
         )
 }
 ```

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -121,18 +121,23 @@ type Mutation {
 
 ## @broadcast
 
-Broadcast mutation results to subscribed clients.
-[Read More](../extensions/subscriptions.md#requirements)
+Broadcast the results of a mutation to subscribed clients.
+[Read more about subscriptions](../extensions/subscriptions.md)
 
-_Note: There should be a subscription with a field with the same name as the `subscription` argument._
+The `subscription` argument must reference the name of a subscription field. 
 
 ```graphql
 type Mutation {
     createPost(input: CreatePostInput!): Post
         @broadcast(subscription: "postCreated")
+}
+```
 
-    # The `@broadcast` directive also takes an optional `queue` argument
-    # to determine if this broadcast should go through Laravel's queue.
+You may override the default queueing behaviour from the configuration by
+passing the `queue` argument. 
+
+```graphql
+type Mutation {
     updatePost(input: UpdatePostInput!): Post
         @broadcast(subscription: "postUpdated", queue: false)
 }

--- a/docs/master/extensions/subscriptions.md
+++ b/docs/master/extensions/subscriptions.md
@@ -8,9 +8,7 @@ Much of the credit should be given to the [Ruby implementation](https://github.c
 
 Install the [Pusher PHP Library](https://github.com/pusher/pusher-http-php) for interacting with the Pusher HTTP API.
 
-```bash
-composer require pusher/pusher-php-server
-```
+    composer require pusher/pusher-php-server
 
 Enable the extension in the `lighthouse.php` config file
 
@@ -43,7 +41,6 @@ For example, the field `postUpdated` should have a corresponding class at
 All subscription field classes **must** implement the abstract class
 `Nuwave\Lighthouse\Schema\Types\GraphQLSubscription` and implement two methods:
 `authorize` and `filter`.
-
 
 ```php
 <?php

--- a/docs/master/extensions/subscriptions.md
+++ b/docs/master/extensions/subscriptions.md
@@ -12,7 +12,7 @@ Install the [Pusher PHP Library](https://github.com/pusher/pusher-http-php) for 
 composer require pusher/pusher-php-server
 ```
 
-Enable the extension in the lighthouse.php config file
+Enable the extension in the `lighthouse.php` config file
 
 ```php
 'extensions' => [
@@ -58,7 +58,7 @@ use Nuwave\Lighthouse\Subscriptions\Subscriber;
 use Nuwave\Lighthouse\Schema\Types\GraphQLSubscription;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
-class PostUpdatedSubscription extends GraphQLSubscription
+class PostUpdated extends GraphQLSubscription
 {
     /**
      * Check if subscriber is allowed to listen to the subscription.
@@ -98,7 +98,7 @@ class PostUpdatedSubscription extends GraphQLSubscription
      * @param  string  $fieldName
      * @return string
      */
-    public function encodeTopic(Subscriber $subscriber, $fieldName)
+    public function encodeTopic(Subscriber $subscriber, string $fieldName)
     {
         // Optionally create a unique topic name based on the
         // `author` argument.
@@ -126,7 +126,7 @@ class PostUpdatedSubscription extends GraphQLSubscription
      * Resolve the subscription.
      *
      * @param  \App\Post  $root
-     * @param  array  $args
+     * @param  mixed[]  $args
      * @param  \Nuwave\Lighthouse\Support\Contracts\GraphQLContext  $context
      * @param  \GraphQL\Type\Definition\ResolveInfo $info
      *
@@ -176,7 +176,7 @@ It accepts three parameters:
 
 - `string $subscriptionField` The name of the subscription field you want to trigger
 - `mixed $root` The result object you want to pass through
-- `bool $shouldQuere = null` Optional, overrides the default configuration `lighthouse.subscriptions.queue_broadcasts`
+- `bool $queue = null` Optional, overrides the default configuration `lighthouse.subscriptions.queue_broadcasts`
 
 The following example shows how to trigger a subscription after an update
 to the `Post` model.

--- a/docs/master/extensions/subscriptions.md
+++ b/docs/master/extensions/subscriptions.md
@@ -41,7 +41,7 @@ For example, the field `postUpdated` should have a corresponding class at
 `App\GraphQL\Subscriptions\PostUpdated`.
 
 All subscription field classes **must** implement the abstract class
-`Nuwave\Lighthouse\Schema\Fields\SubscriptionField` and implement two methods:
+`Nuwave\Lighthouse\Schema\Types\GraphQLSubscription` and implement two methods:
 `authorize` and `filter`.
 
 
@@ -98,7 +98,7 @@ class PostUpdated extends GraphQLSubscription
      * @param  string  $fieldName
      * @return string
      */
-    public function encodeTopic(Subscriber $subscriber, string $fieldName)
+    public function encodeTopic(Subscriber $subscriber, string $fieldName): string
     {
         // Optionally create a unique topic name based on the
         // `author` argument.

--- a/docs/master/the-basics/fields.md
+++ b/docs/master/the-basics/fields.md
@@ -256,6 +256,13 @@ This mutation will return the deleted object, so you will have a last chance to 
 }
 ``` 
 
+## Subscribe to data
+ 
+Lighthouse allows you to serve GraphQL subscriptions. Compared to queries and
+mutations, a more elaborate setup is required.
+ 
+[Read more about how to set up subscriptions](../extensions/subscriptions.md)
+
 ## Custom resolvers
 
 Sometimes, the built-in directives just don't cut it - you need more control!

--- a/docs/master/the-basics/schema.md
+++ b/docs/master/the-basics/schema.md
@@ -18,7 +18,13 @@ type User {
 }
 ```
 
-## Queries
+## The Root Types
+
+There can be up to 3 special *root types* in a GraphQL schema.
+They define the root fields that a query may have. While they are
+all [Object Types](types.md#object-type), they differ in functionality.
+
+### Query
 
 Every GraphQL schema must have a `Query` type which contains the queries your API offers.
 Think of queries as REST resources which can take arguments and return a fixed result.
@@ -31,10 +37,9 @@ type Query {
 }
 ```
 
-## Mutations
+### Mutation
 
-There is another special type called `Mutation`.
-It works similar to the `Query` type, but it exposes operations that are
+In contrast to the `Query` type, the fields of the `Mutation` type are
 allowed to change data on the server.
 
 ```graphql
@@ -42,5 +47,16 @@ type Mutation {
   createUser(name: String!, email: String!, password: String!): User
   updateUser(id: ID, email: String, password: String): User
   deleteUser(id: ID): User
+}
+```
+
+### Subscription
+
+Rather than providing a single response, the fields of the `Subscription` type
+return a stream of responses, with real-time updates.
+
+```graphql
+type Subscription {
+  newUser: User
 }
 ```

--- a/src/Console/SubscriptionCommand.php
+++ b/src/Console/SubscriptionCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Nuwave\Lighthouse\Console;
+
+class SubscriptionCommand extends LighthouseGeneratorCommand
+{
+    /**
+     * The name of the console command.
+     *
+     * @var string
+     */
+    protected $name = 'lighthouse:subscription';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a class for a single field on the root Subscription type.';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Subscription';
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace): string
+    {
+        return config('lighthouse.namespaces.subscriptions');
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub(): string
+    {
+        return __DIR__.'/stubs/subscription.stub';
+    }
+}

--- a/src/Console/stubs/subscription.stub
+++ b/src/Console/stubs/subscription.stub
@@ -1,0 +1,34 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Http\Request;
+use Nuwave\Lighthouse\Subscriptions\Subscriber;
+use Nuwave\Lighthouse\Schema\Types\GraphQLSubscription;
+
+class DummyClass extends GraphQLSubscription
+{
+    /**
+     * Check if subscriber is allowed to listen to the subscription.
+     *
+     * @param  \Nuwave\Lighthouse\Subscriptions\Subscriber  $subscriber
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public function authorize(Subscriber $subscriber, Request $request)
+    {
+        // TODO implement authorize
+    }
+
+    /**
+     * Filter subscribers who should receive subscription.
+     *
+     * @param  \Nuwave\Lighthouse\Subscriptions\Subscriber  $subscriber
+     * @param  mixed  $root
+     * @return bool
+     */
+    public function filter(Subscriber $subscriber, $root)
+    {
+        // TODO implement filter
+    }
+}

--- a/src/Providers/LighthouseServiceProvider.php
+++ b/src/Providers/LighthouseServiceProvider.php
@@ -20,6 +20,7 @@ use Nuwave\Lighthouse\Execution\ContextFactory;
 use Nuwave\Lighthouse\Console\ClearCacheCommand;
 use Nuwave\Lighthouse\Console\PrintSchemaCommand;
 use Nuwave\Lighthouse\Execution\GraphQLValidator;
+use Nuwave\Lighthouse\Console\SubscriptionCommand;
 use Nuwave\Lighthouse\Schema\Source\SchemaStitcher;
 use Nuwave\Lighthouse\Console\ValidateSchemaCommand;
 use Nuwave\Lighthouse\Support\Http\Responses\Response;
@@ -105,6 +106,7 @@ class LighthouseServiceProvider extends ServiceProvider
                 PrintSchemaCommand::class,
                 QueryCommand::class,
                 ScalarCommand::class,
+                SubscriptionCommand::class,
                 UnionCommand::class,
                 ValidateSchemaCommand::class,
             ]);

--- a/src/Schema/Directives/Fields/SubscriptionDirective.php
+++ b/src/Schema/Directives/Fields/SubscriptionDirective.php
@@ -2,96 +2,21 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
-use GraphQL\Type\Definition\ResolveInfo;
-use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Subscriptions\Subscriber;
 use Nuwave\Lighthouse\Support\Contracts\Directive;
-use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
-use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
-use Nuwave\Lighthouse\Schema\Types\GraphQLSubscription;
-use Nuwave\Lighthouse\Subscriptions\SubscriptionRegistry;
-use Nuwave\Lighthouse\Schema\Extensions\ExtensionRegistry;
-use Nuwave\Lighthouse\Schema\Extensions\SubscriptionExtension;
-use Nuwave\Lighthouse\Subscriptions\Exceptions\UnauthorizedSubscriber;
 
-class SubscriptionDirective extends BaseDirective implements FieldResolver
+/**
+ * This directive exists as a placeholder and can be used
+ * to point to a custom SubscriptionField class.
+ */
+class SubscriptionDirective implements Directive
 {
-    /** @var SubscriptionRegistry */
-    protected $registry;
-
-    /** @var SubscriptionExtension */
-    protected $extension;
-
-    /**
-     * @param SubscriptionRegistry $registry
-     * @param Extension            $extension
-     */
-    public function __construct(SubscriptionRegistry $registry, ExtensionRegistry $extensions)
-    {
-        $this->registry = $registry;
-        $this->extension = $extensions->get(SubscriptionExtension::name());
-    }
-
     /**
      * Name of the directive.
      *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return 'subscription';
-    }
-
-    /**
-     * Resolve the field directive.
-     *
-     * @param FieldValue $value
-     *
-     * @return FieldValue
-     */
-    public function resolveField(FieldValue $value)
-    {
-        $subscription = $this->getSubscription($value);
-        $fieldName = $value->getFieldName();
-
-        $this->registry->register(
-            $subscription,
-            $value->getFieldName()
-        );
-
-        return $value->setResolver(function ($root, $args, $context, ResolveInfo $info) use ($subscription, $fieldName) {
-            if ($root instanceof Subscriber) {
-                return $subscription->resolve($root->root, $args, $context, $info);
-            }
-
-            $subscriber = Subscriber::initialize(
-                $args,
-                $context,
-                $info,
-                $this->extension->currentQuery()
-            );
-
-            if (! $subscription->can($subscriber)) {
-                throw new UnauthorizedSubscriber('Unauthorized subscription request');
-            }
-
-            $this->registry->subscriber(
-                $subscriber,
-                $subscription->encodeTopic($subscriber, $fieldName)
-            );
-        });
-    }
-
-    /**
-     * @param FieldValue $value
-     *
-     * @return GraphQLSubscription
-     */
-    protected function getSubscription(FieldValue $value): GraphQLSubscription
-    {
-        $className = $this->directiveArgValue('class');
-        $parentNamespaces = $value->defaultNamespacesForParent();
-
-        return app($this->namespaceClassName($className, $parentNamespaces));
     }
 }

--- a/src/Schema/Types/GraphQLSubscription.php
+++ b/src/Schema/Types/GraphQLSubscription.php
@@ -3,15 +3,16 @@
 namespace Nuwave\Lighthouse\Schema\Types;
 
 use Illuminate\Http\Request;
-use Nuwave\Lighthouse\Schema\Context;
 use GraphQL\Type\Definition\ResolveInfo;
 use Nuwave\Lighthouse\Subscriptions\Subscriber;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
 abstract class GraphQLSubscription
 {
     /**
      * Check if subscriber can listen to this subscription.
      *
+     * @param  \Nuwave\Lighthouse\Subscriptions\Subscriber  $subscriber
      * @return bool
      */
     public function can(Subscriber $subscriber)
@@ -22,11 +23,11 @@ abstract class GraphQLSubscription
     /**
      * Encode topic name.
      *
-     * @param Subscriber $subscriber
-     *
+     * @param  \Nuwave\Lighthouse\Subscriptions\Subscriber  $subscriber
+     * @param  string  $fieldName
      * @return string
      */
-    public function encodeTopic(Subscriber $subscriber, $fieldName)
+    public function encodeTopic(Subscriber $subscriber, string $fieldName)
     {
         return strtoupper(snake_case($fieldName));
     }
@@ -34,10 +35,8 @@ abstract class GraphQLSubscription
     /**
      * Decode topic name.
      *
-     * @param string $operationName
-     * @param mixed  $root
-     * @param mixed  $context
-     *
+     * @param  string  $fieldName
+     * @param  mixed  $root
      * @return string
      */
     public function decodeTopic(string $fieldName, $root)
@@ -48,24 +47,22 @@ abstract class GraphQLSubscription
     /**
      * Resolve the subscription.
      *
-     * @param mixed       $root
-     * @param array       $args
-     * @param Context     $context
-     * @param ResolveInfo $info
-     *
+     * @param  mixed $root
+     * @param  mixed[] $args
+     * @param  \Nuwave\Lighthouse\Support\Contracts\GraphQLContext $context
+     * @param  \GraphQL\Type\Definition\ResolveInfo  $info
      * @return mixed
      */
-    public function resolve($root, array $args, $context, ResolveInfo $info)
+    public function resolve($root, array $args, GraphQLContext $context, ResolveInfo $info)
     {
         return $root;
     }
 
     /**
-     * Authorize subscriber request.
+     * Check if subscriber is allowed to listen to the subscription.
      *
-     * @param Subscriber $subscriber
-     * @param Request    $request
-     *
+     * @param  \Nuwave\Lighthouse\Subscriptions\Subscriber  $subscriber
+     * @param  \Illuminate\Http\Request  $request
      * @return bool
      */
     abstract public function authorize(Subscriber $subscriber, Request $request);
@@ -73,9 +70,8 @@ abstract class GraphQLSubscription
     /**
      * Filter subscribers who should receive subscription.
      *
-     * @param Subscriber $subscriber
-     * @param mixed      $root
-     *
+     * @param  \Nuwave\Lighthouse\Subscriptions\Subscriber  $subscriber
+     * @param  mixed  $root
      * @return bool
      */
     abstract public function filter(Subscriber $subscriber, $root);

--- a/src/Schema/Values/FieldValue.php
+++ b/src/Schema/Values/FieldValue.php
@@ -226,7 +226,7 @@ class FieldValue
         if ($directive = ASTHelper::directiveDefinition($this->field, 'subscription')) {
             $className = ASTHelper::directiveArgValue($directive, 'class');
         } else {
-            $className = $this->getFieldName();
+            $className = studly_case($this->getFieldName());
         }
 
         $className = Utils::namespaceClassname(

--- a/src/Schema/Values/FieldValue.php
+++ b/src/Schema/Values/FieldValue.php
@@ -2,34 +2,44 @@
 
 namespace Nuwave\Lighthouse\Schema\Values;
 
+use Closure;
 use GraphQL\Executor\Executor;
 use GraphQL\Type\Definition\Type;
 use Nuwave\Lighthouse\Support\Utils;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Language\AST\StringValueNode;
+use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use GraphQL\Language\AST\FieldDefinitionNode;
+use Nuwave\Lighthouse\Subscriptions\Subscriber;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Schema\Types\GraphQLSubscription;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+use Nuwave\Lighthouse\Subscriptions\SubscriptionRegistry;
+use Nuwave\Lighthouse\Schema\Extensions\ExtensionRegistry;
+use Nuwave\Lighthouse\Schema\Extensions\SubscriptionExtension;
 use Nuwave\Lighthouse\Schema\Conversion\DefinitionNodeConverter;
+use Nuwave\Lighthouse\Subscriptions\Exceptions\UnauthorizedSubscriber;
 
 class FieldValue
 {
     /**
      * An instance of the type that this field returns.
      *
-     * @var Type|null
+     * @var \GraphQL\Type\Definition\Type|null
      */
     protected $returnType;
 
     /**
      * The underlying AST definition of the Field.
      *
-     * @var FieldDefinitionNode
+     * @var \GraphQL\Language\AST\FieldDefinitionNode
      */
     protected $field;
 
     /**
      * The parent type of the field.
      *
-     * @var NodeValue
+     * @var \Nuwave\Lighthouse\Schema\Values\NodeValue
      */
     protected $parent;
 
@@ -64,8 +74,9 @@ class FieldValue
     /**
      * Create new field value instance.
      *
-     * @param NodeValue           $parent
-     * @param FieldDefinitionNode $field
+     * @param  NodeValue  $parent
+     * @param  FieldDefinitionNode  $field
+     * @return void
      */
     public function __construct(NodeValue $parent, FieldDefinitionNode $field)
     {
@@ -76,11 +87,10 @@ class FieldValue
     /**
      * Overwrite the current/default resolver.
      *
-     * @param \Closure $resolver
-     *
-     * @return FieldValue
+     * @param  \Closure  $resolver
+     * @return $this
      */
-    public function setResolver(\Closure $resolver): self
+    public function setResolver(Closure $resolver): self
     {
         $this->resolver = $resolver;
 
@@ -90,11 +100,10 @@ class FieldValue
     /**
      * Define a closure that is used to determine the complexity of the field.
      *
-     * @param \Closure $complexity
-     *
-     * @return FieldValue
+     * @param  \Closure  $complexity
+     * @return $this
      */
-    public function setComplexity(\Closure $complexity): self
+    public function setComplexity(Closure $complexity): self
     {
         $this->complexity = $complexity;
 
@@ -104,9 +113,8 @@ class FieldValue
     /**
      * Set deprecation reason for field.
      *
-     * @param string $deprecationReason
-     *
-     * @return FieldValue
+     * @param  string  $deprecationReason
+     * @return $this
      */
     public function setDeprecationReason(string $deprecationReason): self
     {
@@ -118,7 +126,7 @@ class FieldValue
     /**
      * Get an instance of the return type of the field.
      *
-     * @return Type
+     * @return \GraphQL\Type\Definition\Type
      */
     public function getReturnType(): Type
     {
@@ -132,7 +140,7 @@ class FieldValue
     }
 
     /**
-     * @return NodeValue
+     * @return \Nuwave\Lighthouse\Schema\Values\NodeValue
      */
     public function getParent(): NodeValue
     {
@@ -150,7 +158,7 @@ class FieldValue
     /**
      * Get the underlying AST definition for the field.
      *
-     * @return FieldDefinitionNode
+     * @return \GraphQL\Language\AST\FieldDefinitionNode
      */
     public function getField(): FieldDefinitionNode
     {
@@ -162,7 +170,7 @@ class FieldValue
      *
      * @return \Closure
      */
-    public function getResolver(): \Closure
+    public function getResolver(): Closure
     {
         if (! isset($this->resolver)) {
             $this->resolver = $this->defaultResolver();
@@ -174,12 +182,14 @@ class FieldValue
     /**
      * Get default field resolver.
      *
-     * @throws DefinitionException
-     *
      * @return \Closure
      */
-    protected function defaultResolver(): \Closure
+    protected function defaultResolver(): Closure
     {
+        if ($this->getParentName() === 'Subscription') {
+            return $this->defaultSubscriptionResolver();
+        }
+
         if ($this->parentIsRootType()) {
             $resolverClass = Utils::namespaceClassname(
                 studly_case($this->getFieldName()),
@@ -201,8 +211,80 @@ class FieldValue
         }
 
         return \Closure::fromCallable(
-             [Executor::class, 'defaultFieldResolver']
-         );
+            [Executor::class, 'defaultFieldResolver']
+        );
+    }
+
+    /**
+     * Get the default resolver for a subscription field.
+     *
+     * @return \Closure
+     * @throws \Nuwave\Lighthouse\Exceptions\DefinitionException
+     */
+    protected function defaultSubscriptionResolver(): Closure
+    {
+        if ($directive = ASTHelper::directiveDefinition($this->field, 'subscription')) {
+            $className = ASTHelper::directiveArgValue($directive, 'class');
+        } else {
+            $className = $this->getFieldName();
+        }
+
+        $className = Utils::namespaceClassname(
+            $className,
+            $this->defaultNamespacesForParent(),
+            function (string $class): bool {
+                return is_subclass_of($class, GraphQLSubscription::class);
+            }
+        );
+
+        if (! $className) {
+            throw new DefinitionException(
+                "No class found for the subscription field {$this->getFieldName()}"
+            );
+        }
+
+        /** @var GraphQLSubscription $subscription */
+        $subscription = app($className);
+        /** @var SubscriptionRegistry $subscriptionRegistry */
+        $subscriptionRegistry = app(SubscriptionRegistry::class);
+
+        // Subscriptions can only be placed on a single field on the root
+        // query, so there is no need to consider the field path
+        $subscriptionRegistry->register(
+            $subscription,
+            $this->getFieldName()
+        );
+
+        return function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($subscription, $subscriptionRegistry) {
+            if ($root instanceof Subscriber) {
+                return $subscription->resolve($root->root, $args, $context, $resolveInfo);
+            }
+
+            /** @var ExtensionRegistry $extensionRegistry */
+            $extensionRegistry = app(ExtensionRegistry::class);
+            /** @var SubscriptionExtension $subscriptionExtension */
+            $subscriptionExtension = $extensionRegistry->get(SubscriptionExtension::name());
+
+            $subscriber = Subscriber::initialize(
+                $args,
+                $context,
+                $resolveInfo,
+                $subscriptionExtension->currentQuery()
+            );
+
+            if (! $subscription->can($subscriber)) {
+                throw new UnauthorizedSubscriber(
+                    'Unauthorized subscription request'
+                );
+            }
+
+            $subscriptionRegistry->subscriber(
+                $subscriber,
+                $subscription->encodeTopic($subscriber, $this->getFieldName())
+            );
+
+            return null;
+        };
     }
 
     /**
@@ -225,9 +307,9 @@ class FieldValue
     }
 
     /**
-     * @return StringValueNode|null
+     * @return \GraphQL\Language\AST\StringValueNode|null
      */
-    public function getDescription()
+    public function getDescription(): ?StringValueNode
     {
         return $this->field->description;
     }
@@ -237,7 +319,7 @@ class FieldValue
      *
      * @return \Closure|null
      */
-    public function getComplexity()
+    public function getComplexity(): ?Closure
     {
         return $this->complexity;
     }
@@ -267,7 +349,7 @@ class FieldValue
     {
         return in_array(
             $this->getParentName(),
-            ['Query', 'Mutation']
+            ['Query', 'Mutation', 'Subscription']
         );
     }
 }

--- a/src/Schema/Values/FieldValue.php
+++ b/src/Schema/Values/FieldValue.php
@@ -282,8 +282,6 @@ class FieldValue
                 $subscriber,
                 $subscription->encodeTopic($subscriber, $this->getFieldName())
             );
-
-            return null;
         };
     }
 

--- a/tests/Integration/Subscriptions/SubscriptionTest.php
+++ b/tests/Integration/Subscriptions/SubscriptionTest.php
@@ -47,14 +47,16 @@ class SubscriptionTest extends TestCase
             onPostCreated {
                 body
             }
-        }';
+        }
+        ';
 
         $subscription2 = '
         subscription OnPostCreatedV2 {
             onPostCreated {
                 body
             }
-        }';
+        }
+        ';
 
         $json = [
             ['query' => $subscription1],
@@ -85,7 +87,8 @@ class SubscriptionTest extends TestCase
             createPost(post: "Foobar") {
                 body
             }
-        }';
+        }
+        ';
 
         $this->subscribe();
         $this->postJson('/graphql', ['query' => $mutation])->json();
@@ -160,7 +163,8 @@ class SubscriptionTest extends TestCase
             onPostCreated {
                 body
             }
-        }';
+        }
+        ';
 
         $json = [
             'query' => $subscription,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -69,6 +69,7 @@ class TestCase extends BaseTestCase
                     'Tests\\Utils\\Mutations',
                     'Tests\\Utils\\MutationsSecondary',
                 ],
+                'subscriptions' => 'Tests\\Utils\\Subscriptions',
                 'interfaces' => [
                     'Tests\\Utils\\Interfaces',
                     'Tests\\Utils\\InterfacesSecondary',

--- a/tests/Utils/Subscriptions/OnPostCreated.php
+++ b/tests/Utils/Subscriptions/OnPostCreated.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Tests\Utils\Directives;
+namespace Tests\Utils\Subscriptions;
 
 use Illuminate\Http\Request;
 use Nuwave\Lighthouse\Subscriptions\Subscriber;
 use Nuwave\Lighthouse\Schema\Types\GraphQLSubscription;
 
-class FooSubscription extends GraphQLSubscription
+class OnPostCreated extends GraphQLSubscription
 {
     /**
      * Authorize subscriber request.

--- a/tests/Utils/Subscriptions/OnPostCreated.php
+++ b/tests/Utils/Subscriptions/OnPostCreated.php
@@ -9,14 +9,13 @@ use Nuwave\Lighthouse\Schema\Types\GraphQLSubscription;
 class OnPostCreated extends GraphQLSubscription
 {
     /**
-     * Authorize subscriber request.
+     * Check if subscriber is allowed to listen to the subscription.
      *
-     * @param Subscriber $subscriber
-     * @param Request    $request
-     *
+     * @param  \Nuwave\Lighthouse\Subscriptions\Subscriber  $subscriber
+     * @param  \Illuminate\Http\Request  $request
      * @return bool
      */
-    public function authorize(Subscriber $subscriber, Request $request)
+    public function authorize(Subscriber $subscriber, Request $request): bool
     {
         return true;
     }
@@ -24,12 +23,11 @@ class OnPostCreated extends GraphQLSubscription
     /**
      * Filter subscribers who should receive subscription.
      *
-     * @param Subscriber $subscriber
-     * @param mixed      $root
-     *
+     * @param  \Nuwave\Lighthouse\Subscriptions\Subscriber  $subscriber
+     * @param  mixed  $root
      * @return bool
      */
-    public function filter(Subscriber $subscriber, $root)
+    public function filter(Subscriber $subscriber, $root): bool
     {
         return true;
     }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions

**Related Issue/Intent**

Subscriptions now can be defined just like other fields, default namespaces
will work consistently.

**Changes**

- Default namespaces for Subscriptions now work without directives, just like
those for Queries and Mutations do.
- Split subscription docs into defining fields and triggering subscriptions, each with a few examples.

**Breaking changes**

Changed type hints for the methods `resolve` and `encodeTopic` on `Nuwave\Lighthouse\Schema\Fields\SubscriptionField`.

Both methods do have default implementations, so there are probably just a few users who did overwrite them.
