### PR TITLE
Add @whereJsonContains directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 
+services:
+  - mysql
+
 cache:
   directories:
     - $HOME/.composer/cache
@@ -47,6 +50,7 @@ matrix:
 before_install:
   - phpenv config-rm xdebug.ini || true
   - echo "memory_limit=4G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - mysql -e 'CREATE DATABASE test;'
 
 install:
   - composer require "illuminate/contracts:${LARAVEL}" --no-interaction --no-update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add the `@whereJsonContains` directive to an input value as a [whereJsonContains filter](https://laravel.com/docs/queries#json-where-clauses)
+- Add the `@whereJsonContains` directive to an input value as a [whereJsonContains filter](https://laravel.com/docs/queries#json-where-clauses) https://github.com/nuwave/lighthouse/pull/919
 
 ## [4.0.0](https://github.com/nuwave/lighthouse/compare/v3.7.0...v4.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.0.0...master)
 
+### Added
+
+- Add the `@whereJsonContains` directive to an input value as a [whereJsonContains filter](https://laravel.com/docs/queries#json-where-clauses)
+
 ## [4.0.0](https://github.com/nuwave/lighthouse/compare/v3.7.0...v4.0.0)
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-configure zip --with-libzip \
     && docker-php-ext-install \
         zip \
+        mysqli \
+        pdo_mysql \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer \
@@ -17,4 +19,3 @@ ENV COMPOSER_ALLOW_SUPERUSER=1
 
 RUN pecl install xdebug \
     && docker-php-ext-enable xdebug
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,13 @@ services:
       XDEBUG_CONFIG: "remote_enable=1 remote_mode=req remote_port=9000 remote_host=host.docker.internal remote_connect_back=0"
       PHP_IDE_CONFIG: "serverName=lighthouse"
 
+  mysql:
+    image: mysql:5.7
+    tmpfs: /var/lib/mysql
+    environment:
+      MYSQL_DATABASE: test
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+
   node:
     image: node
     volumes:

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2160,6 +2160,12 @@ directive @where(
   operator: String = "="
 
   """
+  Specify the database column to compare. 
+  Only required if database column has a different name than the attribute in your schema.
+  """
+  key: String
+
+  """
   Use Laravel's where clauses upon the query builder.
   """
   clause: String
@@ -2301,6 +2307,39 @@ input WhereConstraints {
 }
 
 scalar Mixed @scalar(class: "MLL\\GraphQLScalars\\Mixed")
+```
+
+## @whereJsonContains
+
+Use an input value as a [whereJsonContains filter](https://laravel.com/docs/queries#json-where-clauses).
+
+```graphql
+type Query {
+    posts(tags: [String]! @whereJsonContains): [Post!]! @all
+}
+```
+
+You may use the `key` argument to look into the JSON content:
+
+```graphql
+type Query {
+    posts(tags: [String]! @whereJsonContains(key: "tags->recent")): [Post!]! @all
+}
+```
+
+### Definition
+
+```graphql
+"""
+Use an input value as a [whereJsonContains filter](https://laravel.com/docs/queries#json-where-clauses).
+"""
+directive @whereJsonContains(
+  """
+  Specify the database column and path inside the JSON to compare. 
+  Only required if database column has a different name than the attribute in your schema.
+  """
+  key: String
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 ## @whereNotBetween

--- a/src/Schema/Directives/WhereJsonContainsDirective.php
+++ b/src/Schema/Directives/WhereJsonContainsDirective.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Directives;
+
+use Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective;
+
+class WhereJsonContainsDirective extends BaseDirective implements ArgBuilderDirective
+{
+    /**
+     * Name of the directive.
+     *
+     * @return string
+     */
+    public function name(): string
+    {
+        return 'whereJsonContains';
+    }
+
+    /**
+     * Add a "WHERE JSON_CONTAINS()" clause to the builder.
+     *
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $builder
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder
+     */
+    public function handleBuilder($builder, $value)
+    {
+        return $builder->whereJsonContains(
+            $this->directiveArgValue('key', $this->definitionNode->name->value),
+            $value
+        );
+    }
+}

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -20,11 +20,12 @@ abstract class DBTestCase extends TestCase
     {
         parent::getEnvironmentSetUp($app);
 
-        $app['config']->set('database.default', 'sqlite');
-        $app['config']->set('database.connections.sqlite', [
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-            'prefix' => '',
+        $app['config']->set('database.default', 'mysql');
+        $app['config']->set('database.connections.mysql', [
+            'driver' => 'mysql',
+            'database' => 'test',
+            'host' => env('TRAVIS') ? '127.0.0.1' : 'mysql',
+            'username' => 'root',
         ]);
     }
 }

--- a/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
@@ -362,10 +362,10 @@ class BelongsToManyTest extends DBTestCase
                     'id' => '1',
                     'users' => [
                         [
-                            'id' => '2',
+                            'id' => '1',
                         ],
                         [
-                            'id' => '1',
+                            'id' => '2',
                         ],
                     ],
                 ],
@@ -411,10 +411,10 @@ class BelongsToManyTest extends DBTestCase
                     'id' => '1',
                     'users' => [
                         [
-                            'id' => '2',
+                            'id' => '1',
                         ],
                         [
-                            'id' => '1',
+                            'id' => '2',
                         ],
                     ],
                 ],

--- a/tests/Integration/Schema/Directives/CacheDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/CacheDirectiveTest.php
@@ -277,7 +277,7 @@ class CacheDirectiveTest extends DBTestCase
 
         $dbQueryCountForPost = 0;
         DB::listen(function (QueryExecuted $query) use (&$dbQueryCountForPost): void {
-            if (Str::contains($query->sql, 'select * from "posts"')) {
+            if (Str::contains($query->sql, 'select * from `posts`')) {
                 $dbQueryCountForPost++;
             }
         });
@@ -344,7 +344,7 @@ class CacheDirectiveTest extends DBTestCase
 
         $dbQueryCountForPost = 0;
         DB::listen(function (QueryExecuted $query) use (&$dbQueryCountForPost): void {
-            if (Str::contains($query->sql, 'select * from "posts"')) {
+            if (Str::contains($query->sql, 'select * from `posts`')) {
                 $dbQueryCountForPost++;
             }
         });

--- a/tests/Unit/Schema/Directives/WhereJsonContainsDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/WhereJsonContainsDirectiveTest.php
@@ -25,13 +25,13 @@ class WhereJsonContainsDirectiveTest extends DBTestCase
         $this->markTestSkipped('Can not be functionally tested with the SQLite test database we currently use.');
         factory(User::class)->create([
             'name' => \Safe\json_encode([
-                'nested' => 'bar'
-            ])
+                'nested' => 'bar',
+            ]),
         ]);
         factory(User::class)->create([
             'name' => \Safe\json_encode([
-                'nested' => 'baz'
-            ])
+                'nested' => 'baz',
+            ]),
         ]);
 
         $this->graphQL('

--- a/tests/Unit/Schema/Directives/WhereJsonContainsDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/WhereJsonContainsDirectiveTest.php
@@ -22,11 +22,11 @@ class WhereJsonContainsDirectiveTest extends DBTestCase
      */
     public function itCanOrderByTheGivenFieldAndSortOrderASC(): void
     {
-        $this->markTestSkipped('Can not be functionally tested with the SQLite test database we currently use.');
+        $nestedBar = \Safe\json_encode([
+            'nested' => 'bar',
+        ]);
         factory(User::class)->create([
-            'name' => \Safe\json_encode([
-                'nested' => 'bar',
-            ]),
+            'name' => $nestedBar,
         ]);
         factory(User::class)->create([
             'name' => \Safe\json_encode([
@@ -44,7 +44,7 @@ class WhereJsonContainsDirectiveTest extends DBTestCase
             'data' => [
                 'users' => [
                     [
-                        'name' => 'bar',
+                        'name' => $nestedBar,
                     ],
                 ],
             ],

--- a/tests/Unit/Schema/Directives/WhereJsonContainsDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/WhereJsonContainsDirectiveTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit\Schema\Directives;
+
+use Tests\DBTestCase;
+use Tests\Utils\Models\User;
+
+class WhereJsonContainsDirectiveTest extends DBTestCase
+{
+    protected $schema = '
+    type Query {
+        users(foo: String! @whereJsonContains(key: "name->nested")): [User!]! @all
+    }
+
+    type User {
+        name: String
+    }    
+    ';
+
+    /**
+     * @test
+     */
+    public function itCanOrderByTheGivenFieldAndSortOrderASC(): void
+    {
+        $this->markTestSkipped('Can not be functionally tested with the SQLite test database we currently use.');
+        factory(User::class)->create([
+            'name' => \Safe\json_encode([
+                'nested' => 'bar'
+            ])
+        ]);
+        factory(User::class)->create([
+            'name' => \Safe\json_encode([
+                'nested' => 'baz'
+            ])
+        ]);
+
+        $this->graphQL('
+        {
+            users(foo: "bar") {
+                name
+            }
+        }
+        ')->assertExactJson([
+            'data' => [
+                'users' => [
+                    [
+                        'name' => 'bar',
+                    ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Unit/Schema/Directives/WhereJsonContainsDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/WhereJsonContainsDirectiveTest.php
@@ -17,10 +17,19 @@ class WhereJsonContainsDirectiveTest extends DBTestCase
     }    
     ';
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ((float) $this->app->version() < 5.6) {
+            $this->markTestSkipped('Laravel supports whereJsonContains from version 5.6.');
+        }
+    }
+
     /**
      * @test
      */
-    public function itCanOrderByTheGivenFieldAndSortOrderASC(): void
+    public function itCanApplyWhereJsonContainsFilter(): void
     {
         $nestedBar = \Safe\json_encode([
             'nested' => 'bar',

--- a/tests/database/migrations/2018_02_28_000000_create_testbench_hours_table.php
+++ b/tests/database/migrations/2018_02_28_000000_create_testbench_hours_table.php
@@ -13,7 +13,7 @@ class CreateTestbenchHoursTable extends Migration
     {
         Schema::create('hours', function (Blueprint $table): void {
             $table->increments('id');
-            $table->string('hourable_type', 15)->nullable();
+            $table->string('hourable_type')->nullable();
             $table->unsignedInteger('hourable_id')->nullable();
             $table->string('from', 5)->nullable();
             $table->string('to', 5)->nullable();


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

**Related Issue/Intent**

While the `@where` directive offers flexible clauses, it did not work for a `whereJsonContains` query, as the method does not take a second argument `operator`.

**Changes**

Use an input value as a [whereJsonContains filter](https://laravel.com/docs/queries#json-where-clauses).

```graphql
type Query {
    posts(tags: [String]! @whereJsonContains): [Post!]! @all
}
```

You may use the `key` argument to look into the JSON content:

```graphql
type Query {
    posts(tags: [String]! @whereJsonContains(key: "tags->recent")): [Post!]! @all
}
```

### Definition

```graphql
"""
Use an input value as a [whereJsonContains filter](https://laravel.com/docs/queries#json-where-clauses).
"""
directive @whereJsonContains(
  """
  Specify the database column and path inside the JSON to compare. 
  Only required if database column has a different name than the attribute in your schema.
  """
  key: String
) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
```

**Breaking changes**

Nope
