### PR TITLE
Allow additional route configurations `prefix` and `domain`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Wrap route in group to allow additional configurations such as domain https://github.com/nuwave/lighthouse/pull/951
+- Allow additional route configurations `prefix` and `domain` https://github.com/nuwave/lighthouse/pull/951
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.3.0...master)
 
+### Changed
+
+- Wrap route in group to allow additional configurations such as domain https://github.com/nuwave/lighthouse/pull/951
+
 ## [4.3.0](https://github.com/nuwave/lighthouse/compare/v4.2.1...v4.3.0)
 
 ### Added

--- a/config/config.php
+++ b/config/config.php
@@ -33,6 +33,12 @@ return [
         'middleware' => [
             \Nuwave\Lighthouse\Support\Http\Middleware\AcceptJson::class,
         ],
+
+        /*
+         * The `prefix` and `domain` configuration options are optional.
+         */
+        #'prefix' => '',
+        #'domain' => '',
     ],
 
     /*

--- a/config/config.php
+++ b/config/config.php
@@ -37,8 +37,8 @@ return [
         /*
          * The `prefix` and `domain` configuration options are optional.
          */
-        #'prefix' => '',
-        #'domain' => '',
+        //'prefix' => '',
+        //'domain' => '',
     ],
 
     /*

--- a/docs/master/getting-started/configuration.md
+++ b/docs/master/getting-started/configuration.md
@@ -49,8 +49,8 @@ return [
         /*
          * The `prefix` and `domain` configuration options are optional.
          */
-        #'prefix' => '',
-        #'domain' => '',
+        //'prefix' => '',
+        //'domain' => '',
     ],
 
     /*

--- a/docs/master/getting-started/configuration.md
+++ b/docs/master/getting-started/configuration.md
@@ -45,6 +45,12 @@ return [
         'middleware' => [
             \Nuwave\Lighthouse\Support\Http\Middleware\AcceptJson::class,
         ],
+
+        /*
+         * The `prefix` and `domain` configuration options are optional.
+         */
+        #'prefix' => '',
+        #'domain' => '',
     ],
 
     /*

--- a/src/Support/Http/routes.php
+++ b/src/Support/Http/routes.php
@@ -22,5 +22,4 @@ if ($routeConfig = config('lighthouse.route')) {
             ]
         );
     });
-
 }

--- a/src/Support/Http/routes.php
+++ b/src/Support/Http/routes.php
@@ -6,18 +6,21 @@ if ($routeConfig = config('lighthouse.route')) {
     /** @var \Illuminate\Contracts\Routing\Registrar $router */
     $router = app('router');
 
-    $method = 'addRoute';
-    if (Str::startsWith(app()->version(), '5.5.')) {
-        $method = 'match';
-    }
+    $router->group(config('lighthouse.route', []), function () use ($router, $routeConfig): void {
 
-    $router->$method(
-        ['GET', 'POST'],
-        $routeConfig['uri'] ?? 'graphql',
-        [
-            'as' => $routeConfig['name'] ?? 'graphql',
-            'uses' => \Nuwave\Lighthouse\Support\Http\Controllers\GraphQLController::class.'@query',
-            'middleware' => $routeConfig['middleware'],
-        ]
-    );
+        $method = 'addRoute';
+        if (Str::startsWith(app()->version(), '5.5.')) {
+            $method = 'match';
+        }
+
+        $router->$method(
+            ['GET', 'POST'],
+            $routeConfig['uri'] ?? 'graphql',
+            [
+                'as' => $routeConfig['name'] ?? 'graphql',
+                'uses' => \Nuwave\Lighthouse\Support\Http\Controllers\GraphQLController::class.'@query',
+                'middleware' => $routeConfig['middleware'],
+            ]
+        );
+    });
 }

--- a/src/Support/Http/routes.php
+++ b/src/Support/Http/routes.php
@@ -6,23 +6,28 @@ if ($routeConfig = config('lighthouse.route')) {
     /** @var \Illuminate\Contracts\Routing\Registrar $router */
     $router = app('router');
 
-    $router->group(
-        config('lighthouse.route', []),
-        function () use ($router, $routeConfig): void {
-            $method = 'addRoute';
-            if (Str::startsWith(app()->version(), '5.5.')) {
-                $method = 'match';
-            }
+    $method = 'addRoute';
+    if (Str::startsWith(app()->version(), '5.5.')) {
+        $method = 'match';
+    }
 
-            $router->$method(
-                ['GET', 'POST'],
-                $routeConfig['uri'] ?? 'graphql',
-                [
-                    'as' => $routeConfig['name'] ?? 'graphql',
-                    'uses' => \Nuwave\Lighthouse\Support\Http\Controllers\GraphQLController::class.'@query',
-                    'middleware' => $routeConfig['middleware'],
-                ]
-            );
-        }
+    $actions = [
+        'as' => $routeConfig['name'] ?? 'graphql',
+        'uses' => \Nuwave\Lighthouse\Support\Http\Controllers\GraphQLController::class.'@query',
+        'middleware' => $routeConfig['middleware'],
+    ];
+
+    if(isset($routeConfig['prefix'])) {
+        $actions['prefix'] = $routeConfig['prefix'];
+    }
+
+    if(isset($routeConfig['domain'])) {
+        $actions['domain'] = $routeConfig['domain'];
+    }
+
+    $router->$method(
+        ['GET', 'POST'],
+        $routeConfig['uri'] ?? 'graphql',
+        $actions
     );
 }

--- a/src/Support/Http/routes.php
+++ b/src/Support/Http/routes.php
@@ -7,7 +7,6 @@ if ($routeConfig = config('lighthouse.route')) {
     $router = app('router');
 
     $router->group(config('lighthouse.route', []), function () use ($router, $routeConfig): void {
-
         $method = 'addRoute';
         if (Str::startsWith(app()->version(), '5.5.')) {
             $method = 'match';
@@ -23,4 +22,5 @@ if ($routeConfig = config('lighthouse.route')) {
             ]
         );
     });
+
 }

--- a/src/Support/Http/routes.php
+++ b/src/Support/Http/routes.php
@@ -6,20 +6,23 @@ if ($routeConfig = config('lighthouse.route')) {
     /** @var \Illuminate\Contracts\Routing\Registrar $router */
     $router = app('router');
 
-    $router->group(config('lighthouse.route', []), function () use ($router, $routeConfig): void {
-        $method = 'addRoute';
-        if (Str::startsWith(app()->version(), '5.5.')) {
-            $method = 'match';
-        }
+    $router->group(
+        config('lighthouse.route', []),
+        function () use ($router, $routeConfig): void {
+            $method = 'addRoute';
+            if (Str::startsWith(app()->version(), '5.5.')) {
+                $method = 'match';
+            }
 
-        $router->$method(
-            ['GET', 'POST'],
-            $routeConfig['uri'] ?? 'graphql',
-            [
-                'as' => $routeConfig['name'] ?? 'graphql',
-                'uses' => \Nuwave\Lighthouse\Support\Http\Controllers\GraphQLController::class.'@query',
-                'middleware' => $routeConfig['middleware'],
-            ]
-        );
-    });
+            $router->$method(
+                ['GET', 'POST'],
+                $routeConfig['uri'] ?? 'graphql',
+                [
+                    'as' => $routeConfig['name'] ?? 'graphql',
+                    'uses' => \Nuwave\Lighthouse\Support\Http\Controllers\GraphQLController::class.'@query',
+                    'middleware' => $routeConfig['middleware'],
+                ]
+            );
+        }
+    );
 }

--- a/src/Support/Http/routes.php
+++ b/src/Support/Http/routes.php
@@ -17,11 +17,11 @@ if ($routeConfig = config('lighthouse.route')) {
         'middleware' => $routeConfig['middleware'],
     ];
 
-    if(isset($routeConfig['prefix'])) {
+    if (isset($routeConfig['prefix'])) {
         $actions['prefix'] = $routeConfig['prefix'];
     }
 
-    if(isset($routeConfig['domain'])) {
+    if (isset($routeConfig['domain'])) {
         $actions['domain'] = $routeConfig['domain'];
     }
 

--- a/tests/Integration/RouteRegistrationTest.php
+++ b/tests/Integration/RouteRegistrationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Integration;
+
+use Nuwave\Lighthouse\LighthouseServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class RouteRegistrationTest extends TestCase
+{
+
+    /**
+     * Get package providers.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return string[]
+     */
+    protected function getPackageProviders($app)
+    {
+        return [
+            LighthouseServiceProvider::class,
+        ];
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = $app['config'];
+        $config->set(
+            'lighthouse.route.prefix',
+            'foo'
+        );
+    }
+
+    public function testRegisterRouteWithCustomConfig(): void
+    {
+        /** @var \Illuminate\Routing\Router|\Laravel\Lumen\Routing\Router $router */
+        $router = app('router');
+        $routes = $router->getRoutes();
+
+        $graphqlRoute = $routes->getByName('graphql');
+        $this->assertEquals(
+            ['GET', 'POST', 'HEAD'],
+            $graphqlRoute->methods()
+        );
+        $this->assertSame('foo', $graphqlRoute->getPrefix());
+    }
+}

--- a/tests/Integration/RouteRegistrationTest.php
+++ b/tests/Integration/RouteRegistrationTest.php
@@ -2,12 +2,11 @@
 
 namespace Tests\Integration;
 
-use Nuwave\Lighthouse\LighthouseServiceProvider;
 use Orchestra\Testbench\TestCase;
+use Nuwave\Lighthouse\LighthouseServiceProvider;
 
 class RouteRegistrationTest extends TestCase
 {
-
     /**
      * Get package providers.
      *


### PR DESCRIPTION
- [x] Added Docs for all relevant versions
- [x] Updated the changelog
- [x] Added or updated tests

**Changes**

Adds support for graphql route group, so we can use router group specific config like domain, prefix, etc.

**Breaking changes**

None
