### PR TITLE
[docs] Fix chronological  order for "yarn docs:version"

### DIFF
--- a/docs/.vuepress/lib/versioning.js
+++ b/docs/.vuepress/lib/versioning.js
@@ -59,8 +59,14 @@ module.exports = {
     try {
       fse.copySync(`${path}/master`, `${path}/${version}`)
 
-      // update versions.json file
+      // remove 'master' from the top of list
+      versions.shift()
+      // add new generated version on top of list
       versions.unshift(version)
+      // add 'master' again on top of list
+      versions.unshift('master')
+
+      // write to versions.json
 
       fs.writeFileSync(
         `${path}/.vuepress/versions.json`,


### PR DESCRIPTION
For new upcoming versions this fix will always keep 'master' version on top of list followed by new generated version.

```
yarn docs:version 4.0
```

versions.js

```js
[
  "master",
  "4.0", // <--- will be inserted in here
  "3.7",
  "3.6",
  "3.5",
  "3.4",
  "3.3",
  "3.2",
  "3.1",
  "3.0",
  "2.6"
]
```
