### PR TITLE
Fix the links to the events in plugin development

### DIFF
--- a/docs/master/guides/plugin-development.md
+++ b/docs/master/guides/plugin-development.md
@@ -9,17 +9,25 @@ may utilize this to offer users extra functionality that is not available in the
 - Consider improving the extensibility of Lighthouse with a PR instead of doing workarounds.
 - Add your plugin to the Resources page once it is done.
 
-## Add schema definitions
+## Events
+
+Lighthouse offers a unified way of hooking into the complete execution lifecycle
+through [Laravel's event system](https://laravel.com/docs/events).
+You may use the Service Provider of your package to register listeners.
+
+You can find a complete list of all dispatched events [in the events API reference](../api-reference/events.md).
+
+### Add schema definitions
 
 You might want to provide some additional types to the schema. The preferred way to
-do this is to listen for the [`BuildSchemaString`](../api-reference/events.md#buildSchemaString) event.
+do this is to listen for the [`BuildSchemaString`](../api-reference/events.md#buildschemastring) event.
 
 Check out [the test suite](https://github.com/nuwave/lighthouse/tree/master/tests/Integration/Events/BuildSchemaStringTest.php)
 for an example of how this works.
 
-## Add custom directives
+### Add custom directives
 
-You can add your custom directives to Lighthouse by listening for the `RegisterDirectiveNamespaces` event.
+You can add your custom directives to Lighthouse by listening for the [`RegisterDirectiveNamespaces`](../api-reference/events.md#registerdirectivenamespaces) event.
 
 Check out [the test suite](https://github.com/nuwave/lighthouse/tree/master/tests/Integration/Events/RegisterDirectiveNamespacesTest.php)
 for an example of how this works.

--- a/tests/Integration/Events/BuildSchemaStringTest.php
+++ b/tests/Integration/Events/BuildSchemaStringTest.php
@@ -5,7 +5,7 @@ namespace Tests\Integration\Events;
 use Tests\TestCase;
 use Nuwave\Lighthouse\Events\BuildSchemaString;
 
-class BuildingASTTest extends TestCase
+class BuildSchemaStringTest extends TestCase
 {
     /**
      * @test

--- a/tests/Integration/Events/RegisterDirectiveNamespacesTest.php
+++ b/tests/Integration/Events/RegisterDirectiveNamespacesTest.php
@@ -8,7 +8,7 @@ use Nuwave\Lighthouse\Schema\Factories\DirectiveFactory;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 use Tests\Utils\Directives\FieldDirective as TestFieldDirective;
 
-class RegisteringDirectiveBaseNamespacesTest extends TestCase
+class RegisterDirectiveNamespacesTest extends TestCase
 {
     /**
      * @var \Nuwave\Lighthouse\Schema\Factories\DirectiveFactory


### PR DESCRIPTION
Should make the section on plugin development more straightforward and easier to understand, and it actually has working links now :)