### PR TITLE
Prevent crash when invalid JSON variables are given

### DIFF
--- a/src/Support/Http/Controllers/GraphQLController.php
+++ b/src/Support/Http/Controllers/GraphQLController.php
@@ -127,11 +127,11 @@ class GraphQLController extends Controller
      */
     protected function ensureVariablesAreArray($variables): array
     {
-        return is_string($variables)
-            ? json_decode($variables, true)
-            : $variables === null
-                ? []
-                : $variables;
+        if (is_string($variables)) {
+            return json_decode($variables, true) ?? [];
+        }
+
+        return $variables ?? [];
     }
 
     /**

--- a/tests/Integration/GraphQLTest.php
+++ b/tests/Integration/GraphQLTest.php
@@ -201,4 +201,17 @@ class GraphQLTest extends DBTestCase
             $result->jsonGet('errors.0.message')
         );
     }
+
+    /**
+     * @test
+     */
+    public function itIgnoresInvalidJSONVariables(): void
+    {
+        $result = $this->postGraphQL([
+            'query' => '{}',
+            'variables' => '{}',
+        ]);
+
+        $result->assertStatus(200);
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions

**Related Issue/Intent**

When an invalid or empty (JSON) `variables` parameter is given (default behaviour of  https://github.com/graphql/graphiql), `json_decode` can return `null`, causing the following exception:
![screenshot 2019-01-21 at 21 50 23](https://user-images.githubusercontent.com/1752195/51498541-2f410b00-1dc7-11e9-956e-6446d140e747.png)

**Changes**

- Adds an empty array as fallback for when json_decode fails / returns null.

**Breaking changes**

 None.
