### PR TITLE
Simplify the route configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable the schema caching option `lighthouse.cache.enable` by default https://github.com/nuwave/lighthouse/pull/768 
 - Lazily load types from the schema. Directives defined on parts of the schema that are not used within the current
   query are no longer run on every request https://github.com/nuwave/lighthouse/pull/768
-- Simplify the default route configuration
+- Simplify the default route configuration https://github.com/nuwave/lighthouse/pull/820
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable the schema caching option `lighthouse.cache.enable` by default https://github.com/nuwave/lighthouse/pull/768 
 - Lazily load types from the schema. Directives defined on parts of the schema that are not used within the current
   query are no longer run on every request https://github.com/nuwave/lighthouse/pull/768
+- Simplify the default route configuration
 
 ### Removed
 

--- a/config/config.php
+++ b/config/config.php
@@ -9,15 +9,25 @@ return [
     |
     | Controls the HTTP route that your GraphQL server responds to.
     |
-    | Beware that middleware defined here runs before the GraphQL execution phase,
-    | so you have to take extra care to return spec-compliant error responses.
-    | To apply middleware on a field level, use the @middleware directive.
-    |
     */
 
     'route' => [
+        /*
+         * The URI the endpoint responds to, e.g. mydomain.com/graphql.
+         */
         'uri' => 'graphql',
+
+        /*
+         * Lighthouse creates a named route for convenient URL generation and redirects.
+         */
         'name' => 'graphql',
+
+        /*
+         *
+         * Beware that middleware defined here runs before the GraphQL execution phase,
+         * so you have to take extra care to return spec-compliant error responses.
+         * To apply middleware on a field level, use the @middleware directive.
+         */
         'middleware' => [
             \Nuwave\Lighthouse\Support\Http\Middleware\AcceptJson::class,
         ],

--- a/config/config.php
+++ b/config/config.php
@@ -8,6 +8,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | Controls the HTTP route that your GraphQL server responds to.
+    | You may set `route` => false, to disable the default route
+    | registration and take full control.
     |
     */
 

--- a/config/config.php
+++ b/config/config.php
@@ -4,44 +4,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | GraphQL Endpoint
-    |--------------------------------------------------------------------------
-    |
-    | Set the endpoint to which the GraphQL server responds.
-    | The default route endpoint is "yourdomain.com/graphql".
-    |
-    */
-
-    'route_name' => 'graphql',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Enable GET Requests
-    |--------------------------------------------------------------------------
-    |
-    | This setting controls if GET requests to the GraphQL endpoint are allowed.
-    |
-    */
-
-    'route_enable_get' => true,
-
-    /*
-    |--------------------------------------------------------------------------
     | Route Configuration
     |--------------------------------------------------------------------------
     |
-    | Additional configuration for the route group https://lumen.laravel.com/docs/routing#route-groups
+    | Controls the HTTP route that your GraphQL server responds to.
     |
-    | Beware that middleware defined here runs before the GraphQL execution phase.
-    | This means that errors will cause the whole query to abort and return a
-    | response that is not spec-compliant. It is preferable to use directives
-    | to add middleware to single fields in the schema.
-    | Read more https://lighthouse-php.com/docs/auth.html#apply-auth-middleware
+    | Beware that middleware defined here runs before the GraphQL execution phase,
+    | so you have to take extra care to return spec-compliant error responses.
+    | To apply middleware on a field level, use the @middleware directive.
     |
     */
 
     'route' => [
-        'prefix' => '',
+        'uri' => 'graphql',
+        'name' => 'graphql',
         'middleware' => [
             \Nuwave\Lighthouse\Support\Http\Middleware\AcceptJson::class,
         ],
@@ -170,18 +146,6 @@ return [
     'error_handlers' => [
         \Nuwave\Lighthouse\Execution\ExtensionErrorHandler::class,
     ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | DEPRECATED GraphQL Controller
-    |--------------------------------------------------------------------------
-    |
-    | Specify which controller (and method) you want to handle GraphQL requests.
-    | This option will be removed in v4.
-    |
-    */
-
-    'controller' => \Nuwave\Lighthouse\Support\Http\Controllers\GraphQLController::class.'@query',
 
     /*
     |--------------------------------------------------------------------------

--- a/docs/master/getting-started/configuration.md
+++ b/docs/master/getting-started/configuration.md
@@ -21,15 +21,25 @@ return [
     |
     | Controls the HTTP route that your GraphQL server responds to.
     |
-    | Beware that middleware defined here runs before the GraphQL execution phase.
-    | Make sure that errors result in spec-compliant responses. For field level
-    | granularity, you may use the @middleware directive instead.
-    |
     */
 
     'route' => [
+        /*
+         * The URI the endpoint responds to, e.g. mydomain.com/graphql.
+         */
         'uri' => 'graphql',
-        'as' => 'graphql',
+
+        /*
+         * Lighthouse creates a named route for convenient URL generation and redirects.
+         */
+        'name' => 'graphql',
+
+        /*
+         *
+         * Beware that middleware defined here runs before the GraphQL execution phase,
+         * so you have to take extra care to return spec-compliant error responses.
+         * To apply middleware on a field level, use the @middleware directive.
+         */
         'middleware' => [
             \Nuwave\Lighthouse\Support\Http\Middleware\AcceptJson::class,
         ],

--- a/docs/master/getting-started/configuration.md
+++ b/docs/master/getting-started/configuration.md
@@ -20,6 +20,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | Controls the HTTP route that your GraphQL server responds to.
+    | You may set `route` => false, to disable the default route
+    | registration and take full control.
     |
     */
 

--- a/docs/master/getting-started/configuration.md
+++ b/docs/master/getting-started/configuration.md
@@ -16,44 +16,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | GraphQL Endpoint
-    |--------------------------------------------------------------------------
-    |
-    | Set the endpoint to which the GraphQL server responds.
-    | The default route endpoint is "yourdomain.com/graphql".
-    |
-    */
-
-    'route_name' => 'graphql',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Enable GET Requests
-    |--------------------------------------------------------------------------
-    |
-    | This setting controls if GET requests to the GraphQL endpoint are allowed.
-    |
-    */
-
-    'route_enable_get' => true,
-
-    /*
-    |--------------------------------------------------------------------------
     | Route Configuration
     |--------------------------------------------------------------------------
     |
-    | Additional configuration for the route group https://lumen.laravel.com/docs/routing#route-groups
+    | Controls the HTTP route that your GraphQL server responds to.
     |
     | Beware that middleware defined here runs before the GraphQL execution phase.
-    | This means that errors will cause the whole query to abort and return a
-    | response that is not spec-compliant. It is preferable to use directives
-    | to add middleware to single fields in the schema.
-    | Read more https://lighthouse-php.com/docs/auth.html#apply-auth-middleware
+    | Make sure that errors result in spec-compliant responses. For field level
+    | granularity, you may use the @middleware directive instead.
     |
     */
 
     'route' => [
-        'prefix' => '',
+        'uri' => 'graphql',
+        'as' => 'graphql',
         'middleware' => [
             \Nuwave\Lighthouse\Support\Http\Middleware\AcceptJson::class,
         ],
@@ -79,14 +55,14 @@ return [
     | Schema Cache
     |--------------------------------------------------------------------------
     |
-    | A large part of schema generation is parsing the schema into an AST.
-    | This operation is pretty expensive so it is recommended to enable
-    | caching in production mode, especially for large schemas.
+    | A large part of schema generation consists of parsing and AST manipulation.
+    | This operation is very expensive, so it is highly recommended to enable
+    | caching of the final schema to optimize performance of large schemas.
     |
     */
 
     'cache' => [
-        'enable' => env('LIGHTHOUSE_CACHE_ENABLE', false),
+        'enable' => env('LIGHTHOUSE_CACHE_ENABLE', true),
         'key' => env('LIGHTHOUSE_CACHE_KEY', 'lighthouse-schema'),
         'ttl' => env('LIGHTHOUSE_CACHE_TTL', null),
     ],
@@ -182,18 +158,6 @@ return [
     'error_handlers' => [
         \Nuwave\Lighthouse\Execution\ExtensionErrorHandler::class,
     ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | DEPRECATED GraphQL Controller
-    |--------------------------------------------------------------------------
-    |
-    | Specify which controller (and method) you want to handle GraphQL requests.
-    | This option will be removed in v4.
-    |
-    */
-
-    'controller' => \Nuwave\Lighthouse\Support\Http\Controllers\GraphQLController::class.'@query',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Support/Http/routes.php
+++ b/src/Support/Http/routes.php
@@ -1,6 +1,6 @@
 <?php
 
-if($routeConfig = config('lighthouse.route')) {
+if ($routeConfig = config('lighthouse.route')) {
     /** @var \Illuminate\Contracts\Routing\Registrar $router */
     $router = app('router');
 

--- a/src/Support/Http/routes.php
+++ b/src/Support/Http/routes.php
@@ -1,18 +1,16 @@
 <?php
 
-/** @var \Illuminate\Contracts\Routing\Registrar $router */
-$router = app('router');
+if($routeConfig = config('lighthouse.route')) {
+    /** @var \Illuminate\Contracts\Routing\Registrar $router */
+    $router = app('router');
 
-$router->group(config('lighthouse.route', []), function () use ($router): void {
-    $routeName = config('lighthouse.route_name', 'graphql');
-    $controller = config('lighthouse.controller');
-
-    $methods = config('lighthouse.route_enable_get', false)
-        ? ['GET', 'POST']
-        : ['POST'];
-
-    $router->match($methods, $routeName, [
-        'as' => 'lighthouse.graphql',
-        'uses' => $controller,
-    ]);
-});
+    $router->match(
+        ['GET', 'POST'],
+        $routeConfig['uri'] ?? 'graphql',
+        [
+            'as' => $routeConfig['name'] ?? 'graphql',
+            'uses' => \Nuwave\Lighthouse\Support\Http\Controllers\GraphQLController::class.'@query',
+            'middleware' => $routeConfig['middleware'],
+        ]
+    );
+}

--- a/src/Testing/MakesGraphQLRequests.php
+++ b/src/Testing/MakesGraphQLRequests.php
@@ -104,14 +104,8 @@ trait MakesGraphQLRequests
      *
      * @return string
      */
-    private function graphQLEndpointUrl(): string
+    protected function graphQLEndpointUrl(): string
     {
-        $path = config('lighthouse.route_name');
-
-        if ($prefix = config('lighthouse.route.prefix')) {
-            $path = $prefix.'/'.$path;
-        }
-
-        return $path;
+        return config('lighthouse.route.uri');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -213,8 +213,7 @@ abstract class TestCase extends BaseTestCase
     protected function buildSchemaWithPlaceholderQuery(string $schema): Schema
     {
         return $this->buildSchema(
-            $schema
-            .$this->placeholderQuery()
+            $schema.$this->placeholderQuery()
         );
     }
 


### PR DESCRIPTION
Remove settings that provide little to no benefit and are unlikely to be used:

- `controller`
- `route_enable_get`

...and reduce the route configuration to 3 clearly named options that are useful, all nested within the `route` key to clearly group them together.