### PR TITLE
Enable cache when not local

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -68,7 +68,7 @@ return [
     */
 
     'cache' => [
-        'enable' => env('LIGHTHOUSE_CACHE_ENABLE', true),
+        'enable' => env('LIGHTHOUSE_CACHE_ENABLE', env('APP_ENV') === 'production'),
         'key' => env('LIGHTHOUSE_CACHE_KEY', 'lighthouse-schema'),
         'ttl' => env('LIGHTHOUSE_CACHE_TTL', null),
     ],

--- a/config/config.php
+++ b/config/config.php
@@ -68,7 +68,7 @@ return [
     */
 
     'cache' => [
-        'enable' => env('LIGHTHOUSE_CACHE_ENABLE', env('APP_ENV') === 'production'),
+        'enable' => env('LIGHTHOUSE_CACHE_ENABLE', env('APP_ENV') !== 'local'),
         'key' => env('LIGHTHOUSE_CACHE_KEY', 'lighthouse-schema'),
         'ttl' => env('LIGHTHOUSE_CACHE_TTL', null),
     ],


### PR DESCRIPTION
Many users had issues with the schema cache being on by default.

This couples the config value to the `APP_ENV`, which is default in any Laravel installation.

**Breaking changes**

No, as the cache only concerns performance. When following standard Laravel conventions, this works out of the box perfectly.