### PR TITLE
Fix querying for falsy values through `@whereConstraints`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add compatibility layer to allow `@middleware` to support Lumen https://github.com/nuwave/lighthouse/pull/786
 - Add option `decode` to `@globaldId` to control the result of decoding https://github.com/nuwave/lighthouse/pull/796
 
+### Fixed
+
+- Fix querying for falsy values through `@whereConstraints` https://github.com/nuwave/lighthouse/pull/800
+
 ## [3.6.1](https://github.com/nuwave/lighthouse/compare/v3.6.0...v3.6.1)
 
 ### Fixed

--- a/src/WhereConstraints/WhereConstraintsDirective.php
+++ b/src/WhereConstraints/WhereConstraintsDirective.php
@@ -67,8 +67,6 @@ class WhereConstraintsDirective extends BaseDirective implements ArgBuilderDirec
                 );
             }
 
-            $value = $whereConstraints['value'];
-
             if (! \Safe\preg_match('/^(?![0-9])[A-Za-z0-9_-]*$/', $column)) {
                 throw new Error(
                     self::INVALID_COLUMN_MESSAGE
@@ -82,7 +80,7 @@ class WhereConstraintsDirective extends BaseDirective implements ArgBuilderDirec
             $builder->{$where}(
                 $column,
                 $whereConstraints['operator'],
-                $value
+                $whereConstraints['value']
             );
         }
 

--- a/src/WhereConstraints/WhereConstraintsDirective.php
+++ b/src/WhereConstraints/WhereConstraintsDirective.php
@@ -61,11 +61,13 @@ class WhereConstraintsDirective extends BaseDirective implements ArgBuilderDirec
         }
 
         if ($column = $whereConstraints['column'] ?? null) {
-            if (! $value = $whereConstraints['value']) {
+            if (! isset($whereConstraints['value'])) {
                 throw new Error(
                     "Did not receive a value to match the WhereConstraints for column {$column}."
                 );
             }
+
+            $value = $whereConstraints['value'];
 
             if (! \Safe\preg_match('/^(?![0-9])[A-Za-z0-9_-]*$/', $column)) {
                 throw new Error(

--- a/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
+++ b/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
@@ -222,7 +222,7 @@ class WhereConstraintsDirectiveTest extends DBTestCase
                     [
                         'id' => $userNamedEmptyString->id,
                         'name' => $userNamedEmptyString->name,
-                    ]
+                    ],
                 ],
             ],
         ]);

--- a/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
+++ b/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
@@ -219,7 +219,7 @@ class WhereConstraintsDirectiveTest extends DBTestCase
                 'users' => [
                     'id'   => $user->id,
                     'name' => $user->name,
-                ]
+                ],
             ],
         ]);
     }

--- a/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
+++ b/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
@@ -192,4 +192,25 @@ class WhereConstraintsDirectiveTest extends DBTestCase
             'message' => WhereConstraintsDirective::INVALID_COLUMN_MESSAGE,
         ]);
     }
+
+    /**
+     * @test
+     */
+    public function itQueriesEmptyStrings(): void
+    {
+        $this->query('
+        {
+            users(
+                where: {
+                    column: "id"
+                    value: ""
+                }
+            ) {
+                id
+            }
+        }
+        ')->assertExactJson([
+            'data' => ['users' => []],
+        ]);
+    }
 }

--- a/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
+++ b/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
@@ -198,19 +198,29 @@ class WhereConstraintsDirectiveTest extends DBTestCase
      */
     public function itQueriesEmptyStrings(): void
     {
+        factory(User::class, 3)->create();
+        $user = factory(User::class, 1)->create([
+            'name' => '',
+        ]);
         $this->query('
         {
             users(
                 where: {
-                    column: "id"
+                    column: "name"
                     value: ""
                 }
             ) {
                 id
+                name
             }
         }
-        ')->assertExactJson([
-            'data' => ['users' => []],
+        ')->assertJson([
+            'data' => [
+                'users' => [
+                    'id'   => $user->id,
+                    'name' => $user->name,
+                ]
+            ],
         ]);
     }
 }

--- a/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
+++ b/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
@@ -173,7 +173,7 @@ class WhereConstraintsDirectiveTest extends DBTestCase
      */
     public function itRejectsInvalidColumnName(): void
     {
-        $result = $this->query('
+        $this->query('
         {
             users(
                 where: {
@@ -199,7 +199,8 @@ class WhereConstraintsDirectiveTest extends DBTestCase
     public function itQueriesEmptyStrings(): void
     {
         factory(User::class, 3)->create();
-        $users = factory(User::class, 1)->create([
+
+        $userNamedEmptyString = factory(User::class)->create([
             'name' => '',
         ]);
 
@@ -217,12 +218,12 @@ class WhereConstraintsDirectiveTest extends DBTestCase
         }
         ')->assertJson([
             'data' => [
-                'users' => $users->map(function ($user) {
-                    return [
-                        'id' => $user->id,
-                        'name' => $user->name,
-                    ];
-                })->all(),
+                'users' => [
+                    [
+                        'id' => $userNamedEmptyString->id,
+                        'name' => $userNamedEmptyString->name,
+                    ]
+                ],
             ],
         ]);
     }

--- a/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
+++ b/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
@@ -199,9 +199,10 @@ class WhereConstraintsDirectiveTest extends DBTestCase
     public function itQueriesEmptyStrings(): void
     {
         factory(User::class, 3)->create();
-        $user = factory(User::class, 1)->create([
+        $users = factory(User::class, 1)->create([
             'name' => '',
         ]);
+
         $this->query('
         {
             users(
@@ -216,10 +217,12 @@ class WhereConstraintsDirectiveTest extends DBTestCase
         }
         ')->assertJson([
             'data' => [
-                'users' => [
-                    'id'   => $user->id,
-                    'name' => $user->name,
-                ],
+                'users' => $users->map(function ($user) {
+                    return [
+                        'id' => $user->id,
+                        'name' => $user->name,
+                    ];
+                })->all(),
             ],
         ]);
     }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

**Related Issue/Intent**

<!-- Link to related issues this PR resolves, e.g. "Resolves #236",
or a description of what this PR is trying to achieve. -->

Resolves #799 

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

Searching for an empty string using where constraints use to cause an error, it now searches for an empty string 

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->

If someone was counting on searching for an empty string returning an error it will no longer do that
