### PR TITLE
Enable search for docs

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -20,13 +20,13 @@ module.exports = {
         editLinks: true, //  "Edit this page" at the bottom of each page
         lastUpdated: 'Last Updated', //  "Last Updated" at the bottom of each page
         repo: 'nuwave/lighthouse', //  Github repo
-        docsDir: 'docs/', //  Github repo docs folder    
+        docsDir: 'docs/', //  Github repo docs folder
         versions: {
             latest: versioning.versions.latest,
             selected: versioning.versions.latest,
             all: versioning.versions.all
         },
-        search: false,
+        search: true,
         nav: [
             {
                 text: `Docs`,


### PR DESCRIPTION
**Changes**
Enabled search for the documentation. It would be nice if there was full text search but you would need to sign up for Algolia (I guess you want to do it yourself as a package owner). Documentation for Algolia search can be found [here](https://vuepress.vuejs.org/default-theme-config/#algolia-search)
