### PR TITLE
Actually use Y-m-d H:i:s for DateTime scalar

### DIFF
--- a/src/Schema/Types/Scalars/DateTime.php
+++ b/src/Schema/Types/Scalars/DateTime.php
@@ -20,11 +20,12 @@ class DateTime extends ScalarType
     public function serialize($value): string
     {
         if ($value instanceof Carbon) {
-            return $value->toAtomString();
+            return $value->toDateTimeString();
         }
 
-        return $this->tryParsingDateTime($value, InvariantViolation::class)
-            ->toAtomString();
+        return $this
+            ->tryParsingDateTime($value, InvariantViolation::class)
+            ->toDateTimeString();
     }
 
     /**
@@ -50,7 +51,10 @@ class DateTime extends ScalarType
     public function parseLiteral($valueNode, ?array $variables = null): Carbon
     {
         if (! $valueNode instanceof StringValueNode) {
-            throw new Error('Query error: Can only parse strings got: '.$valueNode->kind, [$valueNode]);
+            throw new Error(
+                'Query error: Can only parse strings got: '.$valueNode->kind,
+                [$valueNode]
+            );
         }
 
         return $this->tryParsingDateTime($valueNode->value, Error::class);
@@ -71,7 +75,9 @@ class DateTime extends ScalarType
             return Carbon::createFromFormat(Carbon::DEFAULT_TO_STRING_FORMAT, $value);
         } catch (\Exception $e) {
             throw new $exceptionClass(
-                Utils::printSafeJson($e->getMessage())
+                Utils::printSafeJson(
+                    $e->getMessage()
+                )
             );
         }
     }

--- a/tests/Unit/Schema/Types/Scalars/DateTimeTest.php
+++ b/tests/Unit/Schema/Types/Scalars/DateTimeTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Unit\Schema\Types\Scalars;
+
+use Carbon\Carbon;
+use Tests\TestCase;
+use GraphQL\Error\Error;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Language\AST\IntValueNode;
+use GraphQL\Language\AST\StringValueNode;
+use Nuwave\Lighthouse\Schema\Types\Scalars\DateTime;
+
+class DateTimeTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider invalidDateTimeValues
+     *
+     * @param  mixed  $value
+     */
+    public function itThrowsIfSerializingNonString($value): void
+    {
+        $this->expectException(InvariantViolation::class);
+
+        (new DateTime())->serialize($value);
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidDateTimeValues
+     *
+     * @param  mixed  $value
+     */
+    public function itThrowsIfParseValueNonString($value): void
+    {
+        $this->expectException(Error::class);
+
+        (new DateTime())->parseValue($value);
+    }
+
+    /**
+     * Those values should fail passing as a date.
+     *
+     * @return mixed[]
+     */
+    public function invalidDateTimeValues(): array
+    {
+        return [
+            [1],
+            ['rolf'],
+            [new class() {
+            }],
+            [null],
+            [''],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function itParsesValueString(): void
+    {
+        $date = '2018-10-01 12:45:01';
+        $this->assertEquals(
+            (new Carbon($date))->toDateTimeString(),
+            (new DateTime())->parseValue($date)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itParsesLiteral(): void
+    {
+        $dateLiteral = new StringValueNode(
+            ['value' => '2018-10-01 12:45:01']
+        );
+        $result = (new DateTime())->parseLiteral($dateLiteral);
+
+        $this->assertSame(
+            $dateLiteral->value,
+            $result->toDateTimeString()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itThrowsIfParseLiteralNonString(): void
+    {
+        $this->expectException(Error::class);
+
+        (new DateTime())->parseLiteral(
+            new IntValueNode([])
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itSerializesCarbonInstance(): void
+    {
+        $now = now();
+        $result = (new DateTime())->serialize($now);
+
+        $this->assertSame(
+            $now->toDateTimeString(),
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itSerializesValidDateTimeString(): void
+    {
+        $date = '2018-10-01 12:45:01';
+        $result = (new DateTime())->serialize($date);
+
+        $this->assertSame(
+            $date,
+            $result
+        );
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests

**Related Issue/Intent**

Resolves #599 	

**Changes**

The description for DateTime scalars was lying and the behaviour was inconsistent.
Now they are always formatted/parsed as Y-m-d H:i:s
