### PR TITLE
Respect the model's connection for database transaction  during `@create` and `@update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/nuwave/lighthouse/compare/v3.5.2...master)
+## [Unreleased](https://github.com/nuwave/lighthouse/compare/v3.5.3...master)
+
+## [3.5.3](https://github.com/nuwave/lighthouse/compare/v3.5.2...v3.5.3)
+
+### Fixed
+
+- Respect the model's connection for database transaction during `@create` and `@update` https://github.com/nuwave/lighthouse/pull/777
 
 ## [3.5.2](https://github.com/nuwave/lighthouse/compare/v3.5.1...v3.5.2)
 

--- a/src/Schema/Directives/CreateDirective.php
+++ b/src/Schema/Directives/CreateDirective.php
@@ -61,7 +61,7 @@ class CreateDirective extends BaseDirective implements FieldResolver
                 };
 
                 return config('lighthouse.transactional_mutations', true)
-                    ? $this->databaseManager->connection()->transaction($executeMutation)
+                    ? $this->databaseManager->connection($model->getConnectionName())->transaction($executeMutation)
                     : $executeMutation();
             }
         );

--- a/src/Schema/Directives/UpdateDirective.php
+++ b/src/Schema/Directives/UpdateDirective.php
@@ -77,7 +77,7 @@ class UpdateDirective extends BaseDirective implements FieldResolver
                 };
 
                 return config('lighthouse.transactional_mutations', true)
-                    ? $this->databaseManager->connection()->transaction($executeMutation)
+                    ? $this->databaseManager->connection($model->getConnectionName())->transaction($executeMutation)
                     : $executeMutation();
             }
         );


### PR DESCRIPTION
- [ ] Added or updated tests
not sure how to go about this, no tests exist for these classes
- [ ] Added Docs for all relevant versions
no documentation necessary
- [ ] Updated the changelog
not sure how to go about this

**Related Issue/Intent**

When using Lighthouse on a Lumen or Laravel project with multiple database connections, the `@create` and `@update` directives use the default database without respecting the model's declared connection. This trivial patch fixes this.

**Changes**

When calling `DatabaseManager::connection()`, provide `Model::getConnectionName()` for the optional `name` argument. This will then open a transaction on the main model's connection. The case where nested models define different database connections for themselves is NOT handled, as in that case, transactional behaviour cannot be guaranteed anyway.

**Breaking changes**

This is a trivial fix and should not break any existing behaviour.
