### PR TITLE
Remove Lighthouse Utils package from plugins list

### DIFF
--- a/docs/pages/resources.md
+++ b/docs/pages/resources.md
@@ -6,7 +6,6 @@ sidebar: false
 
 ## Plugins
 
-- [deinternetjongens/lighthouse-utils](https://github.com/deInternetJongens/Lighthouse-Utils)
 - [joselfonseca/lighthouse-graphql-passport-auth](https://github.com/joselfonseca/lighthouse-graphql-passport-auth)
 
 ## Tutorials


### PR DESCRIPTION
Package is no longer maintained
