### PR TITLE
Add config option pagination_amount_argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The pagination field argument that controls the amount of results
   will default to `first` instead of `count` in v4. The config `pagination_amount_argument`
-  can be used to change the argument name now 
+  can be used to change the argument name now https://github.com/nuwave/lighthouse/pull/752
 
 ## [3.4.0](https://github.com/nuwave/lighthouse/compare/v3.3.0...v3.4.0) - 2019-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default the config to always set the `Accept: application/json` header https://github.com/nuwave/lighthouse/pull/743
 - Declare a single named route which handles POST/GET instead of 2 seperate routes https://github.com/nuwave/lighthouse/pull/738
 
+### Deprecated
+
+- The pagination field argument that controls the amount of results
+  will default to `first` instead of `count` in v4. The config `pagination_amount_argument`
+  can be used to change the argument name now 
+
 ## [3.4.0](https://github.com/nuwave/lighthouse/compare/v3.3.0...v3.4.0) - 2019-04-18
 
 ### Added

--- a/config/config.php
+++ b/config/config.php
@@ -4,7 +4,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | GraphQL endpoint
+    | GraphQL Endpoint
     |--------------------------------------------------------------------------
     |
     | Set the endpoint to which the GraphQL server responds.
@@ -16,7 +16,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Enable GET requests
+    | Enable GET Requests
     |--------------------------------------------------------------------------
     |
     | This setting controls if GET requests to the GraphQL endpoint are allowed.
@@ -27,7 +27,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Route configuration
+    | Route Configuration
     |--------------------------------------------------------------------------
     |
     | Additional configuration for the route group https://lumen.laravel.com/docs/routing#route-groups
@@ -49,7 +49,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Schema declaration
+    | Schema Declaration
     |--------------------------------------------------------------------------
     |
     | This is a path that points to where your GraphQL schema is located
@@ -129,6 +129,19 @@ return [
     */
 
     'paginate_max_count' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Amount Argument
+    |--------------------------------------------------------------------------
+    |
+    | Set the name to use for the generated argument on paginated fields
+    | that controls how many results are returned.
+    | This will default to "first" in v4.
+    |
+    */
+
+    'pagination_amount_argument' => 'count',
 
     /*
     |--------------------------------------------------------------------------

--- a/docs/master/getting-started/configuration.md
+++ b/docs/master/getting-started/configuration.md
@@ -12,14 +12,11 @@ The following configuration will be placed in `config/lighthouse.php`.
 ```php
 <?php
 
-use GraphQL\Error\Debug;
-use GraphQL\Validator\Rules\DisableIntrospection;
-
 return [
 
     /*
     |--------------------------------------------------------------------------
-    | GraphQL endpoint
+    | GraphQL Endpoint
     |--------------------------------------------------------------------------
     |
     | Set the endpoint to which the GraphQL server responds.
@@ -31,7 +28,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Enable GET requests
+    | Enable GET Requests
     |--------------------------------------------------------------------------
     |
     | This setting controls if GET requests to the GraphQL endpoint are allowed.
@@ -42,7 +39,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Route configuration
+    | Route Configuration
     |--------------------------------------------------------------------------
     |
     | Additional configuration for the route group https://lumen.laravel.com/docs/routing#route-groups
@@ -57,12 +54,14 @@ return [
 
     'route' => [
         'prefix' => '',
-        // 'middleware' => ['loghttp']
+        'middleware' => [
+            \Nuwave\Lighthouse\Support\Http\Middleware\AcceptJson::class,
+        ],
     ],
 
     /*
     |--------------------------------------------------------------------------
-    | Schema declaration
+    | Schema Declaration
     |--------------------------------------------------------------------------
     |
     | This is a path that points to where your GraphQL schema is located
@@ -127,7 +126,7 @@ return [
     'security' => [
         'max_query_complexity' => 0,
         'max_query_depth' => 0,
-        'disable_introspection' => DisableIntrospection::DISABLED,
+        'disable_introspection' => \GraphQL\Validator\Rules\DisableIntrospection::DISABLED,
     ],
 
     /*
@@ -145,6 +144,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Pagination Amount Argument
+    |--------------------------------------------------------------------------
+    |
+    | Set the name to use for the generated argument on paginated fields
+    | that controls how many results are returned.
+    | This will default to "first" in v4.
+    |
+    */
+
+    'pagination_amount_argument' => 'count',
+
+    /*
+    |--------------------------------------------------------------------------
     | Debug
     |--------------------------------------------------------------------------
     |
@@ -153,7 +165,7 @@ return [
     |
     */
 
-    'debug' => Debug::INCLUDE_DEBUG_MESSAGE | Debug::INCLUDE_TRACE,
+    'debug' => \GraphQL\Error\Debug::INCLUDE_DEBUG_MESSAGE | \GraphQL\Error\Debug::INCLUDE_TRACE,
 
     /*
     |--------------------------------------------------------------------------
@@ -216,6 +228,19 @@ return [
     */
 
     'transactional_mutations' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | New Between Directives
+    |--------------------------------------------------------------------------
+    |
+    | Use the new @whereBetween and @whereBetween directives that will
+    | replace their current implementation in v4 by setting this to true.
+    | As the old versions are removed, this will not have an effect anymore.
+    |
+    */
+
+    'new_between_directives' => false,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Execution/DataLoader/RelationBatchLoader.php
+++ b/src/Execution/DataLoader/RelationBatchLoader.php
@@ -101,14 +101,14 @@ class RelationBatchLoader extends BatchLoader
                 $modelRelationFetcher->loadRelationsForPage($first, $currentPage);
                 break;
             case PaginationManipulator::PAGINATION_TYPE_PAGINATOR:
-                // count must be set so we can safely get it like this
-                /** @var int $count */
-                $count = $this->args['count'];
-                Pagination::throwIfPaginateMaxCountExceeded($this->paginateMaxCount, $count);
+                // first must be set so we can safely get it like this
+                /** @var int $first */
+                $first = $this->args[config('lighthouse.pagination_amount_argument')];
+                Pagination::throwIfPaginateMaxCountExceeded($this->paginateMaxCount, $first);
 
                 $page = Arr::get($this->args, 'page', 1);
 
-                $modelRelationFetcher->loadRelationsForPage($count, $page);
+                $modelRelationFetcher->loadRelationsForPage($first, $page);
                 break;
             default:
                 $modelRelationFetcher->loadRelations();

--- a/src/Schema/Directives/ComplexityDirective.php
+++ b/src/Schema/Directives/ComplexityDirective.php
@@ -43,7 +43,7 @@ class ComplexityDirective extends BaseDirective implements FieldMiddleware
                 $complexity = Arr::get(
                     $args,
                     'first',
-                    Arr::get($args, 'count', 1)
+                    Arr::get($args, config('lighthouse.pagination_amount_argument'), 1)
                 );
 
                 return $childrenComplexity * $complexity;

--- a/src/Schema/Directives/PaginateDirective.php
+++ b/src/Schema/Directives/PaginateDirective.php
@@ -91,7 +91,7 @@ class PaginateDirective extends BaseDirective implements FieldResolver, FieldMan
                     $context,
                     $resolveInfo,
                     $args['page'] ?? 1,
-                    $args['count']
+                    $args[config('lighthouse.pagination_amount_argument')]
                 );
             }
         );

--- a/src/Schema/Directives/PaginationManipulator.php
+++ b/src/Schema/Directives/PaginationManipulator.php
@@ -162,7 +162,7 @@ class PaginationManipulator
         ");
 
         $inputValueDefinitions = [
-            self::countArgument('count', $defaultCount, $maxCount),
+            self::countArgument(config('lighthouse.pagination_amount_argument'), $defaultCount, $maxCount),
             "\"The offset from which elements are returned.\"\npage: Int",
         ];
 

--- a/src/Schema/Types/PaginatorField.php
+++ b/src/Schema/Types/PaginatorField.php
@@ -15,25 +15,16 @@ class PaginatorField
      */
     public function paginatorInfoResolver(LengthAwarePaginator $root): array
     {
-        $count = $root->count();
-        $currentPage = $root->currentPage();
-        $firstItem = $root->firstItem();
-        $hasMorePages = $root->hasMorePages();
-        $lastItem = $root->lastItem();
-        $lastPage = $root->lastPage();
-        $perPage = $root->perPage();
-        $total = $root->total();
-
-        return compact(
-            'count',
-            'currentPage',
-            'firstItem',
-            'hasMorePages',
-            'lastItem',
-            'lastPage',
-            'perPage',
-            'total'
-        );
+        return [
+            'count' => $root->count(),
+            'currentPage' => $root->currentPage(),
+            'firstItem' => $root->firstItem(),
+            'hasMorePages' => $root->hasMorePages(),
+            'lastItem' => $root->lastItem(),
+            'lastPage' => $root->lastPage(),
+            'perPage' => $root->perPage(),
+            'total' => $root->total(),
+        ];
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -92,6 +92,7 @@ abstract class TestCase extends BaseTestCase
                 'storage' => 'array',
                 'broadcaster' => 'log',
             ],
+            'pagination_amount_argument' => 'count'
         ]);
 
         $app['config']->set('app.debug', true);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -92,7 +92,7 @@ abstract class TestCase extends BaseTestCase
                 'storage' => 'array',
                 'broadcaster' => 'log',
             ],
-            'pagination_amount_argument' => 'count'
+            'pagination_amount_argument' => 'count',
         ]);
 
         $app['config']->set('app.debug', true);

--- a/tests/Unit/Schema/Directives/ComplexityDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/ComplexityDirectiveTest.php
@@ -27,7 +27,7 @@ class ComplexityDirectiveTest extends TestCase
             ->getComplexityFn();
 
         $this->assertSame(100, $complexityFn(10, ['first' => 10]));
-        $this->assertSame(100, $complexityFn(10, ['count' => 10]));
+        $this->assertSame(100, $complexityFn(10, [config('lighthouse.pagination_amount_argument') => 10]));
     }
 
     /**

--- a/tests/Unit/Schema/Directives/PaginateDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/PaginateDirectiveTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit\Schema\Directives;
 
-use GraphQL\Type\Definition\FieldArgument;
 use Tests\TestCase;
+use GraphQL\Type\Definition\FieldArgument;
 use GraphQL\Type\Definition\FieldDefinition;
 
 class PaginateDirectiveTest extends TestCase

--- a/tests/Unit/Schema/Directives/PaginateDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/PaginateDirectiveTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Schema\Directives;
 
+use GraphQL\Type\Definition\FieldArgument;
 use Tests\TestCase;
 use GraphQL\Type\Definition\FieldDefinition;
 
@@ -119,7 +120,7 @@ class PaginateDirectiveTest extends TestCase
 
         $this->assertSame(
             'Limits number of fetched elements. Maximum allowed value: 5.',
-            $queryType->getField('defaultPaginated')->getArg('count')->description
+            $queryType->getField('defaultPaginated')->getArg(config('lighthouse.pagination_amount_argument'))->description
         );
 
         $this->assertSame(
@@ -129,12 +130,34 @@ class PaginateDirectiveTest extends TestCase
 
         $this->assertSame(
             'Limits number of fetched elements. Maximum allowed value: 10.',
-            $queryType->getField('customPaginated')->getArg('count')->description
+            $queryType->getField('customPaginated')->getArg(config('lighthouse.pagination_amount_argument'))->description
         );
 
         $this->assertSame(
             'Limits number of fetched elements. Maximum allowed value: 10.',
             $queryType->getField('customRelay')->getArg('first')->description
+        );
+    }
+
+    public function itCanChangePaginationAmountArgument(): void
+    {
+        config(['lighthouse.pagination_amount_argument' => 'first']);
+
+        $queryType = $this
+            ->buildSchema('
+            type Query {
+                defaultPaginated: [User!]! @paginate
+            }
+
+            type User {
+                id: ID!
+            }
+            ')
+            ->getQueryType();
+
+        $this->assertInstanceOf(
+            FieldArgument::class,
+            $queryType->getField('defaultPaginated')->getArg('first')
         );
     }
 }


### PR DESCRIPTION
It sets the name to use for the generated argument on paginated fields
that controls how many results are returned.
This will default to "first" in v4.

- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

**Related Issue/Intent**

Resolves https://github.com/nuwave/lighthouse/issues/620

**Changes**

Users can now use `first` instead of `count` when using default pagination.

**Breaking changes**

No, but the default will change in v4.
