### PR TITLE
Refresh GraphQLRequest singleton between multiple requests

### DIFF
--- a/src/LighthouseServiceProvider.php
+++ b/src/LighthouseServiceProvider.php
@@ -115,7 +115,7 @@ class LighthouseServiceProvider extends ServiceProvider
 
         $this->app->bind(GlobalIdContract::class, GlobalId::class);
 
-        $this->app->singleton(GraphQLRequest::class, function (Container $app): GraphQLRequest {
+        $this->app->bind(GraphQLRequest::class, function (Container $app): GraphQLRequest {
             /** @var \Illuminate\Http\Request $request */
             $request = $app->make('request');
 

--- a/src/LighthouseServiceProvider.php
+++ b/src/LighthouseServiceProvider.php
@@ -115,7 +115,7 @@ class LighthouseServiceProvider extends ServiceProvider
 
         $this->app->bind(GlobalIdContract::class, GlobalId::class);
 
-        $this->app->bind(GraphQLRequest::class, function (Container $app): GraphQLRequest {
+        $this->app->singleton(GraphQLRequest::class, function (Container $app): GraphQLRequest {
             /** @var \Illuminate\Http\Request $request */
             $request = $app->make('request');
 

--- a/src/Support/Http/Controllers/GraphQLController.php
+++ b/src/Support/Http/Controllers/GraphQLController.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Support\Http\Controllers;
 
 use Nuwave\Lighthouse\GraphQL;
 use Illuminate\Routing\Controller;
+use Illuminate\Container\Container;
 use Nuwave\Lighthouse\Events\StartRequest;
 use Nuwave\Lighthouse\Execution\GraphQLRequest;
 use Nuwave\Lighthouse\Support\Contracts\CreatesContext;
@@ -33,24 +34,32 @@ class GraphQLController extends Controller
     protected $createsResponse;
 
     /**
+     * @var \Illuminate\Container\Container
+     */
+    protected $container;
+
+    /**
      * Inject middleware into request.
      *
      * @param  \Nuwave\Lighthouse\GraphQL  $graphQL
      * @param  \Nuwave\Lighthouse\Support\Contracts\CreatesContext  $createsContext
      * @param  \Illuminate\Contracts\Events\Dispatcher  $eventsDispatcher
      * @param  \Nuwave\Lighthouse\Support\Contracts\CreatesResponse  $createsResponse
+     * @param  \Illuminate\Container\Container  $container
      * @return void
      */
     public function __construct(
         GraphQL $graphQL,
         CreatesContext $createsContext,
         EventsDispatcher $eventsDispatcher,
-        CreatesResponse $createsResponse
+        CreatesResponse $createsResponse,
+        Container $container
     ) {
         $this->graphQL = $graphQL;
         $this->createsContext = $createsContext;
         $this->eventsDispatcher = $eventsDispatcher;
         $this->createsResponse = $createsResponse;
+        $this->container = $container;
     }
 
     /**
@@ -69,7 +78,14 @@ class GraphQLController extends Controller
             ? $this->executeBatched($request)
             : $this->graphQL->executeRequest($request);
 
-        return $this->createsResponse->createResponse($result);
+        $response = $this->createsResponse->createResponse($result);
+
+        // When handling multiple requests during the application lifetime,
+        // for example in tests, we need a new GraphQLRequest instance
+        // for each HTTP request, so we forget the singleton here.
+        $this->container->forgetInstance(GraphQLRequest::class);
+
+        return $response;
     }
 
     /**

--- a/tests/Integration/MultipleRequestsTest.php
+++ b/tests/Integration/MultipleRequestsTest.php
@@ -24,8 +24,8 @@ class MultipleRequestsTest extends TestCase
         }
         ')->assertJson([
             'data' => [
-                'return' => 'foo'
-            ]
+                'return' => 'foo',
+            ],
         ]);
 
         $this->query('
@@ -34,8 +34,8 @@ class MultipleRequestsTest extends TestCase
         }
         ')->assertJson([
            'data' => [
-               'return' => 'bar'
-           ]
+               'return' => 'bar',
+           ],
         ]);
     }
 

--- a/tests/Integration/MultipleRequestsTest.php
+++ b/tests/Integration/MultipleRequestsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Integration;
+
+use Tests\TestCase;
+
+class MultipleRequestsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itCanFireMultipleRequestsInOneTest(): void
+    {
+        $resolver = addslashes(self::class).'@resolve';
+        $this->schema = "
+        type Query {
+            return(this: String!): String @field(resolver:\"{$resolver}\")
+        }
+        ";
+
+        $this->query('
+        {
+            return(this: "foo")
+        }
+        ')->assertJson([
+            'data' => [
+                'return' => 'foo'
+            ]
+        ]);
+
+        $this->query('
+        {
+            return(this: "bar")
+        }
+        ')->assertJson([
+           'data' => [
+               'return' => 'bar'
+           ]
+        ]);
+    }
+
+    public function resolve($root, array $args): string
+    {
+        return $args['this'];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,7 +11,6 @@ use Laravel\Scout\ScoutServiceProvider;
 use Tests\Utils\Policies\AuthServiceProvider;
 use Orchestra\Database\ConsoleServiceProvider;
 use Illuminate\Foundation\Testing\TestResponse;
-use Nuwave\Lighthouse\Execution\GraphQLRequest;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Nuwave\Lighthouse\LighthouseServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
@@ -215,11 +214,10 @@ abstract class TestCase extends BaseTestCase
      */
     protected function postGraphQL(array $data, array $headers = []): TestResponse
     {
-        $this->app->forgetInstance(GraphQLRequest::class);
-
         return $this->postJson(
             'graphql',
-            $data
+            $data,
+            $headers
         );
     }
 


### PR DESCRIPTION
**Related Issue/Intent**

This prevents a weird error that occurs in tests.

If `GraphQLRequest` is a singleton and test code fires multiple HTTP requests, Lighthouse
always receives the same request.

**Changes**

Forget the  `GraphQLRequest` in the container after resolving each individual HTTP request.

**Breaking changes**

No
