### PR TITLE
Prevent throwing in `lighthouse:ide-helper` when no custom directives are defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Prevent throwing in `lighthouse:ide-helper` when no custom directives are defined
+- Prevent throwing in `lighthouse:ide-helper` when no custom directives are defined https://github.com/nuwave/lighthouse/pull/948
 
 ## [4.2.1](https://github.com/nuwave/lighthouse/compare/v4.2.0...v4.2.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `@softDeletes` and `@trashed` directives to enable
   filtering soft deleted models https://github.com/nuwave/lighthouse/pull/937
 
+### Fixed
+
+- Prevent throwing in `lighthouse:ide-helper` when no custom directives are defined
+
 ## [4.2.1](https://github.com/nuwave/lighthouse/compare/v4.2.0...v4.2.1)
 
 ### Fixed

--- a/src/Console/IdeHelperCommand.php
+++ b/src/Console/IdeHelperCommand.php
@@ -2,13 +2,13 @@
 
 namespace Nuwave\Lighthouse\Console;
 
-use HaydenPierce\ClassFinder\Exception\ClassFinderException;
 use Illuminate\Console\Command;
 use HaydenPierce\ClassFinder\ClassFinder;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
 use Nuwave\Lighthouse\Schema\DirectiveNamespaces;
 use Nuwave\Lighthouse\Support\Contracts\Directive;
 use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
+use HaydenPierce\ClassFinder\Exception\ClassFinderException;
 
 class IdeHelperCommand extends Command
 {

--- a/src/Console/IdeHelperCommand.php
+++ b/src/Console/IdeHelperCommand.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Console;
 
+use HaydenPierce\ClassFinder\Exception\ClassFinderException;
 use Illuminate\Console\Command;
 use HaydenPierce\ClassFinder\ClassFinder;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
@@ -75,7 +76,16 @@ SDL;
         $directives = [];
 
         foreach ($directiveNamespaces as $directiveNamespace) {
-            foreach (ClassFinder::getClassesInNamespace($directiveNamespace) as $class) {
+            try {
+                $classesInNamespace = ClassFinder::getClassesInNamespace($directiveNamespace);
+            } catch (ClassFinderException $classFinderException) {
+                // TODO remove if https://gitlab.com/hpierce1102/ClassFinder/merge_requests/16 is merged
+                // The ClassFinder throws if no classes are found. Since we can not know
+                // in advance if the user has defined custom directives, this behaviour is problematic.
+                continue;
+            }
+
+            foreach ($classesInNamespace as $class) {
                 $reflection = new \ReflectionClass($class);
                 if (! $reflection->isInstantiable()) {
                     continue;

--- a/tests/Unit/Console/IdeHelperCommandTest.php
+++ b/tests/Unit/Console/IdeHelperCommandTest.php
@@ -47,4 +47,21 @@ class IdeHelperCommandTest extends TestCase
         );
         $this->assertContains(UnionDirective::class, $generated);
     }
+
+    /**
+     * @test
+     */
+    public function itDoesNotRequireCustomDirectives(): void
+    {
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = $this->app['config'];
+
+        $config->set('lighthouse.namespaces.directives', [
+            'Empty\\Because\\The\\User\\Has\\Not\\Created\\Custom\\Directives\\Yet',
+        ]);
+
+        $this->artisan('lighthouse:ide-helper');
+
+        $this->assertFileExists(IdeHelperCommand::filePath());
+    }
 }


### PR DESCRIPTION
- [x ] Added or updated tests
~~- [ ] Added Docs for all relevant version~~
- [x ] Updated the changelog

**Related Issue/Intent**

Resolves #947 

**Changes**

TODO remove if https://gitlab.com/hpierce1102/ClassFinder/merge_requests/16 is merged
The ClassFinder throws if no classes are found. Since we can not know
in advance if the user has defined custom directives, this behaviour is problematic.

**Breaking changes**

No.
