### PR TITLE
Add documentation about the empty Query type in the root schema.

### DIFF
--- a/docs/3.0/guides/schema-organisation.md
+++ b/docs/3.0/guides/schema-organisation.md
@@ -90,6 +90,17 @@ type Query
 #import post.graphql
 ```
 
+The same applies for mutations: if you want to use them, you can define 
+an empty `Mutation` type (without curly braces) within your root schema:
+
+```graphql
+type Query
+
+type Mutation
+
+#import post.graphql
+```
+
 Now you want to add a few queries to actually fetch posts. You could add them to the main `Query` type
 in your main file, but that spreads the definition apart, and could also grow quite large over time.
 

--- a/docs/3.0/guides/schema-organisation.md
+++ b/docs/3.0/guides/schema-organisation.md
@@ -80,7 +80,15 @@ type Query {
 
 __Attention__: A valid `Query` type definition with at least one field
 must be present in the root schema.
-This is because `extend type` needs the original type to get merged into. 
+This is because `extend type` needs the original type to get merged into.
+
+You can provide an empty `Query` type (without curly braces) in the root schema:
+
+```graphql
+type Query
+
+#import post.graphql
+```
 
 Now you want to add a few queries to actually fetch posts. You could add them to the main `Query` type
 in your main file, but that spreads the definition apart, and could also grow quite large over time.

--- a/tests/Unit/Schema/SchemaBuilderTest.php
+++ b/tests/Unit/Schema/SchemaBuilderTest.php
@@ -26,6 +26,24 @@ class SchemaBuilderTest extends TestCase
     /**
      * @test
      */
+    public function itGeneratesWithEmptyQueryType(): void
+    {
+        $schema = $this->buildSchema('
+        type Query
+        
+        extend type Query {
+            foo: Int
+        }
+        ');
+
+        $this->assertInstanceOf(Schema::class, $schema);
+        // This would throw if the schema were invalid
+        $schema->assertValid();
+    }
+
+    /**
+     * @test
+     */
     public function itCanResolveEnumTypes(): void
     {
         $schema = $this->buildSchemaWithPlaceholderQuery('

--- a/tests/Unit/Schema/SchemaBuilderTest.php
+++ b/tests/Unit/Schema/SchemaBuilderTest.php
@@ -44,6 +44,28 @@ class SchemaBuilderTest extends TestCase
     /**
      * @test
      */
+    public function itGeneratesWithEmptyMutationType(): void
+    {
+        $schema = $this->buildSchema('
+        type Query
+        
+        type Mutation
+        
+        extend type Mutation {
+            foo(bar: String! baz: String): String
+        }
+        ');
+
+        /** @var \GraphQL\Type\Definition\ObjectType $mutationObjectType */
+        $mutationObjectType = $schema->getType('Mutation');
+        $foo = $mutationObjectType->getField('foo');
+
+        $this->assertSame('foo', $foo->name);
+    }
+
+    /**
+     * @test
+     */
     public function itCanResolveEnumTypes(): void
     {
         $schema = $this->buildSchemaWithPlaceholderQuery('


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

**Related Issue/Intent**

<!-- Link to related issues this PR resolves, e.g. "Resolves #236",
or a description of what this PR is trying to achieve. -->
Developers often think that they have to provide dummy queries or mutations in the root schema in order to avoid this error: `Error: Query root type must be provided`

Actually adding an empty `type Query` (without curly braces) is enough.

The same applies for `type Mutation`, to avoid the following error: `"Schema is not configured for mutations."`

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->
Add documentation about the empty Query field in the root schema.

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->
None

**TODO**

- [x] Add a test