### PR TITLE
 Ensure validation actually runs before the final resolver

### DIFF
--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Nuwave\Lighthouse\Exceptions;
+
+class ValidationException extends \Illuminate\Validation\ValidationException implements RendersErrorsExtensions
+{
+    /**
+     * Returns true when exception message is safe to be displayed to a client.
+     *
+     * @return bool
+     */
+    public function isClientSafe()
+    {
+        return true;
+    }
+
+    /**
+     * Returns string describing a category of the error.
+     *
+     * @return string
+     */
+    public function getCategory()
+    {
+        return 'validation';
+    }
+
+    /**
+     * Return the content that is put in the "extensions" part
+     * of the returned error.
+     *
+     * @return array
+     */
+    public function extensionsContent(): array
+    {
+        return ['validation' => $this->errors()];
+    }
+}

--- a/src/Schema/Directives/ValidationDirective.php
+++ b/src/Schema/Directives/ValidationDirective.php
@@ -4,8 +4,8 @@ namespace Nuwave\Lighthouse\Schema\Directives;
 
 use Closure;
 use GraphQL\Type\Definition\ResolveInfo;
-use Nuwave\Lighthouse\Exceptions\ValidationException;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Exceptions\ValidationException;
 use Nuwave\Lighthouse\Support\Contracts\ProvidesRules;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;

--- a/src/Schema/Directives/ValidationDirective.php
+++ b/src/Schema/Directives/ValidationDirective.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Schema\Directives;
 
 use Closure;
 use GraphQL\Type\Definition\ResolveInfo;
+use Nuwave\Lighthouse\Exceptions\ValidationException;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\ProvidesRules;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
@@ -56,9 +57,9 @@ abstract class ValidationDirective extends BaseDirective implements FieldMiddlew
                             ]
                         );
 
-                    // The validation exception is caught in the FieldFactory and merged with
-                    // argument directive based validation
-                    $validator->validate();
+                    if ($validator->fails()) {
+                        throw new ValidationException($validator);
+                    }
 
                     return $resolver($root, $args, $context, $resolveInfo);
                 }

--- a/tests/Integration/ValidationTest.php
+++ b/tests/Integration/ValidationTest.php
@@ -60,7 +60,7 @@ class ValidationTest extends DBTestCase
     ';
 
     /** @var bool */
-    private $wasCalled = false;
+    private static $wasCalled = false;
 
     /**
      * @param  mixed  $root
@@ -101,7 +101,7 @@ class ValidationTest extends DBTestCase
         }
         ');
 
-        $this->assertFalse($this->wasCalled);
+        $this->assertFalse(self::$wasCalled);
         $this->assertValidationKeysSame(
             ['bar'],
             $response
@@ -110,7 +110,7 @@ class ValidationTest extends DBTestCase
 
     public function resolveDoNotCall()
     {
-        $this->wasCalled = true;
+        self::$wasCalled = true;
     }
 
     /**


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

**Related Issue/Intent**

Resolves https://github.com/nuwave/lighthouse/issues/897

**Changes**

Ensure validation actually runs before the final resolver

I skipped the test `itCombinesFieldValidationAndArgumentValidation` for now, as it would require a larger rework of how we run validation.

**Breaking changes**

This ensures that `v4` does not cause regressions.