### PR TITLE
Allow Query input argument using `@spread` to be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/nuwave/lighthouse/compare/v3.5.1...master)
+## [Unreleased](https://github.com/nuwave/lighthouse/compare/v3.5.2...master)
+
+## [3.5.2](https://github.com/nuwave/lighthouse/compare/v3.5.1...v3.5.2)
+
+### Fixed
+
+- `input` arguments that were `@spread` into the parent can now be optional https://github.com/nuwave/lighthouse/pull/774
 
 ## [3.5.1](https://github.com/nuwave/lighthouse/compare/v3.5.0...v3.5.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `input` arguments that were `@spread` into the parent can now be optional https://github.com/nuwave/lighthouse/pull/774
 
+### Deprecated
+
+- The class `SubscriptionExceptionHandler` will be moved to the namespace Nuwave\Lighthouse\Subscriptions\Contracts
+
 ## [3.5.1](https://github.com/nuwave/lighthouse/compare/v3.5.0...v3.5.1)
 
 ### Fixed
 
 - Throw error if pagination amount `<= 0` is requested https://github.com/nuwave/lighthouse/pull/765
-
-### Deprecated
-
-- The class `SubscriptionExceptionHandler` will be moved to the namespace Nuwave\Lighthouse\Subscriptions\Contracts
 
 ## [3.5.0](https://github.com/nuwave/lighthouse/compare/v3.4.0...v3.5.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `input` arguments that were `@spread` into the parent can now be optional https://github.com/nuwave/lighthouse/pull/774
+- You can now omit an `input` argument from a query that uses
+  the `@spread` directive without getting an error https://github.com/nuwave/lighthouse/pull/774
 
 ### Deprecated
 

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -105,7 +105,7 @@ class FieldFactory
      *
      * @var array[]
      */
-    protected $spreadPaths = [];
+    protected $pathsToSpread = [];
 
     /**
      * @param  \Nuwave\Lighthouse\Schema\Factories\DirectiveFactory  $directiveFactory
@@ -188,19 +188,26 @@ class FieldFactory
 
                 // Apply the argument spreadings after we are finished with all
                 // the other argument handling
-                foreach ($this->spreadPaths as $argumentPath) {
+                foreach ($this->pathsToSpread as $argumentPath) {
                     $inputValues = $this->argValue($argumentPath);
+
+                    // If no input is given, there is nothing to spread
+                    if(!$inputValues){
+                        continue;
+                    }
+
+                    // We remove the value from where it was defined before
                     $this->unsetArgValue($argumentPath);
 
+                    // The last part of the path is the name of the input value,
+                    // the exact thing we want to remove
                     array_pop($argumentPath);
-
-                    if (is_array($inputValues)) {
-                        foreach ($inputValues as $key => $value) {
-                            $this->setArgValue(
-                                array_merge($argumentPath, [$key]),
-                                $value
-                            );
-                        }
+                    
+                    foreach ($inputValues as $key => $value) {
+                        $this->setArgValue(
+                            array_merge($argumentPath, [$key]),
+                            $value
+                        );
                     }
                 }
 
@@ -272,7 +279,7 @@ class FieldFactory
             })
             && $type instanceof InputObjectType
         ) {
-            $this->spreadPaths [] = $argumentPath;
+            $this->pathsToSpread [] = $argumentPath;
         }
 
         // Handle the argument itself. At this point, it can be wrapped

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -193,7 +193,7 @@ class FieldFactory
                     $this->unsetArgValue($argumentPath);
 
                     array_pop($argumentPath);
-                    
+
                     if (is_array($inputValues)) {
                         foreach ($inputValues as $key => $value) {
                             $this->setArgValue(

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -193,12 +193,14 @@ class FieldFactory
                     $this->unsetArgValue($argumentPath);
 
                     array_pop($argumentPath);
-
-                    foreach ($inputValues as $key => $value) {
-                        $this->setArgValue(
-                            array_merge($argumentPath, [$key]),
-                            $value
-                        );
+                    
+                    if (is_array($inputValues)) {
+                        foreach ($inputValues as $key => $value) {
+                            $this->setArgValue(
+                                array_merge($argumentPath, [$key]),
+                                $value
+                            );
+                        }
                     }
                 }
 

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -192,7 +192,7 @@ class FieldFactory
                     $inputValues = $this->argValue($argumentPath);
 
                     // If no input is given, there is nothing to spread
-                    if(!$inputValues){
+                    if (! $inputValues) {
                         continue;
                     }
 
@@ -202,7 +202,7 @@ class FieldFactory
                     // The last part of the path is the name of the input value,
                     // the exact thing we want to remove
                     array_pop($argumentPath);
-                    
+
                     foreach ($inputValues as $key => $value) {
                         $this->setArgValue(
                             array_merge($argumentPath, [$key]),

--- a/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
@@ -10,31 +10,36 @@ class SpreadDirectiveTest extends DBTestCase
     /**
      * @test
      */
-    public function itResolvesWhenSpreadedInputDoesNotExistOnQuery(): void
+    public function itSpreadsTheInputIntoTheQuery(): void
     {
-        factory(User::class)->create();
+        factory(User::class, 2)->create();
 
         $this->schema = '
-        type Query{
+        type Query {
             user(input: UserInput @spread): User @first
         }
-        type User{
+
+        type User {
             id: ID
         }
-        input UserInput{
+
+        input UserInput {
             id: ID @eq
         }
         ';
 
-        $this->query('{
-            user{
+        $this->query('
+        {
+            user(input: {
+                id: 2
+            }) {
                 id
             }
         }
         ')->assertJson([
             'data' => [
                 'user' => [
-                    'id' => 1,
+                    'id' => 2
                 ],
             ],
         ]);
@@ -43,24 +48,27 @@ class SpreadDirectiveTest extends DBTestCase
     /**
      * @test
      */
-    public function itResolvesWhenSpreadedInputDoesExistOnQuery(): void
+    public function itIgnoresSpreadedInputIfNotGiven(): void
     {
         factory(User::class)->create();
 
         $this->schema = '
-        type Query{
+        type Query {
             user(input: UserInput @spread): User @first
         }
-        type User{
+
+        type User {
             id: ID
         }
-        input UserInput{
+
+        input UserInput {
             id: ID @eq
         }
         ';
 
-        $this->query('{
-            user(input: {id: 1}){
+        $this->query('
+        {
+            user{
                 id
             }
         }

--- a/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit\Schema\Directives;
+
+use Tests\DBTestCase;
+use Tests\Utils\Models\User;
+
+class SpreadDirectiveTest extends DBTestCase
+{
+    /**
+     * @test
+     */
+    public function itResolvesWhenSpreadedInputDoesNotExistOnQuery(): void
+    {
+        factory(User::class)->create();
+
+        $this->schema = "
+        type Query{
+            user(input: UserInput @spread): User @first
+        }
+        type User{
+            id: ID
+        }
+        input UserInput{
+            id: ID @eq
+        }
+        ";
+
+        $this->query('{
+            user{
+                id
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'user' => [
+                    'id' => 1
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function itResolvesWhenSpreadedInputDoesExistOnQuery(): void
+    {
+        factory(User::class)->create();
+
+        $this->schema = "
+        type Query{
+            user(input: UserInput @spread): User @first
+        }
+        type User{
+            id: ID
+        }
+        input UserInput{
+            id: ID @eq
+        }
+        ";
+
+        $this->query('{
+            user(input: {id: 1}){
+                id
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'user' => [
+                    'id' => 1
+                ],
+            ],
+        ]);
+    }
+
+
+}

--- a/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
@@ -14,7 +14,7 @@ class SpreadDirectiveTest extends DBTestCase
     {
         factory(User::class)->create();
 
-        $this->schema = "
+        $this->schema = '
         type Query{
             user(input: UserInput @spread): User @first
         }
@@ -24,7 +24,7 @@ class SpreadDirectiveTest extends DBTestCase
         input UserInput{
             id: ID @eq
         }
-        ";
+        ';
 
         $this->query('{
             user{
@@ -34,7 +34,7 @@ class SpreadDirectiveTest extends DBTestCase
         ')->assertJson([
             'data' => [
                 'user' => [
-                    'id' => 1
+                    'id' => 1,
                 ],
             ],
         ]);
@@ -47,7 +47,7 @@ class SpreadDirectiveTest extends DBTestCase
     {
         factory(User::class)->create();
 
-        $this->schema = "
+        $this->schema = '
         type Query{
             user(input: UserInput @spread): User @first
         }
@@ -57,7 +57,7 @@ class SpreadDirectiveTest extends DBTestCase
         input UserInput{
             id: ID @eq
         }
-        ";
+        ';
 
         $this->query('{
             user(input: {id: 1}){
@@ -67,11 +67,9 @@ class SpreadDirectiveTest extends DBTestCase
         ')->assertJson([
             'data' => [
                 'user' => [
-                    'id' => 1
+                    'id' => 1,
                 ],
             ],
         ]);
     }
-
-
 }

--- a/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
@@ -39,7 +39,7 @@ class SpreadDirectiveTest extends DBTestCase
         ')->assertJson([
             'data' => [
                 'user' => [
-                    'id' => 2
+                    'id' => 2,
                 ],
             ],
         ]);


### PR DESCRIPTION
- fixes issue where a where an error occurs if a query that accepts a spreaded input does not actually pass in the input (even if not set as required)
- tests added to verify fix

- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

**Related Issue/Intent**
Resolves #770  

**Changes**

- You can now omit an input from your query that uses the spread directive without getting an error

**Breaking changes**

None