### PR TITLE
Deprecate controller config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v3.5.3...master)
 
+### Deprecated
+
+- The `controller` config option will be removed in v4 
+
 ## [3.5.3](https://github.com/nuwave/lighthouse/compare/v3.5.2...v3.5.3)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- The `controller` config option will be removed in v4 
+- The `controller` config option will be removed in v4 https://github.com/nuwave/lighthouse/pull/781
 
 ## [3.5.3](https://github.com/nuwave/lighthouse/compare/v3.5.2...v3.5.3)
 

--- a/config/config.php
+++ b/config/config.php
@@ -172,10 +172,11 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | GraphQL Controller
+    | DEPRECATED GraphQL Controller
     |--------------------------------------------------------------------------
     |
     | Specify which controller (and method) you want to handle GraphQL requests.
+    | This option will be removed in v4.
     |
     */
 

--- a/docs/master/getting-started/configuration.md
+++ b/docs/master/getting-started/configuration.md
@@ -184,10 +184,11 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | GraphQL Controller
+    | DEPRECATED GraphQL Controller
     |--------------------------------------------------------------------------
     |
     | Specify which controller (and method) you want to handle GraphQL requests.
+    | This option will be removed in v4.
     |
     */
 


### PR DESCRIPTION
This config option is not really necessary and i think nobody is using it, the implementation in the Controller is pretty basic but does enough so that i do not think anyone would want to reimplement it.

It is easy to define another controller thorugh Laravel if needed and call the rest of Lighthouse.

This just marks the config option as deprecated for v4.