### PR TITLE
Extra plus symbol

### DIFF
--- a/docs/master/testing/phpunit.md
+++ b/docs/master/testing/phpunit.md
@@ -12,13 +12,13 @@ from within a PHPUnit test. Just add the `MakesGraphQLRequests` trait to your te
 
 namespace Tests;
 
-+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
-+   use MakesGraphQLRequests;
+    use MakesGraphQLRequests;
 }
 ```
 


### PR DESCRIPTION
Remove an extra '+' symbols from code examples. Maybe it was the purpose but it feels kind of confuse.