### PR TITLE
Allow overwriting the name of Enum types created through `LaravelEnumType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.3.0...master)
 
+### Added
+
+- Allow overwriting the name of Enum types created through `LaravelEnumType`
+
 ### Changed
 
 - Allow additional route configurations `prefix` and `domain` https://github.com/nuwave/lighthouse/pull/951

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Allow overwriting the name of Enum types created through `LaravelEnumType`
+- Allow overwriting the name of Enum types created through `LaravelEnumType` https://github.com/nuwave/lighthouse/pull/968
 
 ### Changed
 

--- a/docs/master/the-basics/types.md
+++ b/docs/master/the-basics/types.md
@@ -219,6 +219,20 @@ class GraphQLServiceProvider extends ServiceProvider
 }
 ```
 
+By default, the generated type will be named just like the given class.
+
+```php
+$enum = new LaravelEnumType(UserType::class);
+var_dump($enum->name); // UserType
+```
+
+You may overwrite the name if the default does not fit or you have a name conflict.
+
+```php
+$enum = new LaravelEnumType(UserType::class, 'UserKind');
+var_dump($enum->name); // UserKind
+```
+
 ## Input
 
 Input types can be used to describe complex objects for field arguments.

--- a/src/Schema/Types/LaravelEnumType.php
+++ b/src/Schema/Types/LaravelEnumType.php
@@ -22,9 +22,10 @@ class LaravelEnumType extends EnumType
      * Create a GraphQL enum from a Laravel enum type.
      *
      * @param  string|\BenSampo\Enum\Enum  $enumClass
+     * @param  string|null  $name
      * @return void
      */
-    public function __construct(string $enumClass)
+    public function __construct(string $enumClass, ?string $name)
     {
         if (! is_subclass_of($enumClass, Enum::class)) {
             throw new InvalidArgumentException(
@@ -35,7 +36,7 @@ class LaravelEnumType extends EnumType
         $this->enumClass = $enumClass;
 
         parent::__construct([
-            'name' => class_basename($enumClass),
+            'name' => $name ?? class_basename($enumClass),
             'values' => array_map(
                 function (Enum $enum): array {
                     return [

--- a/src/Schema/Types/LaravelEnumType.php
+++ b/src/Schema/Types/LaravelEnumType.php
@@ -22,7 +22,7 @@ class LaravelEnumType extends EnumType
      * Create a GraphQL enum from a Laravel enum type.
      *
      * @param  string|\BenSampo\Enum\Enum  $enumClass
-     * @param  string|null  $name  Defaults to the basename of the given class
+     * @param  string|null  $name  The name the enum will have in the schema, defaults to the basename of the given class
      * @return void
      */
     public function __construct(string $enumClass, ?string $name = null)

--- a/src/Schema/Types/LaravelEnumType.php
+++ b/src/Schema/Types/LaravelEnumType.php
@@ -25,7 +25,7 @@ class LaravelEnumType extends EnumType
      * @param  string|null  $name
      * @return void
      */
-    public function __construct(string $enumClass, ?string $name)
+    public function __construct(string $enumClass, ?string $name = null)
     {
         if (! is_subclass_of($enumClass, Enum::class)) {
             throw new InvalidArgumentException(

--- a/src/Schema/Types/LaravelEnumType.php
+++ b/src/Schema/Types/LaravelEnumType.php
@@ -22,7 +22,7 @@ class LaravelEnumType extends EnumType
      * Create a GraphQL enum from a Laravel enum type.
      *
      * @param  string|\BenSampo\Enum\Enum  $enumClass
-     * @param  string|null  $name
+     * @param  string|null  $name  Defaults to the basename of the given class
      * @return void
      */
     public function __construct(string $enumClass, ?string $name = null)

--- a/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
+++ b/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
@@ -22,6 +22,14 @@ class LaravelEnumTypeTest extends DBTestCase
         $this->typeRegistry = $this->app->make(TypeRegistry::class);
     }
 
+    public function testMakeEnumWithCustomName(): void
+    {
+        $customName = 'CustomName';
+        $enumType = new LaravelEnumType(UserType::class, $customName);
+
+        $this->assertSame($customName, $enumType->name);
+    }
+
     public function testUseLaravelEnumType(): void
     {
         $this->schema = '


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

This allows aliasing enum classes in case of unclear naming or name conflicts.

**Changes**

By default, the generated type will be named just like the given class.

```php
$enum = new LaravelEnumType(UserType::class);
var_dump($enum->name); // UserType
```

You may overwrite the name if the default does not fit or you have a name conflict.

```php
$enum = new LaravelEnumType(UserType::class, 'UserKind');
var_dump($enum->name); // UserKind
```

**Breaking changes**

No.
