### PR TITLE
Enhance the basics of resolving fields

### DIFF
--- a/docs/master/api-reference/resolvers.md
+++ b/docs/master/api-reference/resolvers.md
@@ -10,12 +10,7 @@ Resolvers are always called with the same 4 arguments:
 use GraphQL\Type\Definition\ResolveInfo;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
-public function resolve(
-    $rootValue,
-    array $args,
-    GraphQLContext $context,
-    ResolveInfo $resolveInfo
-)
+function ($rootValue, array $args, GraphQLContext $context, ResolveInfo $resolveInfo)
 ```
 
 1. `$rootValue`: The result that was returned from the parent field.
@@ -27,15 +22,15 @@ Lighthouse passes in an instance of `Nuwave\Lighthouse\Schema\Context` by defaul
 4. `ResolveInfo $resolveInfo`: Information about the query itself,
 such as the execution state, the field name, path to the field from the root, and more.
 
+The return value of this must fit the return type defined for the corresponding field from the schema. 
+
 ## Complexity function signature
 
 The complexity function is used to calculate a query complexity score for a field.
 You can define your own complexity function with the [@complexity](../api-reference/directives.md#complexity) directive.
 
 ```php
-<?php
-
-public function complexity(int $childrenComplexity, array $args): int
+function (int $childrenComplexity, array $args): int
 ```
 
 1. `$childrenComplexity`: The complexity of the children of the field. In case you expect to return

--- a/docs/master/getting-started/installation.md
+++ b/docs/master/getting-started/installation.md
@@ -1,5 +1,8 @@
 # Installation
 
+The following section teaches you how to install Lighthouse in your project.
+Make sure you familiarize yourself with [the basics](../the-basics/schema.md) before diving in.
+
 ## Install via composer
 
 ```bash

--- a/docs/master/guides/plugin-development.md
+++ b/docs/master/guides/plugin-development.md
@@ -31,3 +31,22 @@ You can add your custom directives to Lighthouse by listening for the [`Register
 
 Check out [the test suite](https://github.com/nuwave/lighthouse/tree/master/tests/Integration/Events/RegisterDirectiveNamespacesTest.php)
 for an example of how this works.
+
+## Change the default resolver
+
+The first priority when looking for a resolver is always given to `FieldResolver` directives.
+
+After that, Lighthouse attempts to find a default resolver.
+
+The interface [`\Nuwave\Lighthouse\Support\Contracts\ProvidesResolver`](../../../src/Support/Contracts/ProvidesResolver.php)
+is expected to provide a resolver in case no resolver directive is defined for a field.
+
+If the field is defined on the root `Query` or `Mutation` types,
+Lighthouse's default implementation looks for a class with the capitalized name
+of the field in the configured default location.
+
+Non-root fields fall back to [webonyx's default resolver](http://webonyx.github.io/graphql-php/data-fetching/#default-field-resolver).
+You may overwrite this by passing a `callable` to `\GraphQL\Executor\Executor::setDefaultFieldResolver`. 
+
+When the field is defined on the root `Subscription` type, the [`\Nuwave\Lighthouse\Support\Contracts\ProvidesSubscriptionResolver`](../../../src/Support/Contracts/ProvidesSubscriptionResolver.php)
+interface is used instead.

--- a/docs/master/the-basics/fields.md
+++ b/docs/master/the-basics/fields.md
@@ -228,6 +228,8 @@ If you need to implement custom resolvers for fields that are not on one of the
 root types `Query` or `Mutation`, you can use either the
 [@field](../api-reference/directives.md#field) or [@method](../api-reference/directives.md#method) directive.
 
+You may also [change the default resolver](../guides/plugin-development.md#change-the-default-resolver) if you need.
+
 ## Query data
 
 Lighthouse provides many resolvers that are already built-in, so you do not have to define them yourself.

--- a/docs/master/the-basics/types.md
+++ b/docs/master/the-basics/types.md
@@ -7,7 +7,7 @@ look into the [GraphQL documentation](https://graphql.org/learn/schema/)
 ## Object Type
 
 Object types define the resources of your API and are closely related to Eloquent models.
-They must have a unique name and have a set of fields.
+They must have a unique name and contain a set of fields.
 
 ```graphql
 type User {

--- a/src/Defer/DeferrableDirective.php
+++ b/src/Defer/DeferrableDirective.php
@@ -51,13 +51,13 @@ class DeferrableDirective extends BaseDirective implements Directive, FieldMiddl
      */
     public function handleField(FieldValue $value, Closure $next): FieldValue
     {
-        $resolver = $value->getResolver();
+        $previousResolver = $value->getResolver();
         $fieldType = $value->getField()->type;
 
         $value->setResolver(
-            function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($resolver, $fieldType) {
-                $wrappedResolver = function () use ($resolver, $root, $args, $context, $resolveInfo) {
-                    return $resolver($root, $args, $context, $resolveInfo);
+            function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($previousResolver, $fieldType) {
+                $wrappedResolver = function () use ($previousResolver, $root, $args, $context, $resolveInfo) {
+                    return $previousResolver($root, $args, $context, $resolveInfo);
                 };
                 $path = implode('.', $resolveInfo->path);
 
@@ -67,7 +67,7 @@ class DeferrableDirective extends BaseDirective implements Directive, FieldMiddl
 
                 return $this->defer->isStreaming()
                     ? $this->defer->findOrResolve($wrappedResolver, $path)
-                    : $resolver($root, $args, $context, $resolveInfo);
+                    : $previousResolver($root, $args, $context, $resolveInfo);
             }
         );
 

--- a/src/LighthouseServiceProvider.php
+++ b/src/LighthouseServiceProvider.php
@@ -2,12 +2,14 @@
 
 namespace Nuwave\Lighthouse;
 
+use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Validator;
 use Illuminate\Support\ServiceProvider;
 use GraphQL\Type\Definition\ResolveInfo;
 use Nuwave\Lighthouse\Schema\NodeRegistry;
+use Nuwave\Lighthouse\Schema\ResolverProvider;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
 use Nuwave\Lighthouse\Console\QueryCommand;
 use Nuwave\Lighthouse\Console\UnionCommand;
@@ -28,11 +30,14 @@ use Nuwave\Lighthouse\Console\ValidateSchemaCommand;
 use Illuminate\Config\Repository as ConfigRepository;
 use Nuwave\Lighthouse\Execution\MultipartFormRequest;
 use Illuminate\Validation\Factory as ValidationFactory;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\CreatesContext;
 use Nuwave\Lighthouse\Schema\Factories\DirectiveFactory;
 use Nuwave\Lighthouse\Support\Contracts\CreatesResponse;
 use Nuwave\Lighthouse\Schema\Source\SchemaSourceProvider;
 use Nuwave\Lighthouse\Support\Contracts\CanStreamResponse;
+use Nuwave\Lighthouse\Support\Contracts\ProvidesResolver;
+use Nuwave\Lighthouse\Support\Contracts\ProvidesSubscriptionResolver;
 use Nuwave\Lighthouse\Support\Http\Responses\ResponseStream;
 
 class LighthouseServiceProvider extends ServiceProvider
@@ -121,6 +126,18 @@ class LighthouseServiceProvider extends ServiceProvider
             return new SchemaStitcher(
                 config('lighthouse.schema.register', '')
             );
+        });
+
+        $this->app->bind(ProvidesResolver::class, ResolverProvider::class);
+        $this->app->bind(ProvidesSubscriptionResolver::class, function(): ProvidesSubscriptionResolver {
+            return new class() implements ProvidesSubscriptionResolver {
+                public function provideSubscriptionResolver(FieldValue $fieldValue): Closure
+                {
+                   throw new \Exception(
+                       'Add the SubscriptionServiceProvider to your config/app.php to enable subscriptions.'
+                   );
+                }
+            };
         });
 
         if ($this->app->runningInConsole()) {

--- a/src/LighthouseServiceProvider.php
+++ b/src/LighthouseServiceProvider.php
@@ -9,17 +9,18 @@ use Illuminate\Validation\Validator;
 use Illuminate\Support\ServiceProvider;
 use GraphQL\Type\Definition\ResolveInfo;
 use Nuwave\Lighthouse\Schema\NodeRegistry;
-use Nuwave\Lighthouse\Schema\ResolverProvider;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
 use Nuwave\Lighthouse\Console\QueryCommand;
 use Nuwave\Lighthouse\Console\UnionCommand;
 use Nuwave\Lighthouse\Console\ScalarCommand;
 use Illuminate\Contracts\Container\Container;
 use Nuwave\Lighthouse\Console\MutationCommand;
+use Nuwave\Lighthouse\Schema\ResolverProvider;
 use Nuwave\Lighthouse\Console\InterfaceCommand;
 use Nuwave\Lighthouse\Execution\ContextFactory;
 use Nuwave\Lighthouse\Execution\GraphQLRequest;
 use Nuwave\Lighthouse\Execution\SingleResponse;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Console\ClearCacheCommand;
 use Nuwave\Lighthouse\Console\PrintSchemaCommand;
 use Nuwave\Lighthouse\Execution\GraphQLValidator;
@@ -30,15 +31,14 @@ use Nuwave\Lighthouse\Console\ValidateSchemaCommand;
 use Illuminate\Config\Repository as ConfigRepository;
 use Nuwave\Lighthouse\Execution\MultipartFormRequest;
 use Illuminate\Validation\Factory as ValidationFactory;
-use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\CreatesContext;
 use Nuwave\Lighthouse\Schema\Factories\DirectiveFactory;
 use Nuwave\Lighthouse\Support\Contracts\CreatesResponse;
 use Nuwave\Lighthouse\Schema\Source\SchemaSourceProvider;
-use Nuwave\Lighthouse\Support\Contracts\CanStreamResponse;
 use Nuwave\Lighthouse\Support\Contracts\ProvidesResolver;
-use Nuwave\Lighthouse\Support\Contracts\ProvidesSubscriptionResolver;
+use Nuwave\Lighthouse\Support\Contracts\CanStreamResponse;
 use Nuwave\Lighthouse\Support\Http\Responses\ResponseStream;
+use Nuwave\Lighthouse\Support\Contracts\ProvidesSubscriptionResolver;
 
 class LighthouseServiceProvider extends ServiceProvider
 {
@@ -129,11 +129,11 @@ class LighthouseServiceProvider extends ServiceProvider
         });
 
         $this->app->bind(ProvidesResolver::class, ResolverProvider::class);
-        $this->app->bind(ProvidesSubscriptionResolver::class, function(): ProvidesSubscriptionResolver {
+        $this->app->bind(ProvidesSubscriptionResolver::class, function (): ProvidesSubscriptionResolver {
             return new class() implements ProvidesSubscriptionResolver {
                 public function provideSubscriptionResolver(FieldValue $fieldValue): Closure
                 {
-                   throw new \Exception(
+                    throw new \Exception(
                        'Add the SubscriptionServiceProvider to your config/app.php to enable subscriptions.'
                    );
                 }

--- a/src/Schema/Directives/Fields/AllDirective.php
+++ b/src/Schema/Directives/Fields/AllDirective.php
@@ -25,7 +25,6 @@ class AllDirective extends BaseDirective implements FieldResolver
      * Resolve the field directive.
      *
      * @param  \Nuwave\Lighthouse\Schema\Values\FieldValue  $fieldValue
-     *
      * @return \Nuwave\Lighthouse\Schema\Values\FieldValue
      */
     public function resolveField(FieldValue $fieldValue): FieldValue

--- a/src/Schema/Directives/Fields/AuthDirective.php
+++ b/src/Schema/Directives/Fields/AuthDirective.php
@@ -40,7 +40,6 @@ class AuthDirective extends BaseDirective implements FieldResolver
      * Resolve the field directive.
      *
      * @param  \Nuwave\Lighthouse\Schema\Values\FieldValue  $fieldValue
-     *
      * @return \Nuwave\Lighthouse\Schema\Values\FieldValue
      */
     public function resolveField(FieldValue $fieldValue): FieldValue

--- a/src/Schema/Directives/Fields/CanDirective.php
+++ b/src/Schema/Directives/Fields/CanDirective.php
@@ -34,11 +34,11 @@ class CanDirective extends BaseDirective implements FieldMiddleware
      */
     public function handleField(FieldValue $value, Closure $next): FieldValue
     {
-        $resolver = $value->getResolver();
+        $previousResolver = $value->getResolver();
 
         return $next(
             $value->setResolver(
-                function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($resolver) {
+                function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($previousResolver) {
                     $gate = app(Gate::class);
                     $gateArguments = $this->getGateArguments();
 
@@ -48,7 +48,7 @@ class CanDirective extends BaseDirective implements FieldMiddleware
                         }
                     );
 
-                    return call_user_func_array($resolver, func_get_args());
+                    return call_user_func_array($previousResolver, func_get_args());
                 }
             )
         );

--- a/src/Schema/Directives/Fields/EventDirective.php
+++ b/src/Schema/Directives/Fields/EventDirective.php
@@ -6,15 +6,32 @@ use Closure;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 
 class EventDirective extends BaseDirective implements FieldMiddleware
 {
+    /**
+     * @var \Illuminate\Contracts\Events\Dispatcher
+     */
+    protected $eventsDispatcher;
+
+    /**
+     * Construct EventDirective.
+     *
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $eventsDispatcher
+     * @return void
+     */
+    public function __construct(EventsDispatcher $eventsDispatcher)
+    {
+        $this->eventsDispatcher = $eventsDispatcher;
+    }
+
     /**
      * Name of the directive.
      *
      * @return string
      */
-    public function name():string
+    public function name(): string
     {
         return 'event';
     }
@@ -31,14 +48,20 @@ class EventDirective extends BaseDirective implements FieldMiddleware
     {
         $eventBaseName = $this->directiveArgValue('fire') ?? $this->directiveArgValue('class');
         $eventClassName = $this->namespaceClassName($eventBaseName);
-        $resolver = $value->getResolver();
+        $previousResolver = $value->getResolver();
 
-        return $next($value->setResolver(function () use ($resolver, $eventClassName) {
-            $args = func_get_args();
-            $value = call_user_func_array($resolver, $args);
-            event(new $eventClassName($value));
+        return $next(
+            $value->setResolver(
+                function () use ($previousResolver, $eventClassName) {
+                    $result = call_user_func_array($previousResolver, func_get_args());
 
-            return $value;
-        }));
+                    $this->eventsDispatcher->dispatch(
+                        new $eventClassName($result)
+                    );
+
+                    return $result;
+                }
+            )
+        );
     }
 }

--- a/src/Schema/Directives/Fields/FirstDirective.php
+++ b/src/Schema/Directives/Fields/FirstDirective.php
@@ -25,7 +25,6 @@ class FirstDirective extends BaseDirective implements FieldResolver
      * Resolve the field directive.
      *
      * @param  \Nuwave\Lighthouse\Schema\Values\FieldValue  $fieldValue
-     *
      * @return \Nuwave\Lighthouse\Schema\Values\FieldValue
      */
     public function resolveField(FieldValue $fieldValue): FieldValue

--- a/src/Schema/Directives/Fields/InjectDirective.php
+++ b/src/Schema/Directives/Fields/InjectDirective.php
@@ -48,12 +48,12 @@ class InjectDirective extends BaseDirective implements FieldMiddleware
             );
         }
 
-        $previousResolvers = $value->getResolver();
+        $previousResolver = $value->getResolver();
 
         return $next(
             $value->setResolver(
-                function ($rootValue, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($contextAttributeName, $argumentName, $previousResolvers) {
-                    return $previousResolvers(
+                function ($rootValue, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($contextAttributeName, $argumentName, $previousResolver) {
+                    return $previousResolver(
                         $rootValue,
                         Arr::add($args, $argumentName, data_get($context, $contextAttributeName)),
                         $context,

--- a/src/Schema/Directives/Fields/MethodDirective.php
+++ b/src/Schema/Directives/Fields/MethodDirective.php
@@ -24,7 +24,6 @@ class MethodDirective extends BaseDirective implements FieldResolver
      * Resolve the field directive.
      *
      * @param  \Nuwave\Lighthouse\Schema\Values\FieldValue  $fieldValue
-     *
      * @return \Nuwave\Lighthouse\Schema\Values\FieldValue
      */
     public function resolveField(FieldValue $fieldValue): FieldValue

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -6,8 +6,6 @@ use Closure;
 use Illuminate\Support\Collection;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\InputType;
-use Nuwave\Lighthouse\Support\Contracts\ProvidesResolver;
-use Nuwave\Lighthouse\Support\Contracts\ProvidesSubscriptionResolver;
 use Nuwave\Lighthouse\Support\NoValue;
 use GraphQL\Type\Definition\ListOfType;
 use Nuwave\Lighthouse\Support\Pipeline;
@@ -25,11 +23,13 @@ use Nuwave\Lighthouse\Support\Contracts\ArgDirective;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 use Nuwave\Lighthouse\Support\Contracts\HasErrorBuffer;
 use Nuwave\Lighthouse\Support\Contracts\HasArgumentPath;
+use Nuwave\Lighthouse\Support\Contracts\ProvidesResolver;
 use Nuwave\Lighthouse\Support\Traits\HasResolverArguments;
 use Nuwave\Lighthouse\Support\Contracts\ArgFilterDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgDirectiveForArray;
 use Nuwave\Lighthouse\Support\Contracts\ArgValidationDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgTransformerDirective;
+use Nuwave\Lighthouse\Support\Contracts\ProvidesSubscriptionResolver;
 
 class FieldFactory
 {

--- a/src/Schema/ResolverProvider.php
+++ b/src/Schema/ResolverProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema;
+
+use Closure;
+use GraphQL\Executor\Executor;
+use Illuminate\Support\Str;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Support\Contracts\ProvidesResolver;
+use Nuwave\Lighthouse\Support\Utils;
+
+class ResolverProvider implements ProvidesResolver
+{
+    /**
+     * Provide a field resolver in case no resolver directive is defined for a field.
+     *
+     * @param  \Nuwave\Lighthouse\Schema\Values\FieldValue  $fieldValue
+     * @return \Closure
+     *
+     * @throws \Nuwave\Lighthouse\Exceptions\DefinitionException
+     */
+    public function provideResolver(FieldValue $fieldValue): Closure
+    {
+        if ($fieldValue->parentIsRootType()) {
+            $resolverClass = Utils::namespaceClassname(
+                Str::studly($fieldValue->getFieldName()),
+                $fieldValue->defaultNamespacesForParent(),
+                function (string $class): bool {
+                    return method_exists($class, 'resolve');
+                }
+            );
+
+            if (! $resolverClass) {
+                throw new DefinitionException(
+                    "Could not locate a default resolver for the field {$fieldValue->getFieldName()}"
+                );
+            }
+
+            return Closure::fromCallable(
+                [app($resolverClass), 'resolve']
+            );
+        }
+
+        return Closure::fromCallable(
+            Executor::getDefaultFieldResolver()
+        );
+    }
+}

--- a/src/Schema/ResolverProvider.php
+++ b/src/Schema/ResolverProvider.php
@@ -3,12 +3,12 @@
 namespace Nuwave\Lighthouse\Schema;
 
 use Closure;
-use GraphQL\Executor\Executor;
 use Illuminate\Support\Str;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
-use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Support\Contracts\ProvidesResolver;
+use GraphQL\Executor\Executor;
 use Nuwave\Lighthouse\Support\Utils;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Support\Contracts\ProvidesResolver;
 
 class ResolverProvider implements ProvidesResolver
 {

--- a/src/Schema/Values/FieldValue.php
+++ b/src/Schema/Values/FieldValue.php
@@ -169,116 +169,9 @@ class FieldValue
      *
      * @return \Closure
      */
-    public function getResolver(): Closure
+    public function getResolver(): ?Closure
     {
-        if (! isset($this->resolver)) {
-            $this->resolver = $this->defaultResolver();
-        }
-
         return $this->resolver;
-    }
-
-    /**
-     * Get default field resolver.
-     *
-     * @return \Closure
-     *
-     * @throws \Nuwave\Lighthouse\Exceptions\DefinitionException
-     */
-    protected function defaultResolver(): Closure
-    {
-        if ($this->getParentName() === 'Subscription') {
-            return $this->defaultSubscriptionResolver();
-        }
-
-        if ($this->parentIsRootType()) {
-            $resolverClass = Utils::namespaceClassname(
-                Str::studly($this->getFieldName()),
-                $this->defaultNamespacesForParent(),
-                function (string $class): bool {
-                    return method_exists($class, 'resolve');
-                }
-            );
-
-            if (! $resolverClass) {
-                throw new DefinitionException(
-                    "Could not locate a default resolver for the field {$this->field->name->value}"
-                );
-            }
-
-            return Closure::fromCallable(
-                [app($resolverClass), 'resolve']
-            );
-        }
-
-        return Closure::fromCallable(
-            [Executor::class, 'defaultFieldResolver']
-        );
-    }
-
-    /**
-     * Get the default resolver for a subscription field.
-     *
-     * @return \Closure
-     *
-     * @throws \Nuwave\Lighthouse\Exceptions\DefinitionException
-     */
-    protected function defaultSubscriptionResolver(): Closure
-    {
-        if ($directive = ASTHelper::directiveDefinition($this->field, 'subscription')) {
-            $className = ASTHelper::directiveArgValue($directive, 'class');
-        } else {
-            $className = Str::studly($this->getFieldName());
-        }
-
-        $className = Utils::namespaceClassname(
-            $className,
-            $this->defaultNamespacesForParent(),
-            function (string $class): bool {
-                return is_subclass_of($class, GraphQLSubscription::class);
-            }
-        );
-
-        if (! $className) {
-            throw new DefinitionException(
-                "No class found for the subscription field {$this->getFieldName()}"
-            );
-        }
-
-        /** @var \Nuwave\Lighthouse\Schema\Types\GraphQLSubscription $subscription */
-        $subscription = app($className);
-        /** @var \Nuwave\Lighthouse\Subscriptions\SubscriptionRegistry $subscriptionRegistry */
-        $subscriptionRegistry = app(SubscriptionRegistry::class);
-
-        // Subscriptions can only be placed on a single field on the root
-        // query, so there is no need to consider the field path
-        $subscriptionRegistry->register(
-            $subscription,
-            $this->getFieldName()
-        );
-
-        return function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($subscription, $subscriptionRegistry) {
-            if ($root instanceof Subscriber) {
-                return $subscription->resolve($root->root, $args, $context, $resolveInfo);
-            }
-
-            $subscriber = new Subscriber(
-                $args,
-                $context,
-                $resolveInfo
-            );
-
-            if (! $subscription->can($subscriber)) {
-                throw new UnauthorizedSubscriber(
-                    'Unauthorized subscription request'
-                );
-            }
-
-            $subscriptionRegistry->subscriber(
-                $subscriber,
-                $subscription->encodeTopic($subscriber, $this->getFieldName())
-            );
-        };
     }
 
     /**
@@ -339,7 +232,7 @@ class FieldValue
      *
      * @return bool
      */
-    protected function parentIsRootType(): bool
+    public function parentIsRootType(): bool
     {
         return in_array(
             $this->getParentName(),

--- a/src/Schema/Values/FieldValue.php
+++ b/src/Schema/Values/FieldValue.php
@@ -3,21 +3,10 @@
 namespace Nuwave\Lighthouse\Schema\Values;
 
 use Closure;
-use Illuminate\Support\Str;
-use GraphQL\Executor\Executor;
 use GraphQL\Type\Definition\Type;
-use Nuwave\Lighthouse\Support\Utils;
-use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Language\AST\StringValueNode;
-use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use GraphQL\Language\AST\FieldDefinitionNode;
-use Nuwave\Lighthouse\Subscriptions\Subscriber;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
-use Nuwave\Lighthouse\Schema\Types\GraphQLSubscription;
-use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
-use Nuwave\Lighthouse\Subscriptions\SubscriptionRegistry;
 use Nuwave\Lighthouse\Schema\Conversion\DefinitionNodeConverter;
-use Nuwave\Lighthouse\Subscriptions\Exceptions\UnauthorizedSubscriber;
 
 class FieldValue
 {

--- a/src/Subscriptions/SubscriptionResolverProvider.php
+++ b/src/Subscriptions/SubscriptionResolverProvider.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Nuwave\Lighthouse\Subscriptions;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Support\Str;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Schema\AST\ASTHelper;
+use Nuwave\Lighthouse\Schema\Types\GraphQLSubscription;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Subscriptions\Exceptions\UnauthorizedSubscriber;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+use Nuwave\Lighthouse\Support\Contracts\ProvidesSubscriptionResolver;
+use Nuwave\Lighthouse\Support\Utils;
+
+class SubscriptionResolverProvider implements ProvidesSubscriptionResolver
+{
+    /**
+     * @var \Nuwave\Lighthouse\Subscriptions\SubscriptionRegistry
+     */
+    protected $subscriptionRegistry;
+
+    /**
+     * ResolverProvider constructor.
+     *
+     * @param  \Nuwave\Lighthouse\Subscriptions\SubscriptionRegistry  $subscriptionRegistry
+     * @return void
+     */
+    public function __construct(SubscriptionRegistry $subscriptionRegistry)
+    {
+        $this->subscriptionRegistry = $subscriptionRegistry;
+    }
+
+    /**
+     * Provide a field resolver in case no resolver directive is defined for a field.
+     *
+     * @param  \Nuwave\Lighthouse\Schema\Values\FieldValue  $fieldValue
+     * @return \Closure
+     *
+     * @throws \Nuwave\Lighthouse\Exceptions\DefinitionException
+     */
+    public function provideSubscriptionResolver(FieldValue $fieldValue): Closure
+    {
+        $fieldName = $fieldValue->getFieldName();
+
+        if ($directive = ASTHelper::directiveDefinition($fieldValue->getField(), 'subscription')) {
+            $className = ASTHelper::directiveArgValue($directive, 'class');
+        } else {
+            $className = Str::studly($fieldName);
+        }
+
+        $className = Utils::namespaceClassname(
+            $className,
+            $fieldValue->defaultNamespacesForParent(),
+            function (string $class): bool {
+                return is_subclass_of($class, GraphQLSubscription::class);
+            }
+        );
+
+        if (! $className) {
+            throw new DefinitionException(
+                "No class found for the subscription field {$fieldName}"
+            );
+        }
+
+        /** @var \Nuwave\Lighthouse\Schema\Types\GraphQLSubscription $subscription */
+        $subscription = app($className);
+
+        // Subscriptions can only be placed on a single field on the root
+        // query, so there is no need to consider the field path
+        $this->subscriptionRegistry->register(
+            $subscription,
+            $fieldName
+        );
+
+        return function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($subscription, $fieldName) {
+            if ($root instanceof Subscriber) {
+                return $subscription->resolve($root->root, $args, $context, $resolveInfo);
+            }
+
+            $subscriber = new Subscriber(
+                $args,
+                $context,
+                $resolveInfo
+            );
+
+            if (! $subscription->can($subscriber)) {
+                throw new UnauthorizedSubscriber(
+                    'Unauthorized subscription request'
+                );
+            }
+
+            $this->subscriptionRegistry->subscriber(
+                $subscriber,
+                $subscription->encodeTopic($subscriber, $fieldName)
+            );
+        };
+    }
+}

--- a/src/Subscriptions/SubscriptionResolverProvider.php
+++ b/src/Subscriptions/SubscriptionResolverProvider.php
@@ -3,16 +3,16 @@
 namespace Nuwave\Lighthouse\Subscriptions;
 
 use Closure;
-use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Support\Str;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Support\Utils;
+use GraphQL\Type\Definition\ResolveInfo;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
-use Nuwave\Lighthouse\Schema\Types\GraphQLSubscription;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Subscriptions\Exceptions\UnauthorizedSubscriber;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Schema\Types\GraphQLSubscription;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 use Nuwave\Lighthouse\Support\Contracts\ProvidesSubscriptionResolver;
-use Nuwave\Lighthouse\Support\Utils;
+use Nuwave\Lighthouse\Subscriptions\Exceptions\UnauthorizedSubscriber;
 
 class SubscriptionResolverProvider implements ProvidesSubscriptionResolver
 {

--- a/src/Subscriptions/SubscriptionServiceProvider.php
+++ b/src/Subscriptions/SubscriptionServiceProvider.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Nuwave\Lighthouse\Subscriptions\Contracts\ContextSerializer;
 use Nuwave\Lighthouse\Subscriptions\Contracts\StoresSubscriptions;
 use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionIterator;
+use Nuwave\Lighthouse\Support\Contracts\ProvidesSubscriptionResolver;
 use Nuwave\Lighthouse\Support\Contracts\SubscriptionExceptionHandler;
 use Nuwave\Lighthouse\Subscriptions\Contracts\AuthorizesSubscriptions;
 use Nuwave\Lighthouse\Subscriptions\Contracts\BroadcastsSubscriptions;
@@ -72,5 +73,6 @@ class SubscriptionServiceProvider extends ServiceProvider
         $this->app->bind(SubscriptionIterator::class, SyncIterator::class);
         $this->app->bind(SubscriptionExceptionHandler::class, ExceptionHandler::class);
         $this->app->bind(BroadcastsSubscriptions::class, SubscriptionBroadcaster::class);
+        $this->app->bind(ProvidesSubscriptionResolver::class, SubscriptionResolverProvider::class);
     }
 }

--- a/src/Support/Contracts/ProvidesResolver.php
+++ b/src/Support/Contracts/ProvidesResolver.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Nuwave\Lighthouse\Support\Contracts;
+
+use Closure;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+
+interface ProvidesResolver
+{
+    /**
+     * Provide a field resolver in case no resolver directive is defined for a field.
+     *
+     * @param  \Nuwave\Lighthouse\Schema\Values\FieldValue  $fieldValue
+     * @return \Closure
+     */
+    public function provideResolver(FieldValue $fieldValue): Closure;
+}

--- a/src/Support/Contracts/ProvidesSubscriptionResolver.php
+++ b/src/Support/Contracts/ProvidesSubscriptionResolver.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Nuwave\Lighthouse\Support\Contracts;
+
+use Closure;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+
+interface ProvidesSubscriptionResolver
+{
+    /**
+     * Provide a field resolver for subscriptions.
+     *
+     * @param  \Nuwave\Lighthouse\Schema\Values\FieldValue  $fieldValue
+     * @return \Closure
+     */
+    public function provideSubscriptionResolver(FieldValue $fieldValue): Closure;
+}

--- a/tests/Integration/CustomDefaultResolverTest.php
+++ b/tests/Integration/CustomDefaultResolverTest.php
@@ -22,7 +22,7 @@ class CustomDefaultResolverTest extends TestCase
     public function resolve(): array
     {
         return [
-            'bar' => 'This should not be returned.'
+            'bar' => 'This should not be returned.',
         ];
     }
 
@@ -33,7 +33,7 @@ class CustomDefaultResolverTest extends TestCase
     {
         $previous = Executor::getDefaultFieldResolver();
 
-        Executor::setDefaultFieldResolver(function(): int {
+        Executor::setDefaultFieldResolver(function (): int {
             return self::CUSTOM_RESOLVER_RESULT;
         });
 

--- a/tests/Integration/CustomDefaultResolverTest.php
+++ b/tests/Integration/CustomDefaultResolverTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Integration;
+
+use Tests\TestCase;
+use GraphQL\Executor\Executor;
+
+class CustomDefaultResolverTest extends TestCase
+{
+    const CUSTOM_RESOLVER_RESULT = 123;
+
+    protected $schema = '
+    type Query {
+        foo: Foo @field(resolver: "Tests\\\\Integration\\\\CustomDefaultResolverTest@resolve")
+    }
+    
+    type Foo {
+        bar: Int
+    }
+    ';
+
+    public function resolve(): array
+    {
+        return [
+            'bar' => 'This should not be returned.'
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function itCanSpecifyACustomDefaultResolver(): void
+    {
+        $previous = Executor::getDefaultFieldResolver();
+
+        Executor::setDefaultFieldResolver(function(): int {
+            return self::CUSTOM_RESOLVER_RESULT;
+        });
+
+        $this->query('
+        {
+            foo {
+                bar
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'foo' => [
+                    'bar' => self::CUSTOM_RESOLVER_RESULT,
+                ],
+            ],
+        ]);
+
+        Executor::setDefaultFieldResolver($previous);
+    }
+}

--- a/tests/Unit/Schema/ResolverProviderTest.php
+++ b/tests/Unit/Schema/ResolverProviderTest.php
@@ -1,16 +1,29 @@
 <?php
 
-namespace Tests\Unit\Schema\Values;
+namespace Tests\Unit\Schema;
 
 use Closure;
+use Nuwave\Lighthouse\Schema\ResolverProvider;
 use Tests\TestCase;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 
-class FieldValueTest extends TestCase
+class ResolverProviderTest extends TestCase
 {
+    /**
+     * @var \Nuwave\Lighthouse\Schema\ResolverProvider
+     */
+    private $resolverProvider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resolverProvider = new ResolverProvider();
+    }
+
     /**
      * @test
      */
@@ -20,7 +33,7 @@ class FieldValueTest extends TestCase
 
         $this->assertInstanceOf(
             Closure::class,
-            $fieldValue->getResolver()
+            $this->resolverProvider->provideResolver($fieldValue)
         );
     }
 
@@ -33,7 +46,7 @@ class FieldValueTest extends TestCase
 
         $this->assertInstanceOf(
             Closure::class,
-            $fieldValue->getResolver()
+            $this->resolverProvider->provideResolver($fieldValue)
         );
     }
 
@@ -46,7 +59,7 @@ class FieldValueTest extends TestCase
 
         $this->assertInstanceOf(
             Closure::class,
-            $fieldValue->getResolver()
+            $this->resolverProvider->provideResolver($fieldValue)
         );
     }
 
@@ -57,7 +70,9 @@ class FieldValueTest extends TestCase
     {
         $this->expectException(DefinitionException::class);
 
-        $this->constructFieldValue('noFieldClass: Int')->getResolver();
+        $this->resolverProvider->provideResolver(
+            $this->constructFieldValue('noFieldClass: Int')
+        );
     }
 
     protected function constructFieldValue(string $fieldDefinition, string $parentTypeName = 'Query'): FieldValue

--- a/tests/Unit/Schema/ResolverProviderTest.php
+++ b/tests/Unit/Schema/ResolverProviderTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Unit\Schema;
 
 use Closure;
-use Nuwave\Lighthouse\Schema\ResolverProvider;
 use Tests\TestCase;
+use Nuwave\Lighthouse\Schema\ResolverProvider;
 use Nuwave\Lighthouse\Schema\Values\NodeValue;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;


### PR DESCRIPTION
- [x] Added Docs for all relevant versions

Resolves #590

It is now possible to swap out the default resolver for:
- queries and mutations
- subscriptions
- non-root fields

Many people come into Slack and do not understand the basics of how to resolve fields.

I tried to put that in a more prominent position in the docs and hopefully make it easier to spot for newcomers.

**Breaking Changes**

Nope, behaviour is the same.
