### PR TITLE
Remove try-catch around ClassFinder call in IdeHelperCommand

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "require-dev": {
         "bensampo/laravel-enum": "^1.22",
-        "haydenpierce/class-finder": "^0.3.3",
+        "haydenpierce/class-finder": "^0.4.0",
         "laravel/lumen-framework": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0",
         "laravel/scout": "^4.0",
         "mll-lab/graphql-php-scalars": "^2.1",

--- a/src/Console/IdeHelperCommand.php
+++ b/src/Console/IdeHelperCommand.php
@@ -76,14 +76,7 @@ SDL;
         $directives = [];
 
         foreach ($directiveNamespaces as $directiveNamespace) {
-            try {
-                $classesInNamespace = ClassFinder::getClassesInNamespace($directiveNamespace);
-            } catch (ClassFinderException $classFinderException) {
-                // TODO remove if https://gitlab.com/hpierce1102/ClassFinder/merge_requests/16 is merged
-                // The ClassFinder throws if no classes are found. Since we can not know
-                // in advance if the user has defined custom directives, this behaviour is problematic.
-                continue;
-            }
+            $classesInNamespace = ClassFinder::getClassesInNamespace($directiveNamespace);
 
             foreach ($classesInNamespace as $class) {
                 $reflection = new \ReflectionClass($class);

--- a/src/Console/IdeHelperCommand.php
+++ b/src/Console/IdeHelperCommand.php
@@ -8,7 +8,6 @@ use Nuwave\Lighthouse\Schema\AST\PartialParser;
 use Nuwave\Lighthouse\Schema\DirectiveNamespacer;
 use Nuwave\Lighthouse\Support\Contracts\Directive;
 use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
-use HaydenPierce\ClassFinder\Exception\ClassFinderException;
 
 class IdeHelperCommand extends Command
 {


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

No longer needed as of https://gitlab.com/hpierce1102/ClassFinder/merge_requests/16 and the related release of `0.4.0`

**Breaking changes**

No
