### PR TITLE
The `GraphQL` facade and the container alias `graphql` will be removed in v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add compatibility layer to allow `@middleware` to support Lumen https://github.com/nuwave/lighthouse/pull/786
 - Add option `decode` to `@globaldId` to control the result of decoding https://github.com/nuwave/lighthouse/pull/796
 
+### Deprecated
+
+- The `GraphQL` facade and the container alias `graphql` will be removed in v4 
+
 ## [3.6.1](https://github.com/nuwave/lighthouse/compare/v3.6.0...v3.6.1)
 
 ### Fixed

--- a/docs/master/getting-started/installation.md
+++ b/docs/master/getting-started/installation.md
@@ -32,14 +32,3 @@ composer require mll-lab/laravel-graphql-playground
 
 You can also use any external client with Lighthouse, make sure to point it to the URL defined in
 the config. Per default, the endpoint lives at `/graphql` 
-
-## Using the Facade
-
-If you want to use the GraphQL facade, add it to your `config/app.php` file
-
-```php
-'aliases' => [
-    // ...
-    'GraphQL' => Nuwave\Lighthouse\Support\Facades\GraphQLFacade::class,
-]
-```

--- a/src/LighthouseServiceProvider.php
+++ b/src/LighthouseServiceProvider.php
@@ -68,9 +68,7 @@ class LighthouseServiceProvider extends ServiceProvider
             __DIR__.'/../assets/default-schema.graphql' => $configRepository->get('lighthouse.schema.register'),
         ], 'schema');
 
-        if ($configRepository->get('lighthouse.controller')) {
-            $this->loadRoutesFrom(__DIR__.'/Support/Http/routes.php');
-        }
+        $this->loadRoutesFrom(__DIR__.'/Support/Http/routes.php');
 
         $validationFactory->resolver(
             function ($translator, array $data, array $rules, array $messages, array $customAttributes): Validator {

--- a/src/LighthouseServiceProvider.php
+++ b/src/LighthouseServiceProvider.php
@@ -109,7 +109,7 @@ class LighthouseServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'lighthouse');
 
         $this->app->singleton(GraphQL::class);
-        /** @deprecated */
+        /* @deprecated */
         $this->app->alias(GraphQL::class, 'graphql');
 
         $this->app->singleton(DirectiveFactory::class);

--- a/src/LighthouseServiceProvider.php
+++ b/src/LighthouseServiceProvider.php
@@ -60,8 +60,6 @@ class LighthouseServiceProvider extends ServiceProvider
      */
     public function boot(ValidationFactory $validationFactory, ConfigRepository $configRepository): void
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'lighthouse');
-
         $this->publishes([
             __DIR__.'/../config/config.php' => $this->app->make('path.config').DIRECTORY_SEPARATOR.'lighthouse.php',
         ], 'config');
@@ -108,7 +106,10 @@ class LighthouseServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
+        $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'lighthouse');
+
         $this->app->singleton(GraphQL::class);
+        /** @deprecated */
         $this->app->alias(GraphQL::class, 'graphql');
 
         $this->app->singleton(DirectiveFactory::class);

--- a/src/Support/Facades/GraphQLFacade.php
+++ b/src/Support/Facades/GraphQLFacade.php
@@ -4,6 +4,9 @@ namespace Nuwave\Lighthouse\Support\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * @deprecated will be removed in v4
+ */
 class GraphQLFacade extends Facade
 {
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -58,43 +58,54 @@ abstract class TestCase extends BaseTestCase
             }
         );
 
-        $app['config']->set('lighthouse', [
-            'namespaces' => [
-                'models' => [
-                    'Tests\\Utils\\Models',
-                    'Tests\\Utils\\ModelsSecondary',
-                ],
-                'queries' => [
-                    'Tests\\Utils\\Queries',
-                    'Tests\\Utils\\QueriesSecondary',
-                ],
-                'mutations' => [
-                    'Tests\\Utils\\Mutations',
-                    'Tests\\Utils\\MutationsSecondary',
-                ],
-                'subscriptions' => 'Tests\\Utils\\Subscriptions',
-                'interfaces' => [
-                    'Tests\\Utils\\Interfaces',
-                    'Tests\\Utils\\InterfacesSecondary',
-                ],
-                'scalars' => [
-                    'Tests\\Utils\\Scalars',
-                    'Tests\\Utils\\ScalarsSecondary',
-                ],
-                'unions' => [
-                    'Tests\\Utils\\Unions',
-                    'Tests\\Utils\\UnionsSecondary',
-                ],
+        /** @var \Illuminate\Config\Repository $config */
+        $config = $app['config'];
+
+        $config->set('lighthouse.namespaces', [
+            'models' => [
+                'Tests\\Utils\\Models',
+                'Tests\\Utils\\ModelsSecondary',
             ],
-            'debug' => Debug::INCLUDE_DEBUG_MESSAGE | Debug::INCLUDE_TRACE /*| Debug::RETHROW_INTERNAL_EXCEPTIONS*/ | Debug::RETHROW_UNSAFE_EXCEPTIONS,
-            'subscriptions' => [
-                'storage' => 'array',
-                'broadcaster' => 'log',
+            'queries' => [
+                'Tests\\Utils\\Queries',
+                'Tests\\Utils\\QueriesSecondary',
             ],
-            'pagination_amount_argument' => 'count',
+            'mutations' => [
+                'Tests\\Utils\\Mutations',
+                'Tests\\Utils\\MutationsSecondary',
+            ],
+            'subscriptions' => 'Tests\\Utils\\Subscriptions',
+            'interfaces' => [
+                'Tests\\Utils\\Interfaces',
+                'Tests\\Utils\\InterfacesSecondary',
+            ],
+            'scalars' => [
+                'Tests\\Utils\\Scalars',
+                'Tests\\Utils\\ScalarsSecondary',
+            ],
+            'unions' => [
+                'Tests\\Utils\\Unions',
+                'Tests\\Utils\\UnionsSecondary',
+            ],
         ]);
 
-        $app['config']->set('app.debug', true);
+        $config->set(
+            'lighthouse.debug',
+            Debug::INCLUDE_DEBUG_MESSAGE
+            | Debug::INCLUDE_TRACE
+            /*| Debug::RETHROW_INTERNAL_EXCEPTIONS*/
+            | Debug::RETHROW_UNSAFE_EXCEPTIONS
+        );
+
+        $config->set(
+            'lighthouse.subscriptions',
+            [
+                'storage' => 'array',
+                'broadcaster' => 'log',
+            ]
+        );
+
+        $config->set('app.debug', true);
 
         TestResponse::macro(
             'assertErrorCategory',


### PR DESCRIPTION
Reduce incidental complexity and overhead by offering only one way to do things.