### PR TITLE
Fixed order for nested operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Default the config to always set the `Accept: application/json` header https://github.com/nuwave/lighthouse/pull/743
 - Declare a single named route which handles POST/GET instead of 2 seperate routes https://github.com/nuwave/lighthouse/pull/738
+- Apply the nested operations within a nested mutation in a consistent order
+  that makes sense https://github.com/nuwave/lighthouse/pull/754
 
 ## [3.4.0](https://github.com/nuwave/lighthouse/compare/v3.3.0...v3.4.0) - 2019-04-18
 

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -125,7 +125,7 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo $relation */
             $relation = $model->{$relationName}();
 
-            if($create = $nestedOperations['create'] ?? false){
+            if ($create = $nestedOperations['create'] ?? false) {
                 $belongsToModel = self::executeCreate(
                     $relation->getModel()->newInstance(),
                     new Collection($create)
@@ -133,14 +133,14 @@ class MutationExecutor
                 $relation->associate($belongsToModel);
             }
 
-            if($connect = $nestedOperations['connect'] ?? false) {
+            if ($connect = $nestedOperations['connect'] ?? false) {
                 // Inverse can be hasOne or hasMany
                 /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo $belongsTo */
                 $belongsTo = $model->{$relationName}();
                 $belongsTo->associate($connect);
             }
 
-            if($update = $nestedOperations['update'] ?? false){
+            if ($update = $nestedOperations['update'] ?? false) {
                 $belongsToModel = self::executeUpdate(
                     $relation->getModel()->newInstance(),
                     new Collection($update)


### PR DESCRIPTION
**Related Issue/Intent**

Resolves #728
Closes #732

**Changes**

Apply the nested operations within a nested mutation in a consistent order
that makes sense.

This makes sure we are in line with what the spec requirement that the argument
order given by the client must not matter: https://graphql.github.io/graphql-spec/draft/#sec-Language.Arguments

**Breaking changes**

Nope, the previous behaviour was inconsistent and flaky.
