### PR TITLE
Provide Laravel 5.8 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,23 +13,11 @@ env:
 matrix:
   include:
     - php: 7.1
-      env: LARAVEL='5.5.*'
-    - php: 7.1
-      env: LARAVEL='5.6.*'
-    - php: 7.1
-      env: LARAVEL='5.7.*'
+      env: LARAVEL='5.8.*'
     - php: 7.2
-      env: LARAVEL='5.5.*'
-    - php: 7.2
-      env: LARAVEL='5.6.*'
-    - php: 7.2
-      env: LARAVEL='5.7.*'
+      env: LARAVEL='5.8.*'
     - php: 7.3
-      env: LARAVEL='5.5.*'
-    - php: 7.3
-      env: LARAVEL='5.6.*'
-    - php: 7.3
-      env: COVERAGE=1 LARAVEL='5.7.*'
+      env: COVERAGE=1 LARAVEL='5.8.*'
   fast_finish: true
 
 

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,12 @@
         "laravel-graphql"
     ],
     "license": "MIT",
-    "authors": [{
-        "name": "Christopher Moore",
-        "email": "chris@nuwavecommerce.com"
-    }],
+    "authors": [
+        {
+            "name": "Christopher Moore",
+            "email": "chris@nuwavecommerce.com"
+        }
+    ],
     "support": {
         "issues": "https://github.com/nuwave/lighthouse/issues",
         "source": "https://github.com/nuwave/lighthouse"
@@ -20,20 +22,20 @@
     "require": {
         "php": ">= 7.1",
         "ext-json": "*",
-        "illuminate/contracts": "5.5.*|5.6.*|5.7.*",
-        "illuminate/http": "5.5.*|5.6.*|5.7.*",
-        "illuminate/pagination": "5.5.*|5.6.*|5.7.*",
-        "illuminate/routing": "5.5.*|5.6.*|5.7.*",
-        "illuminate/support": "5.5.*|5.6.*|5.7.*",
-        "illuminate/validation": "5.5.*|5.6.*|5.7.*",
+        "illuminate/contracts": "5.8.*",
+        "illuminate/http": "5.8.*",
+        "illuminate/pagination": "5.8.*",
+        "illuminate/routing": "5.8.*",
+        "illuminate/support": "5.8.*",
+        "illuminate/validation": "5.8.*",
         "opis/closure": "^3.0",
         "webonyx/graphql-php": "^0.13"
     },
     "require-dev": {
         "laravel/scout": "^4.0",
         "mockery/mockery": "^1.0",
-        "orchestra/database": "3.5.*|3.6.*|3.7.*",
-        "orchestra/testbench": "3.5.*|3.6.*|3.7.*",
+        "orchestra/database": "3.8.x-dev",
+        "orchestra/testbench": "3.8.*",
         "pusher/pusher-php-server": "^3.2"
     },
     "suggest": {

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -4,7 +4,7 @@ namespace Tests;
 
 abstract class DBTestCase extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/GraphQLTest.php
+++ b/tests/Integration/GraphQLTest.php
@@ -45,7 +45,7 @@ class GraphQLTest extends DBTestCase
      */
     protected $tasks;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Schema/Directives/Args/QueryFilterDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Args/QueryFilterDirectiveTest.php
@@ -12,7 +12,7 @@ class QueryFilterDirectiveTest extends DBTestCase
      */
     protected $users;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Schema/Directives/Args/SearchDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Args/SearchDirectiveTest.php
@@ -21,7 +21,7 @@ class SearchDirectiveTest extends DBTestCase
      */
     protected $engine;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Schema/Directives/Fields/BelongsToManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/BelongsToManyDirectiveTest.php
@@ -29,7 +29,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
      */
     protected $rolesCount = 4;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Schema/Directives/Fields/BelongsToTest.php
+++ b/tests/Integration/Schema/Directives/Fields/BelongsToTest.php
@@ -31,7 +31,7 @@ class BelongsToTest extends DBTestCase
      */
     protected $company;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Schema/Directives/Fields/HasManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/HasManyDirectiveTest.php
@@ -24,7 +24,7 @@ class HasManyDirectiveTest extends DBTestCase
      */
     protected $tasks;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Schema/Directives/Fields/WithDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Fields/WithDirectiveTest.php
@@ -22,7 +22,7 @@ class WithDirectiveTest extends DBTestCase
      */
     protected $tasks;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Schema/Source/SchemaSourceProviderTest.php
+++ b/tests/Integration/Schema/Source/SchemaSourceProviderTest.php
@@ -15,7 +15,7 @@ class SchemaSourceProviderTest extends TestCase
      */
     const SCHEMA_PATH = __DIR__.'/schema/';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -27,7 +27,7 @@ class SchemaSourceProviderTest extends TestCase
         $this->filesystem = new Filesystem(new Local(self::SCHEMA_PATH));
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Integration/Subscriptions/BroadcastManagerTest.php
+++ b/tests/Integration/Subscriptions/BroadcastManagerTest.php
@@ -26,7 +26,7 @@ class BroadcastManagerTest extends TestCase implements GraphQLContext
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Subscriptions/StorageManagerTest.php
+++ b/tests/Integration/Subscriptions/StorageManagerTest.php
@@ -20,7 +20,7 @@ class StorageManagerTest extends TestCase implements GraphQLContext
      */
     protected $storage;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Subscriptions/SubscriptionTest.php
+++ b/tests/Integration/Subscriptions/SubscriptionTest.php
@@ -18,7 +18,7 @@ class SubscriptionTest extends TestCase
         $app['config']->set('lighthouse.extensions', [\Nuwave\Lighthouse\Schema\Extensions\SubscriptionExtension::class]);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Support/DataLoader/ModelRelationLoaderPolymorphicTest.php
+++ b/tests/Integration/Support/DataLoader/ModelRelationLoaderPolymorphicTest.php
@@ -10,7 +10,7 @@ use Nuwave\Lighthouse\Execution\DataLoader\ModelRelationFetcher;
 
 class ModelRelationLoaderPolymorphicTest extends DBTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Support/DataLoader/ModelRelationLoaderTest.php
+++ b/tests/Integration/Support/DataLoader/ModelRelationLoaderTest.php
@@ -10,7 +10,7 @@ use Nuwave\Lighthouse\Execution\DataLoader\ModelRelationFetcher;
 
 class ModelRelationLoaderTest extends DBTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -162,11 +162,22 @@ abstract class TestCase extends BaseTestCase
                 public function renderForConsole($output, Exception $e)
                 {
                 }
+
+                /**
+                 * Determine if the exception should be reported.
+                 *
+                 * @param  \Exception $e
+                 * @return bool
+                 */
+                public function shouldReport(Exception $e)
+                {
+                    return false;
+                }
             };
         });
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Unit/Execution/Utils/SubscriptionTest.php
+++ b/tests/Unit/Execution/Utils/SubscriptionTest.php
@@ -29,7 +29,7 @@ class SubscriptionTest extends TestCase
      */
     protected $broadcaster;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Schema/AST/SchemaStitcherTest.php
+++ b/tests/Unit/Schema/AST/SchemaStitcherTest.php
@@ -25,7 +25,7 @@ class SchemaStitcherTest extends TestCase
      */
     protected $filesystem;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -37,7 +37,7 @@ class SchemaStitcherTest extends TestCase
         $this->filesystem = new Filesystem(new Local(self::SCHEMA_PATH));
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Unit/Schema/Directives/Args/RulesDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/Args/RulesDirectiveTest.php
@@ -14,7 +14,7 @@ class RulesDirectiveTest extends TestCase
         $app['config']->set('app.debug', false);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Schema/Factories/NodeFactoryTest.php
+++ b/tests/Unit/Schema/Factories/NodeFactoryTest.php
@@ -21,7 +21,7 @@ class NodeFactoryTest extends TestCase
      */
     protected $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Subscriptions/Iterators/SyncIteratorTest.php
+++ b/tests/Unit/Subscriptions/Iterators/SyncIteratorTest.php
@@ -19,7 +19,7 @@ class SyncIteratorTest extends TestCase
      */
     protected $iterator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions

**Related Issue/Intent**
Upgrade to Laravel 5.8
<!-- Link to related issues this PR resolves, e.g. "Resolves #236",
or a description of what this PR is trying to achieve. -->

**Changes**
This PR adds support to Laravel 5.8

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**
The master branch cannot support Laravel <5.8 anymore.
The reason for that is the change of signature on setUp and tearDown (`: void`) introduced in orchestral 3.8, so that it can support Phpunit 8.

---

TODO:

- [x] Check caching move to duration in seconds