### PR TITLE
Add config option `cache.ttl` to control expiration time of schema cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add compatibility layer to allow `@middleware` to support Lumen https://github.com/nuwave/lighthouse/pull/786
 - Add option `decode` to `@globaldId` to control the result of decoding https://github.com/nuwave/lighthouse/pull/796
+- Add config option `cache.ttl` for customizing expiration time of schema cache https://github.com/nuwave/lighthouse/pull/801
 
 ## [3.6.1](https://github.com/nuwave/lighthouse/compare/v3.6.0...v3.6.1)
 

--- a/config/config.php
+++ b/config/config.php
@@ -76,6 +76,7 @@ return [
     'cache' => [
         'enable' => env('LIGHTHOUSE_CACHE_ENABLE', false),
         'key' => env('LIGHTHOUSE_CACHE_KEY', 'lighthouse-schema'),
+        'ttl' => env('LIGHTHOUSE_CACHE_TTL', null),
     ],
 
     /*

--- a/docs/master/getting-started/configuration.md
+++ b/docs/master/getting-started/configuration.md
@@ -88,6 +88,7 @@ return [
     'cache' => [
         'enable' => env('LIGHTHOUSE_CACHE_ENABLE', false),
         'key' => env('LIGHTHOUSE_CACHE_KEY', 'lighthouse-schema'),
+        'ttl' => env('LIGHTHOUSE_CACHE_TTL', null),
     ],
 
     /*

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -270,8 +270,9 @@ class GraphQL
         if (empty($this->documentAST)) {
             $this->documentAST = config('lighthouse.cache.enable')
                 ? app('cache')
-                    ->rememberForever(
+                    ->remember(
                         config('lighthouse.cache.key'),
+                        config('lighthouse.cache.ttl'),
                         function (): DocumentAST {
                             return $this->buildAST();
                         }


### PR DESCRIPTION
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

**Related Issue/Intent**

Allow users to customise the expiration time of schema cache.
For example, this is useful when using redis cache with default `maxmemory-policy noeviction`.

**Changes**

Add new config option `cache.ttl`, which mirrors the corresponding parameter of `Cache::remember()`.
The default behaviour of remembering permanently is unaffected.