### PR TITLE
Prefix column references with table name to allow scopes to join other tables

### DIFF
--- a/src/Schema/Directives/AllDirective.php
+++ b/src/Schema/Directives/AllDirective.php
@@ -42,7 +42,7 @@ class AllDirective extends BaseDirective implements FieldResolver
                         $modelClass::query(),
                         $args
                     )
-                    ->get((new $modelClass())->getTable() . '.*');
+                    ->get((new $modelClass())->getTable().'.*');
             }
         );
     }

--- a/src/Schema/Directives/AllDirective.php
+++ b/src/Schema/Directives/AllDirective.php
@@ -42,7 +42,7 @@ class AllDirective extends BaseDirective implements FieldResolver
                         $modelClass::query(),
                         $args
                     )
-                    ->get();
+                    ->get((new $modelClass())->getTable() . '.*');
             }
         );
     }

--- a/src/Schema/Directives/EqDirective.php
+++ b/src/Schema/Directives/EqDirective.php
@@ -25,8 +25,10 @@ class EqDirective extends BaseDirective implements ArgBuilderDirective
      */
     public function handleBuilder($builder, $value)
     {
+        $table = $builder->getModel()->getTable();
+
         return $builder->where(
-            $this->directiveArgValue('key', $this->definitionNode->name->value),
+            $this->directiveArgValue('key', $table . '.' . $this->definitionNode->name->value),
             $value
         );
     }

--- a/src/Schema/Directives/EqDirective.php
+++ b/src/Schema/Directives/EqDirective.php
@@ -28,7 +28,7 @@ class EqDirective extends BaseDirective implements ArgBuilderDirective
         $table = $builder->getModel()->getTable();
 
         return $builder->where(
-            $this->directiveArgValue('key', $table . '.' . $this->definitionNode->name->value),
+            $this->directiveArgValue('key', $table.'.'.$this->definitionNode->name->value),
             $value
         );
     }

--- a/src/Schema/Directives/FindDirective.php
+++ b/src/Schema/Directives/FindDirective.php
@@ -43,7 +43,7 @@ class FindDirective extends BaseDirective implements FieldResolver
                         $model::query(),
                         $args
                     )
-                    ->get();
+                    ->get((new $model())->getTable() . '.*');
 
                 if ($results->count() > 1) {
                     throw new Error('The query returned more than one result.');

--- a/src/Schema/Directives/FindDirective.php
+++ b/src/Schema/Directives/FindDirective.php
@@ -43,7 +43,7 @@ class FindDirective extends BaseDirective implements FieldResolver
                         $model::query(),
                         $args
                     )
-                    ->get((new $model())->getTable() . '.*');
+                    ->get((new $model())->getTable().'.*');
 
                 if ($results->count() > 1) {
                     throw new Error('The query returned more than one result.');

--- a/src/Schema/Directives/InDirective.php
+++ b/src/Schema/Directives/InDirective.php
@@ -28,7 +28,7 @@ class InDirective extends BaseDirective implements ArgBuilderDirective
         $table = $builder->getModel()->getTable();
 
         return $builder->whereIn(
-            $this->directiveArgValue('key', $table . '.' . $this->definitionNode->name->value),
+            $this->directiveArgValue('key', $table.'.'.$this->definitionNode->name->value),
             $values
         );
     }

--- a/src/Schema/Directives/InDirective.php
+++ b/src/Schema/Directives/InDirective.php
@@ -25,8 +25,10 @@ class InDirective extends BaseDirective implements ArgBuilderDirective
      */
     public function handleBuilder($builder, $values)
     {
+        $table = $builder->getModel()->getTable();
+
         return $builder->whereIn(
-            $this->directiveArgValue('key', $this->definitionNode->name->value),
+            $this->directiveArgValue('key', $table . '.' . $this->definitionNode->name->value),
             $values
         );
     }

--- a/src/Schema/Directives/NeqDirective.php
+++ b/src/Schema/Directives/NeqDirective.php
@@ -25,8 +25,10 @@ class NeqDirective extends BaseDirective implements ArgBuilderDirective
      */
     public function handleBuilder($builder, $value)
     {
+        $table = $builder->getModel()->getTable();
+
         return $builder->where(
-            $this->directiveArgValue('key', $this->definitionNode->name->value),
+            $this->directiveArgValue('key', $table . '.' . $this->definitionNode->name->value),
             '<>',
             $value
         );

--- a/src/Schema/Directives/NeqDirective.php
+++ b/src/Schema/Directives/NeqDirective.php
@@ -28,7 +28,7 @@ class NeqDirective extends BaseDirective implements ArgBuilderDirective
         $table = $builder->getModel()->getTable();
 
         return $builder->where(
-            $this->directiveArgValue('key', $table . '.' . $this->definitionNode->name->value),
+            $this->directiveArgValue('key', $table.'.'.$this->definitionNode->name->value),
             '<>',
             $value
         );

--- a/src/Schema/Directives/NotInDirective.php
+++ b/src/Schema/Directives/NotInDirective.php
@@ -25,8 +25,10 @@ class NotInDirective extends BaseDirective implements ArgBuilderDirective
      */
     public function handleBuilder($builder, $values)
     {
+        $table = $builder->getModel()->getTable();
+
         return $builder->whereNotIn(
-            $this->directiveArgValue('key', $this->definitionNode->name->value),
+            $this->directiveArgValue('key', $table . '.' . $this->definitionNode->name->value),
             $values
         );
     }

--- a/src/Schema/Directives/NotInDirective.php
+++ b/src/Schema/Directives/NotInDirective.php
@@ -28,7 +28,7 @@ class NotInDirective extends BaseDirective implements ArgBuilderDirective
         $table = $builder->getModel()->getTable();
 
         return $builder->whereNotIn(
-            $this->directiveArgValue('key', $table . '.' . $this->definitionNode->name->value),
+            $this->directiveArgValue('key', $table.'.'.$this->definitionNode->name->value),
             $values
         );
     }

--- a/src/Schema/Directives/WhereBetweenDirective.php
+++ b/src/Schema/Directives/WhereBetweenDirective.php
@@ -27,8 +27,10 @@ class WhereBetweenDirective extends BaseDirective implements ArgBuilderDirective
      */
     public function handleBuilder($builder, $values)
     {
+        $table = $builder->getModel()->getTable();
+
         return $builder->whereBetween(
-            $this->directiveArgValue('key', $this->definitionNode->name->value),
+            $this->directiveArgValue('key', $table . '.' . $this->definitionNode->name->value),
             $values
         );
     }

--- a/src/Schema/Directives/WhereBetweenDirective.php
+++ b/src/Schema/Directives/WhereBetweenDirective.php
@@ -30,7 +30,7 @@ class WhereBetweenDirective extends BaseDirective implements ArgBuilderDirective
         $table = $builder->getModel()->getTable();
 
         return $builder->whereBetween(
-            $this->directiveArgValue('key', $table . '.' . $this->definitionNode->name->value),
+            $this->directiveArgValue('key', $table.'.'.$this->definitionNode->name->value),
             $values
         );
     }

--- a/src/Schema/Directives/WhereDirective.php
+++ b/src/Schema/Directives/WhereDirective.php
@@ -25,11 +25,13 @@ class WhereDirective extends BaseDirective implements ArgBuilderDirective
      */
     public function handleBuilder($builder, $value)
     {
+        $table = $builder->getModel()->getTable();
+
         // Allow users to overwrite the default "where" clause, e.g. "whereYear"
         $clause = $this->directiveArgValue('clause', 'where');
 
         return $builder->{$clause}(
-            $this->directiveArgValue('key', $this->definitionNode->name->value),
+            $this->directiveArgValue('key', $table . '.' . $this->definitionNode->name->value),
             $operator = $this->directiveArgValue('operator', '='),
             $value
         );

--- a/src/Schema/Directives/WhereDirective.php
+++ b/src/Schema/Directives/WhereDirective.php
@@ -31,7 +31,7 @@ class WhereDirective extends BaseDirective implements ArgBuilderDirective
         $clause = $this->directiveArgValue('clause', 'where');
 
         return $builder->{$clause}(
-            $this->directiveArgValue('key', $table . '.' . $this->definitionNode->name->value),
+            $this->directiveArgValue('key', $table.'.'.$this->definitionNode->name->value),
             $operator = $this->directiveArgValue('operator', '='),
             $value
         );

--- a/src/Schema/Directives/WhereNotBetweenDirective.php
+++ b/src/Schema/Directives/WhereNotBetweenDirective.php
@@ -30,7 +30,7 @@ class WhereNotBetweenDirective extends BaseDirective implements ArgBuilderDirect
         $table = $builder->getModel()->getTable();
 
         return $builder->whereNotBetween(
-            $this->directiveArgValue('key', $table . '.' . $this->definitionNode->name->value),
+            $this->directiveArgValue('key', $table.'.'.$this->definitionNode->name->value),
             $values
         );
     }

--- a/src/Schema/Directives/WhereNotBetweenDirective.php
+++ b/src/Schema/Directives/WhereNotBetweenDirective.php
@@ -27,8 +27,10 @@ class WhereNotBetweenDirective extends BaseDirective implements ArgBuilderDirect
      */
     public function handleBuilder($builder, $values)
     {
+        $table = $builder->getModel()->getTable();
+
         return $builder->whereNotBetween(
-            $this->directiveArgValue('key', $this->definitionNode->name->value),
+            $this->directiveArgValue('key', $table . '.' . $this->definitionNode->name->value),
             $values
         );
     }

--- a/tests/Integration/Schema/Directives/FindDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/FindDirectiveTest.php
@@ -108,8 +108,8 @@ class FindDirectiveTest extends DBTestCase
         $companyA = factory(Company::class)->create(['name' => 'CompanyA']);
         $companyB = factory(Company::class)->create(['name' => 'CompanyB']);
         $userA = factory(User::class)->create(['name' => 'A', 'company_id' => $companyA->id]);
-        $userB = factory(User::class)->create(['name' => 'A', 'company_id' => $companyB->id]);
-        $userC = factory(User::class)->create(['name' => 'B', 'company_id' => $companyA->id]);
+        $userB = factory(User::class)->create(['name' => 'B', 'company_id' => $companyB->id]);
+        $userC = factory(User::class)->create(['name' => 'C', 'company_id' => $companyA->id]);
 
         $this->schema = '
         type Company {
@@ -122,7 +122,7 @@ class FindDirectiveTest extends DBTestCase
         }
         
         type Query {
-            user(name: String @eq, company: String!): User @find(model: "User" scopes: [companyName])
+            user(name: String @eq, company: String!): User @find(model: "User" scopes: ["companyName"])
         }
         ';
 

--- a/tests/Utils/Models/User.php
+++ b/tests/Utils/Models/User.php
@@ -62,10 +62,5 @@ class User extends Authenticatable
         return $query
             ->join('companies', 'users.company_id', '=', 'companies.id')
             ->where('companies.name', $args['company']);
-        
-        /*return $query->whereHas('company', function (Builder $q) use ($args): void {
-            $q->where('name', $args['company']);
-        })->dd();*/
-        
     }
 }

--- a/tests/Utils/Models/User.php
+++ b/tests/Utils/Models/User.php
@@ -59,8 +59,13 @@ class User extends Authenticatable
 
     public function scopeCompanyName(Builder $query, array $args): Builder
     {
-        return $query->whereHas('company', function (Builder $q) use ($args): void {
+        return $query
+            ->join('companies', 'users.company_id', '=', 'companies.id')
+            ->where('companies.name', $args['company']);
+        
+        /*return $query->whereHas('company', function (Builder $q) use ($args): void {
             $q->where('name', $args['company']);
-        });
+        })->dd();*/
+        
     }
 }


### PR DESCRIPTION
- [ ] Added or updated tests
  - I added/adapted integration tests for @all and @find, the last one which also includes @eq
- [ ] Added Docs for all relevant versions
- [ ] Updated the changelog

**Related Issue/Intent**

`@find` and `@all` generate finder queries and can be influenced with `@eq`, `@neq`, `@in`, `@notIn` and `@where*` condition directives, while supporting scopes. A scope method receives the builder as an argument, and it may join other tables to it. When it does so, the already selected columns and generated conditions break the query, because they are not prefixing columns with the corresponding table names.

**Changes**

This patch makes sure that condition directions prefix the columns they add to the builder with the model's table name, and that finder directives prefix `*` with the table name as well, otherwise the result may contain multiple values for the same column name (e.g. "id"), which results in mixed-up values.

**Breaking changes**

Should be a pure bugfix change.

Note: the `FindDirectiveTest` can be made to fail by reverting the changes to either `FindDirective` or `EqDirective`. The `AllDirectiveTest` can be made to fail by reverting the changes to `AllDirective`.