### PR TITLE
Fix @can directive with multiple models and remove deprecated "if" alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make nested mutations work with subclassed relationship types https://github.com/nuwave/lighthouse/pull/825
 - Allow empty arrays and other falsy values as input for nested mutation operations like "sync" https://github.com/nuwave/lighthouse/pull/830
 - Use `Illuminate\Contracts\Config\Repository` instead of `Illuminate\Config\Repository` https://github.com/nuwave/lighthouse/issues/832
+- Allow checking the abilities with `@can` when issuing mass updates on multiple models https://github.com/nuwave/lighthouse/pull/838
 
 ### Changed
 
@@ -38,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use the `@spread` directive instead of the `flatten` argument of `@create`/`@update` https://github.com/nuwave/lighthouse/pull/822
 - Remove `dispatch` aliases `fire` and `class` for dispatching through `@event` https://github.com/nuwave/lighthouse/pull/823
 - Remove the `GraphQL` facade and the container alias `graphql` https://github.com/nuwave/lighthouse/pull/824
+- Remove the alias `if` for specifying the `ability` that has to be met in `@can` https://github.com/nuwave/lighthouse/pull/838
 
 ## [3.7.0](https://github.com/nuwave/lighthouse/compare/v3.6.1...v3.7.0)
 

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -3,7 +3,7 @@
 namespace Nuwave\Lighthouse\Schema\Directives;
 
 use Closure;
-use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Model;
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
@@ -13,6 +13,21 @@ use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
 
 class CanDirective extends BaseDirective implements FieldMiddleware
 {
+    /**
+     * @var \Illuminate\Contracts\Auth\Access\Gate
+     */
+    protected $gate;
+
+    /**
+     * CanDirective constructor.
+     * @param  \Illuminate\Contracts\Auth\Access\Gate  $gate
+     * @return void
+     */
+    public function __construct(Gate $gate)
+    {
+        $this->gate = $gate;
+    }
+
     /**
      * Name of the directive.
      *
@@ -37,28 +52,22 @@ class CanDirective extends BaseDirective implements FieldMiddleware
         return $next(
             $fieldValue->setResolver(
                 function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($previousResolver) {
-                    $gate = app(Gate::class);
-                    $gateArguments = $this->getGateArguments();
+                    $modelClass = $this->getModelClass();
 
-                    if ($id = $args['id'] ?? null) {
-                        /** @var \Illuminate\Database\Eloquent\Model $modelClass */
-                        $modelClass = $this->getModelClass();
+                    if (isset($args['id'])) {
+                        $modelOrModels = $modelClass::findOrFail($args['id']);
 
-                        $gateArguments[0] = $modelClass::findOrFail($id);
-                    }
-
-                    $this->getAbilities()->each(
-                        function (string $ability) use ($context, $gate, $gateArguments): void {
-                            if ($gateArguments[0] instanceof Collection) {
-                                /** @var Collection $gateArguments[0] */
-                                $gateArguments[0]->each(function ($argument) use ($context, $gate, $ability) {
-                                    $this->authorize($context->user(), $gate, $ability, [$argument]);
-                                });
-                            } else {
-                                $this->authorize($context->user(), $gate, $ability, $gateArguments);
-                            }
+                        if($modelOrModels instanceof Model) {
+                            $modelOrModels = [$modelOrModels];
                         }
-                    );
+
+                        /** @var \Illuminate\Database\Eloquent\Model $model */
+                        foreach($modelOrModels as $model){
+                            $this->authorize($context->user(), $model);
+                        }
+                    } else {
+                        $this->authorize($context->user(), $modelClass);
+                    }
 
                     return call_user_func_array($previousResolver, func_get_args());
                 }
@@ -67,18 +76,31 @@ class CanDirective extends BaseDirective implements FieldMiddleware
     }
 
     /**
-     * Get the ability argument.
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
+     * @param  string|\Illuminate\Database\Eloquent\Model  $model
+     * @return void
      *
-     * For compatibility reasons, the alias "if" will be kept until the next major version.
-     *
-     * @return \Illuminate\Support\Collection<string>
+     * @throws \Nuwave\Lighthouse\Exceptions\AuthorizationException
      */
-    protected function getAbilities(): Collection
+    protected function authorize($user, $model): void
     {
-        return new Collection(
-            $this->directiveArgValue('ability')
-            ?? $this->directiveArgValue('if')
-        );
+        // The signature of the second argument `$arguments` of `Gate::check`
+        // should be [modelClassName, additionalArg, additionalArg...]
+        $arguments = $this->getAdditionalArguments();
+        array_unshift($arguments, $model);
+
+        $can = $this->gate
+            ->forUser($user)
+            ->check(
+                $this->directiveArgValue('ability'),
+                $arguments
+            );
+
+        if (! $can) {
+            throw new AuthorizationException(
+                "You are not authorized to access {$this->definitionNode->name->value}"
+            );
+        }
     }
 
     /**
@@ -86,35 +108,8 @@ class CanDirective extends BaseDirective implements FieldMiddleware
      *
      * @return mixed[]
      */
-    protected function getGateArguments(): array
+    protected function getAdditionalArguments(): array
     {
-        $modelClass = $this->getModelClass();
-        $args = (array) $this->directiveArgValue('args');
-
-        // The signature of the second argument `$arguments` of `Gate::check`
-        // should be [modelClassName, additionalArg, additionalArg...]
-        array_unshift($args, $modelClass);
-
-        return $args;
-    }
-
-    /**
-     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
-     * @param  \Illuminate\Contracts\Auth\Access\Gate  $gate
-     * @param  string  $ability
-     * @param  array  $args
-     * @return void
-     *
-     * @throws \Nuwave\Lighthouse\Exceptions\AuthorizationException
-     */
-    protected function authorize($user, Gate $gate, string $ability, array $args): void
-    {
-        $can = $gate->forUser($user)->check($ability, $args);
-
-        if (! $can) {
-            throw new AuthorizationException(
-                "You are not authorized to access {$this->definitionNode->name->value}"
-            );
-        }
+        return (array) $this->directiveArgValue('args');
     }
 }

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -49,7 +49,14 @@ class CanDirective extends BaseDirective implements FieldMiddleware
 
                     $this->getAbilities()->each(
                         function (string $ability) use ($context, $gate, $gateArguments): void {
-                            $this->authorize($context->user(), $gate, $ability, $gateArguments);
+                            if ($gateArguments[0] instanceof Collection) {
+                                /** @var Collection $gateArguments[0] */
+                                $gateArguments[0]->each(function ($argument) use ($context, $gate, $ability) {
+                                    $this->authorize($context->user(), $gate, $ability, [$argument]);
+                                });
+                            } else {
+                                $this->authorize($context->user(), $gate, $ability, $gateArguments);
+                            }
                         }
                     );
 

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -57,12 +57,12 @@ class CanDirective extends BaseDirective implements FieldMiddleware
                     if (isset($args['id'])) {
                         $modelOrModels = $modelClass::findOrFail($args['id']);
 
-                        if($modelOrModels instanceof Model) {
+                        if ($modelOrModels instanceof Model) {
                             $modelOrModels = [$modelOrModels];
                         }
 
                         /** @var \Illuminate\Database\Eloquent\Model $model */
-                        foreach($modelOrModels as $model){
+                        foreach ($modelOrModels as $model) {
                             $this->authorize($context->user(), $model);
                         }
                     } else {

--- a/tests/Unit/Schema/Directives/CanDirectiveDbTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveDbTest.php
@@ -5,8 +5,8 @@ namespace Tests\Unit\Schema\Directives;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Post;
 use Tests\Utils\Models\User;
-use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Tests\Utils\Policies\UserPolicy;
+use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 
 class CanDirectiveDbTest extends DBTestCase
 {
@@ -139,7 +139,7 @@ class CanDirectiveDbTest extends DBTestCase
                     ],
                     [
                         'title' => 'Harry Potter and the Chamber of Secrets',
-                    ]
+                    ],
                 ],
             ],
         ]);

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -5,24 +5,21 @@ namespace Tests\Unit\Schema\Directives;
 use Tests\TestCase;
 use Tests\Utils\Models\User;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
+use Tests\Utils\Policies\UserPolicy;
 
 class CanDirectiveTest extends TestCase
 {
     /**
      * @test
-     * @dataProvider provideAcceptableArgumentNames
-     *
-     * @param  string  $argumentName
-     * @return void
      */
-    public function itThrowsIfNotAuthorized(string $argumentName): void
+    public function itThrowsIfNotAuthorized(): void
     {
         $this->be(new User);
 
         $this->schema = '
         type Query {
             user: User!
-                @can('.$argumentName.': "adminOnly")
+                @can(ability: "adminOnly")
                 @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
         }
         
@@ -42,21 +39,17 @@ class CanDirectiveTest extends TestCase
 
     /**
      * @test
-     * @dataProvider provideAcceptableArgumentNames
-     *
-     * @param  string  $argumentName
-     * @return void
      */
-    public function itPassesAuthIfAuthorized(string $argumentName): void
+    public function itPassesAuthIfAuthorized(): void
     {
         $user = new User;
-        $user->name = 'admin';
+        $user->name = UserPolicy::ADMIN;
         $this->be($user);
 
         $this->schema = '
         type Query {
             user: User!
-                @can('.$argumentName.': "adminOnly")
+                @can(ability: "adminOnly")
                 @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
         }
         
@@ -82,12 +75,8 @@ class CanDirectiveTest extends TestCase
 
     /**
      * @test
-     * @dataProvider provideAcceptableArgumentNames
-     *
-     * @param  string  $argumentName
-     * @return void
      */
-    public function itAcceptsGuestUser(string $argumentName): void
+    public function itAcceptsGuestUser(): void
     {
         if ((float) $this->app->version() < 5.7) {
             $this->markTestSkipped('Version less than 5.7 do not support guest user.');
@@ -96,7 +85,7 @@ class CanDirectiveTest extends TestCase
         $this->schema = '
         type Query {
             user: User!
-                @can('.$argumentName.': "guestOnly")
+                @can(ability: "guestOnly")
                 @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
         }
         
@@ -122,21 +111,17 @@ class CanDirectiveTest extends TestCase
 
     /**
      * @test
-     * @dataProvider provideAcceptableArgumentNames
-     *
-     * @param  string  $argumentName
-     * @return void
      */
-    public function itPassesMultiplePolicies(string $argumentName): void
+    public function itPassesMultiplePolicies(): void
     {
         $user = new User;
-        $user->name = 'admin';
+        $user->name = UserPolicy::ADMIN;
         $this->be($user);
 
         $this->schema = '
         type Query {
             user: User!
-                @can('.$argumentName.': ["adminOnly", "alwaysTrue"])
+                @can(ability: ["adminOnly", "alwaysTrue"])
                 @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
         }
         
@@ -162,17 +147,13 @@ class CanDirectiveTest extends TestCase
 
     /**
      * @test
-     * @dataProvider provideAcceptableArgumentNames
-     *
-     * @param  string  $argumentName
-     * @return void
      */
-    public function itProcessesTheArgsArgument(string $argumentName): void
+    public function itProcessesTheArgsArgument(): void
     {
         $this->schema = '
         type Query {
             user: User!
-                @can('.$argumentName.': "dependingOnArg", args: [false])
+                @can(ability: "dependingOnArg", args: [false])
                 @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
         }
         
@@ -196,16 +177,5 @@ class CanDirectiveTest extends TestCase
         $user->name = 'foo';
 
         return $user;
-    }
-
-    /**
-     * @return array[]
-     */
-    public function provideAcceptableArgumentNames(): array
-    {
-        return [
-            ['if'],
-            ['ability'],
-        ];
     }
 }

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -4,8 +4,8 @@ namespace Tests\Unit\Schema\Directives;
 
 use Tests\TestCase;
 use Tests\Utils\Models\User;
-use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Tests\Utils\Policies\UserPolicy;
+use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 
 class CanDirectiveTest extends TestCase
 {

--- a/tests/Utils/Policies/PostPolicy.php
+++ b/tests/Utils/Policies/PostPolicy.php
@@ -14,6 +14,6 @@ class PostPolicy
 
     public function delete(User $user, Post $post): bool
     {
-        return (int)$post->user_id === (int)$user->getKey();
+        return (int) $post->user_id === (int) $user->getKey();
     }
 }

--- a/tests/Utils/Policies/PostPolicy.php
+++ b/tests/Utils/Policies/PostPolicy.php
@@ -11,4 +11,9 @@ class PostPolicy
     {
         return $post->user_id === $user->getKey();
     }
+
+    public function delete(User $user, Post $post): bool
+    {
+        return (int)$post->user_id === (int)$user->getKey();
+    }
 }

--- a/tests/Utils/Policies/UserPolicy.php
+++ b/tests/Utils/Policies/UserPolicy.php
@@ -6,9 +6,11 @@ use Tests\Utils\Models\User;
 
 class UserPolicy
 {
+    const ADMIN = 'admin';
+
     public function adminOnly(User $user): bool
     {
-        return $user->name === 'admin';
+        return $user->name === self::ADMIN;
     }
 
     public function alwaysTrue(): bool


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

**Related Issue/Intent**

`@can` directive fails if an array of `ID` is passed. For example in the `@delete` directive, as it described in the docs. 

```graphql
deletePosts(id: [ID!]!): [Posts!]! @delete @can(ability: "delete")
```

It happens when `[ID!]!` is passed as an input. In this case, we have to handle Collection.

**Changes**

Check if Collection was provided and run `Gate::check` for each item.

**Breaking changes**

Edit by @spawnia:

While i was at it, i removed the deprecated alias `if` of the `@can` directive.

The migration is straightforward:

```diff
type Mutation {
- deletePost(id: ID!): Post @can(if: "delete")
+ deletePost(id: ID!): Post @can(ability: "delete")
}
```
