### PR TITLE
Document usage of native PHP types, add convencience wrapper for bensampo/laravel-enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v3.5.3...master)
 
+### Added
+
+- Add convenience wrapper for registering Enum types based on [BenSampo/laravel-enum](https://github.com/BenSampo/laravel-enum)
+  https://github.com/nuwave/lighthouse/pull/779
+
 ## [3.5.3](https://github.com/nuwave/lighthouse/compare/v3.5.2...v3.5.3)
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,6 @@
         "issues": "https://github.com/nuwave/lighthouse/issues",
         "source": "https://github.com/nuwave/lighthouse"
     },
-    "repositories": [
-        {
-            "url": "https://github.com/mll-lab/laravel-enum.git",
-            "type": "git"
-        }
-    ],
     "require": {
         "php": ">= 7.1",
         "ext-json": "*",
@@ -40,7 +34,7 @@
         "webonyx/graphql-php": "^0.13"
     },
     "require-dev": {
-        "bensampo/laravel-enum": "dev-master",
+        "bensampo/laravel-enum": "^1.19",
         "laravel/scout": "^4.0",
         "mockery/mockery": "^1.0",
         "orchestra/database": "3.5.*|3.6.*|3.7.*|3.8.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,12 @@
         "issues": "https://github.com/nuwave/lighthouse/issues",
         "source": "https://github.com/nuwave/lighthouse"
     },
+    "repositories": [
+        {
+            "url": "https://github.com/mll-lab/laravel-enum.git",
+            "type": "git"
+        }
+    ],
     "require": {
         "php": ">= 7.1",
         "ext-json": "*",
@@ -34,6 +40,7 @@
         "webonyx/graphql-php": "^0.13"
     },
     "require-dev": {
+        "bensampo/laravel-enum": "dev-master",
         "laravel/scout": "^4.0",
         "mockery/mockery": "^1.0",
         "orchestra/database": "3.5.*|3.6.*|3.7.*|3.8.x-dev",
@@ -42,7 +49,8 @@
         "pusher/pusher-php-server": "^3.2"
     },
     "suggest": {
-        "mll-lab/laravel-graphql-playground": "GraphQL IDE for better development workflow - integrated with Laravel"
+        "mll-lab/laravel-graphql-playground": "GraphQL IDE for better development workflow - integrated with Laravel",
+        "bensampo/laravel-enum": "Convenient enum definitions that can easily be registered in your Schema"
     },
     "autoload": {
         "psr-4": {

--- a/docs/master/getting-started/migrating-to-lighthouse.md
+++ b/docs/master/getting-started/migrating-to-lighthouse.md
@@ -29,6 +29,9 @@ If you are coming from libraries such as [Folkloreatelier/laravel-graphql](https
 is originally based upon [webonyx/graphql-php](https://github.com/webonyx/graphql-php),
 you should be able to reuse much of your existing code.
 
+You can also register your existing types within Lighthouse's type registry, so you
+won't have to rewrite them in SDL: [Use native PHP types](../guides/native-php-types.md).
+
 Resolver functions share the same [common signature](../api-reference/resolvers.md#resolver-function-signature),
 so you should be able to reuse any logic you have written for Queries/Mutations.
 

--- a/docs/master/guides/native-php-types.md
+++ b/docs/master/guides/native-php-types.md
@@ -1,0 +1,69 @@
+# Native PHP types
+
+While Lighthouse is a schema first GraphQL server and primarily uses the SDL,
+you can also use native PHP type definitions.
+
+Check out the [webonyx/graphql-php documentation](http://webonyx.github.io/graphql-php/type-system/)
+on how to define types.  
+
+## Use Cases
+
+Note that you will not have access to a large portion of Lighthouse functionality
+that is provided through server-side directives and the definition is much more verbose.
+
+Because of this, we do not recommend you use native PHP types for complex object types.
+
+However, it can be advantageous to use native types for two use cases:
+- [Enum types](http://webonyx.github.io/graphql-php/type-system/enum-types/):
+  Allows you to reuse existing constants in your code
+- [Custom Scalar types](http://webonyx.github.io/graphql-php/type-system/scalar-types/#writing-custom-scalar-types).
+  They will have to be implemented in PHP anyway
+
+## Using the TypeRegistry
+
+Lighthouse provides a type registry out of the box for you to register your types.
+You can get an instance of it through the Laravel Container.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use GraphQL\Type\Definition\Type;
+use Illuminate\Support\ServiceProvider;
+use GraphQL\Type\Definition\ObjectType;
+use Nuwave\Lighthouse\Schema\TypeRegistry;
+
+class GraphQLServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap any application services.
+     *
+     * @param TypeRegistry $typeRegistry
+     *
+     * @return void
+     */
+    public function boot(TypeRegistry $typeRegistry): void
+    {
+        $typeRegistry->register(
+             new ObjectType([
+                 'name' => 'User',
+                 'fields' => function() use ($typeRegistry) {
+                     return [
+                         'email' => [
+                             'type' => Type::string()
+                         ],
+                         'friends' => [
+                             'type' => Type::listOf(
+                                 $typeRegistry->get('User')
+                             )
+                         ]
+                     ];
+                 }
+             ])
+        );
+    }
+}
+```

--- a/docs/master/sidebar.js
+++ b/docs/master/sidebar.js
@@ -26,7 +26,8 @@ module.exports = [{
             'guides/file-uploads',
             'guides/custom-directives',
             'guides/error-handling',
-            'guides/plugin-development'
+            'guides/plugin-development',
+            'guides/native-php-types'
         ]
     },
     {

--- a/src/Schema/Types/LaravelEnumType.php
+++ b/src/Schema/Types/LaravelEnumType.php
@@ -56,7 +56,7 @@ class LaravelEnumType extends EnumType
      */
     public function serialize($value): string
     {
-        if(!$value instanceof Enum){
+        if (! $value instanceof Enum) {
             $value = $this->enumClass::getInstance($value);
         }
 

--- a/src/Schema/Types/LaravelEnumType.php
+++ b/src/Schema/Types/LaravelEnumType.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Schema\Types;
+
+use BenSampo\Enum\Enum;
+use GraphQL\Type\Definition\EnumType;
+
+/**
+ * A convenience wrapper for registering enums programmatically.
+ */
+class LaravelEnumType extends EnumType
+{
+    /**
+     * @var string|\BenSampo\Enum\Enum
+     */
+    protected $enumClass;
+
+    /**
+     * Create a GraphQL enum from a Laravel enum type.
+     *
+     * @param  string|\BenSampo\Enum\Enum  $enumClass
+     * @return void
+     */
+    public function __construct(string $enumClass)
+    {
+        if (! is_subclass_of($enumClass, Enum::class)) {
+            throw new \InvalidArgumentException(
+                "Must pass an instance of \BenSampo\Enum\Enum, got {$enumClass}."
+            );
+        }
+
+        $this->enumClass = $enumClass;
+
+        parent::__construct([
+            'name' => class_basename($enumClass),
+            'values' => array_map(
+                function (Enum $enum): array {
+                    return [
+                        'name' => $enum->key,
+                        'value' => $enum->value,
+                        'description' => "$enum->value",
+                    ];
+                },
+                $enumClass::getInstances()
+            ),
+        ]);
+    }
+
+    /**
+     * Overwrite the native EnumType serialization, as this class does not hold plain values.
+     *
+     * @param  mixed  $value
+     * @return string
+     */
+    public function serialize($value): string
+    {
+        if(!$value instanceof Enum){
+            $value = $this->enumClass::getInstance($value);
+        }
+
+        return $value->key;
+    }
+}

--- a/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
+++ b/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit\Schema\Types;
+
+use Tests\DBTestCase;
+use Tests\Utils\LaravelEnums\UserType;
+use Nuwave\Lighthouse\Schema\TypeRegistry;
+use Nuwave\Lighthouse\Schema\Types\LaravelEnumType;
+
+class LaravelEnumTypeTest extends DBTestCase
+{
+    /**
+     * @var \Nuwave\Lighthouse\Schema\TypeRegistry
+     */
+    protected $typeRegistry;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->typeRegistry = $this->app->make(TypeRegistry::class);
+    }
+
+    public function testUseLaravelEnumType()
+    {
+        $this->schema = '
+        type Query {
+            user(type: UserType @eq): User @find
+        }
+
+        type Mutation {
+            createUser(type: UserType): User @create
+        }
+
+        type User {
+            type: UserType
+        }
+        ';
+
+        $this->typeRegistry->register(
+            new LaravelEnumType(UserType::class)
+        );
+
+        $typeAdmistrator = [
+            'type' => 'Administrator'
+        ];
+
+        $this->query('
+        mutation {
+            createUser(type: Administrator) {
+                type
+            }
+        }
+        ')->assertJsonFragment($typeAdmistrator);
+
+        $this->query('
+        {
+            user(type: Administrator) {
+                type
+            }
+        }
+        ')->assertJsonFragment($typeAdmistrator);
+    }
+}

--- a/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
+++ b/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
@@ -42,7 +42,7 @@ class LaravelEnumTypeTest extends DBTestCase
         );
 
         $typeAdmistrator = [
-            'type' => 'Administrator'
+            'type' => 'Administrator',
         ];
 
         $this->query('

--- a/tests/Utils/LaravelEnums/UserType.php
+++ b/tests/Utils/LaravelEnums/UserType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tests\Utils\LaravelEnums;
+
+use BenSampo\Enum\Enum;
+
+final class UserType extends Enum
+{
+    const Administrator = 'ADMINISTRATOR';
+    const Moderator = 'MODERATOR';
+}

--- a/tests/Utils/Models/User.php
+++ b/tests/Utils/Models/User.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Utils\Models;
 
+use BenSampo\Enum\Traits\CastsEnums;
+use Tests\Utils\LaravelEnums\UserType;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,10 +12,16 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class User extends Authenticatable
 {
+    use CastsEnums;
+
     /**
      * @var mixed[]
      */
     protected $guarded = [];
+
+    protected $enumCasts = [
+        'type' => UserType::class,
+    ];
 
     public function getTaskCountAsString(): string
     {

--- a/tests/database/migrations/2018_02_28_000002_create_testbench_users_table.php
+++ b/tests/database/migrations/2018_02_28_000002_create_testbench_users_table.php
@@ -19,7 +19,7 @@ class CreateTestbenchUsersTable extends Migration
             $table->string('name')->nullable();
             $table->string('email')->nullable();
             $table->string('password')->nullable();
-            $table->enum('type', UserType::getValues());
+            $table->enum('type', UserType::getValues())->nullable();
             $table->timestamps();
         });
     }

--- a/tests/database/migrations/2018_02_28_000002_create_testbench_users_table.php
+++ b/tests/database/migrations/2018_02_28_000002_create_testbench_users_table.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Schema;
+use Tests\Utils\LaravelEnums\UserType;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
@@ -18,6 +19,7 @@ class CreateTestbenchUsersTable extends Migration
             $table->string('name')->nullable();
             $table->string('email')->nullable();
             $table->string('password')->nullable();
+            $table->enum('type', UserType::getValues());
             $table->timestamps();
         });
     }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog
- [x] Passed https://github.com/BenSampo/laravel-enum/pull/59

**Related Issue/Intent**

Resolves https://github.com/nuwave/lighthouse/issues/771

**Changes**

- Explicitely document how to register native PHP types with the TypeRegistry
- Add convenience wrapper for registering Enum types based on [BenSampo/laravel-enum](https://github.com/BenSampo/laravel-enum)

**Breaking changes**

Nope
