### PR TITLE
Get rid of collect() helper.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor
 .idea
 phpunit.xml
 .DS_Store
+.phpunit.result.cache

--- a/src/Execution/DataLoader/BatchLoader.php
+++ b/src/Execution/DataLoader/BatchLoader.php
@@ -4,7 +4,7 @@ namespace Nuwave\Lighthouse\Execution\DataLoader;
 
 use Exception;
 use GraphQL\Deferred;
-use Nuwave\Lighthouse\GraphQL;
+use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Execution\GraphQLRequest;
 use Nuwave\Lighthouse\Support\Traits\HandlesCompositeKey;
 
@@ -84,7 +84,7 @@ abstract class BatchLoader
      */
     public static function instanceKey(array $path): string
     {
-        return collect($path)
+        return (new Collection($path))
             ->filter(function ($path) {
                 // Ignore numeric path entries, as those signify an array of fields
                 // Those are the very purpose for this batch loader, so they must not be included.

--- a/src/Execution/DataLoader/RelationBatchLoader.php
+++ b/src/Execution/DataLoader/RelationBatchLoader.php
@@ -126,6 +126,6 @@ class RelationBatchLoader extends BatchLoader
      */
     protected function getParentModels(): Collection
     {
-        return collect($this->keys)->pluck('parent');
+        return (new Collection($this->keys))->pluck('parent');
     }
 }

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -83,9 +83,9 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo $relation */
             $relation = $model->{$relationName}();
 
-            collect($nestedOperations)->each(function ($values, string $operationKey) use ($relation, $model, $relationName): void {
+            (new Collection($nestedOperations))->each(function ($values, string $operationKey) use ($relation, $model, $relationName): void {
                 if ($operationKey === 'create') {
-                    $belongsToModel = self::executeCreate($relation->getModel()->newInstance(), collect($values));
+                    $belongsToModel = self::executeCreate($relation->getModel()->newInstance(), new Collection($values));
                     $relation->associate($belongsToModel);
                 }
 
@@ -120,7 +120,7 @@ class MutationExecutor
         $multiValues->each(function ($singleValues) use ($relation): void {
             self::executeCreate(
                 $relation->getModel()->newInstance(),
-                collect($singleValues),
+                new Collection($singleValues),
                 $relation
             );
         });
@@ -137,7 +137,7 @@ class MutationExecutor
     {
         self::executeCreate(
             $relation->getModel()->newInstance(),
-            collect($singleValues),
+            new Collection($singleValues),
             $relation
         );
     }
@@ -172,14 +172,14 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\HasMany $relation */
             $relation = $model->{$relationName}();
 
-            collect($nestedOperations)->each(function ($values, string $operationKey) use ($relation): void {
+            (new Collection($nestedOperations))->each(function ($values, string $operationKey) use ($relation): void {
                 if ($operationKey === 'create') {
-                    self::handleMultiRelationCreate(collect($values), $relation);
+                    self::handleMultiRelationCreate(new Collection($values), $relation);
                 }
 
                 if ($operationKey === 'update') {
-                    collect($values)->each(function ($singleValues) use ($relation): void {
-                        self::executeUpdate($relation->getModel()->newInstance(), collect($singleValues), $relation);
+                    (new Collection($values))->each(function ($singleValues) use ($relation): void {
+                        self::executeUpdate($relation->getModel()->newInstance(), new Collection($singleValues), $relation);
                     });
                 }
 
@@ -255,9 +255,9 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\HasMany $relation */
             $relation = $model->{$relationName}();
 
-            collect($nestedOperations)->each(function ($values, string $operationKey) use ($relation): void {
+            (new Collection($nestedOperations))->each(function ($values, string $operationKey) use ($relation): void {
                 if ($operationKey === 'create') {
-                    self::handleMultiRelationCreate(collect($values), $relation);
+                    self::handleMultiRelationCreate(new Collection($values), $relation);
                 }
             });
         });
@@ -276,9 +276,9 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\HasOne $relation */
             $relation = $model->{$relationName}();
 
-            collect($nestedOperations)->each(function ($values, string $operationKey) use ($relation): void {
+            (new Collection($nestedOperations))->each(function ($values, string $operationKey) use ($relation): void {
                 if ($operationKey === 'create') {
-                    self::handleSingleRelationCreate(collect($values), $relation);
+                    self::handleSingleRelationCreate(new Collection($values), $relation);
                 }
             });
         });
@@ -297,9 +297,9 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\MorphMany $relation */
             $relation = $model->{$relationName}();
 
-            collect($nestedOperations)->each(function ($values, string $operationKey) use ($relation): void {
+            (new Collection($nestedOperations))->each(function ($values, string $operationKey) use ($relation): void {
                 if ($operationKey === 'create') {
-                    self::handleMultiRelationCreate(collect($values), $relation);
+                    self::handleMultiRelationCreate(new Collection($values), $relation);
                 }
             });
         });
@@ -318,9 +318,9 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\MorphOne $relation */
             $relation = $model->{$relationName}();
 
-            collect($nestedOperations)->each(function ($values, string $operationKey) use ($relation): void {
+            (new Collection($nestedOperations))->each(function ($values, string $operationKey) use ($relation): void {
                 if ($operationKey === 'create') {
-                    self::handleSingleRelationCreate(collect($values), $relation);
+                    self::handleSingleRelationCreate(new Collection($values), $relation);
                 }
             });
         });
@@ -339,9 +339,9 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\BelongsToMany $relation */
             $relation = $model->{$relationName}();
 
-            collect($nestedOperations)->each(function ($values, string $operationKey) use ($relation): void {
+            (new Collection($nestedOperations))->each(function ($values, string $operationKey) use ($relation): void {
                 if ($operationKey === 'create') {
-                    self::handleMultiRelationCreate(collect($values), $relation);
+                    self::handleMultiRelationCreate(new Collection($values), $relation);
                 }
 
                 if ($operationKey === 'connect') {
@@ -364,9 +364,9 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\HasMany $relation */
             $relation = $model->{$relationName}();
 
-            collect($nestedOperations)->each(function ($values, string $operationKey) use ($relation): void {
+            (new Collection($nestedOperations))->each(function ($values, string $operationKey) use ($relation): void {
                 if ($operationKey === 'create') {
-                    self::handleMultiRelationCreate(collect($values), $relation);
+                    self::handleMultiRelationCreate(new Collection($values), $relation);
                 }
             });
         });

--- a/src/Execution/QueryAST.php
+++ b/src/Execution/QueryAST.php
@@ -24,7 +24,7 @@ class QueryAST
      */
     public function __construct(DocumentNode $documentNode)
     {
-        $this->definitions = collect($documentNode->definitions);
+        $this->definitions = new Collection($documentNode->definitions);
     }
 
     /**

--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -3,6 +3,7 @@
 namespace Nuwave\Lighthouse\Schema\AST;
 
 use GraphQL\Language\AST\Node;
+use Illuminate\Support\Collection;
 use GraphQL\Language\AST\NamedTypeNode;
 use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeExtensionNode;
@@ -123,7 +124,7 @@ class ASTBuilder
     {
         return $document->objectTypeDefinitions()->reduce(
             function (DocumentAST $document, ObjectTypeDefinitionNode $objectType): DocumentAST {
-                return collect($objectType->fields)->reduce(
+                return (new Collection($objectType->fields))->reduce(
                     function (DocumentAST $document, FieldDefinitionNode $fieldDefinition) use ($objectType): DocumentAST {
                         return $this->directiveFactory
                             ->createFieldManipulators($fieldDefinition)
@@ -149,9 +150,9 @@ class ASTBuilder
     {
         return $document->objectTypeDefinitions()->reduce(
             function (DocumentAST $document, ObjectTypeDefinitionNode $parentType): DocumentAST {
-                return collect($parentType->fields)->reduce(
+                return (new Collection($parentType->fields))->reduce(
                     function (DocumentAST $document, FieldDefinitionNode $parentField) use ($parentType): DocumentAST {
-                        return collect($parentField->arguments)->reduce(
+                        return (new Collection($parentField->arguments))->reduce(
                             function (DocumentAST $document, InputValueDefinitionNode $argDefinition) use ($parentType, $parentField): DocumentAST {
                                 return $this->directiveFactory
                                     ->createArgManipulators($argDefinition)
@@ -257,7 +258,7 @@ class ASTBuilder
     {
         $hasTypeImplementingNode = $document->objectTypeDefinitions()
             ->contains(function (ObjectTypeDefinitionNode $objectType): bool {
-                return collect($objectType->interfaces)
+                return (new Collection($objectType->interfaces))
                     ->contains(function (NamedTypeNode $interface): bool {
                         return $interface->name->value === 'Node';
                     });

--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -6,6 +6,7 @@ use GraphQL\Utils\AST;
 use GraphQL\Language\Parser;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeList;
+use Illuminate\Support\Collection;
 use GraphQL\Language\AST\ArgumentNode;
 use GraphQL\Language\AST\ListTypeNode;
 use GraphQL\Language\AST\DirectiveNode;
@@ -52,12 +53,12 @@ class ASTHelper
      */
     public static function mergeUniqueNodeList($original, $addition, bool $overwriteDuplicates = false): NodeList
     {
-        $newNames = collect($addition)
+        $newNames = (new Collection($addition))
             ->pluck('name.value')
             ->filter()
             ->all();
 
-        $remainingDefinitions = collect($original)
+        $remainingDefinitions = (new Collection($original))
             ->reject(function ($definition) use ($newNames, $overwriteDuplicates): bool {
                 $oldName = $definition->name->value;
                 $collisionOccurred = in_array(
@@ -138,7 +139,7 @@ class ASTHelper
      */
     public static function directiveHasArgument(DirectiveNode $directiveDefinition, string $name): bool
     {
-        return collect($directiveDefinition->arguments)
+        return (new Collection($directiveDefinition->arguments))
             ->contains(function (ArgumentNode $argumentNode) use ($name): bool {
                 return $argumentNode->name->value === $name;
             });
@@ -152,7 +153,7 @@ class ASTHelper
      */
     public static function directiveArgValue(DirectiveNode $directive, string $name, $default = null)
     {
-        $arg = collect($directive->arguments)
+        $arg = (new Collection($directive->arguments))
             ->first(function (ArgumentNode $argumentNode) use ($name): bool {
                 return $argumentNode->name->value === $name;
             });
@@ -189,7 +190,7 @@ class ASTHelper
      */
     public static function directiveDefinition(Node $definitionNode, string $name): ?DirectiveNode
     {
-        return collect($definitionNode->directives)
+        return (new Collection($definitionNode->directives))
             ->first(function (DirectiveNode $directiveDefinitionNode) use ($name): bool {
                 return $directiveDefinitionNode->name->value === $name;
             });
@@ -204,7 +205,7 @@ class ASTHelper
      */
     public static function hasDirectiveDefinition(Node $definitionNode, string $name): bool
     {
-        return collect($definitionNode->directives)
+        return (new Collection($definitionNode->directives))
             ->contains(function (DirectiveNode $directiveDefinitionNode) use ($name): bool {
                 return $directiveDefinitionNode->name->value === $name;
             });
@@ -249,7 +250,7 @@ class ASTHelper
                     }
 
                     $objectType->fields = new NodeList(
-                        collect($objectType->fields)
+                        (new Collection($objectType->fields))
                             ->map(function (FieldDefinitionNode $field) use ($directive): FieldDefinitionNode {
                                 $field->directives = $field->directives->merge([$directive]);
 

--- a/src/Schema/AST/DocumentAST.php
+++ b/src/Schema/AST/DocumentAST.php
@@ -46,7 +46,7 @@ class DocumentAST implements Serializable
         /** @var \Illuminate\Support\Collection<\GraphQL\Language\AST\TypeExtensionNode> $typeExtensions */
         /** @var \Illuminate\Support\Collection<\GraphQL\Language\AST\DefinitionNode> $definitionNodes */
         // We can not store type extensions in the map, since they do not have unique names
-        [$typeExtensions, $definitionNodes] = collect($documentNode->definitions)
+        [$typeExtensions, $definitionNodes] = (new Collection($documentNode->definitions))
             ->partition(function (DefinitionNode $definitionNode): bool {
                 return $definitionNode instanceof TypeExtensionNode;
             });
@@ -70,7 +70,7 @@ class DocumentAST implements Serializable
      */
     protected function typeExtensionUniqueKey(TypeExtensionNode $typeExtensionNode): string
     {
-        $fieldNames = collect($typeExtensionNode->fields)
+        $fieldNames = (new Collection($typeExtensionNode->fields))
             ->map(function ($field): string {
                 return $field->name->value;
             })

--- a/src/Schema/Conversion/DefinitionNodeConverter.php
+++ b/src/Schema/Conversion/DefinitionNodeConverter.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Schema\Conversion;
 
 use GraphQL\Type\Definition\Type;
 use GraphQL\Language\AST\NodeKind;
+use Illuminate\Support\Collection;
 use GraphQL\Language\AST\NamedTypeNode;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
 
@@ -54,7 +55,7 @@ class DefinitionNodeConverter
         }
 
         // Re-wrap the type by applying the wrappers in the reversed order
-        return collect($wrappers)
+        return (new Collection($wrappers))
             ->reverse()
             ->reduce(
                 function (Type $type, string $kind): Type {

--- a/src/Schema/Directives/Args/RulesDirective.php
+++ b/src/Schema/Directives/Args/RulesDirective.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
+use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgValidationDirective;
 use Nuwave\Lighthouse\Support\Traits\HasArgumentPath as HasArgumentPathTrait;
@@ -36,7 +37,7 @@ class RulesDirective extends BaseDirective implements ArgValidationDirective, Ha
      */
     public function getMessages(): array
     {
-        return collect($this->directiveArgValue('messages'))
+        return (new Collection($this->directiveArgValue('messages')))
             ->mapWithKeys(function (string $message, string $rule): array {
                 $argumentPath = $this->argumentPathAsDotNotation();
 

--- a/src/Schema/Directives/Args/RulesForArrayDirective.php
+++ b/src/Schema/Directives/Args/RulesForArrayDirective.php
@@ -3,6 +3,7 @@
 namespace Nuwave\Lighthouse\Schema\Directives\Args;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgDirectiveForArray;
 use Nuwave\Lighthouse\Support\Contracts\ArgValidationDirective;
@@ -42,7 +43,7 @@ class RulesForArrayDirective extends BaseDirective implements ArgValidationDirec
      */
     public function getMessages(): array
     {
-        return collect($this->directiveArgValue('messages'))
+        return (new Collection($this->directiveArgValue('messages')))
             ->mapWithKeys(function (string $message, string $rule): array {
                 $argumentPath = $this->argumentPathAsDotNotation();
 

--- a/src/Schema/Directives/Fields/CacheDirective.php
+++ b/src/Schema/Directives/Fields/CacheDirective.php
@@ -6,6 +6,7 @@ use Closure;
 use Carbon\Carbon;
 use GraphQL\Deferred;
 use Illuminate\Cache\CacheManager;
+use Illuminate\Support\Collection;
 use GraphQL\Language\AST\DirectiveNode;
 use GraphQL\Type\Definition\ResolveInfo;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
@@ -145,12 +146,12 @@ class CacheDirective extends BaseDirective implements FieldMiddleware
         }
 
         $fields = data_get($nodeValue->getTypeDefinition(), 'fields', []);
-        $nodeKey = collect($fields)->reduce(function (?string $key, FieldDefinitionNode $field): ?string {
+        $nodeKey = (new Collection($fields))->reduce(function (?string $key, FieldDefinitionNode $field): ?string {
             if ($key) {
                 return $key;
             }
 
-            $hasCacheKey = collect($field->directives)
+            $hasCacheKey = (new Collection($field->directives))
                 ->contains(function (DirectiveNode $directive): bool {
                     return $directive->name->value === 'cacheKey';
                 });
@@ -161,7 +162,7 @@ class CacheDirective extends BaseDirective implements FieldMiddleware
         });
 
         if (! $nodeKey) {
-            $nodeKey = collect($fields)->reduce(function (?string $key, FieldDefinitionNode $field): ?string {
+            $nodeKey = (new Collection($fields))->reduce(function (?string $key, FieldDefinitionNode $field): ?string {
                 if ($key) {
                     return $key;
                 }

--- a/src/Schema/Directives/Fields/CanDirective.php
+++ b/src/Schema/Directives/Fields/CanDirective.php
@@ -63,7 +63,7 @@ class CanDirective extends BaseDirective implements FieldMiddleware
      */
     protected function getAbilities(): Collection
     {
-        return collect(
+        return new Collection(
             $this->directiveArgValue('ability')
             ?? $this->directiveArgValue('if')
         );

--- a/src/Schema/Directives/Fields/CreateDirective.php
+++ b/src/Schema/Directives/Fields/CreateDirective.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
+use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\DatabaseManager;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
@@ -57,11 +58,11 @@ class CreateDirective extends BaseDirective implements FieldResolver
                     : $args;
 
                 if (! config('lighthouse.transactional_mutations', true)) {
-                    return MutationExecutor::executeCreate($model, collect($args))->refresh();
+                    return MutationExecutor::executeCreate($model, new Collection($args))->refresh();
                 }
 
                 return $this->db->connection()->transaction(function () use ($model, $args): Model {
-                    return MutationExecutor::executeCreate($model, collect($args))->refresh();
+                    return MutationExecutor::executeCreate($model, new Collection($args))->refresh();
                 });
             }
         );

--- a/src/Schema/Directives/Fields/MiddlewareDirective.php
+++ b/src/Schema/Directives/Fields/MiddlewareDirective.php
@@ -129,7 +129,7 @@ class MiddlewareDirective extends BaseDirective implements FieldMiddleware, Node
             );
         }
 
-        $middlewareArgValue = collect($middlewareArgValue)
+        $middlewareArgValue = (new Collection($middlewareArgValue))
             ->map(function (string $middleware) : string {
                 // Add slashes, as re-parsing of the values removes a level of slashes
                 return addslashes($middleware);
@@ -139,7 +139,7 @@ class MiddlewareDirective extends BaseDirective implements FieldMiddleware, Node
         $middlewareDirective = PartialParser::directive("@middleware(checks: [\"$middlewareArgValue\"])");
 
         $objectType->fields = new NodeList(
-            collect($objectType->fields)
+            (new Collection($objectType->fields))
                 ->map(function (FieldDefinitionNode $fieldDefinition) use ($middlewareDirective): FieldDefinitionNode {
                     // If the field already has middleware defined, skip over it
                     // Field middleware are more specific then those defined on a type
@@ -169,7 +169,7 @@ class MiddlewareDirective extends BaseDirective implements FieldMiddleware, Node
         $middleware = $router->getMiddleware();
         $middlewareGroups = $router->getMiddlewareGroups();
 
-        return collect($middlewareArgValue)
+        return (new Collection($middlewareArgValue))
             ->map(function (string $name) use ($middleware, $middlewareGroups): array {
                 return (array) MiddlewareNameResolver::resolve($name, $middleware, $middlewareGroups);
             })

--- a/src/Schema/Directives/Fields/UpdateDirective.php
+++ b/src/Schema/Directives/Fields/UpdateDirective.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives\Fields;
 
+use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\DatabaseManager;
 use Nuwave\Lighthouse\Execution\Utils\GlobalId;
@@ -62,11 +63,11 @@ class UpdateDirective extends BaseDirective implements FieldResolver
                 }
 
                 if (! config('lighthouse.transactional_mutations', true)) {
-                    return MutationExecutor::executeUpdate($model, collect($args))->refresh();
+                    return MutationExecutor::executeUpdate($model, new Collection($args))->refresh();
                 }
 
                 return $this->db->connection()->transaction(function () use ($model, $args): Model {
-                    return MutationExecutor::executeUpdate($model, collect($args))->refresh();
+                    return MutationExecutor::executeUpdate($model, new Collection($args))->refresh();
                 });
             }
         );

--- a/src/Schema/Directives/Nodes/GroupDirective.php
+++ b/src/Schema/Directives/Nodes/GroupDirective.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Schema\Directives\Nodes;
 
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeList;
+use Illuminate\Support\Collection;
 use GraphQL\Language\AST\DirectiveNode;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use GraphQL\Language\AST\FieldDefinitionNode;
@@ -75,7 +76,7 @@ class GroupDirective extends BaseDirective implements NodeManipulator
         $namespaceValue = addslashes($namespaceValue);
 
         $objectType->fields = new NodeList(
-            collect($objectType->fields)
+            (new Collection($objectType->fields))
                 ->map(function (FieldDefinitionNode $fieldDefinition) use ($namespaceValue): FieldDefinitionNode {
                     $existingNamespaces = ASTHelper::directiveDefinition(
                         $fieldDefinition,

--- a/src/Schema/Factories/DirectiveFactory.php
+++ b/src/Schema/Factories/DirectiveFactory.php
@@ -60,7 +60,7 @@ class DirectiveFactory
      */
     public function __construct(Dispatcher $dispatcher)
     {
-        $this->directiveBaseNamespaces = collect([
+        $this->directiveBaseNamespaces = (new Collection([
             // User defined directives (top priority)
             config('lighthouse.namespaces.directives'),
 
@@ -71,9 +71,9 @@ class DirectiveFactory
             'Nuwave\\Lighthouse\\Schema\\Directives\\Args',
             'Nuwave\\Lighthouse\\Schema\\Directives\\Fields',
             'Nuwave\\Lighthouse\\Schema\\Directives\\Nodes',
-        ])->flatten()
-            ->filter()
-            ->all();
+        ]))->flatten()
+           ->filter()
+           ->all();
     }
 
     /**
@@ -196,7 +196,7 @@ class DirectiveFactory
      */
     protected function createAssociatedDirectivesOfType(Node $node, string $directiveClass): Collection
     {
-        return collect($node->directives)
+        return (new Collection($node->directives))
             ->map(function (DirectiveNode $directive) use ($node) {
                 return $this->create($directive->name->value, $node);
             })

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -174,7 +174,7 @@ class FieldFactory
      */
     protected function getArgumentValues(): Collection
     {
-        return collect($this->fieldValue->getField()->arguments)
+        return (new Collection($this->fieldValue->getField()->arguments))
             ->map(function (InputValueDefinitionNode $inputValueDefinition): ArgumentValue {
                 return new ArgumentValue($inputValueDefinition, $this->fieldValue);
             });
@@ -270,7 +270,7 @@ class FieldFactory
         }
 
         if ($type instanceof InputObjectType) {
-            collect($type->getFields())
+            (new Collection($type->getFields()))
                 ->each(
                     function (InputObjectField $field) use ($argumentPath, &$argValue): void {
                         $noValuePassedForThisArgument = ! array_key_exists($field->name, $argValue);

--- a/src/Schema/Factories/NodeFactory.php
+++ b/src/Schema/Factories/NodeFactory.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Schema\Factories;
 
 use Closure;
 use GraphQL\Type\Definition\Type;
+use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Support\Utils;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\EnumType;
@@ -167,7 +168,7 @@ class NodeFactory
         return new EnumType([
             'name' => $enumDefinition->name->value,
             'description' => data_get($enumDefinition->description, 'value'),
-            'values' => collect($enumDefinition->values)
+            'values' => (new Collection($enumDefinition->values))
                 ->mapWithKeys(function (EnumValueDefinitionNode $field) {
                     // Get the directive that is defined on the field itself
                     $directive = ASTHelper::directiveDefinition($field, 'enum');
@@ -233,7 +234,7 @@ class NodeFactory
             'description' => data_get($objectDefinition->description, 'value'),
             'fields' => $this->resolveFieldsFunction($objectDefinition),
             'interfaces' => function () use ($objectDefinition) {
-                return collect($objectDefinition->interfaces)
+                return (new Collection($objectDefinition->interfaces))
                     ->map(function (NamedTypeNode $interface) {
                         return $this->typeRegistry->get($interface->name->value);
                     })
@@ -251,7 +252,7 @@ class NodeFactory
     protected function resolveFieldsFunction($definition): Closure
     {
         return function () use ($definition): array {
-            return collect($definition->fields)
+            return (new Collection($definition->fields))
                 ->mapWithKeys(function (FieldDefinitionNode $fieldDefinition) use ($definition): array {
                     $fieldValue = new FieldValue(
                         new NodeValue($definition),
@@ -288,7 +289,7 @@ class NodeFactory
     protected function resolveInputFieldsFunction(InputObjectTypeDefinitionNode $definition): Closure
     {
         return function () use ($definition) {
-            return collect($definition->fields)
+            return (new Collection($definition->fields))
                 ->mapWithKeys(function (InputValueDefinitionNode $inputValueDefinition) {
                     $argumentValue = new ArgumentValue($inputValueDefinition);
 
@@ -382,7 +383,7 @@ class NodeFactory
             'name' => $nodeName,
             'description' => data_get($unionDefinition->description, 'value'),
             'types' => function () use ($unionDefinition) {
-                return collect($unionDefinition->types)
+                return (new Collection($unionDefinition->types))
                     ->map(function (NamedTypeNode $type) {
                         return $this->typeRegistry->get(
                             $type->name->value

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -123,12 +123,12 @@ class SchemaBuilder
                 return new Directive([
                     'name' => $directive->name->value,
                     'description' => data_get($directive->description, 'value'),
-                    'locations' => collect($directive->locations)
+                    'locations' => (new Collection($directive->locations))
                         ->map(function ($location) {
                             return $location->value;
                         })
                         ->toArray(),
-                    'args' => collect($directive->arguments)
+                    'args' => (new Collection($directive->arguments))
                         ->map(function (InputValueDefinitionNode $argument) {
                             $fieldArgumentConfig = [
                                 'name' => $argument->name->value,

--- a/src/Schema/Source/SchemaStitcher.php
+++ b/src/Schema/Source/SchemaStitcher.php
@@ -3,6 +3,7 @@
 namespace Nuwave\Lighthouse\Schema\Source;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class SchemaStitcher implements SchemaSourceProvider
@@ -58,7 +59,7 @@ class SchemaStitcher implements SchemaSourceProvider
             self::throwFileNotFoundException($path);
         }
 
-        return collect(file($path))
+        return (new Collection(file($path)))
             ->map(function (string $line) use ($path) {
                 if (! Str::startsWith(trim($line), '#import ')) {
                     return rtrim($line, PHP_EOL).PHP_EOL;
@@ -79,7 +80,7 @@ class SchemaStitcher implements SchemaSourceProvider
 
                 $importFilePaths = glob($importFilePath);
 
-                return collect($importFilePaths)
+                return (new Collection($importFilePaths))
                     ->map(function ($file) {
                         return self::gatherSchemaImportsRecursively($file);
                     })

--- a/src/Schema/Values/CacheValue.php
+++ b/src/Schema/Values/CacheValue.php
@@ -123,7 +123,7 @@ class CacheValue
 
         ksort($args);
 
-        return collect($args)->map(function ($value, $key) {
+        return (new Collection($args))->map(function ($value, $key) {
             $keyValue = is_array($value)
                 ? json_encode($value, true)
                 : $value;
@@ -159,7 +159,7 @@ class CacheValue
      */
     protected function implode(array $items): string
     {
-        return collect($items)
+        return (new Collection($items))
             ->filter()
             ->values()
             ->implode(':');

--- a/src/Subscriptions/Broadcasters/PusherBroadcaster.php
+++ b/src/Subscriptions/Broadcasters/PusherBroadcaster.php
@@ -5,6 +5,7 @@ namespace Nuwave\Lighthouse\Subscriptions\Broadcasters;
 use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Subscriptions\Subscriber;
 use Nuwave\Lighthouse\Subscriptions\Contracts\Broadcaster;
 use Nuwave\Lighthouse\Subscriptions\Contracts\StoresSubscriptions;
@@ -72,7 +73,7 @@ class PusherBroadcaster implements Broadcaster
      */
     public function hook(Request $request): JsonResponse
     {
-        collect($request->input('events', []))
+        (new Collection($request->input('events', [])))
             ->filter(function ($event): bool {
                 return Arr::get($event, 'name') === 'channel_vacated';
             })

--- a/src/Subscriptions/StorageManager.php
+++ b/src/Subscriptions/StorageManager.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Subscriptions;
 
 use Illuminate\Support\Arr;
 use Illuminate\Cache\CacheManager;
+use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Subscriptions\Contracts\StoresSubscriptions;
 
 class StorageManager implements StoresSubscriptions
@@ -81,12 +82,12 @@ class StorageManager implements StoresSubscriptions
         $key = self::TOPIC_KEY.".{$topic}";
 
         if (! $this->cache->has($key)) {
-            return collect();
+            return new Collection;
         }
 
         $channels = json_decode($this->cache->get($key), true);
 
-        return collect($channels)
+        return (new Collection($channels))
             ->map(function (string $channel): ?Subscriber {
                 return $this->subscriberByChannel($channel);
             })

--- a/src/Subscriptions/SubscriptionRegistry.php
+++ b/src/Subscriptions/SubscriptionRegistry.php
@@ -133,7 +133,7 @@ class SubscriptionRegistry
         // sure the schema has been generated.
         $this->graphQL->prepSchema();
 
-        return collect($subscriber->query->definitions)
+        return (new Collection($subscriber->query->definitions))
             ->filter(function (Node $node): bool {
                 return $node instanceof OperationDefinitionNode;
             })
@@ -141,7 +141,7 @@ class SubscriptionRegistry
                 return $node->operation === 'subscription';
             })
             ->flatMap(function (OperationDefinitionNode $node) {
-                return collect($node->selectionSet->selections)
+                return (new Collection($node->selectionSet->selections))
                     ->map(function (FieldNode $field): string {
                         return $field->name->value;
                     })

--- a/src/Support/Http/Responses/MemoryStream.php
+++ b/src/Support/Http/Responses/MemoryStream.php
@@ -3,6 +3,7 @@
 namespace Nuwave\Lighthouse\Support\Http\Responses;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Support\Contracts\CanStreamResponse;
 
 class MemoryStream extends Stream implements CanStreamResponse
@@ -23,7 +24,7 @@ class MemoryStream extends Stream implements CanStreamResponse
     public function stream(array $data, array $paths, bool $final): void
     {
         if (! empty($paths)) {
-            $data = collect($paths)
+            $data = (new Collection($paths))
                 ->mapWithKeys(function ($path) use ($data): array {
                     $response['data'] = Arr::get($data, "data.{$path}", []);
                     $errors = $this->chunkError($path, $data);

--- a/src/Support/Http/Responses/ResponseStream.php
+++ b/src/Support/Http/Responses/ResponseStream.php
@@ -5,6 +5,7 @@ namespace Nuwave\Lighthouse\Support\Http\Responses;
 use Closure;
 use Exception;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Support\Contracts\CanStreamResponse;
 
 class ResponseStream extends Stream implements CanStreamResponse
@@ -25,14 +26,14 @@ class ResponseStream extends Stream implements CanStreamResponse
     public function stream(array $data, array $paths, bool $final): void
     {
         if (! empty($paths)) {
-            $paths = collect($paths);
+            $paths = new Collection($paths);
             $lastKey = $paths->count() - 1;
 
             $paths
                 ->map(function (string $path, int $i) use ($data, $final, $lastKey): string {
                     $terminating = $final && ($i === $lastKey);
                     $chunk['data'] = Arr::get($data, "data.{$path}");
-                    $chunk['path'] = collect(explode('.', $path))
+                    $chunk['path'] = (new Collection(explode('.', $path)))
                         ->map(function ($partial) {
                             return is_numeric($partial)
                                 ? (int) $partial

--- a/src/Support/Http/Responses/Stream.php
+++ b/src/Support/Http/Responses/Stream.php
@@ -3,6 +3,7 @@
 namespace Nuwave\Lighthouse\Support\Http\Responses;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 
 abstract class Stream
 {
@@ -19,7 +20,7 @@ abstract class Stream
             return null;
         }
 
-        return collect($data['errors'])
+        return (new Collection($data['errors']))
             ->filter(function (array $error) use ($path): bool {
                 return Str::startsWith(implode('.', $error['path']), $path);
             })

--- a/tests/Integration/Defer/DeferDBTest.php
+++ b/tests/Integration/Defer/DeferDBTest.php
@@ -252,7 +252,7 @@ class DeferDBTest extends DBTestCase
 
         $deferredCompanies = $chunks[2];
         $this->assertCount(6, $deferredCompanies);
-        collect($deferredCompanies)->each(function (array $item) use ($companies): void {
+        (new Collection($deferredCompanies))->toBase()->each(function (array $item) use ($companies): void {
             $item = $item['data'];
             $this->assertArrayHasKey('name', $item);
 

--- a/tests/Integration/Schema/Directives/Args/SearchDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/Args/SearchDirectiveTest.php
@@ -7,6 +7,7 @@ use Tests\DBTestCase;
 use Mockery\MockInterface;
 use Tests\Utils\Models\Post;
 use Laravel\Scout\EngineManager;
+use Illuminate\Support\Collection;
 use Laravel\Scout\Engines\NullEngine;
 
 class SearchDirectiveTest extends DBTestCase
@@ -51,7 +52,7 @@ class SearchDirectiveTest extends DBTestCase
             'title' => 'another great title',
         ]);
 
-        $this->engine->shouldReceive('map')->andReturn(collect([$postA, $postC]));
+        $this->engine->shouldReceive('map')->andReturn(new Collection([$postA, $postC]));
 
         $this->schema = '
         type Post {
@@ -106,7 +107,7 @@ class SearchDirectiveTest extends DBTestCase
 
         $this->engine->shouldReceive('map')
             ->andReturn(
-                collect([$postA, $postB])
+                new Collection([$postA, $postB])
             )
             ->once();
 
@@ -120,7 +121,7 @@ class SearchDirectiveTest extends DBTestCase
                 Mockery::any(),
                 Mockery::any()
             )
-            ->andReturn(collect([$postA, $postB]))
+            ->andReturn(new Collection([$postA, $postB]))
             ->once();
 
         $this->schema = '
@@ -176,7 +177,7 @@ class SearchDirectiveTest extends DBTestCase
 
         $this->engine->shouldReceive('map')
             ->andReturn(
-                collect([$postA, $postB])
+                new Collection([$postA, $postB])
             )
             ->once();
 
@@ -186,7 +187,7 @@ class SearchDirectiveTest extends DBTestCase
                 Mockery::any(),
                 Mockery::not('page')
             )
-            ->andReturn(collect([$postA, $postB]))
+            ->andReturn(new Collection([$postA, $postB]))
             ->once();
 
         $this->schema = '

--- a/tests/Integration/Schema/Types/InterfaceTest.php
+++ b/tests/Integration/Schema/Types/InterfaceTest.php
@@ -140,7 +140,8 @@ class InterfaceTest extends DBTestCase
         }
         ');
 
-        $interface = collect($result->jsonGet('data.__schema.types'))
+        $interface = Collection ::make($result->jsonGet('data.__schema.types'))
+            ->toBase()
             ->firstWhere('name', 'Nameable');
 
         $this->assertCount(2, $interface['possibleTypes']);

--- a/tests/Unit/Schema/AST/ASTHelperTest.php
+++ b/tests/Unit/Schema/AST/ASTHelperTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Schema\AST;
 
 use Tests\TestCase;
+use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
@@ -61,7 +62,7 @@ class ASTHelperTest extends TestCase
 
         $this->assertCount(3, $objectType1->fields);
 
-        $firstNameField = collect($objectType1->fields)->first(function ($field) {
+        $firstNameField = (new Collection($objectType1->fields))->first(function ($field) {
             return $field->name->value === 'first_name';
         });
 

--- a/tests/Unit/Schema/Directives/Client/ClientDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/Client/ClientDirectiveTest.php
@@ -40,15 +40,15 @@ class ClientDirectiveTest extends TestCase
     public function resolve($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo): string
     {
         /** @var \GraphQL\Language\AST\ArgumentNode $key */
-        $key = collect($resolveInfo->fieldNodes)
+        $key = (new Collection($resolveInfo->fieldNodes))
             ->flatMap(function (FieldNode $node): Collection {
-                return collect($node->directives);
+                return new Collection($node->directives);
             })
             ->filter(function (DirectiveNode $directive): bool {
                 return $directive->name->value === 'filter';
             })
             ->flatMap(function (DirectiveNode $directive): Collection {
-                return collect($directive->arguments);
+                return new Collection($directive->arguments);
             })
             ->first(function (ArgumentNode $arg): bool {
                 return $arg->name->value === 'key';

--- a/tests/Unit/Subscriptions/Iterators/SyncIteratorTest.php
+++ b/tests/Unit/Subscriptions/Iterators/SyncIteratorTest.php
@@ -69,6 +69,6 @@ class SyncIteratorTest extends TestCase
      */
     protected function items(): Collection
     {
-        return collect([1, 2, 3]);
+        return new Collection([1, 2, 3]);
     }
 }


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Added Docs for all relevant versions

**Related Issue/Intent**

We tend to avoid using helpers, and prefer `Arr` and `Str` classes.
This PR gets rid of `collect()` helper and use directly `\Illuminate\Support\Collection`

Resolves #652 

**Changes**
Use of `->toBase()` method in 2 tests.

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**
None

<!-- If there are any breaking changes, list them here. -->
