### PR TITLE
Add support for Laravel ^6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
       env: LARAVEL='5.7.*'
     - php: "7.2"
       env: LARAVEL='5.8.*'
+    - php: "7.2"
+      env: LARAVEL='^6.0'
     - php: "7.3"
       env: LARAVEL='5.5.*'
     - php: "7.3"
@@ -40,6 +42,8 @@ matrix:
       env: LARAVEL='5.7.*'
     - php: "7.3"
       env: LARAVEL='5.8.*' COVERAGE=1 STATIC_ANALYSIS=1
+    - php: "7.3"
+      env: LARAVEL='^6.0'
     - php: "7.3"
       env: LARAVEL='5.8.*' BENCHMARKS=1
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,6 @@ matrix:
       env: LARAVEL='5.8.*' COVERAGE=1 STATIC_ANALYSIS=1
     - php: "7.3"
       env: LARAVEL='^6.0'
-    - php: "7.3"
-      env: LARAVEL='5.8.*' BENCHMARKS=1
   allow_failures:
     - php: "7.3"
       env: LARAVEL='5.8.*' BENCHMARKS=1
@@ -57,6 +55,7 @@ before_install:
   - mysql -e 'CREATE DATABASE test;'
 
 install:
+  - if [[ $LARAVEL = ^6.0 ]]; then composer remove laravel/lumen-framework; fi
   - composer require "illuminate/contracts:${LARAVEL}" --no-interaction --no-update
   - composer install --prefer-dist --no-interaction --no-suggest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.1.0...master)
 
+### Added
+
+- Support Laravel `^6.0` https://github.com/nuwave/lighthouse/pull/926
+
 ## [4.1.0](https://github.com/nuwave/lighthouse/compare/v4.0.0...v4.1.0)
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
     "require": {
         "php": ">= 7.1",
         "ext-json": "*",
-        "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
-        "illuminate/http": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
-        "illuminate/pagination": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
-        "illuminate/routing": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
-        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
-        "illuminate/validation": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
+        "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0",
+        "illuminate/http": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0",
+        "illuminate/pagination": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0",
+        "illuminate/routing": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0",
+        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0",
+        "illuminate/validation": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0",
         "webonyx/graphql-php": "^0.13.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,8 @@
         "laravel/scout": "^4.0",
         "mll-lab/graphql-php-scalars": "^2.1",
         "mockery/mockery": "^1.0",
-        "orchestra/database": "3.5.*|3.6.*|3.7.*|3.8.*",
-        "orchestra/testbench": "3.5.*|3.6.*|3.7.*|3.8.*",
+        "orchestra/database": "3.5.*|3.6.*|3.7.*|3.8.*|3.9.*",
+        "orchestra/testbench": "3.5.*|3.6.*|3.7.*|3.8.*|3.9.*",
         "phpbench/phpbench": "@dev",
         "pusher/pusher-php-server": "^3.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
     "require": {
         "php": ">= 7.1",
         "ext-json": "*",
-        "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*",
-        "illuminate/http": "5.5.*|5.6.*|5.7.*|5.8.*",
-        "illuminate/pagination": "5.5.*|5.6.*|5.7.*|5.8.*",
-        "illuminate/routing": "5.5.*|5.6.*|5.7.*|5.8.*",
-        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*",
-        "illuminate/validation": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
+        "illuminate/http": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
+        "illuminate/pagination": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
+        "illuminate/routing": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
+        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
+        "illuminate/validation": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
         "webonyx/graphql-php": "^0.13.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "require-dev": {
         "bensampo/laravel-enum": "^1.22",
-        "laravel/lumen-framework": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "laravel/lumen-framework": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0",
         "laravel/scout": "^4.0",
         "mll-lab/graphql-php-scalars": "^2.1",
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Added Docs for all relevant versions
- [ ] Updated the changelog

**Related Issue/Intent**

This PR adds support for the upcoming Laravel 6.x release.

Resolves https://github.com/nuwave/lighthouse/issues/940

**Changes**

Adds `^6.0` to the `composer.json` version constraints for laravel framework packages. Everything appears to be working fine on a Laravel 6 app I'm using this in.
