### PR TITLE
Replace deprecated PHPUnit assertion methods

### DIFF
--- a/tests/Integration/GraphQLTest.php
+++ b/tests/Integration/GraphQLTest.php
@@ -209,8 +209,10 @@ class GraphQLTest extends DBTestCase
         }
         ');
 
+        // TODO remove as we stop supporting Laravel 5.5/PHPUnit 6
         $assertContains = method_exists($this, 'assertStringContainsString')
-            ? 'assertStringContainsString' : 'assertContains';
+            ? 'assertStringContainsString'
+            : 'assertContains';
 
         $this->{$assertContains}(
             'nonExistingField',

--- a/tests/Integration/GraphQLTest.php
+++ b/tests/Integration/GraphQLTest.php
@@ -209,7 +209,10 @@ class GraphQLTest extends DBTestCase
         }
         ');
 
-        $this->assertStringContainsString(
+        $assertContains = method_exists($this, 'assertStringContainsString')
+            ? 'assertStringContainsString' : 'assertContains';
+
+        $this->{$assertContains}(
             'nonExistingField',
             $result->jsonGet('errors.0.message')
         );

--- a/tests/Integration/GraphQLTest.php
+++ b/tests/Integration/GraphQLTest.php
@@ -209,7 +209,7 @@ class GraphQLTest extends DBTestCase
         }
         ');
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'nonExistingField',
             $result->jsonGet('errors.0.message')
         );

--- a/tests/Unit/Schema/Factories/DirectiveFactoryTest.php
+++ b/tests/Unit/Schema/Factories/DirectiveFactoryTest.php
@@ -47,7 +47,11 @@ class DirectiveFactoryTest extends TestCase
         ');
 
         $fieldDirective = $this->directiveFactory->create('field', $fieldDefinition);
-        $this->assertAttributeSame($fieldDefinition, 'definitionNode', $fieldDirective);
+
+        $definitionNode = new \ReflectionProperty($fieldDirective, 'definitionNode');
+        $definitionNode->setAccessible(true);
+
+        $this->assertEquals($fieldDefinition, $definitionNode->getValue($fieldDirective));
     }
 
     /**

--- a/tests/Unit/Schema/Factories/DirectiveFactoryTest.php
+++ b/tests/Unit/Schema/Factories/DirectiveFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Schema\Factories;
 
 use Closure;
+use ReflectionProperty;
 use Tests\TestCase;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
@@ -48,10 +49,13 @@ class DirectiveFactoryTest extends TestCase
 
         $fieldDirective = $this->directiveFactory->create('field', $fieldDefinition);
 
-        $definitionNode = new \ReflectionProperty($fieldDirective, 'definitionNode');
+        $definitionNode = new ReflectionProperty($fieldDirective, 'definitionNode');
         $definitionNode->setAccessible(true);
 
-        $this->assertEquals($fieldDefinition, $definitionNode->getValue($fieldDirective));
+        $this->assertSame(
+            $fieldDefinition,
+            $definitionNode->getValue($fieldDirective)
+        );
     }
 
     /**

--- a/tests/Unit/Schema/Factories/DirectiveFactoryTest.php
+++ b/tests/Unit/Schema/Factories/DirectiveFactoryTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Unit\Schema\Factories;
 
 use Closure;
-use ReflectionProperty;
 use Tests\TestCase;
+use ReflectionProperty;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Added Docs for all relevant versions
- [ ] Updated the changelog

**Related Issue/Intent**

This PR removes a couple of warnings that show up on test execution about PHPUnit's deprecated assertion methods.

**Changes**

No changes in behaviour.

**Breaking changes**

No breaking changes.
