### PR TITLE
Register extension directives only through RegisterDirectiveNamespaces event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.3.0...master)
 
+### Deprecated
+
+- Use the `RegisterDirectiveNamespaces` event instead of `DirectiveFactory#addResolved()` https://github.com/nuwave/lighthouse/pull/950
+
 ## [4.3.0](https://github.com/nuwave/lighthouse/compare/v4.2.1...v4.3.0)
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,8 @@
     },
     "require-dev": {
         "bensampo/laravel-enum": "^1.22",
+        "dms/phpunit-arraysubset-asserts": "^0.1.0",
+        "haydenpierce/class-finder": "^0.3.3",
         "laravel/lumen-framework": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0",
         "laravel/scout": "^4.0",
         "mll-lab/graphql-php-scalars": "^2.1",
@@ -46,8 +48,7 @@
         "orchestra/database": "3.5.*|3.6.*|3.7.*|3.8.*|3.9.*",
         "orchestra/testbench": "3.5.*|3.6.*|3.7.*|3.8.*|3.9.*",
         "phpbench/phpbench": "@dev",
-        "pusher/pusher-php-server": "^3.2",
-        "haydenpierce/class-finder": "^0.3.3"
+        "pusher/pusher-php-server": "^3.2"
     },
     "suggest": {
         "laravel/scout": "Required for the @search directive",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
     },
     "require-dev": {
         "bensampo/laravel-enum": "^1.22",
-        "dms/phpunit-arraysubset-asserts": "^0.1.0",
         "haydenpierce/class-finder": "^0.3.3",
         "laravel/lumen-framework": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0",
         "laravel/scout": "^4.0",

--- a/src/Defer/DeferServiceProvider.php
+++ b/src/Defer/DeferServiceProvider.php
@@ -5,6 +5,7 @@ namespace Nuwave\Lighthouse\Defer;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Events\Dispatcher;
 use Nuwave\Lighthouse\Events\ManipulateAST;
+use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 use Nuwave\Lighthouse\Schema\Factories\DirectiveFactory;
 use Nuwave\Lighthouse\Support\Contracts\CreatesResponse;
 
@@ -19,9 +20,11 @@ class DeferServiceProvider extends ServiceProvider
      */
     public function boot(DirectiveFactory $directiveFactory, Dispatcher $dispatcher): void
     {
-        $directiveFactory->addResolved(
-            DeferrableDirective::NAME,
-            DeferrableDirective::class
+        $dispatcher->listen(
+            RegisterDirectiveNamespaces::class,
+            function (RegisterDirectiveNamespaces $registerDirectiveNamespaces): string {
+                return __NAMESPACE__;
+            }
         );
 
         $dispatcher->listen(

--- a/src/Defer/DeferServiceProvider.php
+++ b/src/Defer/DeferServiceProvider.php
@@ -5,9 +5,9 @@ namespace Nuwave\Lighthouse\Defer;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Events\Dispatcher;
 use Nuwave\Lighthouse\Events\ManipulateAST;
-use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 use Nuwave\Lighthouse\Schema\Factories\DirectiveFactory;
 use Nuwave\Lighthouse\Support\Contracts\CreatesResponse;
+use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 
 class DeferServiceProvider extends ServiceProvider
 {

--- a/src/Schema/Factories/DirectiveFactory.php
+++ b/src/Schema/Factories/DirectiveFactory.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use GraphQL\Language\AST\Node;
 use Illuminate\Support\Collection;
 use GraphQL\Language\AST\DirectiveNode;
+use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 use Nuwave\Lighthouse\Schema\DirectiveNamespacer;
 use Nuwave\Lighthouse\Support\Contracts\Directive;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;
@@ -116,6 +117,9 @@ class DirectiveFactory
     }
 
     /**
+     * @deprecated use the RegisterDirectiveNamespaces instead, will be removed as of v5
+     * @see \Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces
+     *
      * @param  string  $directiveName
      * @param  string  $className
      * @return $this

--- a/src/Schema/Factories/DirectiveFactory.php
+++ b/src/Schema/Factories/DirectiveFactory.php
@@ -7,11 +7,11 @@ use Illuminate\Support\Str;
 use GraphQL\Language\AST\Node;
 use Illuminate\Support\Collection;
 use GraphQL\Language\AST\DirectiveNode;
-use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 use Nuwave\Lighthouse\Schema\DirectiveNamespacer;
 use Nuwave\Lighthouse\Support\Contracts\Directive;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 
 class DirectiveFactory
 {

--- a/src/Tracing/TracingServiceProvider.php
+++ b/src/Tracing/TracingServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Nuwave\Lighthouse\Tracing;
 
 use Illuminate\Support\ServiceProvider;
+use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 use Nuwave\Lighthouse\Events\StartRequest;
 use Nuwave\Lighthouse\Events\ManipulateAST;
 use Nuwave\Lighthouse\Events\StartExecution;
@@ -21,10 +22,13 @@ class TracingServiceProvider extends ServiceProvider
      */
     public function boot(DirectiveFactory $directiveFactory, EventsDispatcher $eventsDispatcher): void
     {
-        $directiveFactory->addResolved(
-            TracingDirective::NAME,
-            TracingDirective::class
+        $eventsDispatcher->listen(
+            RegisterDirectiveNamespaces::class,
+            function (RegisterDirectiveNamespaces $registerDirectiveNamespaces): string {
+                return __NAMESPACE__;
+            }
         );
+
 
         $eventsDispatcher->listen(
             ManipulateAST::class,

--- a/src/Tracing/TracingServiceProvider.php
+++ b/src/Tracing/TracingServiceProvider.php
@@ -3,12 +3,12 @@
 namespace Nuwave\Lighthouse\Tracing;
 
 use Illuminate\Support\ServiceProvider;
-use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 use Nuwave\Lighthouse\Events\StartRequest;
 use Nuwave\Lighthouse\Events\ManipulateAST;
 use Nuwave\Lighthouse\Events\StartExecution;
 use Nuwave\Lighthouse\Events\BuildExtensionsResponse;
 use Nuwave\Lighthouse\Schema\Factories\DirectiveFactory;
+use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 
 class TracingServiceProvider extends ServiceProvider
@@ -28,7 +28,6 @@ class TracingServiceProvider extends ServiceProvider
                 return __NAMESPACE__;
             }
         );
-
 
         $eventsDispatcher->listen(
             ManipulateAST::class,

--- a/src/WhereConstraints/WhereConstraintsServiceProvider.php
+++ b/src/WhereConstraints/WhereConstraintsServiceProvider.php
@@ -5,6 +5,7 @@ namespace Nuwave\Lighthouse\WhereConstraints;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Events\Dispatcher;
 use Nuwave\Lighthouse\Events\ManipulateAST;
+use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
 use GraphQL\Language\AST\InputObjectTypeDefinitionNode;
 use Nuwave\Lighthouse\Schema\Factories\DirectiveFactory;
@@ -20,9 +21,11 @@ class WhereConstraintsServiceProvider extends ServiceProvider
      */
     public function boot(DirectiveFactory $directiveFactory, Dispatcher $dispatcher): void
     {
-        $directiveFactory->addResolved(
-            WhereConstraintsDirective::NAME,
-            WhereConstraintsDirective::class
+        $dispatcher->listen(
+            RegisterDirectiveNamespaces::class,
+            function (RegisterDirectiveNamespaces $registerDirectiveNamespaces): string {
+                return __NAMESPACE__;
+            }
         );
 
         $dispatcher->listen(

--- a/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
+++ b/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
@@ -4,14 +4,11 @@ namespace Tests\Integration\WhereConstraints;
 
 use Tests\DBTestCase;
 use Tests\Utils\Models\User;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Nuwave\Lighthouse\WhereConstraints\WhereConstraintsDirective;
 use Nuwave\Lighthouse\WhereConstraints\WhereConstraintsServiceProvider;
 
 class WhereConstraintsDirectiveTest extends DBTestCase
 {
-    use ArraySubsetAsserts;
-
     protected $schema = '
     type User {
         id: ID!

--- a/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
+++ b/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
@@ -4,11 +4,14 @@ namespace Tests\Integration\WhereConstraints;
 
 use Tests\DBTestCase;
 use Tests\Utils\Models\User;
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Nuwave\Lighthouse\WhereConstraints\WhereConstraintsDirective;
 use Nuwave\Lighthouse\WhereConstraints\WhereConstraintsServiceProvider;
 
 class WhereConstraintsDirectiveTest extends DBTestCase
 {
+    use ArraySubsetAsserts;
+
     protected $schema = '
     type User {
         id: ID!


### PR DESCRIPTION
**Changes**

Change the way, how experimental `@whereConstraints` directive is registered. Earlier it was added to directive factory. Thus `@whereConstraints` was not recognised by IDE Helper.

Now directive is registered via adding its namespace to directives namespaces array. Thus IDE helper has additional namespace, when `WhereConstraintsServiceProvider` is enabled.  

I also fixed deprecated notice for `assertArraySubset`. This assertions seems to be deleted in PHPUnit 9, as there were some misunderstood usages over the time. Author gave no suggestions how to replace it, and people just exported this functionality to an extra package. 

**Breaking changes**

No breaking changes