### PR TITLE
Restrict `@whereConstraints` column names to a well-defined list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Restrict the allowed column names to a well-defined list in `@whereContraints`
   and generate definitions for an `Enum` type and an `Input` type
-  that are restricted to the defined columns. 
+  that are restricted to the defined columns. https://github.com/nuwave/lighthouse/pull/916
 
 ## [4.0.0](https://github.com/nuwave/lighthouse/compare/v3.7.0...v4.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Restrict the allowed column names to a well-defined list in `@whereContraints`
+- Allow to restrict column names to a well-defined list in `@whereContraints`
   and generate definitions for an `Enum` type and an `Input` type
-  that are restricted to the defined columns. https://github.com/nuwave/lighthouse/pull/916
+  that are restricted to the defined columns https://github.com/nuwave/lighthouse/pull/916
+- Add test helpers for introspection queries to `MakesGraphQLRequests` https://github.com/nuwave/lighthouse/pull/916
 
 ## [4.0.0](https://github.com/nuwave/lighthouse/compare/v3.7.0...v4.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v3.7.0...master)
 
+### Added
+
+- Restrict the allowed column names to a well-defined list in `@whereContraints`
+  and generate definitions for an `Enum` type and an `Input` type
+  that are restricted to the defined columns. 
+
 ## [4.0.0](https://github.com/nuwave/lighthouse/compare/v3.7.0...v4.0.0)
 
 ### Added

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2311,6 +2311,7 @@ Lighthouse generates definitions for an `Enum` type and an `Input` type
 that are restricted to the defined columns.
 
 ```graphql
+"Dynamic WHERE constraints for the `where` argument on the query `people`.
 input PeopleWhereWhereConstraints {
     column: PeopleWhereColumn
     operator: String = EQ
@@ -2320,6 +2321,7 @@ input PeopleWhereWhereConstraints {
     NOT: [PeopleWhereWhereConstraints!]
 }
 
+"Allowed column names for the `where` argument on the query `people`."
 enum PeopleWhereColumn {
     AGE @enum(value: "age")
     TYPE @enum(value: "type")

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2205,17 +2205,23 @@ directive @whereNotBetween(
 
 ## @whereConstraints
 
-Add a dynamically client-controlled where constraint to a fields query.
+Add a dynamically client-controlled WHERE constraint to a fields query.
 
 ### Definition
 
 ```graphql
 """
-Add a dynamically client-controlled where constraint to a fields query.
-The input value it is defined on may have any name but **must** be
+Add a dynamically client-controlled WHERE constraint to a fields query.
+The argument it is defined on may have any name but **must** be
 of the input type `WhereConstraints`.
 """
-directive @whereConstraints on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @whereConstraints(
+    """
+    Restrict the allowed column names to a well-defined list.
+    This improves introspection capabilities and security.
+    """
+    columns: [String!]
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 ### Setup
@@ -2233,6 +2239,12 @@ Add the service provider to your `config/app.php`
 Install the dependency [mll-lab/graphql-php-scalars](https://github.com/mll-lab/graphql-php-scalars):
 
     composer require mll-lab/graphql-php-scalars
+
+It contains the scalar type `Mixed`, which enables the dynamic query capabilities.
+
+```graphql
+scalar Mixed @scalar(class: "MLL\\GraphQLScalars\\Mixed")
+```
 
 Add an enum type `Operator` to your schema. Depending on your
 database, you may want to allow different internal values. This default
@@ -2255,7 +2267,9 @@ enum Operator {
 
 ```graphql
 type Query {
-    people(where: WhereConstraints @whereConstraints): [Person!]!
+    people(
+        where: WhereConstraints @whereConstraints(columns: ["age", "type", "haircolour", "height"])
+    ): [Person!]!
 }
 ```
 
@@ -2269,12 +2283,12 @@ that gets actors over age 37 who either have red hair or are at least 150cm.
       where: [
         {
           AND: [
-            { column: "age", operator: GT value: 37 }
-            { column: "type", value: "Actor" }
+            { column: AGE, operator: GT value: 37 }
+            { column: TYPE, value: "Actor" }
             {
               OR: [
-                { column: "haircolour", value: "red" }
-                { column: "height", operator: GTE, value: 150 }
+                { column: HAIRCOLOUR, value: "red" }
+                { column: HEIGHT, operator: GTE, value: 150 }
               ]
             }
           ]
@@ -2287,21 +2301,29 @@ that gets actors over age 37 who either have red hair or are at least 150cm.
 }
 ```
 
-The definition for the `WhereConstraints` input is automatically included
-within your schema.
+Lighthouse generates definitions for an `Enum` type and an `Input` type
+that are restricted to the defined columns.
 
 ```graphql
-input WhereConstraints {
-    column: String
+input PeopleWhereWhereConstraints {
+    column: PeopleWhereColumn
     operator: String = EQ
     value: Mixed
-    AND: [WhereConstraints!]
-    OR: [WhereConstraints!]
-    NOT: [WhereConstraints!]
+    AND: [PeopleWhereWhereConstraints!]
+    OR: [PeopleWhereWhereConstraints!]
+    NOT: [PeopleWhereWhereConstraints!]
 }
 
-scalar Mixed @scalar(class: "MLL\\GraphQLScalars\\Mixed")
+enum PeopleWhereColumn {
+    AGE @enum(value: "age")
+    TYPE @enum(value: "type")
+    HAIRCOLOUR @enum(value: "haircolour")
+    HEIGHT @enum(value: "height")
+}
 ```
+
+When you are not specifying `columns` to allow, a generic input with dynamic
+column names will be used instead.
 
 ## @whereNotBetween
 

--- a/docs/master/testing/phpunit.md
+++ b/docs/master/testing/phpunit.md
@@ -160,3 +160,33 @@ $this->multipartGraphQL(
     ]
 )
 ```
+
+## Introspection
+
+If you create or manipulate parts of your schema programmatically, you might
+want to test that. You can use introspection to query your final schema in tests.
+
+Lighthouse uses the introspection query from [`\GraphQL\Type\Introspection::getIntrospectionQuery()`](https://github.com/webonyx/graphql-php/blob/master/src/Type/Introspection.php).
+
+The `introspect()` helper method runs the full introspection query against your schema.
+
+```php
+$introspectionResult = $this->introspect();
+```
+
+Most often, you will want to look for a specific named type. 
+
+```php
+$generatedType = $this->introspectType('Generated');
+// Ensure the type is present and matches a certain definition
+$this->assertSame(
+    [], // Adjust accordingly
+    $generatedType
+);
+```
+
+You can also introspect client directives.
+
+```php
+$customDirective = $this->introspectDirective('custom');
+```

--- a/src/Testing/MakesGraphQLRequests.php
+++ b/src/Testing/MakesGraphQLRequests.php
@@ -133,7 +133,7 @@ trait MakesGraphQLRequests
      */
     protected function introspectType(string $name): ?array
     {
-        return $this->introspectByName('data.__schema.type', $name);
+        return $this->introspectByName('data.__schema.types', $name);
     }
 
     /**

--- a/src/Testing/MakesGraphQLRequests.php
+++ b/src/Testing/MakesGraphQLRequests.php
@@ -118,7 +118,7 @@ trait MakesGraphQLRequests
      */
     protected function introspect(): TestResponse
     {
-        if($this->introspectionResult) {
+        if ($this->introspectionResult) {
             return $this->introspectionResult;
         }
 
@@ -156,7 +156,7 @@ trait MakesGraphQLRequests
      */
     protected function introspectByName(string $path, string $name): ?array
     {
-        if(! $this->introspectionResult){
+        if (! $this->introspectionResult) {
             $this->introspect();
         }
 

--- a/src/Testing/MakesGraphQLRequests.php
+++ b/src/Testing/MakesGraphQLRequests.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Testing;
 
+use GraphQL\Type\Introspection;
 use Illuminate\Foundation\Testing\TestResponse;
 
 /**
@@ -97,6 +98,105 @@ trait MakesGraphQLRequests
                 'Content-Type' => 'multipart/form-data',
             ])
         );
+    }
+
+    /**
+     * Execute the introspection query on the GraphQL server.
+     *
+     * @return \Illuminate\Foundation\Testing\TestResponse
+     */
+    protected function introspect(): TestResponse
+    {
+        return $this->graphQL(Introspection::getIntrospectionQuery());
+    }
+
+    /**
+     * Return the full introspection query.
+     *
+     * @see https://gist.github.com/craigbeck/b90915d49fda19d5b2b17ead14dcd6da
+     *
+     * @return string
+     */
+    public static function introspectionQuery(): string
+    {
+        return /* @lang GraphQL */
+    <<<'GRAPHQL'
+  query IntrospectionQuery {
+    __schema {
+      queryType { name }
+      mutationType { name }
+      subscriptionType { name }
+      types {
+        ...FullType
+      }
+      directives {
+        name
+        description
+        args {
+          ...InputValue
+        }
+        locations
+      }
+    }
+  }
+
+  fragment FullType on __Type {
+    kind
+    name
+    description
+    fields(includeDeprecated: true) {
+      name
+      description
+      args {
+        ...InputValue
+      }
+      type {
+        ...TypeRef
+      }
+      isDeprecated
+      deprecationReason
+    }
+    inputFields {
+      ...InputValue
+    }
+    interfaces {
+      ...TypeRef
+    }
+    enumValues(includeDeprecated: true) {
+      name
+      description
+      isDeprecated
+      deprecationReason
+    }
+    possibleTypes {
+      ...TypeRef
+    }
+  }
+
+  fragment InputValue on __InputValue {
+    name
+    description
+    type { ...TypeRef }
+    defaultValue
+  }
+
+  fragment TypeRef on __Type {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+        }
+      }
+    }
+  }
+GRAPHQL;
     }
 
     /**

--- a/src/WhereConstraints/WhereConstraintsDirective.php
+++ b/src/WhereConstraints/WhereConstraintsDirective.php
@@ -3,10 +3,18 @@
 namespace Nuwave\Lighthouse\WhereConstraints;
 
 use GraphQL\Error\Error;
+use GraphQL\Language\AST\EnumTypeDefinitionNode;
+use GraphQL\Language\AST\FieldDefinitionNode;
+use GraphQL\Language\AST\InputValueDefinitionNode;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use Illuminate\Support\Str;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+use Nuwave\Lighthouse\Schema\AST\PartialParser;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective;
+use Nuwave\Lighthouse\Support\Contracts\ArgManipulator;
 
-class WhereConstraintsDirective extends BaseDirective implements ArgBuilderDirective
+class WhereConstraintsDirective extends BaseDirective implements ArgBuilderDirective, ArgManipulator
 {
     const NAME = 'whereConstraints';
     const INVALID_COLUMN_MESSAGE = 'Column names may contain only alphanumerics or underscores, and may not begin with a digit.';
@@ -90,5 +98,109 @@ class WhereConstraintsDirective extends BaseDirective implements ArgBuilderDirec
     public static function missingValueForColumn(string $column): string
     {
         return "Did not receive a value to match the WhereConstraints for column {$column}.";
+    }
+
+    /**
+     * Manipulate the AST.
+     *
+     * @param \Nuwave\Lighthouse\Schema\AST\DocumentAST $documentAST
+     * @param \GraphQL\Language\AST\InputValueDefinitionNode $argDefinition
+     * @param \GraphQL\Language\AST\FieldDefinitionNode $parentField
+     * @param \GraphQL\Language\AST\ObjectTypeDefinitionNode $parentType
+     * @return \Nuwave\Lighthouse\Schema\AST\DocumentAST
+     */
+    public function manipulateArgDefinition(DocumentAST &$documentAST, InputValueDefinitionNode &$argDefinition, FieldDefinitionNode &$parentField, ObjectTypeDefinitionNode &$parentType)
+    {
+        $allowedColumns = $this->directiveArgValue('columns');
+        if (! $allowedColumns) {
+            return $documentAST;
+        }
+
+        $restrictedWhereConstraintsName = $this->restrictedWhereConstraintsName($argDefinition, $parentField);
+
+        $argDefinition->type = PartialParser::namedType($restrictedWhereConstraintsName);
+
+        $allowedColumnsEnumName = $this->allowedColumnsEnumName($argDefinition, $parentField);
+
+        return $documentAST
+            ->setTypeDefinition(
+                WhereConstraintsServiceProvider::createWhereConstraintsInputType(
+                    $restrictedWhereConstraintsName,
+                    "Dynamic WHERE constraints for the `{$argDefinition->name->value}` argument on the query `{$parentField->name->value}`.",
+                    $allowedColumnsEnumName
+                )
+            )
+            ->setTypeDefinition(
+                $this->createAllowedColumnsEnum($argDefinition, $parentField, $allowedColumns, $allowedColumnsEnumName)
+            );
+    }
+
+    /**
+     * Create the name for the Enum that holds the allowed columns.
+     *
+     * @example FieldNameArgNameColumn
+     *
+     * @param  \GraphQL\Language\AST\InputValueDefinitionNode  $argDefinition
+     * @param  \GraphQL\Language\AST\FieldDefinitionNode  $parentField
+     * @return string
+     */
+    protected function allowedColumnsEnumName(InputValueDefinitionNode &$argDefinition, FieldDefinitionNode &$parentField): string
+    {
+        return Str::studly($parentField->name->value)
+            . Str::studly($argDefinition->name->value)
+            . 'Column';
+    }
+
+    /**
+     * Create the name for the restricted WhereConstraints input.
+     *
+     * @example FieldNameArgNameWhereConstraints
+     *
+     * @param  \GraphQL\Language\AST\InputValueDefinitionNode  $argDefinition
+     * @param  \GraphQL\Language\AST\FieldDefinitionNode  $parentField
+     * @return string
+     */
+    protected function restrictedWhereConstraintsName(InputValueDefinitionNode &$argDefinition, FieldDefinitionNode &$parentField): string
+    {
+        return Str::studly($parentField->name->value)
+            . Str::studly($argDefinition->name->value)
+            . 'WhereConstraints';
+    }
+
+    /**
+     * Create the Enum that holds the allowed columns.
+     *
+     * @param  \GraphQL\Language\AST\InputValueDefinitionNode  $argDefinition
+     * @param  \GraphQL\Language\AST\FieldDefinitionNode  $parentField
+     * @param  string[]  $allowedColumns
+     * @param  string  $allowedColumnsEnumName
+     * @return \GraphQL\Language\AST\EnumTypeDefinitionNode
+     */
+    public function createAllowedColumnsEnum(
+        InputValueDefinitionNode &$argDefinition,
+        FieldDefinitionNode &$parentField,
+        array $allowedColumns,
+        string $allowedColumnsEnumName
+    ): EnumTypeDefinitionNode
+    {
+        $enumValues = array_map(
+            function (string $columnName): string {
+                return
+                    strtoupper(
+                        Str::snake($columnName)
+                    )
+                    . ' @enum(value: "' . $columnName . '")';
+            },
+            $allowedColumns
+        );
+
+        $enumDefinition = "\"Allowed column names for the `{$argDefinition->name->value}` argument on the query `{$parentField->name->value}`.\"\n"
+            . "enum $allowedColumnsEnumName {\n";
+        foreach ($enumValues as $enumValue) {
+            $enumDefinition .= "$enumValue\n";
+        }
+        $enumDefinition .= '}';
+
+        return PartialParser::enumTypeDefinition($enumDefinition);
     }
 }

--- a/src/WhereConstraints/WhereConstraintsDirective.php
+++ b/src/WhereConstraints/WhereConstraintsDirective.php
@@ -3,16 +3,16 @@
 namespace Nuwave\Lighthouse\WhereConstraints;
 
 use GraphQL\Error\Error;
-use GraphQL\Language\AST\EnumTypeDefinitionNode;
-use GraphQL\Language\AST\FieldDefinitionNode;
-use GraphQL\Language\AST\InputValueDefinitionNode;
-use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Illuminate\Support\Str;
+use GraphQL\Language\AST\FieldDefinitionNode;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
+use GraphQL\Language\AST\EnumTypeDefinitionNode;
+use GraphQL\Language\AST\InputValueDefinitionNode;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
-use Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgManipulator;
+use Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective;
 
 class WhereConstraintsDirective extends BaseDirective implements ArgBuilderDirective, ArgManipulator
 {
@@ -147,8 +147,8 @@ class WhereConstraintsDirective extends BaseDirective implements ArgBuilderDirec
     protected function allowedColumnsEnumName(InputValueDefinitionNode &$argDefinition, FieldDefinitionNode &$parentField): string
     {
         return Str::studly($parentField->name->value)
-            . Str::studly($argDefinition->name->value)
-            . 'Column';
+            .Str::studly($argDefinition->name->value)
+            .'Column';
     }
 
     /**
@@ -163,8 +163,8 @@ class WhereConstraintsDirective extends BaseDirective implements ArgBuilderDirec
     protected function restrictedWhereConstraintsName(InputValueDefinitionNode &$argDefinition, FieldDefinitionNode &$parentField): string
     {
         return Str::studly($parentField->name->value)
-            . Str::studly($argDefinition->name->value)
-            . 'WhereConstraints';
+            .Str::studly($argDefinition->name->value)
+            .'WhereConstraints';
     }
 
     /**
@@ -181,21 +181,20 @@ class WhereConstraintsDirective extends BaseDirective implements ArgBuilderDirec
         FieldDefinitionNode &$parentField,
         array $allowedColumns,
         string $allowedColumnsEnumName
-    ): EnumTypeDefinitionNode
-    {
+    ): EnumTypeDefinitionNode {
         $enumValues = array_map(
             function (string $columnName): string {
                 return
                     strtoupper(
                         Str::snake($columnName)
                     )
-                    . ' @enum(value: "' . $columnName . '")';
+                    .' @enum(value: "'.$columnName.'")';
             },
             $allowedColumns
         );
 
         $enumDefinition = "\"Allowed column names for the `{$argDefinition->name->value}` argument on the query `{$parentField->name->value}`.\"\n"
-            . "enum $allowedColumnsEnumName {\n";
+            ."enum $allowedColumnsEnumName {\n";
         foreach ($enumValues as $enumValue) {
             $enumDefinition .= "$enumValue\n";
         }

--- a/src/WhereConstraints/WhereConstraintsServiceProvider.php
+++ b/src/WhereConstraints/WhereConstraintsServiceProvider.php
@@ -2,11 +2,11 @@
 
 namespace Nuwave\Lighthouse\WhereConstraints;
 
-use GraphQL\Language\AST\InputObjectTypeDefinitionNode;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Events\Dispatcher;
 use Nuwave\Lighthouse\Events\ManipulateAST;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
+use GraphQL\Language\AST\InputObjectTypeDefinitionNode;
 use Nuwave\Lighthouse\Schema\Factories\DirectiveFactory;
 
 class WhereConstraintsServiceProvider extends ServiceProvider

--- a/src/WhereConstraints/WhereConstraintsServiceProvider.php
+++ b/src/WhereConstraints/WhereConstraintsServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\WhereConstraints;
 
+use GraphQL\Language\AST\InputObjectTypeDefinitionNode;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Events\Dispatcher;
 use Nuwave\Lighthouse\Events\ManipulateAST;
@@ -29,16 +30,11 @@ class WhereConstraintsServiceProvider extends ServiceProvider
             function (ManipulateAST $manipulateAST): void {
                 $manipulateAST->documentAST
                     ->setTypeDefinition(
-                        PartialParser::inputObjectTypeDefinition('
-                            input WhereConstraints {
-                                column: String
-                                operator: Operator = EQ
-                                value: Mixed
-                                AND: [WhereConstraints!]
-                                OR: [WhereConstraints!]
-                                NOT: [WhereConstraints!]
-                            }
-                        ')
+                        static::createWhereConstraintsInputType(
+                            'WhereConstraints',
+                            'Dynamic WHERE constraints for queries.',
+                            'String'
+                        )
                     )
                     ->setTypeDefinition(
                         PartialParser::scalarTypeDefinition('
@@ -47,5 +43,19 @@ class WhereConstraintsServiceProvider extends ServiceProvider
                     );
             }
         );
+    }
+
+    public static function createWhereConstraintsInputType(string $name, string $description, string $columnType): InputObjectTypeDefinitionNode
+    {
+        return PartialParser::inputObjectTypeDefinition("
+            input $name {
+                column: $columnType
+                operator: Operator = EQ
+                value: Mixed
+                AND: [$name!]
+                OR: [$name!]
+                NOT: [$name!]
+            }
+        ");
     }
 }

--- a/tests/Integration/IntrospectionTest.php
+++ b/tests/Integration/IntrospectionTest.php
@@ -37,13 +37,13 @@ class IntrospectionTest extends TestCase
         }        
         '.$this->placeholderQuery();
 
-        $this->assertIsArray(
+        $this->assertNotNull(
             $this->introspectType('Foo')
         );
-        $this->assertIsArray(
+        $this->assertNotNull(
             $this->introspectType('Query')
         );
-        $this->assertIsArray(
+        $this->assertNotNull(
             $this->introspectType('Bar')
         );
     }
@@ -58,7 +58,7 @@ class IntrospectionTest extends TestCase
             new Email()
         );
 
-        $this->assertIsArray(
+        $this->assertNotNull(
             $this->introspectType('Email')
         );
     }

--- a/tests/Integration/IntrospectionTest.php
+++ b/tests/Integration/IntrospectionTest.php
@@ -43,7 +43,8 @@ class IntrospectionTest extends TestCase
         $this->assertNotNull(
             $this->introspectType('Query')
         );
-        $this->assertNotNull(
+
+        $this->assertNull(
             $this->introspectType('Bar')
         );
     }

--- a/tests/Integration/IntrospectionTest.php
+++ b/tests/Integration/IntrospectionTest.php
@@ -4,7 +4,6 @@ namespace Tests\Integration;
 
 use Tests\TestCase;
 use Tests\Utils\Scalars\Email;
-use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
 use Illuminate\Foundation\Testing\TestResponse;
 
@@ -38,16 +37,14 @@ class IntrospectionTest extends TestCase
         }        
         '.$this->placeholderQuery();
 
-        $introspection = $this->introspect();
-
-        $this->assertTrue(
-            $this->isTypeNamePresent($introspection, 'Foo')
+        $this->assertIsArray(
+            $this->introspectType('Foo')
         );
-        $this->assertTrue(
-            $this->isTypeNamePresent($introspection, 'Query')
+        $this->assertIsArray(
+            $this->introspectType('Query')
         );
-        $this->assertFalse(
-            $this->isTypeNamePresent($introspection, 'Bar')
+        $this->assertIsArray(
+            $this->introspectType('Bar')
         );
     }
 
@@ -61,16 +58,8 @@ class IntrospectionTest extends TestCase
             new Email()
         );
 
-        $this->assertTrue(
-            $this->isTypeNamePresent($this->introspect(), 'Email')
+        $this->assertIsArray(
+            $this->introspectType('Email')
         );
-    }
-
-    protected function isTypeNamePresent(TestResponse $introspection, string $typeName): bool
-    {
-        return (new Collection($introspection->jsonGet('data.__schema.types')))
-            ->contains(function (array $type) use ($typeName): bool {
-                return $type['name'] === $typeName;
-            });
     }
 }

--- a/tests/Integration/IntrospectionTest.php
+++ b/tests/Integration/IntrospectionTest.php
@@ -10,7 +10,6 @@ use Illuminate\Foundation\Testing\TestResponse;
 
 class IntrospectionTest extends TestCase
 {
-
     /**
      * @var \Nuwave\Lighthouse\Schema\TypeRegistry
      */

--- a/tests/Integration/IntrospectionTest.php
+++ b/tests/Integration/IntrospectionTest.php
@@ -10,87 +10,6 @@ use Illuminate\Foundation\Testing\TestResponse;
 
 class IntrospectionTest extends TestCase
 {
-    /**
-     * @see https://gist.github.com/craigbeck/b90915d49fda19d5b2b17ead14dcd6da
-     */
-    const INTROSPECTION_QUERY = /* @lang GraphQL */
-        <<<'GRAPHQL'
-  query IntrospectionQuery {
-    __schema {
-      queryType { name }
-      mutationType { name }
-      subscriptionType { name }
-      types {
-        ...FullType
-      }
-      directives {
-        name
-        description
-        args {
-          ...InputValue
-        }
-        locations
-      }
-    }
-  }
-
-  fragment FullType on __Type {
-    kind
-    name
-    description
-    fields(includeDeprecated: true) {
-      name
-      description
-      args {
-        ...InputValue
-      }
-      type {
-        ...TypeRef
-      }
-      isDeprecated
-      deprecationReason
-    }
-    inputFields {
-      ...InputValue
-    }
-    interfaces {
-      ...TypeRef
-    }
-    enumValues(includeDeprecated: true) {
-      name
-      description
-      isDeprecated
-      deprecationReason
-    }
-    possibleTypes {
-      ...TypeRef
-    }
-  }
-
-  fragment InputValue on __InputValue {
-    name
-    description
-    type { ...TypeRef }
-    defaultValue
-  }
-
-  fragment TypeRef on __Type {
-    kind
-    name
-    ofType {
-      kind
-      name
-      ofType {
-        kind
-        name
-        ofType {
-          kind
-          name
-        }
-      }
-    }
-  }
-GRAPHQL;
 
     /**
      * @var \Nuwave\Lighthouse\Schema\TypeRegistry
@@ -114,21 +33,22 @@ GRAPHQL;
      */
     public function itFindsTypesFromSchema(): void
     {
-        $this->introspect('
+        $this->schema = '
         type Foo {
             bar: Int
         }        
-        '.$this->placeholderQuery()
-        );
+        '.$this->placeholderQuery();
+
+        $introspection = $this->introspect();
 
         $this->assertTrue(
-            $this->isTypeNamePresent('Foo')
+            $this->isTypeNamePresent($introspection, 'Foo')
         );
         $this->assertTrue(
-            $this->isTypeNamePresent('Query')
+            $this->isTypeNamePresent($introspection, 'Query')
         );
         $this->assertFalse(
-            $this->isTypeNamePresent('Bar')
+            $this->isTypeNamePresent($introspection, 'Bar')
         );
     }
 
@@ -137,29 +57,19 @@ GRAPHQL;
      */
     public function itFindsManuallyRegisteredTypes(): void
     {
+        $this->schema = $this->placeholderQuery();
         $this->typeRegistry->register(
             new Email()
         );
 
-        $this->introspect(
-            $this->placeholderQuery()
-        );
-
         $this->assertTrue(
-            $this->isTypeNamePresent('Email')
+            $this->isTypeNamePresent($this->introspect(), 'Email')
         );
     }
 
-    protected function introspect(string $schema): void
+    protected function isTypeNamePresent(TestResponse $introspection, string $typeName): bool
     {
-        $this->schema = $schema;
-
-        $this->introspectionResult = $this->graphQL(self::INTROSPECTION_QUERY);
-    }
-
-    protected function isTypeNamePresent(string $typeName): bool
-    {
-        return (new Collection($this->introspectionResult->jsonGet('data.__schema.types')))
+        return (new Collection($introspection->jsonGet('data.__schema.types')))
             ->contains(function (array $type) use ($typeName): bool {
                 return $type['name'] === $typeName;
             });

--- a/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
+++ b/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
@@ -316,12 +316,8 @@ class WhereConstraintsDirectiveTest extends DBTestCase
             ],
         ]);
 
-        $types = $this->introspect()->jsonGet('data.__schema.types');
-
         $expectedEnumName = 'WhitelistedColumnsWhereColumn';
-        $enum = Arr::first($types, function (array $type) use ($expectedEnumName): bool {
-            return $type['name'] === $expectedEnumName;
-        });
+        $enum = $this->introspectType($expectedEnumName);
 
         $this->assertArraySubset(
             [

--- a/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
+++ b/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Integration\WhereConstraints;
 
 use Tests\DBTestCase;
-use Illuminate\Support\Arr;
 use Tests\Utils\Models\User;
 use Nuwave\Lighthouse\WhereConstraints\WhereConstraintsDirective;
 use Nuwave\Lighthouse\WhereConstraints\WhereConstraintsServiceProvider;

--- a/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
+++ b/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Integration\WhereConstraints;
 
-use Illuminate\Support\Arr;
 use Tests\DBTestCase;
+use Illuminate\Support\Arr;
 use Tests\Utils\Models\User;
 use Nuwave\Lighthouse\WhereConstraints\WhereConstraintsDirective;
 use Nuwave\Lighthouse\WhereConstraints\WhereConstraintsServiceProvider;
@@ -310,16 +310,16 @@ class WhereConstraintsDirectiveTest extends DBTestCase
                 'whitelistedColumns' => [
                     [
 
-                    'id' => 1
-                    ]
-                ]
-            ]
+                    'id' => 1,
+                    ],
+                ],
+            ],
         ]);
 
         $types = $this->introspect()->jsonGet('data.__schema.types');
 
         $expectedEnumName = 'WhitelistedColumnsWhereColumn';
-        $enum = Arr::first($types, function(array $type) use ($expectedEnumName): bool {
+        $enum = Arr::first($types, function (array $type) use ($expectedEnumName): bool {
             return $type['name'] === $expectedEnumName;
         });
 
@@ -335,7 +335,7 @@ class WhereConstraintsDirectiveTest extends DBTestCase
                     [
                         'name' => 'CAMEL_CASE',
                     ],
-                ]
+                ],
             ],
             $enum
         );

--- a/tests/Unit/Schema/ClientDirectiveTest.php
+++ b/tests/Unit/Schema/ClientDirectiveTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Unit\Schema;
 
 use Tests\TestCase;
-use Illuminate\Support\Arr;
 use GraphQL\Type\Definition\Directive;
 
 class ClientDirectiveTest extends TestCase
@@ -15,13 +14,11 @@ class ClientDirectiveTest extends TestCase
     {
         $this->schema = $this->placeholderQuery();
 
-        $directives = $this->introspectDirectives();
-
         $this->assertNotNull(
-            Arr::first($directives, $this->makeDirectiveNameMatcher(Directive::SKIP_NAME))
+            $this->introspectDirective(Directive::SKIP_NAME)
         );
         $this->assertNotNull(
-            Arr::first($directives, $this->makeDirectiveNameMatcher(Directive::INCLUDE_NAME))
+            $this->introspectDirective(Directive::INCLUDE_NAME)
         );
     }
 
@@ -38,14 +35,15 @@ class ClientDirectiveTest extends TestCase
         ) on FIELD
         '.$this->placeholderQuery();
 
-        $directives = $this->introspectDirectives();
-
-        $bar = Arr::first($directives, $this->makeDirectiveNameMatcher('bar'));
+        $bar = $this->introspectDirective('bar');
 
         $this->assertSame(
             [
                 'name' => 'bar',
                 'description' => 'foo',
+                'locations' => [
+                    'FIELD',
+                ],
                 'args' => [
                     [
                         'name' => 'baz',
@@ -58,28 +56,8 @@ class ClientDirectiveTest extends TestCase
                         'defaultValue' => '"barbaz"',
                     ],
                 ],
-                'locations' => [
-                    'FIELD',
-                ],
             ],
             $bar
         );
-    }
-
-    protected function makeDirectiveNameMatcher(string $name): \Closure
-    {
-        return function (array $directive) use ($name): bool {
-            return $directive['name'] === $name;
-        };
-    }
-
-    /**
-     * @return array[]
-     */
-    public function introspectDirectives(): array
-    {
-        return $this
-            ->introspect()
-            ->jsonGet('data.__schema.directives');
     }
 }

--- a/tests/Unit/Schema/ClientDirectiveTest.php
+++ b/tests/Unit/Schema/ClientDirectiveTest.php
@@ -5,7 +5,6 @@ namespace Tests\Unit\Schema;
 use Tests\TestCase;
 use Illuminate\Support\Arr;
 use GraphQL\Type\Definition\Directive;
-use Tests\Integration\IntrospectionTest;
 
 class ClientDirectiveTest extends TestCase
 {
@@ -79,8 +78,8 @@ class ClientDirectiveTest extends TestCase
      */
     public function introspectDirectives(): array
     {
-        $introspection = $this->graphQL(IntrospectionTest::INTROSPECTION_QUERY);
-
-        return $introspection->jsonGet('data.__schema.directives');
+        return $this
+            ->introspect()
+            ->jsonGet('data.__schema.directives');
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

**Related Issue/Intent**

Restrict the allowed column names to a well-defined list in `@whereContraints`.
This improves introspection capabilities and security.

**Changes**

Through the `columns` argument on `@whereConstraints`, a user may list allowed columns.

```graphql
type Query {
    people(
        where: WhereConstraints @whereConstraints(columns: ["age", "type", "haircolour", "height"])
    ): [Person!]!
}
```

Lighthouse generates definitions for an `Enum` type and an `Input` type
that are restricted to the defined columns.

```graphql
"Dynamic WHERE constraints for the `where` argument on the query `people`.
input PeopleWhereWhereConstraints {
    column: PeopleWhereColumn
    operator: String = EQ
    value: Mixed
    AND: [PeopleWhereWhereConstraints!]
    OR: [PeopleWhereWhereConstraints!]
    NOT: [PeopleWhereWhereConstraints!]
}

"Allowed column names for the `where` argument on the query `people`."
enum PeopleWhereColumn {
    AGE @enum(value: "age")
    TYPE @enum(value: "type")
    HAIRCOLOUR @enum(value: "haircolour")
    HEIGHT @enum(value: "height")
}
```

**Introspection Helpers**

If you create or manipulate parts of your schema programmatically, you might
want to test that. You can use introspection to query your final schema in tests.

Lighthouse uses the introspection query from [`\GraphQL\Type\Introspection::getIntrospectionQuery()`](https://github.com/webonyx/graphql-php/blob/master/src/Type/Introspection.php).

The `introspect()` helper method runs the full introspection query against your schema.

```php
$introspectionResult = $this->introspect();
```

Most often, you will want to look for a specific named type. 

```php
$generatedType = $this->introspectType('Generated');
// Ensure the type is present and matches a certain definition
$this->assertSame(
    [], // Adjust accordingly
    $generatedType
);
```

You can also introspect client directives.

```php
$customDirective = $this->introspectDirective('custom');
```

**Breaking changes**

No