### PR TITLE
Rename the "queue" argument for @broadcast to "shouldQueue"

### DIFF
--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -134,12 +134,12 @@ type Mutation {
 ```
 
 You may override the default queueing behaviour from the configuration by
-passing the `queue` argument. 
+passing the `shouldQueue` argument. 
 
 ```graphql
 type Mutation {
     updatePost(input: UpdatePostInput!): Post
-        @broadcast(subscription: "postUpdated", queue: false)
+        @broadcast(subscription: "postUpdated", shouldQueue: false)
 }
 ```
 

--- a/docs/master/extensions/subscriptions.md
+++ b/docs/master/extensions/subscriptions.md
@@ -172,7 +172,7 @@ It accepts three parameters:
 
 - `string $subscriptionField` The name of the subscription field you want to trigger
 - `mixed $root` The result object you want to pass through
-- `bool $queue = null` Optional, overrides the default configuration `lighthouse.subscriptions.queue_broadcasts`
+- `bool $shouldQueue = null` Optional, overrides the default configuration `lighthouse.subscriptions.queue_broadcasts`
 
 The following example shows how to trigger a subscription after an update
 to the `Post` model.

--- a/src/Execution/Utils/Subscription.php
+++ b/src/Execution/Utils/Subscription.php
@@ -37,16 +37,15 @@ class Subscription
         $shouldQueue = $shouldQueue === null
             ? config('lighthouse.subscriptions.queue_broadcasts', false)
             : $shouldQueue;
+
         $method = $shouldQueue
             ? 'queueBroadcast'
             : 'broadcast';
 
-        $subscription = $registry->subscription($subscriptionField);
-
         try {
             call_user_func(
                 [$broadcaster, $method],
-                $subscription,
+                $registry->subscription($subscriptionField),
                 $subscriptionField,
                 $root
             );

--- a/src/Schema/Directives/Fields/BroadcastDirective.php
+++ b/src/Schema/Directives/Fields/BroadcastDirective.php
@@ -33,17 +33,17 @@ class BroadcastDirective extends BaseDirective implements FieldMiddleware
         $value = $next($value);
         $resolver = $value->getResolver();
         $subscriptionField = $this->directiveArgValue('subscription');
-        $queue = $this->directiveArgValue('queue');
+        $shouldQueue = $this->directiveArgValue('shouldQueue');
 
-        return $value->setResolver(function () use ($resolver, $subscriptionField, $queue) {
+        return $value->setResolver(function () use ($resolver, $subscriptionField, $shouldQueue) {
             $resolved = call_user_func_array($resolver, func_get_args());
 
             if ($resolved instanceof Deferred) {
-                $resolved->then(function ($root) use ($subscriptionField, $queue) {
-                    Subscription::broadcast($subscriptionField, $root, $queue);
+                $resolved->then(function ($root) use ($subscriptionField, $shouldQueue) {
+                    Subscription::broadcast($subscriptionField, $root, $shouldQueue);
                 });
             } else {
-                Subscription::broadcast($subscriptionField, $resolved, $queue);
+                Subscription::broadcast($subscriptionField, $resolved, $shouldQueue);
             }
 
             return $resolved;


### PR DESCRIPTION
This naming is more in line with the well-known Laravel interface `ShouldQueue` and also clearly expresses the boolean nature of the argument.
