### PR TITLE
Prefix the Pusher channels to easily identify them

### DIFF
--- a/src/Subscriptions/Subscriber.php
+++ b/src/Subscriptions/Subscriber.php
@@ -130,7 +130,7 @@ class Subscriber
      */
     public static function uniqueChannelName(): string
     {
-        return 'private-'.Str::random(32).'-'.time();
+        return 'private-lighthouse-'.Str::random(32).'-'.time();
     }
 
     /**


### PR DESCRIPTION
This way the channels can be easily identified and allows me to hook up some custom authentication so I can use a single Pusher client for "normal" websockets and (Apollo) subscriptions.

Also gives me some indication what the channel is supposed to be doing instead of a completely random string 😄 