### PR TITLE
Performance wins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow additional route configurations `prefix` and `domain` https://github.com/nuwave/lighthouse/pull/951
 - Enable schema cache only when `APP_ENV` != 'local' https://github.com/nuwave/lighthouse/pull/957
+- Improve performance of `TypeRegistry` resolving fields https://github.com/nuwave/lighthouse/pull/961
 
 ### Deprecated
 

--- a/src/Schema/TypeRegistry.php
+++ b/src/Schema/TypeRegistry.php
@@ -17,7 +17,6 @@ use GraphQL\Type\Definition\InterfaceType;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use GraphQL\Language\AST\TypeDefinitionNode;
 use GraphQL\Type\Definition\InputObjectType;
-use GraphQL\Language\AST\FieldDefinitionNode;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Values\TypeValue;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
@@ -293,18 +292,19 @@ class TypeRegistry
     protected function resolveFieldsFunction($definition): Closure
     {
         return function () use ($definition): array {
-            return (new Collection($definition->fields))
-                ->mapWithKeys(function (FieldDefinitionNode $fieldDefinition) use ($definition): array {
-                    $fieldValue = new FieldValue(
-                        new TypeValue($definition),
-                        $fieldDefinition
-                    );
+            $fieldFactory = app(FieldFactory::class);
+            $fieldDefinitions = [];
 
-                    return [
-                        $fieldDefinition->name->value => app(FieldFactory::class)->handle($fieldValue),
-                    ];
-                })
-                ->toArray();
+            foreach ($definition->fields as $fieldDefinition) {
+                $fieldValue = new FieldValue(
+                    new TypeValue($definition),
+                    $fieldDefinition
+                );
+
+                $fieldDefinitions[$fieldDefinition->name->value] = $fieldFactory->handle($fieldValue);
+            }
+
+            return $fieldDefinitions;
         };
     }
 


### PR DESCRIPTION
~Work in progress still!~

Figures below are by no means scientific but measured in a real app with a large schema on a local machine while running in production mode with `php artisan optimize`. Tested and compared with Blackfire.

- e6655df: ~10%

It looks so far like the most gains to be had are in the underlying GraphQL library itself related to the query validator.

![image](https://user-images.githubusercontent.com/1090754/64819502-aa516e80-d5ae-11e9-949e-d14a9bbadd3f.png)

The relatively small query I am testing with (fieldnames are dummies):

```graphql
query userDiscovery($id: String!) {
  user(id: $id) {
    id
    field1
    field2
    __typename
  }
  viewer {
    id
    tenant {
      id
      settings {
        field1
        field2
        field3
        __typename
      }
      __typename
    }
    field1
    field2
    field3
    __typename
  }
}

```

---

- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [ ] Updated the changelog

Related #772

**Changes**

Non-breaking changes that should improve the performance of some code paths resulting in faster response times.
