### PR TITLE
Use ExtensionsResponse class for BuildExtensionsResponse

### DIFF
--- a/docs/master/api-reference/events.md
+++ b/docs/master/api-reference/events.md
@@ -197,13 +197,73 @@ namespace Nuwave\Lighthouse\Events;
 /**
  * Fires after a query was resolved.
  *
- * Listeners of this event must return an array comprised of
- * a single key and the extension content as the value, e.g.
- * ['tracing' => ['some' => 'content']]
+ * Listeners of this event may return an instance of
+ * @see \Nuwave\Lighthouse\Execution\ExtensionsResponse
+ * that is then added to the response.
  */
 class BuildExtensionsResponse
 {
     //
+}
+```
+
+```php
+<?php
+
+namespace Nuwave\Lighthouse\Execution;
+
+/**
+ * May be returned from listeners of the event:
+ * @see \Nuwave\Lighthouse\Events\BuildExtensionsResponse
+ */
+class ExtensionsResponse
+{
+    /**
+     * Will be used as the key in the response map.
+     *
+     * @var string
+     */
+    protected $key;
+
+    /**
+     * JSON-encodable content of the extension.
+     *
+     * @var mixed
+     */
+    protected $content;
+
+    /**
+     * ExtensionsResponse constructor.
+     *
+     * @param  string  $key
+     * @param  mixed  $content
+     * @return void
+     */
+    public function __construct(string $key, $content)
+    {
+        $this->key = $key;
+        $this->content = $content;
+    }
+
+    /**
+     * Return the key of the extension.
+     *
+     * @return string
+     */
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * Return the JSON-encodable content of the extension.
+     *
+     * @return mixed
+     */
+    public function content()
+    {
+        return $this->content;
+    }
 }
 ```
 

--- a/src/Events/BuildExtensionsResponse.php
+++ b/src/Events/BuildExtensionsResponse.php
@@ -5,9 +5,9 @@ namespace Nuwave\Lighthouse\Events;
 /**
  * Fires after a query was resolved.
  *
- * Listeners of this event must return an array comprised of
- * a single key and the extension content as the value, e.g.
- * ['tracing' => ['some' => 'content']]
+ * Listeners of this event may return an instance of
+ * @see \Nuwave\Lighthouse\Execution\ExtensionsResponse
+ * that is then added to the response.
  */
 class BuildExtensionsResponse
 {

--- a/src/Execution/ExtensionsResponse.php
+++ b/src/Execution/ExtensionsResponse.php
@@ -3,7 +3,7 @@
 namespace Nuwave\Lighthouse\Execution;
 
 /**
- * May be returned from listeners of the event:
+ * May be returned from listeners of the event:.
  * @see \Nuwave\Lighthouse\Events\BuildExtensionsResponse
  */
 class ExtensionsResponse

--- a/src/Execution/ExtensionsResponse.php
+++ b/src/Execution/ExtensionsResponse.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Nuwave\Lighthouse\Execution;
+
+/**
+ * May be returned from listeners of the event:
+ * @see \Nuwave\Lighthouse\Events\BuildExtensionsResponse
+ */
+class ExtensionsResponse
+{
+    /**
+     * Will be used as the key in the response map.
+     *
+     * @var string
+     */
+    protected $key;
+
+    /**
+     * JSON-encodable content of the extension.
+     *
+     * @var mixed
+     */
+    protected $content;
+
+    /**
+     * ExtensionsResponse constructor.
+     *
+     * @param  string  $key
+     * @param  mixed  $content
+     * @return void
+     */
+    public function __construct(string $key, $content)
+    {
+        $this->key = $key;
+        $this->content = $content;
+    }
+
+    /**
+     * Return the key of the extension.
+     *
+     * @return string
+     */
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * Return the JSON-encodable content of the extension.
+     *
+     * @return mixed
+     */
+    public function content()
+    {
+        return $this->content;
+    }
+}

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -191,19 +191,15 @@ class GraphQL
             $this->getValidationRules() + DocumentValidator::defaultRules()
         );
 
-        // Listeners of this event must return an array comprised of
-        // a single key and the extension content as the value, e.g.
-        // ['tracing' => ['some' => 'content']]
-        $extensionResults = $this->eventDispatcher->dispatch(
+        /** @var \Nuwave\Lighthouse\Execution\ExtensionsResponse[] $extensionsResponses */
+        $extensionsResponses = $this->eventDispatcher->dispatch(
             new BuildExtensionsResponse
         );
 
-        // Ensure we preserve the extension keys while flattening
-        foreach ($extensionResults as $singleExtensionResult) {
-            $result->extensions = array_merge(
-                $result->extensions,
-                $singleExtensionResult
-            );
+        foreach ($extensionsResponses as $extensionsReponse) {
+            if($extensionsReponse){
+                $result->extensions[$extensionsReponse->key()] = $extensionsReponse->content();
+            }
         }
 
         $result->setErrorsHandler(

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -197,7 +197,7 @@ class GraphQL
         );
 
         foreach ($extensionsResponses as $extensionsReponse) {
-            if($extensionsReponse){
+            if ($extensionsReponse) {
                 $result->extensions[$extensionsReponse->key()] = $extensionsReponse->content();
             }
         }

--- a/src/Subscriptions/SubscriptionRegistry.php
+++ b/src/Subscriptions/SubscriptionRegistry.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use GraphQL\Language\AST\FieldNode;
 use Nuwave\Lighthouse\Events\StartExecution;
 use GraphQL\Language\AST\OperationDefinitionNode;
+use Nuwave\Lighthouse\Execution\ExtensionsResponse;
 use Nuwave\Lighthouse\Schema\Types\GraphQLSubscription;
 use Nuwave\Lighthouse\Schema\Types\NotFoundSubscription;
 use Nuwave\Lighthouse\Subscriptions\Contracts\ContextSerializer;
@@ -170,15 +171,16 @@ class SubscriptionRegistry
     /**
      * Get all current subscribers.
      *
-     * @return string[]
+     * @return \Nuwave\Lighthouse\Execution\ExtensionsResponse
      */
-    public function handleBuildExtensionsResponse(): array
+    public function handleBuildExtensionsResponse(): ExtensionsResponse
     {
-        return [
-            'lighthouse_subscriptions' => [
+        return new ExtensionsResponse(
+            'lighthouse_subscriptions',
+            [
                 'version' => 1,
                 'channels' => $this->subscribers,
-            ],
-        ];
+            ]
+        );
     }
 }

--- a/src/Tracing/Tracing.php
+++ b/src/Tracing/Tracing.php
@@ -9,6 +9,7 @@ use Nuwave\Lighthouse\Events\ManipulateAST;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Events\StartExecution;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
+use Nuwave\Lighthouse\Execution\ExtensionsResponse;
 use Nuwave\Lighthouse\Events\BuildExtensionsResponse;
 
 class Tracing
@@ -69,14 +70,15 @@ class Tracing
      * Return additional information for the result.
      *
      * @param  \Nuwave\Lighthouse\Events\BuildExtensionsResponse  $buildExtensionsResponse
-     * @return mixed[]
+     * @return \Nuwave\Lighthouse\Execution\ExtensionsResponse
      */
-    public function handleBuildExtensionsResponse(BuildExtensionsResponse $buildExtensionsResponse): array
+    public function handleBuildExtensionsResponse(BuildExtensionsResponse $buildExtensionsResponse): ExtensionsResponse
     {
         $end = Carbon::now();
 
-        return [
-            'tracing' => [
+        return new ExtensionsResponse(
+            'tracing',
+            [
                 'version' => 1,
                 'startTime' => $this->requestStart->format("Y-m-d\TH:i:s.v\Z"),
                 'endTime' => $end->format("Y-m-d\TH:i:s.v\Z"),
@@ -84,8 +86,8 @@ class Tracing
                 'execution' => [
                     'resolvers' => $this->resolverTraces,
                 ],
-            ],
-        ];
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
- [X] Added Docs for all relevant versions

Improves type safety on the receiving side of the event.

Also, this handles the case of listeners returning nothing/`null`.

Resolves #671 

**Breaking changes**

Yes, but that is why we are still in beta 😉 It concerns only a feature that was just introduced.
