### PR TITLE
Call out @model in @node directive in documentations

### DIFF
--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -1392,6 +1392,8 @@ decoded `id` and resolves to a result.
 function resolveUser($id): \App\User
 ```
 
+Note: if you plan on resolving using an Eloquent Model, be sure to check out the [@model](#model) directive.
+
 ### Definition
 
 ```graphql

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -1392,7 +1392,7 @@ decoded `id` and resolves to a result.
 function resolveUser($id): \App\User
 ```
 
-Note: if you plan on resolving using an Eloquent Model, be sure to check out the [@model](#model) directive.
+Note: if you plan on resolving using an Eloquent Model, be sure to check out the [`@model`](#model) directive.
 
 ### Definition
 


### PR DESCRIPTION
This resolves #888 by directing the reader to check out the `@model` directive when viewing the `@node` directive.