### PR TITLE
Handle Scout pagination arguments

### DIFF
--- a/src/Schema/Directives/Fields/PaginateDirective.php
+++ b/src/Schema/Directives/Fields/PaginateDirective.php
@@ -138,6 +138,10 @@ class PaginateDirective extends BaseDirective implements FieldResolver, FieldMan
             $resolveArgs[3]
         );
 
+        if ($query instanceof \Laravel\Scout\Builder) {
+            return $query->paginate($first, 'page', $page);
+        }
+
         return $query->paginate($first, ['*'], 'page', $page);
     }
 

--- a/src/Schema/Directives/Fields/PaginateDirective.php
+++ b/src/Schema/Directives/Fields/PaginateDirective.php
@@ -3,6 +3,7 @@
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
 use Illuminate\Support\Str;
+use Laravel\Scout\Builder as ScoutBuilder;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Execution\QueryFilter;
 use GraphQL\Language\AST\FieldDefinitionNode;
@@ -138,7 +139,7 @@ class PaginateDirective extends BaseDirective implements FieldResolver, FieldMan
             $resolveArgs[3]
         );
 
-        if ($query instanceof \Laravel\Scout\Builder) {
+        if ($query instanceof ScoutBuilder) {
             return $query->paginate($first, 'page', $page);
         }
 

--- a/tests/Integration/Schema/Directives/Args/SearchDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Args/SearchDirectiveTest.php
@@ -186,6 +186,7 @@ class SearchDirectiveTest extends DBTestCase
                 Mockery::any(),
                 Mockery::not('page')
             )
+            ->andReturn(collect([$postA, $postB]))
             ->once();
 
         $this->schema = '


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Added Docs for all relevant versions

**Related Issue/Intent**

Resolves #592

**Changes**

```php
// Nuwave\Lighthouse\Schema\Directives\Fields\PaginateDirective

protected function getPaginatedResults(array $resolveArgs, int $page, int $first): LengthAwarePaginator
{
    ...

    if ($query instanceof \Laravel\Scout\Builder) {
        return $query->paginate($first, 'page', $page);
    }

    return $query->paginate($first, ['*'], 'page', $page);
}
```

Please review my test case, it could be simpler I think.
