### PR TITLE
Allow empty arrays and other falsy values as input for nested mutation operations like "sync"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Avoid growing the memory extensively when doing complex AST manipulation https://github.com/nuwave/lighthouse/pull/768
 - Make nested mutations work with subclassed relationship types https://github.com/nuwave/lighthouse/pull/825
+- Allow empty arrays and other falsy values as input for nested mutation operations like "sync" https://github.com/nuwave/lighthouse/pull/830
 
 ### Changed
 

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -297,7 +297,7 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\BelongsToMany|\Illuminate\Database\Eloquent\Relations\MorphToMany $relation */
             $relation = $model->{$relationName}();
 
-            if (isset($nestedOperations['sync'])){
+            if (isset($nestedOperations['sync'])) {
                 $relation->sync($nestedOperations['sync']);
             }
 

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -50,8 +50,8 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\HasMany|\Illuminate\Database\Eloquent\Relations\MorphMany $relation */
             $relation = $model->{$relationName}();
 
-            if ($create = $nestedOperations['create'] ?? false) {
-                self::handleMultiRelationCreate(new Collection($create), $relation);
+            if (isset($nestedOperations['create'])) {
+                self::handleMultiRelationCreate(new Collection($nestedOperations['create']), $relation);
             }
         };
         $hasMany->each($createOneToMany);
@@ -61,8 +61,8 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\HasOne|\Illuminate\Database\Eloquent\Relations\MorphOne $relation */
             $relation = $model->{$relationName}();
 
-            if ($create = $nestedOperations['create'] ?? false) {
-                self::handleSingleRelationCreate(new Collection($create), $relation);
+            if (isset($nestedOperations['create'])) {
+                self::handleSingleRelationCreate(new Collection($nestedOperations['create']), $relation);
             }
         };
         $hasOne->each($createOneToOne);
@@ -72,16 +72,16 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\BelongsToMany|\Illuminate\Database\Eloquent\Relations\MorphToMany $relation */
             $relation = $model->{$relationName}();
 
-            if ($sync = $nestedOperations['sync'] ?? false) {
-                $relation->sync($sync);
+            if (isset($nestedOperations['sync'])) {
+                $relation->sync($nestedOperations['sync']);
             }
 
-            if ($create = $nestedOperations['create'] ?? false) {
-                self::handleMultiRelationCreate(new Collection($create), $relation);
+            if (isset($nestedOperations['create'])) {
+                self::handleMultiRelationCreate(new Collection($nestedOperations['create']), $relation);
             }
 
-            if ($update = $nestedOperations['update'] ?? false) {
-                (new Collection($update))->each(function ($singleValues) use ($relation): void {
+            if (isset($nestedOperations['update'])) {
+                (new Collection($nestedOperations['update']))->each(function ($singleValues) use ($relation): void {
                     self::executeUpdate(
                         $relation->getModel()->newInstance(),
                         new Collection($singleValues),
@@ -90,8 +90,8 @@ class MutationExecutor
                 });
             }
 
-            if ($connect = $nestedOperations['connect'] ?? false) {
-                $relation->attach($connect);
+            if (isset($nestedOperations['connect'])) {
+                $relation->attach($nestedOperations['connect']);
             }
         };
         $belongsToMany->each($createManyToMany);
@@ -125,25 +125,25 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo $relation */
             $relation = $model->{$relationName}();
 
-            if ($create = $nestedOperations['create'] ?? false) {
+            if (isset($nestedOperations['create'])) {
                 $belongsToModel = self::executeCreate(
                     $relation->getModel()->newInstance(),
-                    new Collection($create)
+                    new Collection($nestedOperations['create'])
                 );
                 $relation->associate($belongsToModel);
             }
 
-            if ($connect = $nestedOperations['connect'] ?? false) {
+            if (isset($nestedOperations['connect'])) {
                 // Inverse can be hasOne or hasMany
                 /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo $belongsTo */
                 $belongsTo = $model->{$relationName}();
-                $belongsTo->associate($connect);
+                $belongsTo->associate($nestedOperations['connect']);
             }
 
-            if ($update = $nestedOperations['update'] ?? false) {
+            if (isset($nestedOperations['update'])) {
                 $belongsToModel = self::executeUpdate(
                     $relation->getModel()->newInstance(),
-                    new Collection($update)
+                    new Collection($nestedOperations['update'])
                 );
                 $relation->associate($belongsToModel);
             }
@@ -249,12 +249,12 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\HasMany|\Illuminate\Database\Eloquent\Relations\MorphMany $relation */
             $relation = $model->{$relationName}();
 
-            if ($create = $nestedOperations['create'] ?? false) {
-                self::handleMultiRelationCreate(new Collection($create), $relation);
+            if (isset($nestedOperations['create'])) {
+                self::handleMultiRelationCreate(new Collection($nestedOperations['create']), $relation);
             }
 
-            if ($update = $nestedOperations['update'] ?? false) {
-                (new Collection($update))->each(function ($singleValues) use ($relation): void {
+            if (isset($nestedOperations['update'])) {
+                (new Collection($nestedOperations['update']))->each(function ($singleValues) use ($relation): void {
                     self::executeUpdate(
                         $relation->getModel()->newInstance(),
                         new Collection($singleValues),
@@ -263,8 +263,8 @@ class MutationExecutor
                 });
             }
 
-            if ($delete = $nestedOperations['delete'] ?? false) {
-                $relation->getModel()::destroy($delete);
+            if (isset($nestedOperations['delete'])) {
+                $relation->getModel()::destroy($nestedOperations['delete']);
             }
         };
         $hasMany->each($updateOneToMany);
@@ -274,20 +274,20 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\HasOne|\Illuminate\Database\Eloquent\Relations\MorphOne $relation */
             $relation = $model->{$relationName}();
 
-            if ($create = $nestedOperations['create'] ?? false) {
-                self::handleSingleRelationCreate(new Collection($create), $relation);
+            if (isset($nestedOperations['create'])) {
+                self::handleSingleRelationCreate(new Collection($nestedOperations['create']), $relation);
             }
 
-            if ($update = $nestedOperations['update'] ?? false) {
+            if (isset($nestedOperations['update'])) {
                 self::executeUpdate(
                     $relation->getModel()->newInstance(),
-                    new Collection($update),
+                    new Collection($nestedOperations['update']),
                     $relation
                 );
             }
 
-            if ($delete = $nestedOperations['delete'] ?? false) {
-                $relation->getModel()::destroy($delete);
+            if (isset($nestedOperations['delete'])) {
+                $relation->getModel()::destroy($nestedOperations['delete']);
             }
         };
         $hasOne->each($updateOneToOne);
@@ -297,16 +297,16 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\BelongsToMany|\Illuminate\Database\Eloquent\Relations\MorphToMany $relation */
             $relation = $model->{$relationName}();
 
-            if (($sync = $nestedOperations['sync'] ?? false) !== false) {
-                $relation->sync($sync);
+            if (isset($nestedOperations['sync'])){
+                $relation->sync($nestedOperations['sync']);
             }
 
-            if ($create = $nestedOperations['create'] ?? false) {
-                self::handleMultiRelationCreate(new Collection($create), $relation);
+            if (isset($nestedOperations['create'])) {
+                self::handleMultiRelationCreate(new Collection($nestedOperations['create']), $relation);
             }
 
-            if ($update = $nestedOperations['update'] ?? false) {
-                (new Collection($update))->each(function ($singleValues) use ($relation): void {
+            if (isset($nestedOperations['update'])) {
+                (new Collection($nestedOperations['update']))->each(function ($singleValues) use ($relation): void {
                     self::executeUpdate(
                         $relation->getModel()->newInstance(),
                         new Collection($singleValues),
@@ -315,17 +315,17 @@ class MutationExecutor
                 });
             }
 
-            if ($delete = $nestedOperations['delete'] ?? false) {
-                $relation->detach($delete);
-                $relation->getModel()::destroy($delete);
+            if (isset($nestedOperations['delete'])) {
+                $relation->detach($nestedOperations['delete']);
+                $relation->getModel()::destroy($nestedOperations['delete']);
             }
 
-            if ($connect = $nestedOperations['connect'] ?? false) {
-                $relation->attach($connect);
+            if (isset($nestedOperations['connect'])) {
+                $relation->attach($nestedOperations['connect']);
             }
 
-            if ($disconnect = $nestedOperations['disconnect'] ?? false) {
-                $relation->detach($disconnect);
+            if (isset($nestedOperations['disconnect'])) {
+                $relation->detach($nestedOperations['disconnect']);
             }
         };
         $belongsToMany->each($updateManyToMany);

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -297,7 +297,7 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\BelongsToMany|\Illuminate\Database\Eloquent\Relations\MorphToMany $relation */
             $relation = $model->{$relationName}();
 
-            if ($sync = $nestedOperations['sync'] ?? false) {
+            if (($sync = $nestedOperations['sync'] ?? false) !== false) {
                 $relation->sync($sync);
             }
 

--- a/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
@@ -520,13 +520,14 @@ class BelongsToManyTest extends DBTestCase
      */
     public function itCanDisconnectAllRelatedModelsOnEmptySync(): void
     {
-        factory(User::class)->create();
-        factory(Role::class)
-            ->create()
-            ->users()
-            ->attach(
-                factory(User::class)->create()
-            );
+        /** @var User $user */
+        $user = factory(User::class)->create();
+        /** @var Role $role */
+        $role = $user->roles()->save(
+            factory(Role::class)->make()
+        );
+
+        $this->assertCount(1, $role->users);
 
         $this->graphQL('
         mutation {
@@ -552,8 +553,8 @@ class BelongsToManyTest extends DBTestCase
             ],
         ]);
 
-        /** @var Role $role */
-        $role = Role::first();
-        $this->assertCount(0, $role->users()->get());
+        $role->refresh();
+
+        $this->assertCount(0, $role->users);
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

**Related Issue/Intent**

In `belongsToMany` relationships, when using `sync` nested operation with an empty array no updates are executed. The expected behaviour from Eloquent is to disconnect all related models on an empty sync operation.

**Changes**

A change was made in `MutationExecution` class to correctly validate and pass empty arrays when present on sync operations.

**Breaking changes**

It will behave differently if someone relies on the current behaviour of not executing updates on the relationship when sync is called with an empty array.

I believe Lighthouse should follow Eloquent functionality verbatim and that's why I suggest this change.