### PR TITLE
[docs] Change behavior of docs entrypoint

### DIFF
--- a/docs/.vuepress/lib/versioning.js
+++ b/docs/.vuepress/lib/versioning.js
@@ -7,8 +7,9 @@ const path = process.cwd()
 
 module.exports = {
   versions: {
+    // latest stable release
     get latest () {
-      return versions[0]
+      return versions[1]
     },
     get all () {
       return versions


### PR DESCRIPTION
By default when using  `composer require nuwave/lighthouse` you get **latest stable release** , not "master".

For that reason the default entrypoint should point to the "latest stable release" of docs, not "master".

Mainly will change home page buttons links like "READ MORE" and "READ THE DOCS".

NOTE: This PR does not fix a broken link on home page (Eloquent section). Will be fixed by #904.