### PR TITLE
Convert schema-defined enum default values to internal values

### DIFF
--- a/src/Schema/Directives/Fields/FindDirective.php
+++ b/src/Schema/Directives/Fields/FindDirective.php
@@ -43,10 +43,9 @@ class FindDirective extends BaseDirective implements FieldResolver
                     $this->directiveArgValue('scopes', []),
                     $resolveInfo
                 );
-                $total = $query->count();
 
-                if ($total > 1) {
-                    throw new Error('Query returned more than one result.');
+                if ($query->count() > 1) {
+                    throw new Error('The query returned more than one result.');
                 }
 
                 return $query->first();

--- a/tests/Unit/Schema/SchemaBuilderTest.php
+++ b/tests/Unit/Schema/SchemaBuilderTest.php
@@ -202,4 +202,31 @@ class SchemaBuilderTest extends TestCase
 
         $this->assertSame('yo?', $type->getField('bar')->description);
     }
+
+    /**
+     * @test
+     */
+    public function itResolvesEnumDefaultValuesToInternalValues(): void
+    {
+        $schema = $this->buildSchema('
+        type Query {
+            foo(
+                bar: Baz = FOOBAR
+            ): Int
+        }
+        
+        enum Baz {
+            FOOBAR @enum(value: "internal")
+        }
+        ');
+
+        $this->assertSame(
+            'internal',
+            $schema
+                ->getQueryType()
+                ->getField('foo')
+                ->getArg('bar')
+                ->defaultValue
+        );
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests

This resolves a bug where a schema definition like this:

```graphql
        type Query {
            foo(
                bar: Baz = FOOBAR
            ): Int
        }
        
        enum Baz {
            FOOBAR @enum(value: "internal")
        }
```

would pass `string("FOOBAR")` to the field resolver instead of the internal value.