### PR TITLE
Add docker config for Xdebug

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@
 .travis.yml export-ignore
 _ide_helper.php export-ignore
 docker-compose.yml export-ignore
+Dockerfile export-ignore
 logo.png export-ignore
 netlify.toml export-ignore
 phpunit.xml.dist export-ignore

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,6 +23,12 @@ Just clone the project and run the following in the project root:
     composer install
     composer test
 
+If you want to use Xdebug, you can enter that container instead:
+
+    docker-compose exec xdebug sh
+
+Here is how to set up Xdebug in PhpStorm https://www.jetbrains.com/help/phpstorm/configuring-xdebug.html
+
 ## Committing code
 
 1. Fork the project
@@ -74,7 +80,7 @@ function foo(array $bar): string
 
 For aggregate types such as the commonly used `Collection` class, use
 the generic type hint style. While not officially part of PHPDoc, it is understood
-by PHPStorm and most other editors.
+by PhpStorm and most other editors.
 
 ```php
 /**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM php:7.2-fpm
+
+WORKDIR /var/www
+
+RUN apt-get update && apt-get install -y \
+        git \
+        libzip-dev \
+        zip \
+    && docker-php-ext-configure zip --with-libzip \
+    && docker-php-ext-install \
+        zip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer \
+    && composer global require hirak/prestissimo --no-progress --no-suggest --no-interaction
+
+RUN pecl install xdebug \
+    && docker-php-ext-enable xdebug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,11 @@ services:
     image: spawnia/php7.1-fpm:dev-1.3.1
     volumes:
     - ./:/var/www
+
+  xdebug:
+    build: .
+    environment:
+      XDEBUG_CONFIG: "remote_enable=1 remote_mode=req remote_port=9000 remote_host=10.0.2.2 remote_connect_back=0"
+      PHP_IDE_CONFIG: "serverName=lighthouse"
+    volumes:
+    - ./:/var/www


### PR DESCRIPTION
This adds a Dockerfile as well as the appropriate docker-compose config to run PHP with Xdebug enabled.