### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 vendor
 .idea
 phpunit.xml
+.DS_Store


### PR DESCRIPTION
**Related Issue/Intent**

No open issue.

**Changes**

.DS_Store is a file that holds meta data used by macOS to determine
things about the files enclosing folder. This file doesn't need to be
commited to git.

**Breaking changes**

N/A :+1:
