### PR TITLE
Allow pivot columns on a belongsToMany @update nested mutation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
     },
     "scripts": {
         "test": "phpunit --colors=always",
+        "test:failing": "phpunit --colors=always --group=failing",
         "test:unit": "phpunit --colors=always --testsuite Unit",
         "test:integration": "phpunit --colors=always --testsuite Integration"
     },

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -301,6 +301,15 @@ input CreatePostInput {
 }
 ```
 
+If the name of the Eloquent model does not match the return type of the field,
+or is located in a non-default namespace, set it with the `model` argument.
+
+```graphql
+type Mutation {
+    createPost(title: String!): Post @create(model: "Foo\\Bar\\MyPost")
+}
+```
+
 ## @delete
 
 Delete a model with a given id field. The field must be an `ID` type.
@@ -327,6 +336,15 @@ deleted models.
 ```graphql
 type Mutation {
     deletePosts(id: [ID!]!): [Post!]! @delete
+}
+```
+
+If the name of the Eloquent model does not match the return type of the field,
+or is located in a non-default namespace, set it with the `model` argument.
+
+```graphql
+type Mutation {
+    deletePost(id: ID!): Post @delete(model: "Bar\\Baz\\MyPost")
 }
 ```
 
@@ -1174,7 +1192,8 @@ type Mutation {
 }
 ```
 
-If the name of the Eloquent model does not match the return type of the field, set it with the `model` argument.
+If the name of the Eloquent model does not match the return type of the field,
+or is located in a non-default namespace, set it with the `model` argument.
 
 ```graphql
 type Mutation {

--- a/tests/Utils/Models/Role.php
+++ b/tests/Utils/Models/Role.php
@@ -14,7 +14,7 @@ class Role extends Model
 
     public function users(): BelongsToMany
     {
-        return $this->belongsToMany(User::class);
+        return $this->belongsToMany(User::class)->withPivot('approved', 'priority')->as("organizational");
     }
 
     public function acl(): BelongsTo

--- a/tests/Utils/Models/User.php
+++ b/tests/Utils/Models/User.php
@@ -46,7 +46,7 @@ class User extends Authenticatable
 
     public function roles(): BelongsToMany
     {
-        return $this->belongsToMany(Role::class);
+        return $this->belongsToMany(Role::class)->withPivot('approved', 'priority')->as("organizational");
     }
 
     public function scopeCompanyName(Builder $query, array $args): Builder

--- a/tests/database/migrations/2018_10_07_000010_create_testbench_role_user_table.php
+++ b/tests/database/migrations/2018_10_07_000010_create_testbench_role_user_table.php
@@ -15,6 +15,8 @@ class CreateTestbenchRoleUserTable extends Migration
             $table->unsignedInteger('user_id');
             $table->unsignedInteger('role_id');
             $table->primary(['user_id', 'role_id']);
+            $table->boolean('approved')->default(true);
+            $table->unsignedInteger('priority')->default(1);
         });
     }
 


### PR DESCRIPTION
- [X] Added or updated tests
- [x] Added Docs for all relevant versions

**Related Issue/Intent**

Resolves #691 

**Changes**

pivot is recognized as a special case while @updating nested mutation is processed.

**RFC**
I needed to access the protected property `accessor` on `$parentRelation` to make this work, I didn't see any other way? [See laravel API docs](https://laravel.com/api/5.8/Illuminate/Database/Eloquent/Relations/BelongsToMany.html)

so I had to make a kind of hacky helper function. I don't really know where it could be better put? Or if there would be a less hacky way of doing it?

