### PR TITLE
Replace incidental usage of private with protected

### DIFF
--- a/src/Defer/DeferrableDirective.php
+++ b/src/Defer/DeferrableDirective.php
@@ -21,7 +21,7 @@ class DeferrableDirective extends BaseDirective implements Directive, FieldMiddl
     /**
      * @var \Nuwave\Lighthouse\Defer\Defer
      */
-    private $defer;
+    protected $defer;
 
     /**
      * @param  \Nuwave\Lighthouse\Defer\Defer  $defer

--- a/src/Execution/DataLoader/BatchLoader.php
+++ b/src/Execution/DataLoader/BatchLoader.php
@@ -26,14 +26,14 @@ abstract class BatchLoader
      *
      * @var mixed[]
      */
-    private $results = [];
+    protected $results = [];
 
     /**
      * Check if data has been loaded.
      *
      * @var bool
      */
-    private $hasLoaded = false;
+    protected $hasLoaded = false;
 
     /**
      * Return an instance of a BatchLoader for a specific field.

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -82,7 +82,7 @@ class GraphQL
      *
      * @var \Nuwave\Lighthouse\Support\Contracts\CreatesContext
      */
-    private $createsContext;
+    protected $createsContext;
 
     /**
      * GraphQL constructor.

--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -19,7 +19,7 @@ class ASTBuilder
     /**
      * @var \Nuwave\Lighthouse\Schema\Factories\DirectiveFactory
      */
-    private $directiveFactory;
+    protected $directiveFactory;
 
     /**
      * ASTBuilder constructor.

--- a/src/Schema/Directives/Fields/AuthDirective.php
+++ b/src/Schema/Directives/Fields/AuthDirective.php
@@ -13,7 +13,7 @@ class AuthDirective extends BaseDirective implements FieldResolver
     /**
      * @var \Illuminate\Contracts\Auth\Factory
      */
-    private $authFactory;
+    protected $authFactory;
 
     /**
      * AuthDirective constructor.

--- a/src/Schema/Directives/Fields/CreateDirective.php
+++ b/src/Schema/Directives/Fields/CreateDirective.php
@@ -17,7 +17,7 @@ class CreateDirective extends BaseDirective implements FieldResolver
      *
      * @var \Illuminate\Database\DatabaseManager
      */
-    private $db;
+    protected $db;
 
     /**
      * @param  \Illuminate\Database\DatabaseManager  $database

--- a/src/Schema/Directives/Fields/UpdateDirective.php
+++ b/src/Schema/Directives/Fields/UpdateDirective.php
@@ -18,7 +18,7 @@ class UpdateDirective extends BaseDirective implements FieldResolver
      *
      * @var \Illuminate\Database\DatabaseManager
      */
-    private $db;
+    protected $db;
 
     /**
      * @param  \Illuminate\Database\DatabaseManager  $database

--- a/src/Schema/Types/Scalars/Date.php
+++ b/src/Schema/Types/Scalars/Date.php
@@ -69,7 +69,7 @@ class Date extends ScalarType
      *
      * @throws \GraphQL\Error\InvariantViolation|Error
      */
-    private function tryParsingDate($value, string $exceptionClass): Carbon
+    protected function tryParsingDate($value, string $exceptionClass): Carbon
     {
         try {
             return Carbon::createFromFormat('Y-m-d', $value)->startOfDay();

--- a/src/Schema/Types/Scalars/DateTime.php
+++ b/src/Schema/Types/Scalars/DateTime.php
@@ -70,7 +70,7 @@ class DateTime extends ScalarType
      *
      * @throws \GraphQL\Error\InvariantViolation|Error
      */
-    private function tryParsingDateTime($value, string $exceptionClass): Carbon
+    protected function tryParsingDateTime($value, string $exceptionClass): Carbon
     {
         try {
             return Carbon::createFromFormat(Carbon::DEFAULT_TO_STRING_FORMAT, $value);

--- a/src/Support/Http/Controllers/GraphQLController.php
+++ b/src/Support/Http/Controllers/GraphQLController.php
@@ -30,7 +30,7 @@ class GraphQLController extends Controller
     /**
      * @var \Nuwave\Lighthouse\Support\Contracts\CreatesResponse
      */
-    private $createsResponse;
+    protected $createsResponse;
 
     /**
      * Inject middleware into request.

--- a/src/Tracing/Tracing.php
+++ b/src/Tracing/Tracing.php
@@ -143,7 +143,7 @@ class Tracing
      * @param  float|int  $end
      * @return int
      */
-    private function diffTimeInNanoseconds($start, $end): int
+    protected function diffTimeInNanoseconds($start, $end): int
     {
         if ($this->platformSupportsNanoseconds()) {
             return $end - $start;
@@ -161,7 +161,7 @@ class Tracing
      *
      * @return bool
      */
-    private function platformSupportsNanoseconds(): bool
+    protected function platformSupportsNanoseconds(): bool
     {
         return function_exists('hrtime');
     }

--- a/tests/Integration/Schema/Directives/CacheDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/CacheDirectiveTest.php
@@ -15,7 +15,7 @@ class CacheDirectiveTest extends DBTestCase
     /**
      * @var \Illuminate\Cache\CacheManager|\Illuminate\Contracts\Cache\Repository
      */
-    private $cache;
+    protected $cache;
 
     protected function getEnvironmentSetUp($app)
     {


### PR DESCRIPTION
Change all `private` accessors to `protected`.

There is value in having a smaller public API (which `protected` class members are a part of by nature of inheritence), but the current usage of `private` was rather incidental.

Let's at least have it consistent for now.