### PR TITLE
Assert that a 200 is returned when a model is not found.

### DIFF
--- a/tests/Integration/Schema/Directives/FindDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/FindDirectiveTest.php
@@ -142,4 +142,34 @@ class FindDirectiveTest extends DBTestCase
             ],
         ]);
     }
+
+    /**
+     * @test
+     */
+    public function itReturnsAnEmptyObjectWhenTheModelIsNotFound(): void
+    {
+        $this->schema = '
+        type User {
+            id: ID!
+            name: String!
+        }
+        
+        type Query {
+            user(name: String @eq): User @find(model: "User")
+        }
+        ';
+
+        $this->query('
+        {
+            user(name: "A") {
+                id
+                name
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'user' => null,
+            ],
+        ])->assertStatus(200);
+    }
 }


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Added Docs for all relevant versions
- [ ] Updated the changelog

**Related Issue/Intent**

When ModelNotFound exception is triggered, assert that an empty object will be returned with a 200 status code.
Closes https://github.com/nuwave/lighthouse/issues/500

<!-- Link to related issues this PR resolves, e.g. "Resolves #236",
or a description of what this PR is trying to achieve. -->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->
