### PR TITLE
Avoid calling ->toArray on collections when we just want to unwrap it

### DIFF
--- a/src/Schema/Directives/GroupDirective.php
+++ b/src/Schema/Directives/GroupDirective.php
@@ -85,7 +85,7 @@ class GroupDirective extends BaseDirective implements NodeManipulator
 
                     return $fieldDefinition;
                 })
-                ->toArray()
+                ->all()
         );
 
         return $objectType;

--- a/src/Schema/Directives/MiddlewareDirective.php
+++ b/src/Schema/Directives/MiddlewareDirective.php
@@ -150,7 +150,7 @@ class MiddlewareDirective extends BaseDirective implements FieldMiddleware, Node
 
                     return $fieldDefinition;
                 })
-                ->toArray()
+                ->all()
         );
 
         return $objectType;

--- a/src/Schema/Factories/NodeFactory.php
+++ b/src/Schema/Factories/NodeFactory.php
@@ -157,7 +157,7 @@ class NodeFactory
                         ],
                     ];
                 })
-                ->toArray(),
+                ->all(),
         ]);
     }
 
@@ -212,7 +212,7 @@ class NodeFactory
                     ->map(function (NamedTypeNode $interface): Type {
                         return $this->typeRegistry->get($interface->name->value);
                     })
-                    ->toArray();
+                    ->all();
             },
         ]);
     }
@@ -237,7 +237,7 @@ class NodeFactory
                         $fieldDefinition->name->value => app(FieldFactory::class)->handle($fieldValue),
                     ];
                 })
-                ->toArray();
+                ->all();
         };
     }
 
@@ -259,7 +259,7 @@ class NodeFactory
                             $inputValueDefinition->name->value => $this->argumentFactory->handle($argumentValue),
                         ];
                     })
-                    ->toArray();
+                    ->all();
             },
         ]);
     }
@@ -352,7 +352,7 @@ class NodeFactory
                             $type->name->value
                         );
                     })
-                    ->toArray();
+                    ->all();
             },
             'resolveType' => $typeResolver,
         ]);

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -91,7 +91,7 @@ class SchemaBuilder
             )
             ->setDirectives(
                 $this->convertDirectives($documentAST)
-                    ->toArray()
+                    ->all()
             );
 
         // Those are optional so only add them if they are present in the schema
@@ -127,7 +127,7 @@ class SchemaBuilder
                         ->map(function ($location) {
                             return $location->value;
                         })
-                        ->toArray(),
+                        ->all(),
                     'args' => (new Collection($directive->arguments))
                         ->map(function (InputValueDefinitionNode $argument) {
                             $fieldArgumentConfig = [
@@ -144,7 +144,7 @@ class SchemaBuilder
 
                             return new FieldArgument($fieldArgumentConfig);
                         })
-                        ->toArray(),
+                        ->all(),
                     'astNode' => $directive,
                 ]);
             });

--- a/src/Subscriptions/SubscriptionRegistry.php
+++ b/src/Subscriptions/SubscriptionRegistry.php
@@ -146,7 +146,7 @@ class SubscriptionRegistry
                     ->map(function (FieldNode $field): string {
                         return $field->name->value;
                     })
-                    ->toArray();
+                    ->all();
             })
             ->map(function ($subscriptionField): GraphQLSubscription {
                 return Arr::get(

--- a/src/Support/Http/Responses/MemoryStream.php
+++ b/src/Support/Http/Responses/MemoryStream.php
@@ -34,7 +34,7 @@ class MemoryStream extends Stream implements CanStreamResponse
 
                     return [$path => $response];
                 })
-                ->toArray();
+                ->all();
         }
 
         $this->chunks[] = $data;

--- a/src/Support/Http/Responses/ResponseStream.php
+++ b/src/Support/Http/Responses/ResponseStream.php
@@ -39,7 +39,7 @@ class ResponseStream extends Stream implements CanStreamResponse
                                 ? (int) $partial
                                 : $partial;
                         })
-                        ->toArray();
+                        ->all();
 
                     $errors = $this->chunkError($path, $data);
                     if (! empty($errors)) {

--- a/src/Support/Http/Responses/Stream.php
+++ b/src/Support/Http/Responses/Stream.php
@@ -25,6 +25,6 @@ abstract class Stream
                 return Str::startsWith(implode('.', $error['path']), $path);
             })
             ->values()
-            ->toArray();
+            ->all();
     }
 }

--- a/src/Support/Pipeline.php
+++ b/src/Support/Pipeline.php
@@ -19,7 +19,7 @@ class Pipeline extends BasePipeline
     public function through($pipes)
     {
         if ($pipes instanceof Collection) {
-            $pipes = $pipes->toArray();
+            $pipes = $pipes->all();
         }
 
         return parent::through($pipes);

--- a/tests/Integration/Defer/DeferDBTest.php
+++ b/tests/Integration/Defer/DeferDBTest.php
@@ -164,7 +164,7 @@ class DeferDBTest extends DBTestCase
                     return ['email' => $user->email];
                 })
                 ->values()
-                ->toArray(),
+                ->all(),
             $deferredUsers['user.company.users']['data']
         );
     }
@@ -245,7 +245,7 @@ class DeferDBTest extends DBTestCase
                             'company' => null,
                         ];
                     })
-                    ->toArray(),
+                    ->all(),
                 $deferredUsers[$key]['data']
             );
         });

--- a/tests/Integration/GraphQLTest.php
+++ b/tests/Integration/GraphQLTest.php
@@ -87,7 +87,8 @@ class GraphQLTest extends DBTestCase
                             function (Task $task): array {
                                 return ['name' => $task->name];
                             }
-                        )->toArray(),
+                        )
+                        ->all(),
                 ],
             ],
         ]);
@@ -121,7 +122,7 @@ class GraphQLTest extends DBTestCase
                         ->map(function (Task $task): array {
                             return ['name' => $task->name];
                         })
-                        ->toArray(),
+                        ->all(),
                 ],
             ],
         ]);


### PR DESCRIPTION
The `toArray()` function actually calls `toArray()` recursively, which is not actually what we want in all of those cases - we just need the underlying items.

This should improve performance a bit.