### PR TITLE
Typo Fix

### DIFF
--- a/docs/3.4/api-reference/directives.md
+++ b/docs/3.4/api-reference/directives.md
@@ -1146,7 +1146,7 @@ input PostInput {
 }
 ```
 
-The chema does not change, client side usage works the same:
+The schema does not change, client side usage works the same:
 
 ```graphql
 mutation {


### PR DESCRIPTION
Typo fixed in `docs/3.4/api-reference/directives.md `