### PR TITLE
Unbox laravel-enum inputs when using the builder directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.1.0...master)
+## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.1.1...master)
+
+## [4.1.1](https://github.com/nuwave/lighthouse/compare/v4.1.0...v4.1.1)
+
+### Fixed
+
+- Unbox laravel-enum inputs when using the builder directives https://github.com/nuwave/lighthouse/pull/927
 
 ## [4.1.0](https://github.com/nuwave/lighthouse/compare/v4.0.0...v4.1.0)
 

--- a/src/Execution/Builder.php
+++ b/src/Execution/Builder.php
@@ -31,6 +31,12 @@ class Builder
     public function apply($builder, array $args)
     {
         foreach ($args as $key => $value) {
+            // TODO switch to instanceof when we require bensampo/laravel-enum
+            // Unbox Enum values to ensure their underlying value is used for queries
+            if (is_a($value, '\BenSampo\Enum\Enum')) {
+                $value = $value->value;
+            }
+
             /** @var \Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective $builderDirective */
             if ($builderDirective = Arr::get($this->builderDirectives, $key)) {
                 $builder = $builderDirective->handleBuilder($builder, $value);

--- a/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
+++ b/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
@@ -89,6 +89,10 @@ class LaravelEnumTypeTest extends DBTestCase
 
     public function testWhereJsonContainsUsingEnumType(): void
     {
+        if ((float) $this->app->version() < 5.6) {
+            $this->markTestSkipped('Laravel supports whereJsonContains from version 5.6.');
+        }
+
         // We use the "name" field to store the "type" JSON
         $this->schema = '
         type Query {

--- a/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
+++ b/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
@@ -3,10 +3,10 @@
 namespace Tests\Unit\Schema\Types;
 
 use Tests\DBTestCase;
+use Tests\Utils\Models\User;
 use Tests\Utils\LaravelEnums\UserType;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
 use Nuwave\Lighthouse\Schema\Types\LaravelEnumType;
-use Tests\Utils\Models\User;
 
 class LaravelEnumTypeTest extends DBTestCase
 {
@@ -122,8 +122,8 @@ class LaravelEnumTypeTest extends DBTestCase
             'data' => [
                 'user' => [
                     'name' => $encodedType,
-                ]
-            ]
+                ],
+            ],
         ]);
     }
 


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

**Related Issue/Intent**

When using laravel-enum based values with builder directives such as `@whereJsonContains`, Laravel did not use the internal value of the Enum.

Fixes a regression caused through https://github.com/nuwave/lighthouse/pull/908

**Changes**

Unbox instances of `\BenSampo\Enum\Enum` when using them in a builder directive.

**Breaking changes**

No
