### PR TITLE
Use the spec-compliant default deprecation reason for `@deprecate` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Use the spec-compliant default deprecation reason for `@deprecate` directive
+- Use the spec-compliant default deprecation reason for `@deprecate` directive https://github.com/nuwave/lighthouse/pull/787
 
 ## [3.6.0](https://github.com/nuwave/lighthouse/compare/v3.5.3...v3.6.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v3.6.0...master)
 
+### Fixed
+
+- Use the spec-compliant default deprecation reason for `@deprecate` directive
+
 ## [3.6.0](https://github.com/nuwave/lighthouse/compare/v3.5.3...v3.6.0)
 
 ### Added

--- a/src/Schema/Directives/DeprecatedDirective.php
+++ b/src/Schema/Directives/DeprecatedDirective.php
@@ -3,8 +3,8 @@
 namespace Nuwave\Lighthouse\Schema\Directives;
 
 use Closure;
+use GraphQL\Type\Definition\Directive;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
 
 class DeprecatedDirective extends BaseDirective implements FieldMiddleware
@@ -30,13 +30,7 @@ class DeprecatedDirective extends BaseDirective implements FieldMiddleware
      */
     public function handleField(FieldValue $fieldValue, Closure $next): FieldValue
     {
-        $reason = $this->directiveArgValue('reason');
-
-        if (! $reason) {
-            throw new DirectiveException(
-                "The @{$this->name()} directive requires a `reason` argument [defined on {$fieldValue->getParentName()}]"
-            );
-        }
+        $reason = $this->directiveArgValue('reason', Directive::DEFAULT_DEPRECATION_REASON);
 
         $fieldValue->setDeprecationReason($reason);
 

--- a/tests/Unit/Schema/Directives/DeprecatedDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/DeprecatedDirectiveTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Schema\Directives;
 use Tests\TestCase;
 use Illuminate\Support\Arr;
 use Tests\Utils\Resolvers\Foo;
+use GraphQL\Type\Definition\Directive;
 
 class DeprecatedDirectiveTest extends TestCase
 {
@@ -21,6 +22,8 @@ class DeprecatedDirectiveTest extends TestCase
                 @deprecated(reason: \"{$reason}\") 
                 @field(resolver: \"{$resolver}\")
             bar: String
+                @field(resolver: \"{$resolver}\")
+            withDefaultReason: String
                 @field(resolver: \"{$resolver}\")
         }
         ";
@@ -60,8 +63,17 @@ class DeprecatedDirectiveTest extends TestCase
                 return $field['isDeprecated'];
             }
         );
-        $this->assertCount(1, $deprecatedFields);
-        $this->assertSame($reason, $deprecatedFields[0]['deprecationReason']);
+        $this->assertCount(2, $deprecatedFields);
+        $this->assertSame(
+            $reason,
+            $deprecatedFields[0]['deprecationReason'],
+            'Should show user-defined deprecation reason.'
+        );
+        $this->assertSame(
+            Directive::DEFAULT_DEPRECATION_REASON,
+            $deprecatedFields[1]['deprecationReason'],
+            'Should fallback to the default deprecation reason'
+        );
 
         $this->query('
         {

--- a/tests/Unit/Schema/Directives/DeprecatedDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/DeprecatedDirectiveTest.php
@@ -18,13 +18,11 @@ class DeprecatedDirectiveTest extends TestCase
         $resolver = addslashes(Foo::class).'@bar';
         $this->schema = "
         type Query {
-            foo: String 
+            foo: String @field(resolver: \"{$resolver}\")
                 @deprecated(reason: \"{$reason}\") 
-                @field(resolver: \"{$resolver}\")
-            bar: String
-                @field(resolver: \"{$resolver}\")
-            withDefaultReason: String
-                @field(resolver: \"{$resolver}\")
+            withDefaultReason: String @field(resolver: \"{$resolver}\")
+                @deprecated
+            bar: String @field(resolver: \"{$resolver}\")
         }
         ";
 


### PR DESCRIPTION
https://graphql.github.io/graphql-spec/draft/#sec--deprecated

No breaking changes.