### PR TITLE
Add guard argument to auth directive

### DIFF
--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -10,7 +10,8 @@ type Query {
 }
 ```
 
-If you need to use a guard besides the default to resolve the authenticated user, you can pass the guard name as the `guard` argument
+If you need to use a guard besides the default to resolve the authenticated user,
+you can pass the guard name as the `guard` argument
 
 ```graphql
 type Query {

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -10,6 +10,14 @@ type Query {
 }
 ```
 
+If you need to use a guard besides the default to resolve the authenticated user, you can pass the guard name as the `guard` argument
+
+```graphql
+type Query {
+    me: User @auth(guard: "api")
+}
+```
+
 ## @all
 
 Fetch all Eloquent models and return the collection as the result for a field.

--- a/src/Schema/Directives/Fields/AuthDirective.php
+++ b/src/Schema/Directives/Fields/AuthDirective.php
@@ -28,9 +28,11 @@ class AuthDirective extends BaseDirective implements FieldResolver
      */
     public function resolveField(FieldValue $fieldValue): FieldValue
     {
+        $guard = $this->directiveArgValue('guard');
+
         return $fieldValue->setResolver(
-            function (): ?Authenticatable {
-                return auth()->user();
+            function () use ($guard): ?Authenticatable {
+                return auth($guard)->user();
             }
         );
     }

--- a/src/Schema/Directives/Fields/AuthDirective.php
+++ b/src/Schema/Directives/Fields/AuthDirective.php
@@ -4,11 +4,28 @@ namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
 use Illuminate\Contracts\Auth\Authenticatable;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 
 class AuthDirective extends BaseDirective implements FieldResolver
 {
+    /**
+     * @var \Illuminate\Contracts\Auth\Factory
+     */
+    private $authFactory;
+
+    /**
+     * AuthDirective constructor.
+     *
+     * @param  \Illuminate\Contracts\Auth\Factory  $authFactory
+     * @return void
+     */
+    public function __construct(AuthFactory $authFactory)
+    {
+        $this->authFactory = $authFactory;
+    }
+
     /**
      * Name of the directive.
      *
@@ -28,11 +45,15 @@ class AuthDirective extends BaseDirective implements FieldResolver
      */
     public function resolveField(FieldValue $fieldValue): FieldValue
     {
+        /** @var string|null $guard */
         $guard = $this->directiveArgValue('guard');
 
         return $fieldValue->setResolver(
             function () use ($guard): ?Authenticatable {
-                return auth($guard)->user();
+                return $this
+                    ->authFactory
+                    ->guard($guard)
+                    ->user();
             }
         );
     }

--- a/src/Schema/Values/CacheValue.php
+++ b/src/Schema/Values/CacheValue.php
@@ -74,7 +74,7 @@ class CacheValue
                 ? 'auth'
                 : null,
             $this->privateCache
-                ? auth()->user()->getKey()
+                ? app('auth')->user()->getKey()
                 : null,
             strtolower($this->resolveInfo->parentType->name),
             $this->fieldKey,

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -15,18 +15,6 @@ if (! function_exists('graphql')) {
     }
 }
 
-if (! function_exists('auth')) {
-    /**
-     * Get instance of auth container.
-     *
-     * @return \Illuminate\Auth\AuthManager
-     */
-    function auth()
-    {
-        return app('auth');
-    }
-}
-
 if (! function_exists('config_path')) {
     /**
      * Get base configuration path.

--- a/tests/Unit/Schema/Directives/Fields/AuthDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/Fields/AuthDirectiveTest.php
@@ -39,4 +39,38 @@ class AuthDirectiveTest extends TestCase
             ],
         ]);
     }
+
+    /**
+     * @test
+     */
+    public function itCanResolveAuthenticatedUserWithGuardArgument(): void
+    {
+        $user = new User(['foo' => 'bar']);
+
+        $this->app['auth']->guard('api')->setUser($user);
+
+        $this->schema = '
+        type User {
+            foo: String!
+        }
+        
+        type Query {
+            user: User! @auth(guard: "api")
+        }
+        ';
+
+        $this->query('
+        {
+            user {
+                foo
+            }
+        }           
+        ')->assertJson([
+            'data' => [
+                'user' => [
+                    'foo' => 'bar',
+                ],
+            ],
+        ]);
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions

**Changes**

Adds a `guard` argument to the auth directive so one can specify a different guard to resolve the authenticated user

**Breaking changes**

No breaking changes, if the `guard` argument is not specified it uses the default guard resolver
