### PR TITLE
Fixed bug in RuleFactory.php

### DIFF
--- a/src/Schema/Factories/RuleFactory.php
+++ b/src/Schema/Factories/RuleFactory.php
@@ -214,7 +214,7 @@ class RuleFactory
         $resolvedPath = collect();
 
         /** @var InputValueDefinitionNode $input */
-        $input = collect($inputPath)->reduce(function (Node $node, string $path) use ($documentAST, $resolvedPath) {
+        $input = collect($inputPath)->reduce(function (Node $node = null, string $path) use ($documentAST, $resolvedPath) {
             if (is_null($node)) {
                 $resolvedPath->push($path);
 


### PR DESCRIPTION

- [ ] Added or updated tests
- [ ] Added Docs for all relevant versions

**Related Issue/Intent**

<!-- Link to related issues this PR resolves, e.g. "Resolves #236",
or a description of what this PR is trying to achieve. -->

Resolves #573 

**Changes**

The anonymous function no longer throws an exception if `$node` = null.
The function has logic that expects $node to be null, but it must be allowed as an input.

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->
