### PR TITLE
Implement `connect`, `disconnect` and `delete` operations for nested mutations upon MorphTo relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `@defer` extension now supports deferring nested fields of mutations https://github.com/nuwave/lighthouse/pull/855
 - Add a simple way to define complex validation directives by extending `\Nuwave\Lighthouse\Schema\Directives\ValidationDirective` https://github.com/nuwave/lighthouse/pull/846
 - Extend the `@belongsToMany` directive to support pivot data on a custom Relay style Edge type https://github.com/nuwave/lighthouse/pull/871
-- Implement `connect` and `disconnect` operations for nested mutations upon MorphTo relationships
+- Implement `connect`, `disconnect` and `delete` operations for nested mutations upon MorphTo relationships https://github.com/nuwave/lighthouse/pull/879
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `@defer` extension now supports deferring nested fields of mutations https://github.com/nuwave/lighthouse/pull/855
 - Add a simple way to define complex validation directives by extending `\Nuwave\Lighthouse\Schema\Directives\ValidationDirective` https://github.com/nuwave/lighthouse/pull/846
 - Extend the `@belongsToMany` directive to support pivot data on a custom Relay style Edge type https://github.com/nuwave/lighthouse/pull/871
+- Implement `connect` and `disconnect` operations for nested mutations upon MorphTo relationships
 
 ### Fixed
 

--- a/docs/master/eloquent/nested-mutations.md
+++ b/docs/master/eloquent/nested-mutations.md
@@ -476,17 +476,13 @@ input UpdateAuthorInput {
 
 ## MorphTo
 
-```graphql
-type Mutation {
-  createHour(input: CreateHourInput! @spread): Hour @create
-}
+__The GraphQL Specification does not support Input Union types,
+for now we are limiting this implementation to `connect` and `disconnect` operations.__
 
-input CreateHourInput {
-  hourable_type: String!
-  hourable_id: Int!
-  from: String
-  to: String
-  weekday: Int
+```graphql
+type Task {
+  id: ID
+  name: String
 }
 
 type Hour {
@@ -495,21 +491,75 @@ type Hour {
   hourable: Task
 }
 
-type Task {
-  id: ID
-  name: String
-  hour: Hour
+type Mutation {
+  createHour(input: CreateHourInput! @spread): Hour @create
+  updateHour(input: UpdateHourInput! @spread): Hour @update
+}
+
+input CreateHourInput {
+  from: String
+  to: String
+  weekday: Int
+  hourable: CreateHourableOperations
+}
+
+input UpdateHourInput {
+  id: ID!
+  from: String
+  to: String
+  weekday: Int
+  hourable: UpdateHourableOperations
+}
+
+input CreateHourableOperations {
+  connect: ConnectHourableInput
+}
+
+input UpdateHourableOperations {
+  connect: ConnectHourableInput
+  disconnect: Boolean
+}
+
+input ConnectHourableInput {
+  type: String!
+  id: ID!
 }
 ```
+
+You can use `connect` to associate existing models.
 
 ```graphql
 mutation {
   createHour(input: {
-    hourable_type: "App\\\Task"
-    hourable_id: 1
     weekday: 2
+    hourable: {
+      connect: {
+        type: "Tests\\\Utils\\\Models\\\Task"
+        id: 1
+      }
+    }
   }) {
     id
+    weekday
+    hourable {
+      id
+      name
+    }
+  }
+}
+```
+
+The `disconnect` operations allows you to detach the currently associated model.
+
+```graphql
+mutation {
+  updateHour(input: {
+    id: 1
+    weekday: 2
+    hourable: {
+      disconnect: true
+    }
+  }) {
     weekday
     hourable {
       id

--- a/docs/master/eloquent/nested-mutations.md
+++ b/docs/master/eloquent/nested-mutations.md
@@ -534,7 +534,7 @@ mutation {
     weekday: 2
     hourable: {
       connect: {
-        type: "Tests\\\Utils\\\Models\\\Task"
+        type: "App\\\Models\\\Task"
         id: 1
       }
     }

--- a/docs/master/eloquent/nested-mutations.md
+++ b/docs/master/eloquent/nested-mutations.md
@@ -536,7 +536,7 @@ mutation {
     weekday: 2
     hourable: {
       connect: {
-        type: "App\\\Models\\\Task"
+        type: "App\\Models\\Task"
         id: 1
       }
     }

--- a/docs/master/eloquent/nested-mutations.md
+++ b/docs/master/eloquent/nested-mutations.md
@@ -477,7 +477,8 @@ input UpdateAuthorInput {
 ## MorphTo
 
 __The GraphQL Specification does not support Input Union types,
-for now we are limiting this implementation to `connect` and `disconnect` operations.__
+for now we are limiting this implementation to `connect`, `disconnect` and `delete` operations.
+See https://github.com/nuwave/lighthouse/issues/900 for further discussion.__
 
 ```graphql
 type Task {
@@ -518,6 +519,7 @@ input CreateHourableOperations {
 input UpdateHourableOperations {
   connect: ConnectHourableInput
   disconnect: Boolean
+  delete: Boolean
 }
 
 input ConnectHourableInput {
@@ -558,6 +560,26 @@ mutation {
     weekday: 2
     hourable: {
       disconnect: true
+    }
+  }) {
+    weekday
+    hourable {
+      id
+      name
+    }
+  }
+}
+```
+
+The `delete` operation both detaches and deletes the currently associated model.
+
+```graphql
+mutation {
+  updateHour(input: {
+    id: 1
+    weekday: 2
+    hourable: {
+      delete: true
     }
   }) {
     weekday

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -172,19 +172,7 @@ class MutationExecutor
             /** @var \Illuminate\Database\Eloquent\Relations\MorphTo $relation */
             $relation = $model->{$relationName}();
 
-            // TODO at this point the lack of polymorphic input types becomes problematic
-//            if (isset($nestedOperations['create'])) {
-//                $createArgs = $nestedOperations['create'];
-//                $morphToModel = $relation->createModelByType(
-//                    $createArgs['type']
-//                );
-//
-//                $morphToModel = self::executeCreate(
-//                    $morphToModel,
-//                    new Collection($createArgs['input'])
-//                );
-//                $relation->associate($morphToModel);
-//            }
+            // TODO implement create and update once we figure out how to do polymorphic input types https://github.com/nuwave/lighthouse/issues/900
 
             if (isset($nestedOperations['connect'])) {
                 $connectArgs = $nestedOperations['connect'];
@@ -199,19 +187,6 @@ class MutationExecutor
 
                 $relation->associate($morphToModel);
             }
-
-//            if (isset($nestedOperations['update'])) {
-//                $updateArgs = $nestedOperations['update'];
-//                $morphToModel = $relation->createModelByType(
-//                    $updateArgs['type']
-//                );
-//
-//                $morphToModel = self::executeUpdate(
-//                    $morphToModel,
-//                    new Collection($updateArgs['input'])
-//                );
-//                $relation->associate($morphToModel);
-//            }
 
             // We proceed with disconnecting/deleting only if the given $values is truthy.
             // There is no other information to be passed when issuing those operations,

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -2,14 +2,13 @@
 
 namespace Nuwave\Lighthouse\Execution;
 
-use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Illuminate\Support\Arr;
 use ReflectionClass;
 use ReflectionNamedType;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -168,7 +167,7 @@ class MutationExecutor
             }
         });
 
-        $morphTo->each(function(array $nestedOperations, string $relationName) use ($model): void {
+        $morphTo->each(function (array $nestedOperations, string $relationName) use ($model): void {
             /** @var \Illuminate\Database\Eloquent\Relations\MorphTo $relation */
             $relation = $model->{$relationName}();
 

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -221,9 +221,9 @@ class MutationExecutor
                 $relation->dissociate();
             }
 
-//            if ($nestedOperations['delete'] ?? false) {
-//                $relation->delete();
-//            }
+            if ($nestedOperations['delete'] ?? false) {
+                $relation->delete();
+            }
         });
 
         if ($parentRelation && ! $parentRelation instanceof BelongsToMany) {

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -2,14 +2,13 @@
 
 namespace Nuwave\Lighthouse\Execution;
 
-use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Illuminate\Support\Arr;
 use ReflectionClass;
 use ReflectionNamedType;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -168,11 +167,11 @@ class MutationExecutor
             }
         });
 
-        $morphTo->each(function(array $nestedOperations, string $relationName) use ($model): void {
+        $morphTo->each(function (array $nestedOperations, string $relationName) use ($model): void {
             /** @var \Illuminate\Database\Eloquent\Relations\MorphTo $relation */
             $relation = $model->{$relationName}();
 
-            # TODO at this point the lack of polymorphic input types becomes problematic
+            // TODO at this point the lack of polymorphic input types becomes problematic
 //            if (isset($nestedOperations['create'])) {
 //                $createArgs = $nestedOperations['create'];
 //                $morphToModel = $relation->createModelByType(

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -121,7 +121,7 @@ class MutationExecutor
 
         [$morphTo, $remaining] = self::partitionArgsByRelationType(
             $reflection,
-            $args,
+            $remaining,
             MorphTo::class
         );
 

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -2,13 +2,14 @@
 
 namespace Nuwave\Lighthouse\Execution;
 
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Arr;
 use ReflectionClass;
 use ReflectionNamedType;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -167,22 +168,23 @@ class MutationExecutor
             }
         });
 
-        $morphTo->each(function (array $nestedOperations, string $relationName) use ($model): void {
+        $morphTo->each(function(array $nestedOperations, string $relationName) use ($model): void {
             /** @var \Illuminate\Database\Eloquent\Relations\MorphTo $relation */
             $relation = $model->{$relationName}();
 
-            if (isset($nestedOperations['create'])) {
-                $createArgs = $nestedOperations['create'];
-                $morphToModel = $relation->createModelByType(
-                    $createArgs['type']
-                );
-
-                $morphToModel = self::executeCreate(
-                    $morphToModel,
-                    new Collection($createArgs['input'])
-                );
-                $relation->associate($morphToModel);
-            }
+            # TODO at this point the lack of polymorphic input types becomes problematic
+//            if (isset($nestedOperations['create'])) {
+//                $createArgs = $nestedOperations['create'];
+//                $morphToModel = $relation->createModelByType(
+//                    $createArgs['type']
+//                );
+//
+//                $morphToModel = self::executeCreate(
+//                    $morphToModel,
+//                    new Collection($createArgs['input'])
+//                );
+//                $relation->associate($morphToModel);
+//            }
 
             if (isset($nestedOperations['connect'])) {
                 $connectArgs = $nestedOperations['connect'];
@@ -198,18 +200,18 @@ class MutationExecutor
                 $relation->associate($morphToModel);
             }
 
-            if (isset($nestedOperations['update'])) {
-                $updateArgs = $nestedOperations['update'];
-                $morphToModel = $relation->createModelByType(
-                    $updateArgs['type']
-                );
-
-                $morphToModel = self::executeUpdate(
-                    $morphToModel,
-                    new Collection($updateArgs['input'])
-                );
-                $relation->associate($morphToModel);
-            }
+//            if (isset($nestedOperations['update'])) {
+//                $updateArgs = $nestedOperations['update'];
+//                $morphToModel = $relation->createModelByType(
+//                    $updateArgs['type']
+//                );
+//
+//                $morphToModel = self::executeUpdate(
+//                    $morphToModel,
+//                    new Collection($updateArgs['input'])
+//                );
+//                $relation->associate($morphToModel);
+//            }
 
             // We proceed with disconnecting/deleting only if the given $values is truthy.
             // There is no other information to be passed when issuing those operations,
@@ -219,9 +221,9 @@ class MutationExecutor
                 $relation->dissociate();
             }
 
-            if ($nestedOperations['delete'] ?? false) {
-                $relation->delete();
-            }
+//            if ($nestedOperations['delete'] ?? false) {
+//                $relation->delete();
+//            }
         });
 
         if ($parentRelation && ! $parentRelation instanceof BelongsToMany) {

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -113,16 +113,17 @@ class MutationExecutor
     {
         $reflection = new ReflectionClass($model);
 
-        [$belongsTo, $remaining] = self::partitionArgsByRelationType(
-            $reflection,
-            $args,
-            BelongsTo::class
-        );
-
+        // Extract $morphTo first, as MorphTo extends BelongsTo
         [$morphTo, $remaining] = self::partitionArgsByRelationType(
             $reflection,
-            $remaining,
+            $args,
             MorphTo::class
+        );
+
+        [$belongsTo, $remaining] = self::partitionArgsByRelationType(
+            $reflection,
+            $remaining,
+            BelongsTo::class
         );
 
         // Use all the remaining attributes and fill the model

--- a/tests/Integration/Execution/MutationExecutor/MorphToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Integration\Execution\MutationExecutor;
 
 use Tests\DBTestCase;
-use Tests\Utils\Models\Hour;
 use Tests\Utils\Models\Task;
 
 class MorphToTest extends DBTestCase

--- a/tests/Integration/Execution/MutationExecutor/MorphToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToTest.php
@@ -47,6 +47,7 @@ class MorphToTest extends DBTestCase
     input UpdateHourableOperations {
         connect: ConnectHourableInput
         disconnect: Boolean
+        delete: Boolean
     }
     
     input ConnectHourableInput {
@@ -144,8 +145,6 @@ class MorphToTest extends DBTestCase
      */
     public function itDeletesMorphTo(): void
     {
-        $this->markTestIncomplete('Not implemented correctly right now');
-
         /** @var \Tests\Utils\Models\Task $task */
         $task = factory(Task::class)->create(['name' => 'first_task']);
         $task->hour()->create([
@@ -179,7 +178,7 @@ class MorphToTest extends DBTestCase
 
         $this->assertSame(
             0,
-            Hour::count()
+            Task::count()
         );
     }
 }

--- a/tests/Integration/Execution/MutationExecutor/MorphToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToTest.php
@@ -29,6 +29,20 @@ class MorphToTest extends DBTestCase
         from: String
         to: String
         weekday: Int
+        hourable: CreateHourableOperations
+    }
+    
+    input CreateHourableOperations {
+        create: CreateHourableInput
+    
+    input CreateHourableInput {
+        type: String!
+        # TODO at this point the lack of polymorphic input types becomes problematic
+        input: CreateXXX
+
+    input ConnectHourableInput {
+        id: Int!
+        type: String!
     }
     ';
 

--- a/tests/database/migrations/2018_02_28_000000_create_testbench_hours_table.php
+++ b/tests/database/migrations/2018_02_28_000000_create_testbench_hours_table.php
@@ -13,8 +13,8 @@ class CreateTestbenchHoursTable extends Migration
     {
         Schema::create('hours', function (Blueprint $table): void {
             $table->increments('id');
-            $table->string('hourable_type', 15);
-            $table->unsignedInteger('hourable_id');
+            $table->string('hourable_type', 15)->nullable();
+            $table->unsignedInteger('hourable_id')->nullable();
             $table->string('from', 5)->nullable();
             $table->string('to', 5)->nullable();
             $table->unsignedTinyInteger('weekday')->nullable();


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

**Related Issue/Intent**

Allows connecting and disconnecting polymorphic associations for a MorphTo relation using nested mutations.

**Changes**

Implement `connect` and `disconnect`

The GraphQL Specification does not support Input Union types,
for now we are limiting this implementation to `connect` and `disconnect` operations.

Let's see which one of the current RFC's makes it and base the implementation of `create` and `update` upon that. https://github.com/graphql/graphql-spec/issues/114

**Breaking changes**

Nope