### PR TITLE
Fix field stub by PSR

### DIFF
--- a/src/Console/stubs/field.stub
+++ b/src/Console/stubs/field.stub
@@ -16,7 +16,7 @@ class DummyClass
      * @param  \GraphQL\Type\Definition\ResolveInfo|null  $resolveInfo Information about the query itself, such as the execution state, the field name, path to the field from the root, and more.
      * @return mixed
      */
-    public function resolve($rootValue, array $args, GraphQLContext $context = null, ResolveInfo $resolveInfo null)
+    public function resolve($rootValue, array $args, GraphQLContext $context = null, ResolveInfo $resolveInfo = null)
     {
         // TODO implement the resolver
     }

--- a/src/Console/stubs/field.stub
+++ b/src/Console/stubs/field.stub
@@ -13,10 +13,10 @@ class DummyClass
      * @param  null  $rootValue Usually contains the result returned from the parent field. In this case, it is always `null`.
      * @param  array  $args The arguments that were passed into the field.
      * @param  \Nuwave\Lighthouse\Support\Contracts\GraphQLContext|null  $context Arbitrary data that is shared between all fields of a single query.
-     * @param  \GraphQL\Type\Definition\ResolveInfo  $resolveInfo Information about the query itself, such as the execution state, the field name, path to the field from the root, and more.
+     * @param  \GraphQL\Type\Definition\ResolveInfo|null  $resolveInfo Information about the query itself, such as the execution state, the field name, path to the field from the root, and more.
      * @return mixed
      */
-    public function resolve($rootValue, array $args, GraphQLContext $context = null, ResolveInfo $resolveInfo)
+    public function resolve($rootValue, array $args, GraphQLContext $context = null, ResolveInfo $resolveInfo null)
     {
         // TODO implement the resolver
     }


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Added Docs for all relevant versions

**Related Issue/Intent**

Command `lighthouse:query` creates new query class with non valid arguments by [psr-2](https://www.php-fig.org/psr/psr-2/#44-method-arguments) in `resolve` method. 

**Changes**

This PR changes `field.stub` and fixes creation queries with cli
