### PR TITLE
Upgrade to vuepress 1.0.3

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,7 @@
     "license": "MIT",
     "dependencies": {
         "fs-extra": "^7.0.1",
-        "vuepress": "^1.0.0-alpha.22",
+        "vuepress": "^1.0.3",
         "vuepress-theme-lighthouse": "file:./packages/vuepress-theme-lighthouse"
     },
     "scripts": {


### PR DESCRIPTION
@spawnia  No luck :(

Just have noticed in the past someone has ejected default theme in order to work on a custom theme.

Most related to https://vuepress.vuejs.org/default-theme-config/#ejecting

Options: 
- Wait next stable release from Vuepress
- Rework docs and sticky to default theme, with minimal customizations..