### PR TITLE
Fix validators not having access to the given args for the query or mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed the `ValidationDirective` not setting the mutation or query arguments to itself 
+- Fixed the `ValidationDirective` not setting the mutation or query arguments to itself https://github.com/nuwave/lighthouse/pull/915
 
 ## [4.0.0](https://github.com/nuwave/lighthouse/compare/v3.7.0...v4.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v3.7.0...master)
 
+### Fixed
+- Fixed the `ValidationDirective` not setting the mutation or query arguments to itself 
+
 ## [4.0.0](https://github.com/nuwave/lighthouse/compare/v3.7.0...v4.0.0)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v3.7.0...master)
 
 ### Fixed
+
 - Fixed the `ValidationDirective` not setting the mutation or query arguments to itself 
 
 ## [4.0.0](https://github.com/nuwave/lighthouse/compare/v3.7.0...v4.0.0)

--- a/src/Schema/Directives/ValidationDirective.php
+++ b/src/Schema/Directives/ValidationDirective.php
@@ -44,6 +44,7 @@ abstract class ValidationDirective extends BaseDirective implements FieldMiddlew
         return $next(
             $fieldValue->setResolver(
                 function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($resolver) {
+                    $this->setArgs($args);
                     $validator = $this->validationFactory
                         ->make(
                             $args,

--- a/src/Schema/Directives/ValidationDirective.php
+++ b/src/Schema/Directives/ValidationDirective.php
@@ -44,7 +44,8 @@ abstract class ValidationDirective extends BaseDirective implements FieldMiddlew
         return $next(
             $fieldValue->setResolver(
                 function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($resolver) {
-                    $this->setArgs($args);
+                    $this->setResolverArguments($root, $args, $context, $resolveInfo);
+
                     $validator = $this->validationFactory
                         ->make(
                             $args,

--- a/tests/Integration/ValidationTest.php
+++ b/tests/Integration/ValidationTest.php
@@ -485,11 +485,10 @@ class ValidationTest extends DBTestCase
             'data' => [
                 'updateUser' => [
                     'id' => 2,
-                    'name' => 'bar'
-                ]
-            ]
+                    'name' => 'bar',
+                ],
+            ],
         ]);
-
     }
 
     /**

--- a/tests/Integration/ValidationTest.php
+++ b/tests/Integration/ValidationTest.php
@@ -460,13 +460,7 @@ class ValidationTest extends DBTestCase
         }
         '.$this->placeholderQuery();
 
-        factory(User::class)->create([
-                                         'name' => 'foo',
-                                     ]);
-
-        factory(User::class)->create([
-                                         'name' => 'bar',
-                                     ]);
+        factory(User::class)->create(['name' => 'bar',]);
 
         $updateSelf = $this->graphQL('
         mutation {

--- a/tests/Integration/ValidationTest.php
+++ b/tests/Integration/ValidationTest.php
@@ -460,7 +460,7 @@ class ValidationTest extends DBTestCase
         }
         '.$this->placeholderQuery();
 
-        factory(User::class)->create(['name' => 'bar',]);
+        factory(User::class)->create(['name' => 'bar']);
 
         $updateSelf = $this->graphQL('
         mutation {

--- a/tests/Integration/ValidationTest.php
+++ b/tests/Integration/ValidationTest.php
@@ -466,7 +466,7 @@ class ValidationTest extends DBTestCase
         mutation {
             updateUser(
                 input: {
-                    id: 2
+                    id: 1
                     name: "bar"
                 }
             ) {
@@ -478,7 +478,7 @@ class ValidationTest extends DBTestCase
         $updateSelf->assertJson([
             'data' => [
                 'updateUser' => [
-                    'id' => 2,
+                    'id' => 1,
                     'name' => 'bar',
                 ],
             ],

--- a/tests/Utils/Directives/ComplexValidationDirective.php
+++ b/tests/Utils/Directives/ComplexValidationDirective.php
@@ -25,8 +25,8 @@ class ComplexValidationDirective extends ValidationDirective
     public function rules(): array
     {
         return [
-            'input.id' => ['required'],
-            'input.name' => ['sometimes', Rule::unique('users', 'name')->ignore($this->args['id'], 'id')],
+            'id' => ['required'],
+            'name' => ['sometimes', Rule::unique('users', 'name')->ignore((int)$this->args['id'], 'id')],
         ];
     }
 
@@ -36,7 +36,7 @@ class ComplexValidationDirective extends ValidationDirective
     public function messages(): array
     {
         return [
-            'input.name.unique' => self::UNIQUE_VALIDATION_MESSAGE,
+            'name.unique' => self::UNIQUE_VALIDATION_MESSAGE,
         ];
     }
 }

--- a/tests/Utils/Directives/ComplexValidationDirective.php
+++ b/tests/Utils/Directives/ComplexValidationDirective.php
@@ -26,7 +26,11 @@ class ComplexValidationDirective extends ValidationDirective
     {
         return [
             'id' => ['required'],
-            'name' => ['sometimes', Rule::unique('users', 'name')->ignore($this->args['id'], 'id')],
+            'name' => [
+                'sometimes',
+                Rule::unique('users', 'name')
+                    ->ignore($this->args['id'], 'id'),
+            ],
         ];
     }
 

--- a/tests/Utils/Directives/ComplexValidationDirective.php
+++ b/tests/Utils/Directives/ComplexValidationDirective.php
@@ -26,7 +26,7 @@ class ComplexValidationDirective extends ValidationDirective
     {
         return [
             'id' => ['required'],
-            'name' => ['sometimes', Rule::unique('users', 'name')->ignore((int)$this->args['id'], 'id')],
+            'name' => ['sometimes', Rule::unique('users', 'name')->ignore($this->args['id'], 'id')],
         ];
     }
 


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] ~~Added Docs for all relevant versions~~
- [x] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236",
or a description of what this PR is trying to achieve. -->
Fixes `$this->args` being `null` inside the `rules()` method of validators extending `ValidationDirective`
**Changes**
Adds $this->setArgs($args) to the `ValidationDirective`. I've updated and added a test to ensure this works.
<!-- Detail the changes in behaviour this PR introduces. -->
The test that tested if the `$this->args` was set, did not actually test it. It only tested if the unique rule was being applied. That it did, but it tried to update a different record, which has no effect on the value for the `->ignore()` part. In order to actually test this, I wrote a test that updated the same entity with the same name. Now, it started to complain that it was not unique. This got me to look into to the actual generated rule string, and it turns out the id value was `NULL`, instead of the value we wanted it to be.
![image](https://user-images.githubusercontent.com/2302867/63093790-cab5eb00-bf66-11e9-9aac-d058db5a57ac.png)

After this fix, the rule has the expected values
![image](https://user-images.githubusercontent.com/2302867/63093836-ef11c780-bf66-11e9-9749-7def88a70d01.png)
