### PR TITLE
Instantiate the ErrorBuffer directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   will default to `first` instead of `count` in v4. The config `pagination_amount_argument`
   can be used to change the argument name now https://github.com/nuwave/lighthouse/pull/752
 
+### Fixed
+
+- Instantiate the `ErrorBuffer` directly, its dependencies can not be resolved through the container https://github.com/nuwave/lighthouse/pull/756
+
 ## [3.4.0](https://github.com/nuwave/lighthouse/compare/v3.3.0...v3.4.0) - 2019-04-18
 
 ### Added

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -169,7 +169,7 @@ class FieldFactory
             function () use ($argumentValues, $resolverWithMiddleware) {
                 $this->setResolverArguments(...func_get_args());
 
-                $this->validationErrorBuffer = app(ErrorBuffer::class)->setErrorType('validation');
+                $this->validationErrorBuffer = (new ErrorBuffer())->setErrorType('validation');
                 $this->builder = new Builder();
 
                 $this->queryFilter = QueryFilter::getInstance($this->fieldValue);

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -169,7 +169,7 @@ class FieldFactory
             function () use ($argumentValues, $resolverWithMiddleware) {
                 $this->setResolverArguments(...func_get_args());
 
-                $this->validationErrorBuffer = (new ErrorBuffer())->setErrorType('validation');
+                $this->validationErrorBuffer = (new ErrorBuffer)->setErrorType('validation');
                 $this->builder = new Builder();
 
                 $this->queryFilter = QueryFilter::getInstance($this->fieldValue);


### PR DESCRIPTION
This avoids unnecessary calls into the container and fixes a bug that prevented
its instantiation.

Resolves #755 ~~(hopefully)~~ definitely!