### PR TITLE
Allow null to be supplied in anonymous function in RuleFactory.php

### DIFF
--- a/src/Schema/Factories/RuleFactory.php
+++ b/src/Schema/Factories/RuleFactory.php
@@ -248,7 +248,7 @@ class RuleFactory
         $resolvedPath = collect();
 
         /** @var InputValueDefinitionNode $input */
-        $input = collect($inputPath)->reduce(function (Node $node, string $path) use ($documentAST, $resolvedPath) {
+        $input = collect($inputPath)->reduce(function (Node $node = null, string $path) use ($documentAST, $resolvedPath) {
             if (is_null($node)) {
                 $resolvedPath->push($path);
 


### PR DESCRIPTION
**Related Issue/Intent**

Resolves #573

**Changes**

The anonymous function already accounts for `$node = null`, but it now also allows `$node = null` as input. Please note that the changes are meant for v. 2.6.3, but since it doesn't have a branch i chose `master`.

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->
