### PR TITLE
Move subscription exception handler namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable the schema caching option `lighthouse.cache.enable` by default https://github.com/nuwave/lighthouse/pull/768 
 - Lazily load types from the schema. Directives defined on parts of the schema that are not used within the current
   query are no longer run on every request https://github.com/nuwave/lighthouse/pull/768
-- Move `SubscriptionExceptionHandler` into namespace `Nuwave\Lighthouse\Subscriptions\Contracts`
+- Move `SubscriptionExceptionHandler` into namespace `Nuwave\Lighthouse\Subscriptions\Contracts` https://github.com/nuwave/lighthouse/pull/819
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable the schema caching option `lighthouse.cache.enable` by default https://github.com/nuwave/lighthouse/pull/768 
 - Lazily load types from the schema. Directives defined on parts of the schema that are not used within the current
   query are no longer run on every request https://github.com/nuwave/lighthouse/pull/768
+- Move `SubscriptionExceptionHandler` into namespace `Nuwave\Lighthouse\Subscriptions\Contracts`
 
 ### Removed
 

--- a/src/Execution/Utils/Subscription.php
+++ b/src/Execution/Utils/Subscription.php
@@ -6,8 +6,8 @@ use Throwable;
 use InvalidArgumentException;
 use Nuwave\Lighthouse\GraphQL;
 use Nuwave\Lighthouse\Subscriptions\SubscriptionRegistry;
-use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionExceptionHandler;
 use Nuwave\Lighthouse\Subscriptions\Contracts\BroadcastsSubscriptions;
+use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionExceptionHandler;
 
 class Subscription
 {

--- a/src/Execution/Utils/Subscription.php
+++ b/src/Execution/Utils/Subscription.php
@@ -6,7 +6,7 @@ use Throwable;
 use InvalidArgumentException;
 use Nuwave\Lighthouse\GraphQL;
 use Nuwave\Lighthouse\Subscriptions\SubscriptionRegistry;
-use Nuwave\Lighthouse\Support\Contracts\SubscriptionExceptionHandler;
+use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionExceptionHandler;
 use Nuwave\Lighthouse\Subscriptions\Contracts\BroadcastsSubscriptions;
 
 class Subscription
@@ -55,7 +55,7 @@ class Subscription
                 $root
             );
         } catch (Throwable $e) {
-            /** @var \Nuwave\Lighthouse\Support\Contracts\SubscriptionExceptionHandler $exceptionHandler */
+            /** @var \Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionExceptionHandler $exceptionHandler */
             $exceptionHandler = app(SubscriptionExceptionHandler::class);
 
             $exceptionHandler->handleBroadcastError($e);

--- a/src/Subscriptions/Authorizer.php
+++ b/src/Subscriptions/Authorizer.php
@@ -6,7 +6,7 @@ use Exception;
 use Illuminate\Http\Request;
 use Nuwave\Lighthouse\Schema\Types\GraphQLSubscription;
 use Nuwave\Lighthouse\Subscriptions\Contracts\StoresSubscriptions;
-use Nuwave\Lighthouse\Support\Contracts\SubscriptionExceptionHandler;
+use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionExceptionHandler;
 use Nuwave\Lighthouse\Subscriptions\Contracts\AuthorizesSubscriptions;
 
 class Authorizer implements AuthorizesSubscriptions
@@ -22,14 +22,14 @@ class Authorizer implements AuthorizesSubscriptions
     protected $registry;
 
     /**
-     * @var \Nuwave\Lighthouse\Support\Contracts\SubscriptionExceptionHandler
+     * @var \Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionExceptionHandler
      */
     protected $exceptionHandler;
 
     /**
      * @param  \Nuwave\Lighthouse\Subscriptions\Contracts\StoresSubscriptions  $storage
      * @param  \Nuwave\Lighthouse\Subscriptions\SubscriptionRegistry  $registry
-     * @param  \Nuwave\Lighthouse\Support\Contracts\SubscriptionExceptionHandler  $exceptionHandler
+     * @param  \Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionExceptionHandler  $exceptionHandler
      * @return void
      */
     public function __construct(

--- a/src/Subscriptions/Authorizer.php
+++ b/src/Subscriptions/Authorizer.php
@@ -6,8 +6,8 @@ use Exception;
 use Illuminate\Http\Request;
 use Nuwave\Lighthouse\Schema\Types\GraphQLSubscription;
 use Nuwave\Lighthouse\Subscriptions\Contracts\StoresSubscriptions;
-use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionExceptionHandler;
 use Nuwave\Lighthouse\Subscriptions\Contracts\AuthorizesSubscriptions;
+use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionExceptionHandler;
 
 class Authorizer implements AuthorizesSubscriptions
 {

--- a/src/Subscriptions/Contracts/SubscriptionExceptionHandler.php
+++ b/src/Subscriptions/Contracts/SubscriptionExceptionHandler.php
@@ -1,12 +1,9 @@
 <?php
 
-namespace Nuwave\Lighthouse\Support\Contracts;
+namespace Nuwave\Lighthouse\Subscriptions\Contracts;
 
 use Throwable;
 
-/**
- * @deprecated will be moved to the namespace Nuwave\Lighthouse\Subscriptions\Contracts
- */
 interface SubscriptionExceptionHandler
 {
     /**

--- a/src/Subscriptions/ExceptionHandler.php
+++ b/src/Subscriptions/ExceptionHandler.php
@@ -3,7 +3,7 @@
 namespace Nuwave\Lighthouse\Subscriptions;
 
 use Throwable;
-use Nuwave\Lighthouse\Support\Contracts\SubscriptionExceptionHandler;
+use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionExceptionHandler;
 
 class ExceptionHandler implements SubscriptionExceptionHandler
 {

--- a/src/Subscriptions/SubscriptionServiceProvider.php
+++ b/src/Subscriptions/SubscriptionServiceProvider.php
@@ -13,11 +13,11 @@ use Nuwave\Lighthouse\Subscriptions\Contracts\ContextSerializer;
 use Nuwave\Lighthouse\Subscriptions\Contracts\StoresSubscriptions;
 use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionIterator;
 use Nuwave\Lighthouse\Support\Contracts\ProvidesSubscriptionResolver;
-use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionExceptionHandler;
 use Nuwave\Lighthouse\Subscriptions\Contracts\AuthorizesSubscriptions;
 use Nuwave\Lighthouse\Subscriptions\Contracts\BroadcastsSubscriptions;
 use Nuwave\Lighthouse\Subscriptions\Events\BroadcastSubscriptionEvent;
 use Nuwave\Lighthouse\Subscriptions\Events\BroadcastSubscriptionListener;
+use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionExceptionHandler;
 
 class SubscriptionServiceProvider extends ServiceProvider
 {

--- a/src/Subscriptions/SubscriptionServiceProvider.php
+++ b/src/Subscriptions/SubscriptionServiceProvider.php
@@ -13,7 +13,7 @@ use Nuwave\Lighthouse\Subscriptions\Contracts\ContextSerializer;
 use Nuwave\Lighthouse\Subscriptions\Contracts\StoresSubscriptions;
 use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionIterator;
 use Nuwave\Lighthouse\Support\Contracts\ProvidesSubscriptionResolver;
-use Nuwave\Lighthouse\Support\Contracts\SubscriptionExceptionHandler;
+use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionExceptionHandler;
 use Nuwave\Lighthouse\Subscriptions\Contracts\AuthorizesSubscriptions;
 use Nuwave\Lighthouse\Subscriptions\Contracts\BroadcastsSubscriptions;
 use Nuwave\Lighthouse\Subscriptions\Events\BroadcastSubscriptionEvent;


### PR DESCRIPTION
As announced in the deprecation notice:

Move `SubscriptionExceptionHandler` into namespace `Nuwave\Lighthouse\Subscriptions\Contracts`