### PR TITLE
Typo: Rename model Users to User

### DIFF
--- a/docs/3.6/getting-started/tutorial.md
+++ b/docs/3.6/getting-started/tutorial.md
@@ -254,7 +254,7 @@ Remember to run the migrations:
 
     php artisan migrate
 
-Finally, add the `posts` relation to `app/Users.php`
+Finally, add the `posts` relation to `app/User.php`
 
 ```php
 <?php

--- a/docs/master/getting-started/tutorial.md
+++ b/docs/master/getting-started/tutorial.md
@@ -254,7 +254,7 @@ Remember to run the migrations:
 
     php artisan migrate
 
-Finally, add the `posts` relation to `app/Users.php`
+Finally, add the `posts` relation to `app/User.php`
 
 ```php
 <?php


### PR DESCRIPTION
Fixed typo in the file name from `Users.php` to the correct singular name `User.php`

- [ ] Added or updated tests
- [ ] Added Docs for all relevant versions
- [ ] Updated the changelog

**Related Issue/Intent**

<!-- Link to related issues this PR resolves, e.g. "Resolves #236",
or a description of what this PR is trying to achieve. -->

**Changes**
Fixed a typo in name of `User.php`, before it was named as plural `Users.php`
Found in this [Getting started tutorial](https://lighthouse-php.com/3.6/getting-started/tutorial.html#the-models)
<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->
