### PR TITLE
Add webhook to subscription docs

### DIFF
--- a/docs/master/subscriptions/getting-started.md
+++ b/docs/master/subscriptions/getting-started.md
@@ -20,3 +20,16 @@ Add the service provider to your `config/app.php`
     \Nuwave\Lighthouse\Subscriptions\SubscriptionServiceProvider::class,
 ],
 ```
+
+### Pusher webhook
+
+Subscriptions does not expire by themselves. Unless a subscription is deleted, it will continue to broadcast events after the client has disconnected.
+Using the webhook, will mitigate this problem. When a pusher-channel is abandoned (ie. unsubscribed), it will trigger the webhook, which will instruct Lighthouse to delete the subscription.
+
+The webhook-URL is:
+
+```
+<graph-uri>/subscriptions/webhook
+```
+
+You can add the webhook in the Pusher Dashboard. Select the type `Presence`.

--- a/docs/master/subscriptions/getting-started.md
+++ b/docs/master/subscriptions/getting-started.md
@@ -21,15 +21,19 @@ Add the service provider to your `config/app.php`
 ],
 ```
 
-### Pusher webhook
+### Pusher Webhook
 
-Subscriptions does not expire by themselves. Unless a subscription is deleted, it will continue to broadcast events after the client has disconnected.
-Using the webhook, will mitigate this problem. When a pusher-channel is abandoned (ie. unsubscribed), it will trigger the webhook, which will instruct Lighthouse to delete the subscription.
+Subscriptions do not expire by themselves.
+Unless a subscription is deleted, it will continue to broadcast events after the client has disconnected.
 
-The webhook-URL is:
+Using a `Presence` webhook will mitigate this problem.
+When a Pusher channel is abandoned (ie. unsubscribed), it will trigger the webhook,
+which will instruct Lighthouse to delete the subscription.
+
+The webhook URL will typically be:
 
 ```
-<graph-uri>/subscriptions/webhook
+/graphql/subscriptions/webhook
 ```
 
 You can add the webhook in the Pusher Dashboard. Select the type `Presence`.


### PR DESCRIPTION
- [x] Added Docs for all relevant versions

**Related Issue/Intent**

Currently, we do not mention the webhook at all. Not using the webhook, causes a pile of subscriptions to build up over time, which increases the Pusher-usage significantly.