### PR TITLE
Cast MorphTo relation argument `type` to string before connect

### DIFF
--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -178,7 +178,7 @@ class MutationExecutor
                 $connectArgs = $nestedOperations['connect'];
 
                 $morphToModel = $relation->createModelByType(
-                    $connectArgs['type']
+                    (string) $connectArgs['type']
                 );
                 $morphToModel->setAttribute(
                     $morphToModel->getKeyName(),


### PR DESCRIPTION
**Related Issue/Intent**

This prevents an error that occurs when using an Enum to represent the argument and ensures the actual classname of the Model is passed on.

**Breaking changes**

Nope
