### PR TITLE
Change the `Nuwave\Lighthouse\Schema\Types\LaravelEnumType` wrapper to map to Enum instances internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make the argument used for finding a model to check @can against configurable.
   The previous behaviour of implicitely using the `id` argument for finding a specific
   model to authorize against now no longer works. https://github.com/nuwave/lighthouse/pull/856
-- Change the `Nuwave\Lighthouse\Schema\Types\LaravelEnumType` wrapper to map to Enum instances internally
+- Change the `Nuwave\Lighthouse\Schema\Types\LaravelEnumType` wrapper to map to Enum instances internally https://github.com/nuwave/lighthouse/pull/908
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make the argument used for finding a model to check @can against configurable.
   The previous behaviour of implicitely using the `id` argument for finding a specific
   model to authorize against now no longer works. https://github.com/nuwave/lighthouse/pull/856
+- Change the `Nuwave\Lighthouse\Schema\Types\LaravelEnumType` wrapper to map to Enum instances internally
 
 ### Removed
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "webonyx/graphql-php": "^0.13.2"
     },
     "require-dev": {
-        "bensampo/laravel-enum": "^1.19",
+        "bensampo/laravel-enum": "^1.22",
         "laravel/lumen-framework": "5.5.*|5.6.*|5.7.*|5.8.*",
         "laravel/scout": "^4.0",
         "mll-lab/graphql-php-scalars": "^2.1",

--- a/docs/master/the-basics/types.md
+++ b/docs/master/the-basics/types.md
@@ -167,7 +167,7 @@ $typeRegistry->register($episodeEnum);
 ```
 
 If you are using [BenSampo/laravel-enum](https://github.com/BenSampo/laravel-enum)
-you can use a convenient wrapper to construct an enum type from it.
+you can use `Nuwave\Lighthouse\Schema\Types\LaravelEnumType` to construct an enum type from it.
 
 Given the following enum:
 

--- a/src/Schema/Types/LaravelEnumType.php
+++ b/src/Schema/Types/LaravelEnumType.php
@@ -40,7 +40,7 @@ class LaravelEnumType extends EnumType
                 function (Enum $enum): array {
                     return [
                         'name' => $enum->key,
-                        'value' => $enum->value,
+                        'value' => $enum,
                         'description' => "$enum->value",
                     ];
                 },

--- a/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
+++ b/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
@@ -61,4 +61,33 @@ class LaravelEnumTypeTest extends DBTestCase
         }
         ')->assertJsonFragment($typeAdmistrator);
     }
+
+    public function testReceivesEnumInstanceInternally(): void
+    {
+        $resolver = $this->qualifyTestResolver();
+        $this->schema = "
+        type Query {
+            foo(bar: UserType): Boolean @field(resolver: \"$resolver\")
+        }
+        ";
+
+        $this->typeRegistry->register(
+            new LaravelEnumType(UserType::class)
+        );
+
+        $this->graphQL('
+        {
+            foo(bar: Administrator)
+        }
+        ')->assertJson([
+            'data' => [
+                'foo' => true,
+            ],
+        ]);
+    }
+
+    public function resolve($root, array $args): bool
+    {
+        return $args['bar'] instanceof UserType;
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

When receiving enum values as an input, they are now converted to Enum instances instead of their internal values.

Given a query like this:

```graphql
{
	foo(bar: BAZ)
}
```

And an enum like this:

```php
<?php

namespace App\Enums;

use BenSampo\Enum\Enum;

/**
 * @method static static BAZ
 */
final class Bar extends Enum
{
    const BAZ = 123;
}
```

The argument passed to the resolver is now an enum instance:

```diff
function resolveFoo($root, array $args)
{
	var_dump($args['bar'])
-   int(123)
+   class App\Enums\Baz#3120 (3) {
+     public $key =>
+     string(7) "BAZ"
+     public $value =>
+     int(123)
+     public $description =>
+     string(3) "123"
+  }
}
```

Code like this will now work:

```php
function resolveFoo($root, array $args)
{
	doSomethingWithBar($args['bar'])
}

function doSomethingWithBar(\App\Enums\Bar $bar)
```


I had to bump the requirement of `"bensampo/laravel-enum": "^1.22"`, as `Enum::__toString()` is needed when using Enums in database queries.