### PR TITLE
Eager-load the subscription fields to ensure they are registered

### DIFF
--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -56,8 +56,13 @@ class SchemaBuilder
             );
         }
         if (isset($documentAST->types['Subscription'])) {
+            /** @var \GraphQL\Type\Definition\ObjectType $subscription */
+            $subscription = $this->typeRegistry->get('Subscription');
+            // Eager-load the subscription fields to ensure they are registered
+            $subscription->getFields();
+
             $config->setSubscription(
-                $this->typeRegistry->get('Subscription')
+                $subscription
             );
         }
 

--- a/src/Subscriptions/SubscriptionResolverProvider.php
+++ b/src/Subscriptions/SubscriptionResolverProvider.php
@@ -34,7 +34,7 @@ class SubscriptionResolverProvider implements ProvidesSubscriptionResolver
     }
 
     /**
-     * Provide a field resolver in case no resolver directive is defined for a field.
+     * Provide a resolver for a subscription field in case no resolver directive is defined.
      *
      * @param  \Nuwave\Lighthouse\Schema\Values\FieldValue  $fieldValue
      * @return \Closure

--- a/src/Support/Contracts/ProvidesSubscriptionResolver.php
+++ b/src/Support/Contracts/ProvidesSubscriptionResolver.php
@@ -8,7 +8,7 @@ use Nuwave\Lighthouse\Schema\Values\FieldValue;
 interface ProvidesSubscriptionResolver
 {
     /**
-     * Provide a field resolver for subscriptions.
+     * Provide a resolver for a subscription field in case no resolver directive is defined.
      *
      * @param  \Nuwave\Lighthouse\Schema\Values\FieldValue  $fieldValue
      * @return \Closure

--- a/tests/Unit/Subscriptions/Broadcast/BroadcastTest.php
+++ b/tests/Unit/Subscriptions/Broadcast/BroadcastTest.php
@@ -2,16 +2,15 @@
 
 namespace Tests\Unit\Subscriptions\Iterators;
 
+use Tests\DBTestCase;
 use Mockery\MockInterface;
+use Tests\Utils\Models\Task;
 use Nuwave\Lighthouse\Execution\Utils\Subscription;
 use Nuwave\Lighthouse\Subscriptions\SubscriptionBroadcaster;
 use Nuwave\Lighthouse\Subscriptions\SubscriptionServiceProvider;
-use Tests\DBTestCase;
-use Tests\Utils\Models\Task;
 
 class BroadcastTest extends DBTestCase
 {
-
     protected $schema = '
     type Task {
         id: ID!
@@ -43,10 +42,11 @@ class BroadcastTest extends DBTestCase
     /**
      * @return MockInterface
      */
-    public function withMockedBroadcasts (): MockInterface
+    public function withMockedBroadcasts(): MockInterface
     {
         $broadcast = \Mockery::mock(SubscriptionBroadcaster::class);
         $this->app->instance(SubscriptionBroadcaster::class, $broadcast);
+
         return $broadcast;
     }
 
@@ -67,7 +67,7 @@ class BroadcastTest extends DBTestCase
                         name
                     }
                 }
-            '
+            ',
         ]);
 
         // Broadcast
@@ -91,7 +91,7 @@ class BroadcastTest extends DBTestCase
                         name
                     }
                 }
-            '
+            ',
         ]);
 
         // Broadcast
@@ -102,7 +102,7 @@ class BroadcastTest extends DBTestCase
                         name
                     }
                 }
-            '
+            ',
         ]);
     }
 }

--- a/tests/Unit/Subscriptions/Broadcast/BroadcastTest.php
+++ b/tests/Unit/Subscriptions/Broadcast/BroadcastTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Unit\Subscriptions\Iterators;
+
+use Mockery\MockInterface;
+use Nuwave\Lighthouse\Execution\Utils\Subscription;
+use Nuwave\Lighthouse\Subscriptions\SubscriptionBroadcaster;
+use Nuwave\Lighthouse\Subscriptions\SubscriptionServiceProvider;
+use Tests\DBTestCase;
+use Tests\Utils\Models\Task;
+
+class BroadcastTest extends DBTestCase
+{
+
+    protected $schema = '
+    type Task {
+        id: ID!
+        name: String!
+    }
+    
+    type Query {
+        task(id: Int @eq): Task @first
+    }
+    
+    type Mutation {
+        updateTask(id: Int! @eq, name: String!): Task @update @broadcast(subscription: "taskUpdated")
+    }
+    
+    type Subscription {
+        taskUpdated: Task
+    }
+    ';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app()->register(SubscriptionServiceProvider::class);
+
+        factory(Task::class, 1)->create();
+    }
+
+    /**
+     * @return MockInterface
+     */
+    public function withMockedBroadcasts (): MockInterface
+    {
+        $broadcast = \Mockery::mock(SubscriptionBroadcaster::class);
+        $this->app->instance(SubscriptionBroadcaster::class, $broadcast);
+        return $broadcast;
+    }
+
+    /**
+     * @test
+     */
+    public function itBroadcastsFromPhp(): void
+    {
+        // Assert
+        $broadcast = $this->withMockedBroadcasts();
+        $broadcast->shouldReceive('broadcast')->once();
+
+        // Subscribe to event
+        $this->postGraphQL([
+            'query' => '
+                subscription UserUpdated {
+                    taskUpdated {
+                        name
+                    }
+                }
+            '
+        ]);
+
+        // Broadcast
+        Subscription::broadcast('taskUpdated', []);
+    }
+
+    /**
+     * @test
+     */
+    public function itBroadcastsFromSchema(): void
+    {
+        // Assert
+        $broadcast = $this->withMockedBroadcasts();
+        $broadcast->shouldReceive('broadcast')->once();
+
+        // Subscribe to event
+        $this->postGraphQL([
+            'query' => '
+                subscription TaskUpdated {
+                    taskUpdated {
+                        name
+                    }
+                }
+            '
+        ]);
+
+        // Broadcast
+        $this->postGraphQL([
+            'query' => '
+                mutation {
+                    updateTask(id: 1, name: "New name") {
+                        name
+                    }
+                }
+            '
+        ]);
+    }
+}

--- a/tests/Unit/Subscriptions/Broadcast/BroadcastTest.php
+++ b/tests/Unit/Subscriptions/Broadcast/BroadcastTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Subscriptions\Iterators;
+namespace Tests\Unit\Subscriptions\Broadcasts;
 
 use Tests\DBTestCase;
 use Mockery\MockInterface;

--- a/tests/Unit/Subscriptions/Broadcast/BroadcastTest.php
+++ b/tests/Unit/Subscriptions/Broadcast/BroadcastTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Subscriptions\Broadcasts;
+namespace Tests\Unit\Subscriptions\Broadcast;
 
 use Tests\DBTestCase;
 use Mockery\MockInterface;

--- a/tests/Utils/Subscriptions/TaskUpdated.php
+++ b/tests/Utils/Subscriptions/TaskUpdated.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Utils\Subscriptions;
+
+use Illuminate\Http\Request;
+use Nuwave\Lighthouse\Subscriptions\Subscriber;
+use Nuwave\Lighthouse\Schema\Types\GraphQLSubscription;
+
+class TaskUpdated extends GraphQLSubscription
+{
+    /**
+     * Check if subscriber is allowed to listen to the subscription.
+     *
+     * @param  \Nuwave\Lighthouse\Subscriptions\Subscriber  $subscriber
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public function authorize(Subscriber $subscriber, Request $request): bool
+    {
+        return true;
+    }
+
+    /**
+     * Filter which subscribers should receive the subscription.
+     *
+     * @param  \Nuwave\Lighthouse\Subscriptions\Subscriber  $subscriber
+     * @param  mixed  $root
+     * @return bool
+     */
+    public function filter(Subscriber $subscriber, $root): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog (Not necessary, as this just fixes something that was broken inbetween releases)

**Related Issue/Intent**

Resolves https://github.com/nuwave/lighthouse/issues/851

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->
