### PR TITLE
Custom Lighthouse key for retrieving model

### DIFF
--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -201,12 +201,18 @@ class MutationExecutor
      */
     public static function executeUpdate(Model $model, Collection $args, ?HasMany $parentRelation = null): Model
     {
-        $id = $args->pull('id')
+
+        $key = $model->getKeyName();
+        $value = $args->pull('id')
             ?? $args->pull(
                 $model->getKeyName()
             );
 
-        $model = $model->newQuery()->findOrFail($id);
+        if (method_exists($model, 'getLighthouseKeyName')) {
+            $key = $model->getLighthouseKeyName();
+        }
+
+        $model = $model->newQuery()->where($key, $value)->firstOrFail();
 
         $reflection = new \ReflectionClass($model);
 

--- a/tests/Integration/Schema/Directives/Fields/UpdateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/UpdateDirectiveTest.php
@@ -5,6 +5,7 @@ namespace Tests\Integration\Schema\Directives\Fields;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
+use Tests\Utils\Models\Project;
 use Tests\Utils\Models\Company;
 use Tests\Utils\Models\Category;
 
@@ -202,6 +203,48 @@ class UpdateDirectiveTest extends DBTestCase
             ],
         ]);
         $this->assertSame('bar', Category::first()->name);
+    }
+
+    /**
+     * @test
+     */
+    public function itCanUpdateWithCustomLighthouseKey(): void
+    {
+        factory(Project::class)->create(['title' => 'foo', 'uuid' => '679b592c-1d77-4994-80b5-6b5cb5c5930f']);
+
+        $this->schema = '
+        type Project {
+            id: String! @rename(attribute: "uuid")
+            title: String!
+        }
+        
+        type Mutation {
+            updateProject(
+                id: String!
+                title: String
+            ): Project @update
+        }
+        '.$this->placeholderQuery();
+
+        $this->query('
+        mutation {
+            updateProject(
+                id: "679b592c-1d77-4994-80b5-6b5cb5c5930f"
+                title: "bar"
+            ) {
+                id
+                title
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'updateProject' => [
+                    'id' => '679b592c-1d77-4994-80b5-6b5cb5c5930f',
+                    'title' => 'bar',
+                ],
+            ],
+        ]);
+        $this->assertSame('bar', Project::first()->title);
     }
 
     /**

--- a/tests/Utils/Models/Project.php
+++ b/tests/Utils/Models/Project.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Utils\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Project extends Model
+{
+    protected $guarded = [];
+
+    public function getLighthouseKeyName(): string
+    {
+        return 'uuid';
+    }
+}

--- a/tests/database/factories/ProjectFactory.php
+++ b/tests/database/factories/ProjectFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+use Faker\Generator as Faker;
+use Tests\Utils\Models\Project;
+
+/* @var \Illuminate\Database\Eloquent\Factory $factory */
+$factory->define(Project::class, function (Faker $faker) {
+    return [
+        'uuid' => $faker->uuid,
+    ];
+});

--- a/tests/database/migrations/2018_12_08_000001_create_testbench_projects_table.php
+++ b/tests/database/migrations/2018_12_08_000001_create_testbench_projects_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTestbenchProjectsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('projects', function (Blueprint $table) {
+            $table->increments('id');
+            $table->uuid('uuid')->unique();
+            $table->string('title');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::drop('projects');
+    }
+}


### PR DESCRIPTION
- [x ] Added or updated tests
- [ ] Added Docs for all relevant versions

**Related Issue/Intent**

In my current project I have models where we use different keys for querying models (uuid). In the current implementation Lighthouse only allows; id or by changing the ```$primaryKey``` attribute. Changing ```$primaryKey``` however breaks the rest of our application. 

**Changes**

Added the ability to overwrite the key to search models.

**Breaking changes**

Not to my knowledge


