### PR TITLE
Announce deprecation: The class `SubscriptionExceptionHandler` will be moved to the namespace Nuwave\Lighthouse\Subscriptions\Contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v3.5.0...master)
 
+### Deprecated
+
+- The class `SubscriptionExceptionHandler` will be moved to the namespace Nuwave\Lighthouse\Subscriptions\Contracts
+
 ## [3.5.0](https://github.com/nuwave/lighthouse/compare/v3.4.0...v3.5.0)
 
 ### Changed

--- a/src/Support/Contracts/SubscriptionExceptionHandler.php
+++ b/src/Support/Contracts/SubscriptionExceptionHandler.php
@@ -4,6 +4,9 @@ namespace Nuwave\Lighthouse\Support\Contracts;
 
 use Throwable;
 
+/**
+ * @deprecated will be moved to the namespace Nuwave\Lighthouse\Subscriptions\Contracts
+ */
 interface SubscriptionExceptionHandler
 {
     /**


### PR DESCRIPTION
Let's bundle all the Subscription related classes together.

We can apply the announced change in v4.