### PR TITLE
Convert method names fully to test* convention

### DIFF
--- a/tests/Integration/CustomDefaultResolverTest.php
+++ b/tests/Integration/CustomDefaultResolverTest.php
@@ -26,10 +26,7 @@ class CustomDefaultResolverTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     */
-    public function itCanSpecifyACustomDefaultResolver(): void
+    public function testCanSpecifyACustomDefaultResolver(): void
     {
         $previous = Executor::getDefaultFieldResolver();
 

--- a/tests/Integration/Defer/DeferDBTest.php
+++ b/tests/Integration/Defer/DeferDBTest.php
@@ -35,10 +35,7 @@ class DeferDBTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanDeferBelongsToFields(): void
+    public function testCanDeferBelongsToFields(): void
     {
         $company = factory(Company::class)->create();
         $user = factory(User::class)->create([
@@ -93,10 +90,7 @@ class DeferDBTest extends DBTestCase
         $this->assertSame($company->name, Arr::get($deferredCompany['user.company']['data'], 'name'));
     }
 
-    /**
-     * @test
-     */
-    public function itCanDeferNestedRelationshipFields(): void
+    public function testCanDeferNestedRelationshipFields(): void
     {
         $company = factory(Company::class)->create();
         $users = factory(User::class, 5)->create([
@@ -170,10 +164,7 @@ class DeferDBTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanDeferNestedListFields(): void
+    public function testCanDeferNestedListFields(): void
     {
         /** @var \Illuminate\Database\Eloquent\Collection<\Tests\Utils\Models\Company> $companies */
         $companies = factory(Company::class, 2)

--- a/tests/Integration/Defer/DeferTest.php
+++ b/tests/Integration/Defer/DeferTest.php
@@ -33,10 +33,7 @@ class DeferTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itAddsTheDeferClientDirective(): void
+    public function testAddsTheDeferClientDirective(): void
     {
         $this->schema = $this->placeholderQuery();
 
@@ -58,10 +55,7 @@ class DeferTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanDeferFields(): void
+    public function testCanDeferFields(): void
     {
         self::$data = [
             'name' => 'John Doe',
@@ -114,10 +108,7 @@ class DeferTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanDeferNestedFields(): void
+    public function testCanDeferNestedFields(): void
     {
         self::$data = [
             'name' => 'John Doe',
@@ -170,10 +161,7 @@ class DeferTest extends TestCase
         $this->assertSame(self::$data['parent']['parent']['name'], $nestedDeferred['data']['name']);
     }
 
-    /**
-     * @test
-     */
-    public function itCanDeferNestedFieldsOnMutations(): void
+    public function testCanDeferNestedFieldsOnMutations(): void
     {
         self::$data = [
             'name' => 'John Doe',
@@ -233,10 +221,7 @@ class DeferTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanDeferListFields(): void
+    public function testCanDeferListFields(): void
     {
         self::$data = [
             [
@@ -291,10 +276,7 @@ class DeferTest extends TestCase
         $this->assertSame(self::$data[1]['author']['name'], Arr::get($deferredPost2, 'name'));
     }
 
-    /**
-     * @test
-     */
-    public function itCanDeferGroupedListFields(): void
+    public function testCanDeferGroupedListFields(): void
     {
         self::$data = [
             [
@@ -371,10 +353,7 @@ class DeferTest extends TestCase
         $this->assertSame(self::$data[1]['comments'][0]['message'], Arr::get($deferredComment2[0], 'message'));
     }
 
-    /**
-     * @test
-     */
-    public function itCancelsDefermentAfterMaxExecutionTime(): void
+    public function testCancelsDefermentAfterMaxExecutionTime(): void
     {
         $this->schema = "
         type User {
@@ -429,10 +408,7 @@ class DeferTest extends TestCase
         $this->assertSame(self::$data['parent']['parent']['name'], $deferred['data']['parent']['name']);
     }
 
-    /**
-     * @test
-     */
-    public function itCancelsDefermentAfterMaxNestedFields(): void
+    public function testCancelsDefermentAfterMaxNestedFields(): void
     {
         $this->schema = "
         type User {
@@ -485,10 +461,7 @@ class DeferTest extends TestCase
         $this->assertSame(self::$data['parent']['parent']['name'], $deferred['data']['parent']['name']);
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsExceptionOnNunNullableFields(): void
+    public function testThrowsExceptionOnNunNullableFields(): void
     {
         self::$data = [
             'name' => 'John Doe',
@@ -526,10 +499,7 @@ class DeferTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itDoesNotDeferWithIncludeAndSkipDirectives(): void
+    public function testDoesNotDeferWithIncludeAndSkipDirectives(): void
     {
         self::$data = [
             'name' => 'John Doe',
@@ -582,10 +552,7 @@ class DeferTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itRequiresDeferDirectiveOnAllFieldDeclarations(): void
+    public function testRequiresDeferDirectiveOnAllFieldDeclarations(): void
     {
         self::$data = [
             'name' => 'John Doe',
@@ -627,10 +594,7 @@ class DeferTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsIfTryingToDeferRootMutationFields(): void
+    public function testThrowsIfTryingToDeferRootMutationFields(): void
     {
         self::$data = [
             'name' => 'John Doe',
@@ -667,10 +631,7 @@ class DeferTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itDoesNotDeferFieldsIfFalse(): void
+    public function testDoesNotDeferFieldsIfFalse(): void
     {
         self::$data = [
             'name' => 'John Doe',
@@ -706,10 +667,7 @@ class DeferTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itIncludesErrorsForDeferredFields(): void
+    public function testIncludesErrorsForDeferredFields(): void
     {
         self::$data = [
             'name' => 'John Doe',

--- a/tests/Integration/Events/BuildSchemaStringTest.php
+++ b/tests/Integration/Events/BuildSchemaStringTest.php
@@ -7,10 +7,7 @@ use Nuwave\Lighthouse\Events\BuildSchemaString;
 
 class BuildSchemaStringTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itInjectsSourceSchemaIntoEvent(): void
+    public function testInjectsSourceSchemaIntoEvent(): void
     {
         $schema = $this->placeholderQuery();
 
@@ -24,10 +21,7 @@ class BuildSchemaStringTest extends TestCase
         $this->buildSchema($schema);
     }
 
-    /**
-     * @test
-     */
-    public function itCanAddAdditionalSchemaThroughEvent(): void
+    public function testCanAddAdditionalSchemaThroughEvent(): void
     {
         app('events')->listen(
             BuildSchemaString::class,

--- a/tests/Integration/Events/ManipulateResultTest.php
+++ b/tests/Integration/Events/ManipulateResultTest.php
@@ -9,10 +9,7 @@ use Nuwave\Lighthouse\Events\ManipulateResult;
 
 class ManipulateResultTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itCanManipulateTheResult(): void
+    public function testCanManipulateTheResult(): void
     {
         $this->schema = $this->placeholderQuery();
 

--- a/tests/Integration/Events/RegisterDirectiveNamespacesTest.php
+++ b/tests/Integration/Events/RegisterDirectiveNamespacesTest.php
@@ -32,20 +32,14 @@ class RegisterDirectiveNamespacesTest extends TestCase
         parent::getEnvironmentSetUp($app);
     }
 
-    /**
-     * @test
-     */
-    public function itCanAddAdditionalDirectiveBaseNamespacesThroughEvent(): void
+    public function testCanAddAdditionalDirectiveBaseNamespacesThroughEvent(): void
     {
         $directive = $this->directiveFactory->create('foo');
 
         $this->assertInstanceOf(FooDirective::class, $directive);
     }
 
-    /**
-     * @test
-     */
-    public function itCanOverwriteDefaultDirectiveThroughEvent(): void
+    public function testCanOverwriteDefaultDirectiveThroughEvent(): void
     {
         $directive = $this->directiveFactory->create('field');
 

--- a/tests/Integration/Execution/BuilderTest.php
+++ b/tests/Integration/Execution/BuilderTest.php
@@ -26,10 +26,7 @@ class BuilderTest extends DBTestCase
         ';
     }
 
-    /**
-     * @test
-     */
-    public function itCanAttachEqFilterToQuery(): void
+    public function testCanAttachEqFilterToQuery(): void
     {
         $this->schema .= '
         type Query {
@@ -46,10 +43,7 @@ class BuilderTest extends DBTestCase
         ')->assertJsonCount(1, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itCanAttachEqFilterFromInputObject(): void
+    public function testCanAttachEqFilterFromInputObject(): void
     {
         $this->schema .= '
         type Query {
@@ -74,10 +68,7 @@ class BuilderTest extends DBTestCase
         ')->assertJsonCount(1, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itCanAttachNeqFilterToQuery(): void
+    public function testCanAttachNeqFilterToQuery(): void
     {
         $this->schema .= '
         type Query {
@@ -94,10 +85,7 @@ class BuilderTest extends DBTestCase
         ')->assertJsonCount(4, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itCanAttachInFilterToQuery(): void
+    public function testCanAttachInFilterToQuery(): void
     {
         $this->schema .= '
         type Query {
@@ -117,10 +105,7 @@ class BuilderTest extends DBTestCase
         ')->assertJsonCount(2, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itCanAttachNotInFilterToQuery(): void
+    public function testCanAttachNotInFilterToQuery(): void
     {
         $this->schema .= '
         type Query {
@@ -140,10 +125,7 @@ class BuilderTest extends DBTestCase
         ')->assertJsonCount(3, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itCanAttachWhereFilterToQuery(): void
+    public function testCanAttachWhereFilterToQuery(): void
     {
         $this->schema .= '
         type Query {
@@ -162,10 +144,7 @@ class BuilderTest extends DBTestCase
         ')->assertJsonCount(4, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itCanAttachTwoWhereFilterWithTheSameKeyToQuery(): void
+    public function testCanAttachTwoWhereFilterWithTheSameKeyToQuery(): void
     {
         $this->schema .= '
         type Query {
@@ -188,10 +167,7 @@ class BuilderTest extends DBTestCase
         ')->assertJsonCount(3, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itCanAttachWhereBetweenFilterToQuery(): void
+    public function testCanAttachWhereBetweenFilterToQuery(): void
     {
         $this->schema .= '
         type Query {
@@ -223,10 +199,7 @@ class BuilderTest extends DBTestCase
         ')->assertJsonCount(2, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itCanUseInputObjectsForWhereBetweenFilter(): void
+    public function testCanUseInputObjectsForWhereBetweenFilter(): void
     {
         $this->schema .= '
         type Query {
@@ -266,10 +239,7 @@ class BuilderTest extends DBTestCase
         ')->assertJsonCount(2, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itCanAttachWhereNotBetweenFilterToQuery(): void
+    public function testCanAttachWhereNotBetweenFilterToQuery(): void
     {
         $this->schema .= '
         type Query {
@@ -301,10 +271,7 @@ class BuilderTest extends DBTestCase
         ')->assertJsonCount(3, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itCanAttachWhereClauseFilterToQuery(): void
+    public function testCanAttachWhereClauseFilterToQuery(): void
     {
         $this->schema .= '
         type Query {
@@ -333,10 +300,7 @@ class BuilderTest extends DBTestCase
         ')->assertJsonCount(2, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itOnlyProcessesFilledArguments(): void
+    public function testOnlyProcessesFilledArguments(): void
     {
         $this->schema .= '
         type Query {

--- a/tests/Integration/Execution/DataLoader/BatchLoaderTest.php
+++ b/tests/Integration/Execution/DataLoader/BatchLoaderTest.php
@@ -8,10 +8,7 @@ use Tests\Utils\Models\User;
 
 class BatchLoaderTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itCanResolveBatchedFieldsFromBatchedRequests(): void
+    public function testCanResolveBatchedFieldsFromBatchedRequests(): void
     {
         $users = factory(User::class, 2)
             ->create()

--- a/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
@@ -68,10 +68,7 @@ class BelongsToManyTest extends DBTestCase
         $this->schema .= $this->placeholderQuery();
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateWithNewBelongsToMany(): void
+    public function testCanCreateWithNewBelongsToMany(): void
     {
         $this->graphQL('
         mutation {
@@ -110,10 +107,7 @@ class BelongsToManyTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateAndConnectWithBelongsToMany(): void
+    public function testCanCreateAndConnectWithBelongsToMany(): void
     {
         factory(User::class)->create(['name' => 'user_one']);
         factory(User::class)->create(['name' => 'user_two']);
@@ -156,10 +150,7 @@ class BelongsToManyTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateWithBelongsToMany(): void
+    public function testCanCreateWithBelongsToMany(): void
     {
         factory(Role::class)->create([
             'name' => 'is_admin',
@@ -212,10 +203,7 @@ class BelongsToManyTest extends DBTestCase
         $this->assertSame('is_user', $role->name);
     }
 
-    /**
-     * @test
-     */
-    public function itCanUpdateWithBelongsToMany(): void
+    public function testCanUpdateWithBelongsToMany(): void
     {
         factory(Role::class)
             ->create([
@@ -275,10 +263,7 @@ class BelongsToManyTest extends DBTestCase
         $this->assertSame('is_user', $role->name);
     }
 
-    /**
-     * @test
-     */
-    public function itCanDeleteWithBelongsToMany(): void
+    public function testCanDeleteWithBelongsToMany(): void
     {
         factory(Role::class)
             ->create([
@@ -328,10 +313,7 @@ class BelongsToManyTest extends DBTestCase
         $this->assertNotNull(User::find(2));
     }
 
-    /**
-     * @test
-     */
-    public function itCanConnectWithBelongsToMany(): void
+    public function testCanConnectWithBelongsToMany(): void
     {
         factory(User::class)->create();
         factory(Role::class)
@@ -377,10 +359,7 @@ class BelongsToManyTest extends DBTestCase
         $this->assertCount(2, $role->users()->get());
     }
 
-    /**
-     * @test
-     */
-    public function itCanSyncWithBelongsToMany(): void
+    public function testCanSyncWithBelongsToMany(): void
     {
         factory(User::class)->create();
         factory(Role::class)
@@ -426,10 +405,7 @@ class BelongsToManyTest extends DBTestCase
         $this->assertCount(2, $role->users()->get());
     }
 
-    /**
-     * @test
-     */
-    public function itCanDisconnectWithBelongsToMany(): void
+    public function testCanDisconnectWithBelongsToMany(): void
     {
         factory(Role::class)
             ->create()
@@ -473,10 +449,7 @@ class BelongsToManyTest extends DBTestCase
         $this->assertNotNull(User::find(2));
     }
 
-    /**
-     * @test
-     */
-    public function itCanSyncExistingUsersDuringCreateToABelongsToManyRelation(): void
+    public function testCanSyncExistingUsersDuringCreateToABelongsToManyRelation(): void
     {
         factory(User::class, 2)->create();
 
@@ -515,10 +488,7 @@ class BelongsToManyTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanDisconnectAllRelatedModelsOnEmptySync(): void
+    public function testCanDisconnectAllRelatedModelsOnEmptySync(): void
     {
         /** @var User $user */
         $user = factory(User::class)->create();

--- a/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
@@ -64,10 +64,7 @@ class BelongsToTest extends DBTestCase
         $this->schema .= $this->placeholderQuery();
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateAndConnectWithBelongsTo(): void
+    public function testCanCreateAndConnectWithBelongsTo(): void
     {
         factory(User::class)->create();
 
@@ -99,10 +96,7 @@ class BelongsToTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateWithNewBelongsTo(): void
+    public function testCanCreateWithNewBelongsTo(): void
     {
         $this->graphQL('
         mutation {
@@ -134,10 +128,7 @@ class BelongsToTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateAndUpdateBelongsTo(): void
+    public function testCanCreateAndUpdateBelongsTo(): void
     {
         factory(User::class)->create([
             'name' => 'foo',
@@ -176,10 +167,7 @@ class BelongsToTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanUpdateAndDisconnectBelongsTo(): void
+    public function testCanUpdateAndDisconnectBelongsTo(): void
     {
         factory(Task::class)->create();
 
@@ -220,10 +208,7 @@ class BelongsToTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanUpdateAndDeleteBelongsTo(): void
+    public function testCanUpdateAndDeleteBelongsTo(): void
     {
         factory(Task::class)->create();
 
@@ -264,10 +249,7 @@ class BelongsToTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itDoesNotDeleteOrDisconnectOnFalsyValues(): void
+    public function testDoesNotDeleteOrDisconnectOnFalsyValues(): void
     {
         factory(Task::class)->create();
 

--- a/tests/Integration/Execution/MutationExecutor/HasManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasManyTest.php
@@ -63,10 +63,7 @@ class HasManyTest extends DBTestCase
         $this->schema .= $this->placeholderQuery();
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateWithNewHasMany(): void
+    public function testCanCreateWithNewHasMany(): void
     {
         $this->graphQL('
         mutation {
@@ -102,10 +99,7 @@ class HasManyTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateHasMany(): void
+    public function testCanCreateHasMany(): void
     {
         factory(User::class)->create();
 
@@ -144,10 +138,7 @@ class HasManyTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanUpdateHasMany(): void
+    public function testCanUpdateHasMany(): void
     {
         factory(User::class)
             ->create()
@@ -192,10 +183,7 @@ class HasManyTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanDeleteHasMany(): void
+    public function testCanDeleteHasMany(): void
     {
         factory(User::class)
             ->create()

--- a/tests/Integration/Execution/MutationExecutor/HasOneTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasOneTest.php
@@ -64,10 +64,7 @@ class HasOneTest extends DBTestCase
         $this->schema .= $this->placeholderQuery();
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateWithNewHasOne(): void
+    public function testCanCreateWithNewHasOne(): void
     {
         $this->graphQL('
         mutation {
@@ -101,10 +98,7 @@ class HasOneTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanUpdateWithNewHasOne(): void
+    public function testCanUpdateWithNewHasOne(): void
     {
         factory(Task::class)->create();
 
@@ -141,10 +135,7 @@ class HasOneTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanUpdateAndUpdateHasOne(): void
+    public function testCanUpdateAndUpdateHasOne(): void
     {
         factory(Task::class)
             ->create()
@@ -187,10 +178,7 @@ class HasOneTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanUpdateAndDeleteHasOne(): void
+    public function testCanUpdateAndDeleteHasOne(): void
     {
         factory(Task::class)
             ->create()

--- a/tests/Integration/Execution/MutationExecutor/MorphManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphManyTest.php
@@ -62,10 +62,7 @@ class MorphManyTest extends DBTestCase
         $this->schema .= $this->placeholderQuery();
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateWithNewMorphMany(): void
+    public function testCanCreateWithNewMorphMany(): void
     {
         $this->graphQL('
         mutation {
@@ -99,10 +96,7 @@ class MorphManyTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanUpdateWithNewMorphMany(): void
+    public function testCanUpdateWithNewMorphMany(): void
     {
         factory(Task::class)->create();
 
@@ -139,10 +133,7 @@ class MorphManyTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanUpdateAndUpdateMorphMany(): void
+    public function testCanUpdateAndUpdateMorphMany(): void
     {
         factory(Task::class)
             ->create()
@@ -185,10 +176,7 @@ class MorphManyTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanUpdateAndDeleteMorphMany(): void
+    public function testCanUpdateAndDeleteMorphMany(): void
     {
         factory(Task::class)
             ->create()

--- a/tests/Integration/Execution/MutationExecutor/MorphOneTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphOneTest.php
@@ -62,10 +62,7 @@ class MorphOneTest extends DBTestCase
         $this->schema .= $this->placeholderQuery();
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateWithNewMorphOne(): void
+    public function testCanCreateWithNewMorphOne(): void
     {
         $this->graphQL('
         mutation {
@@ -97,10 +94,7 @@ class MorphOneTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanUpdateWithNewMorphOne(): void
+    public function testCanUpdateWithNewMorphOne(): void
     {
         factory(Task::class)->create();
 
@@ -135,10 +129,7 @@ class MorphOneTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanUpdateAndUpdateMorphOne(): void
+    public function testCanUpdateAndUpdateMorphOne(): void
     {
         factory(Task::class)
             ->create()
@@ -179,10 +170,7 @@ class MorphOneTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanUpdateAndDeleteMorphOne(): void
+    public function testCanUpdateAndDeleteMorphOne(): void
     {
         factory(Task::class)
             ->create()

--- a/tests/Integration/Execution/MutationExecutor/MorphToManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToManyTest.php
@@ -46,10 +46,7 @@ class MorphToManyTest extends DBTestCase
         $this->schema .= $this->placeholderQuery();
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateATaskWithExistingTagsByUsingConnect(): void
+    public function testCanCreateATaskWithExistingTagsByUsingConnect(): void
     {
         $id = factory(Tag::class)->create(['name' => 'php'])->id;
 
@@ -79,10 +76,7 @@ class MorphToManyTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateATaskWithExistingTagsByUsingSync(): void
+    public function testCanCreateATaskWithExistingTagsByUsingSync(): void
     {
         $id = factory(Tag::class)->create(['name' => 'php'])->id;
 
@@ -112,10 +106,7 @@ class MorphToManyTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateANewTagRelationByUsingCreate(): void
+    public function testCanCreateANewTagRelationByUsingCreate(): void
     {
         $this->graphQL('
         mutation {

--- a/tests/Integration/Execution/MutationExecutor/MorphToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToTest.php
@@ -62,10 +62,7 @@ class MorphToTest extends DBTestCase
         $this->schema .= $this->placeholderQuery();
     }
 
-    /**
-     * @test
-     */
-    public function itConnectsMorphTo(): void
+    public function testConnectsMorphTo(): void
     {
         factory(Task::class)->create(['name' => 'first_task']);
 
@@ -102,10 +99,7 @@ class MorphToTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itDisconnectsMorphTo(): void
+    public function testDisconnectsMorphTo(): void
     {
         /** @var \Tests\Utils\Models\Task $task */
         $task = factory(Task::class)->create(['name' => 'first_task']);
@@ -139,10 +133,7 @@ class MorphToTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itDeletesMorphTo(): void
+    public function testDeletesMorphTo(): void
     {
         /** @var \Tests\Utils\Models\Task $task */
         $task = factory(Task::class)->create(['name' => 'first_task']);

--- a/tests/Integration/GraphQLTest.php
+++ b/tests/Integration/GraphQLTest.php
@@ -64,10 +64,7 @@ class GraphQLTest extends DBTestCase
         $this->be($this->user);
     }
 
-    /**
-     * @test
-     */
-    public function itResolvesQueryViaPostRequest(): void
+    public function testResolvesQueryViaPostRequest(): void
     {
         $this->graphQL('
         query UserWithTasks {
@@ -94,10 +91,7 @@ class GraphQLTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itResolvesQueryViaGetRequest(): void
+    public function testResolvesQueryViaGetRequest(): void
     {
         $this->getJson(
             'graphql?'
@@ -128,10 +122,7 @@ class GraphQLTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveBatchedQueries(): void
+    public function testCanResolveBatchedQueries(): void
     {
         $this->postGraphQL([
             [
@@ -170,10 +161,7 @@ class GraphQLTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itResolvesNamedOperation(): void
+    public function testResolvesNamedOperation(): void
     {
         $this->postGraphQL([
             'query' => '
@@ -198,10 +186,7 @@ class GraphQLTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itRejectsInvalidQuery(): void
+    public function testRejectsInvalidQuery(): void
     {
         $result = $this->graphQL('
         {
@@ -220,10 +205,7 @@ class GraphQLTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itIgnoresInvalidJSONVariables(): void
+    public function testIgnoresInvalidJSONVariables(): void
     {
         $result = $this->postGraphQL([
             'query' => '{}',
@@ -233,10 +215,7 @@ class GraphQLTest extends DBTestCase
         $result->assertStatus(200);
     }
 
-    /**
-     * @test
-     */
-    public function itResolvesQueryViaMultipartRequest(): void
+    public function testResolvesQueryViaMultipartRequest(): void
     {
         $this->multipartGraphQL(
             [
@@ -261,10 +240,9 @@ class GraphQLTest extends DBTestCase
     }
 
     /**
-     * @test
      * https://github.com/jaydenseric/graphql-multipart-request-spec#single-file
      */
-    public function itResolvesUploadViaMultipartRequest(): void
+    public function testResolvesUploadViaMultipartRequest(): void
     {
         $this->multipartGraphQL(
             [
@@ -295,10 +273,9 @@ class GraphQLTest extends DBTestCase
     }
 
     /**
-     * @test
      * https://github.com/jaydenseric/graphql-multipart-request-spec#batching
      */
-    public function itResolvesUploadViaBatchedMultipartRequest(): void
+    public function testResolvesUploadViaBatchedMultipartRequest(): void
     {
         $this->multipartGraphQL(
             [

--- a/tests/Integration/GraphQLTest.php
+++ b/tests/Integration/GraphQLTest.php
@@ -240,7 +240,7 @@ class GraphQLTest extends DBTestCase
     }
 
     /**
-     * https://github.com/jaydenseric/graphql-multipart-request-spec#single-file
+     * https://github.com/jaydenseric/graphql-multipart-request-spec#single-file.
      */
     public function testResolvesUploadViaMultipartRequest(): void
     {
@@ -273,7 +273,7 @@ class GraphQLTest extends DBTestCase
     }
 
     /**
-     * https://github.com/jaydenseric/graphql-multipart-request-spec#batching
+     * https://github.com/jaydenseric/graphql-multipart-request-spec#batching.
      */
     public function testResolvesUploadViaBatchedMultipartRequest(): void
     {

--- a/tests/Integration/IntrospectionTest.php
+++ b/tests/Integration/IntrospectionTest.php
@@ -26,10 +26,7 @@ class IntrospectionTest extends TestCase
         $this->typeRegistry = $this->app->make(TypeRegistry::class);
     }
 
-    /**
-     * @test
-     */
-    public function itFindsTypesFromSchema(): void
+    public function testFindsTypesFromSchema(): void
     {
         $this->schema = '
         type Foo {
@@ -49,10 +46,7 @@ class IntrospectionTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itFindsManuallyRegisteredTypes(): void
+    public function testFindsManuallyRegisteredTypes(): void
     {
         $this->schema = $this->placeholderQuery();
         $this->typeRegistry->register(

--- a/tests/Integration/Models/UserTest.php
+++ b/tests/Integration/Models/UserTest.php
@@ -8,20 +8,14 @@ use Illuminate\Support\Facades\DB;
 
 class UserTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itCanInsertRecordsIntoTestDB(): void
+    public function testCanInsertRecordsIntoTestDB(): void
     {
         factory(User::class, 2)->create();
 
         $this->assertCount(2, DB::table('users')->get());
     }
 
-    /**
-     * @test
-     */
-    public function itRefreshesDB(): void
+    public function testRefreshesDB(): void
     {
         $this->assertCount(0, DB::table('users')->get());
     }

--- a/tests/Integration/MultipleRequestsTest.php
+++ b/tests/Integration/MultipleRequestsTest.php
@@ -6,10 +6,7 @@ use Tests\TestCase;
 
 class MultipleRequestsTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itCanFireMultipleRequestsInOneTest(): void
+    public function testCanFireMultipleRequestsInOneTest(): void
     {
         $this->schema = '
         type Query {

--- a/tests/Integration/Schema/Directives/AllDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/AllDirectiveTest.php
@@ -8,10 +8,7 @@ use Tests\Utils\Models\User;
 
 class AllDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itCanGetAllModelsAsRootField(): void
+    public function testCanGetAllModelsAsRootField(): void
     {
         factory(User::class, 2)->create();
 
@@ -36,10 +33,7 @@ class AllDirectiveTest extends DBTestCase
         ')->assertJsonCount(2, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itCanGetAllAsNestedField(): void
+    public function testCanGetAllAsNestedField(): void
     {
         factory(Post::class, 2)->create([
             // Do not create those, as they would create more users
@@ -96,10 +90,7 @@ class AllDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanGetAllModelsFiltered(): void
+    public function testCanGetAllModelsFiltered(): void
     {
         $users = factory(User::class, 3)->create();
         $userName = $users->first()->name;

--- a/tests/Integration/Schema/Directives/BelongsToDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/BelongsToDirectiveTest.php
@@ -43,10 +43,7 @@ class BelongsToDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveBelongsToRelationship(): void
+    public function testCanResolveBelongsToRelationship(): void
     {
         $this->be($this->user);
 
@@ -83,10 +80,7 @@ class BelongsToDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveBelongsToWithCustomName(): void
+    public function testCanResolveBelongsToWithCustomName(): void
     {
         $this->be($this->user);
 
@@ -123,10 +117,7 @@ class BelongsToDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveBelongsToRelationshipWithTwoRelation(): void
+    public function testCanResolveBelongsToRelationshipWithTwoRelation(): void
     {
         $this->be($this->user);
 
@@ -174,10 +165,7 @@ class BelongsToDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveBelongsToRelationshipWhenMainModelHasCompositePrimaryKey(): void
+    public function testCanResolveBelongsToRelationshipWhenMainModelHasCompositePrimaryKey(): void
     {
         $this->be($this->user);
 

--- a/tests/Integration/Schema/Directives/BelongsToManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/BelongsToManyDirectiveTest.php
@@ -46,10 +46,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
         $this->be($this->user);
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryBelongsToManyRelationship(): void
+    public function testCanQueryBelongsToManyRelationship(): void
     {
         $this->schema = '
         type User {
@@ -77,10 +74,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
         ')->assertJsonCount($this->rolesCount, 'data.user.roles');
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryBelongsToManyPaginator(): void
+    public function testCanQueryBelongsToManyPaginator(): void
     {
         $this->schema = '
         type User {
@@ -127,10 +121,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
         ])->assertJsonCount(2, 'data.user.roles.data');
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryBelongsToManyRelayConnection(): void
+    public function testCanQueryBelongsToManyRelayConnection(): void
     {
         $this->schema = '
         type User {
@@ -175,10 +166,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
         ])->assertJsonCount(2, 'data.user.roles.edges');
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryBelongsToManyRelayConnectionWithCustomEdgeUsingDirective(): void
+    public function testCanQueryBelongsToManyRelayConnectionWithCustomEdgeUsingDirective(): void
     {
         $this->schema = '
         type User {
@@ -229,10 +217,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
         ])->assertJsonCount(2, 'data.user.roles.edges');
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsExceptionForInvalidEdgeTypeFromDirective(): void
+    public function testThrowsExceptionForInvalidEdgeTypeFromDirective(): void
     {
         $this->schema = '
         type User {
@@ -267,10 +252,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
         ');
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryBelongsToManyRelayConnectionWithCustomMagicEdge(): void
+    public function testCanQueryBelongsToManyRelayConnectionWithCustomMagicEdge(): void
     {
         $this->schema = '
         type User {
@@ -324,10 +306,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
         ])->assertJsonCount(2, 'data.user.roles.edges');
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryBelongsToManyNestedRelationships(): void
+    public function testCanQueryBelongsToManyNestedRelationships(): void
     {
         $this->schema = '
         type User {
@@ -398,10 +377,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
         $this->assertSame(Arr::get($userRolesEdges, 'node.1.acl.id'), Arr::get($nestedUserRolesEdges, 'node.1.acl.id'));
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsErrorWithUnknownTypeArg(): void
+    public function testThrowsErrorWithUnknownTypeArg(): void
     {
         $this->expectExceptionMessageRegExp('/^Found invalid pagination type/');
 

--- a/tests/Integration/Schema/Directives/BuilderDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/BuilderDirectiveTest.php
@@ -7,10 +7,7 @@ use Tests\Utils\Models\User;
 
 class BuilderDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itCallsCustomBuilderMethod(): void
+    public function testCallsCustomBuilderMethod(): void
     {
         $this->schema = '
         type Query {

--- a/tests/Integration/Schema/Directives/CacheDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/CacheDirectiveTest.php
@@ -24,10 +24,7 @@ class CacheDirectiveTest extends DBTestCase
         $this->cache = $app->make('cache');
     }
 
-    /**
-     * @test
-     */
-    public function itCanStoreResolverResultInCache(): void
+    public function testCanStoreResolverResultInCache(): void
     {
         $this->schema = "
         type User {
@@ -57,10 +54,7 @@ class CacheDirectiveTest extends DBTestCase
         $this->assertSame('foobar', $this->cache->get('user:1:name'));
     }
 
-    /**
-     * @test
-     */
-    public function itCanPlaceCacheKeyOnAnyField(): void
+    public function testCanPlaceCacheKeyOnAnyField(): void
     {
         $this->schema = "
         type User {
@@ -91,10 +85,7 @@ class CacheDirectiveTest extends DBTestCase
         $this->assertSame('foobar', $this->cache->get('user:foo@bar.com:name'));
     }
 
-    /**
-     * @test
-     */
-    public function itCanStoreResolverResultInPrivateCache(): void
+    public function testCanStoreResolverResultInPrivateCache(): void
     {
         $user = factory(User::class)->create();
         $this->be($user);
@@ -128,10 +119,7 @@ class CacheDirectiveTest extends DBTestCase
         $this->assertSame('foobar', $this->cache->get($cacheKey));
     }
 
-    /**
-     * @test
-     */
-    public function itCanStoreResolverResultInCacheWhenUseModelDirective(): void
+    public function testCanStoreResolverResultInCacheWhenUseModelDirective(): void
     {
         $this->schema = "
         type Post {
@@ -165,10 +153,7 @@ class CacheDirectiveTest extends DBTestCase
         $this->assertSame('foobar', $this->cache->get('user:1:name'));
     }
 
-    /**
-     * @test
-     */
-    public function itFallsBackToPublicCacheIfUserIsNotAuthenticated(): void
+    public function testFallsBackToPublicCacheIfUserIsNotAuthenticated(): void
     {
         $this->schema = "
         type User {
@@ -198,10 +183,7 @@ class CacheDirectiveTest extends DBTestCase
         $this->assertSame('foobar', $this->cache->get('user:1:name'));
     }
 
-    /**
-     * @test
-     */
-    public function itCanStorePaginateResolverInCache(): void
+    public function testCanStorePaginateResolverInCache(): void
     {
         factory(User::class, 5)->create();
 
@@ -233,10 +215,7 @@ class CacheDirectiveTest extends DBTestCase
         $this->assertCount(5, $result);
     }
 
-    /**
-     * @test
-     */
-    public function itCanCacheHasManyResolver(): void
+    public function testCanCacheHasManyResolver(): void
     {
         $user = factory(User::class)->create();
 
@@ -297,10 +276,7 @@ class CacheDirectiveTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanAttachTagsToCache(): void
+    public function testCanAttachTagsToCache(): void
     {
         config(['lighthouse.cache.tags' => true]);
 

--- a/tests/Integration/Schema/Directives/CreateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/CreateDirectiveTest.php
@@ -9,10 +9,7 @@ use Tests\Utils\Models\User;
 
 class CreateDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itCanCreateFromFieldArguments(): void
+    public function testCanCreateFromFieldArguments(): void
     {
         $this->schema = '
         type Company {
@@ -42,10 +39,7 @@ class CreateDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateFromInputObject(): void
+    public function testCanCreateFromInputObject(): void
     {
         $this->schema = '
         type Company {
@@ -81,10 +75,7 @@ class CreateDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCreatesAnEntryWithDatabaseDefaultsAndReturnsItImmediately(): void
+    public function testCreatesAnEntryWithDatabaseDefaultsAndReturnsItImmediately(): void
     {
         $this->schema = '
         type Mutation {
@@ -114,10 +105,7 @@ class CreateDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itDoesNotCreateWithFailingRelationship(): void
+    public function testDoesNotCreateWithFailingRelationship(): void
     {
         factory(Task::class)->create(['name' => 'Uniq']);
 
@@ -183,10 +171,7 @@ class CreateDirectiveTest extends DBTestCase
         $this->assertCount(1, User::all());
     }
 
-    /**
-     * @test
-     */
-    public function itDoesCreateWithFailingRelationshipAndTransactionParam(): void
+    public function testDoesCreateWithFailingRelationshipAndTransactionParam(): void
     {
         factory(Task::class)->create(['name' => 'Uniq']);
 
@@ -257,10 +242,7 @@ class CreateDirectiveTest extends DBTestCase
         $this->assertCount(2, User::all());
     }
 
-    /**
-     * @test
-     */
-    public function itDoesNotFailWhenPropertyNameMatchesModelsNativeMethods(): void
+    public function testDoesNotFailWhenPropertyNameMatchesModelsNativeMethods(): void
     {
         $this->schema = '
         type Task {

--- a/tests/Integration/Schema/Directives/DeleteDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/DeleteDirectiveTest.php
@@ -8,10 +8,7 @@ use Nuwave\Lighthouse\Exceptions\DirectiveException;
 
 class DeleteDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itDeletesUserAndReturnsIt(): void
+    public function testDeletesUserAndReturnsIt(): void
     {
         factory(User::class)->create();
 
@@ -42,10 +39,7 @@ class DeleteDirectiveTest extends DBTestCase
         $this->assertCount(0, User::all());
     }
 
-    /**
-     * @test
-     */
-    public function itDeletesMultipleUsersAndReturnsThem(): void
+    public function testDeletesMultipleUsersAndReturnsThem(): void
     {
         factory(User::class, 2)->create();
 
@@ -71,10 +65,7 @@ class DeleteDirectiveTest extends DBTestCase
         $this->assertCount(0, User::all());
     }
 
-    /**
-     * @test
-     */
-    public function itRejectsDefinitionWithNullableArgument(): void
+    public function testRejectsDefinitionWithNullableArgument(): void
     {
         $this->expectException(DirectiveException::class);
 
@@ -90,10 +81,7 @@ class DeleteDirectiveTest extends DBTestCase
         ');
     }
 
-    /**
-     * @test
-     */
-    public function itRejectsDefinitionWithNoArgument(): void
+    public function testRejectsDefinitionWithNoArgument(): void
     {
         $this->expectException(DirectiveException::class);
 
@@ -108,10 +96,7 @@ class DeleteDirectiveTest extends DBTestCase
         ');
     }
 
-    /**
-     * @test
-     */
-    public function itRejectsDefinitionWithMultipleArguments(): void
+    public function testRejectsDefinitionWithMultipleArguments(): void
     {
         $this->expectException(DirectiveException::class);
 

--- a/tests/Integration/Schema/Directives/EventDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/EventDirectiveTest.php
@@ -8,10 +8,7 @@ use Illuminate\Support\Facades\Event;
 
 class EventDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itDispatchesAnEvent(): void
+    public function testDispatchesAnEvent(): void
     {
         Event::fake([
             CompanyWasCreatedEvent::class,

--- a/tests/Integration/Schema/Directives/FindDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/FindDirectiveTest.php
@@ -8,10 +8,7 @@ use Tests\Utils\Models\Company;
 
 class FindDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itReturnsSingleUser(): void
+    public function testReturnsSingleUser(): void
     {
         $userA = factory(User::class)->create(['name' => 'A']);
         $userB = factory(User::class)->create(['name' => 'B']);
@@ -41,10 +38,7 @@ class FindDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itDefaultsToFieldTypeIfNoModelIsSupplied(): void
+    public function testDefaultsToFieldTypeIfNoModelIsSupplied(): void
     {
         $userA = factory(User::class)->create(['name' => 'A']);
         $userB = factory(User::class)->create(['name' => 'B']);
@@ -71,10 +65,7 @@ class FindDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCannotFetchIfMultipleModelsMatch(): void
+    public function testCannotFetchIfMultipleModelsMatch(): void
     {
         factory(User::class)->create(['name' => 'A']);
         factory(User::class)->create(['name' => 'A']);
@@ -100,10 +91,7 @@ class FindDirectiveTest extends DBTestCase
         ')->assertJsonCount(1, 'errors');
     }
 
-    /**
-     * @test
-     */
-    public function itCanUseScopes(): void
+    public function testCanUseScopes(): void
     {
         $companyA = factory(Company::class)->create(['name' => 'CompanyA']);
         $companyB = factory(Company::class)->create(['name' => 'CompanyB']);
@@ -143,10 +131,7 @@ class FindDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itReturnsAnEmptyObjectWhenTheModelIsNotFound(): void
+    public function testReturnsAnEmptyObjectWhenTheModelIsNotFound(): void
     {
         $this->schema = '
         type User {

--- a/tests/Integration/Schema/Directives/FirstDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/FirstDirectiveTest.php
@@ -7,10 +7,7 @@ use Tests\Utils\Models\User;
 
 class FirstDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itReturnsASingleUser(): void
+    public function testReturnsASingleUser(): void
     {
         $this->schema = '
         type User {
@@ -42,10 +39,7 @@ class FirstDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itReturnsASingleUserWhenMultiplesMatch(): void
+    public function testReturnsASingleUserWhenMultiplesMatch(): void
     {
         $this->schema = '
         type User {

--- a/tests/Integration/Schema/Directives/HasManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/HasManyDirectiveTest.php
@@ -42,10 +42,7 @@ class HasManyDirectiveTest extends DBTestCase
         $this->be($this->user);
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryHasManyRelationship(): void
+    public function testCanQueryHasManyRelationship(): void
     {
         $this->schema = '
         type User {
@@ -80,10 +77,7 @@ class HasManyDirectiveTest extends DBTestCase
         ')->assertJsonCount(3, 'data.user.tasks');
     }
 
-    /**
-     * @test
-     */
-    public function itCallsScopeWithResolverArgs(): void
+    public function testCallsScopeWithResolverArgs(): void
     {
         $this->assertCount(3, $this->user->tasks);
 
@@ -113,10 +107,7 @@ class HasManyDirectiveTest extends DBTestCase
         ')->assertJsonCount(2, 'data.user.tasks');
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryHasManyPaginator(): void
+    public function testCanQueryHasManyPaginator(): void
     {
         $this->schema = '
         type User {
@@ -167,9 +158,6 @@ class HasManyDirectiveTest extends DBTestCase
         ])->assertJsonCount(2, 'data.user.tasks.data');
     }
 
-    /**
-     * @test
-     */
     public function paginatorTypeIsLimitedByMaxCountFromDirective(): void
     {
         config(['lighthouse.paginate_max_count' => 1]);
@@ -206,10 +194,7 @@ class HasManyDirectiveTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itHandlesPaginationWithCountZero(): void
+    public function testHandlesPaginationWithCountZero(): void
     {
         $this->schema = '
         type User {
@@ -247,9 +232,6 @@ class HasManyDirectiveTest extends DBTestCase
         ])->assertErrorCategory(Error::CATEGORY_GRAPHQL);
     }
 
-    /**
-     * @test
-     */
     public function relayTypeIsLimitedByMaxCountFromDirective(): void
     {
         config(['lighthouse.paginate_max_count' => 1]);
@@ -288,9 +270,6 @@ class HasManyDirectiveTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
     public function paginatorTypeIsLimitedToMaxCountFromConfig(): void
     {
         config(['lighthouse.paginate_max_count' => 2]);
@@ -327,9 +306,6 @@ class HasManyDirectiveTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
     public function relayTypeIsLimitedToMaxCountFromConfig(): void
     {
         config(['lighthouse.paginate_max_count' => 2]);
@@ -368,10 +344,7 @@ class HasManyDirectiveTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itUsesEdgeTypeForRelayConnections(): void
+    public function testUsesEdgeTypeForRelayConnections(): void
     {
         $this->schema = '
         type User {
@@ -415,10 +388,7 @@ class HasManyDirectiveTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryHasManyPaginatorWithADefaultCount(): void
+    public function testCanQueryHasManyPaginatorWithADefaultCount(): void
     {
         $this->schema = '
         type User {
@@ -464,10 +434,7 @@ class HasManyDirectiveTest extends DBTestCase
         ])->assertJsonCount(2, 'data.user.tasks.data');
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryHasManyRelayConnection(): void
+    public function testCanQueryHasManyRelayConnection(): void
     {
         $this->schema = '
         type User {
@@ -511,10 +478,7 @@ class HasManyDirectiveTest extends DBTestCase
         ])->assertJsonCount(2, 'data.user.tasks.edges');
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryHasManyRelayConnectionWithADefaultCount(): void
+    public function testCanQueryHasManyRelayConnectionWithADefaultCount(): void
     {
         $this->schema = '
         type User {
@@ -558,10 +522,7 @@ class HasManyDirectiveTest extends DBTestCase
         ])->assertJsonCount(2, 'data.user.tasks.edges');
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryHasManyNestedRelationships(): void
+    public function testCanQueryHasManyNestedRelationships(): void
     {
         $this->schema = '
         type User {
@@ -616,10 +577,7 @@ class HasManyDirectiveTest extends DBTestCase
         ->assertJsonCount(2, 'data.user.tasks.edges.0.node.user.tasks.edges');
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryHasManySelfReferencingRelationships(): void
+    public function testCanQueryHasManySelfReferencingRelationships(): void
     {
         $post1 = factory(Post::class)->create([
             'id' => 1,
@@ -686,10 +644,7 @@ class HasManyDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsErrorWithUnknownTypeArg(): void
+    public function testThrowsErrorWithUnknownTypeArg(): void
     {
         $this->expectExceptionMessageRegExp('/^Found invalid pagination type/');
 

--- a/tests/Integration/Schema/Directives/HasManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/HasManyDirectiveTest.php
@@ -158,7 +158,7 @@ class HasManyDirectiveTest extends DBTestCase
         ])->assertJsonCount(2, 'data.user.tasks.data');
     }
 
-    public function paginatorTypeIsLimitedByMaxCountFromDirective(): void
+    public function testPaginatorTypeIsLimitedByMaxCountFromDirective(): void
     {
         config(['lighthouse.paginate_max_count' => 1]);
 
@@ -232,7 +232,7 @@ class HasManyDirectiveTest extends DBTestCase
         ])->assertErrorCategory(Error::CATEGORY_GRAPHQL);
     }
 
-    public function relayTypeIsLimitedByMaxCountFromDirective(): void
+    public function testRelayTypeIsLimitedByMaxCountFromDirective(): void
     {
         config(['lighthouse.paginate_max_count' => 1]);
 
@@ -270,7 +270,7 @@ class HasManyDirectiveTest extends DBTestCase
         );
     }
 
-    public function paginatorTypeIsLimitedToMaxCountFromConfig(): void
+    public function testPaginatorTypeIsLimitedToMaxCountFromConfig(): void
     {
         config(['lighthouse.paginate_max_count' => 2]);
 
@@ -306,7 +306,7 @@ class HasManyDirectiveTest extends DBTestCase
         );
     }
 
-    public function relayTypeIsLimitedToMaxCountFromConfig(): void
+    public function testRelayTypeIsLimitedToMaxCountFromConfig(): void
     {
         config(['lighthouse.paginate_max_count' => 2]);
 

--- a/tests/Integration/Schema/Directives/HasOneDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/HasOneDirectiveTest.php
@@ -8,10 +8,7 @@ use Tests\Utils\Models\Task;
 
 class HasOneDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itCanQueryHasOneRelationship(): void
+    public function testCanQueryHasOneRelationship(): void
     {
         // Task with id 1, no post
         factory(Task::class)->create();

--- a/tests/Integration/Schema/Directives/InjectDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/InjectDirectiveTest.php
@@ -7,10 +7,7 @@ use Tests\Utils\Models\User;
 
 class InjectDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itCanCreateFromInputObjectWithDeepInjection(): void
+    public function testCanCreateFromInputObjectWithDeepInjection(): void
     {
         $user = factory(User::class)->create();
         $this->be($user);

--- a/tests/Integration/Schema/Directives/MorphManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/MorphManyDirectiveTest.php
@@ -229,7 +229,7 @@ class MorphManyDirectiveTest extends DBTestCase
         ])->assertJsonCount($this->postHours->count(), 'data.post.hours.data');
     }
 
-    public function paginatorTypeIsLimitedByMaxCountFromDirective(): void
+    public function testPaginatorTypeIsLimitedByMaxCountFromDirective(): void
     {
         config(['lighthouse.paginate_max_count' => 1]);
 
@@ -273,7 +273,7 @@ class MorphManyDirectiveTest extends DBTestCase
         );
     }
 
-    public function paginatorTypeIsLimitedToMaxCountFromConfig(): void
+    public function testPaginatorTypeIsLimitedToMaxCountFromConfig(): void
     {
         config(['lighthouse.paginate_max_count' => 2]);
 
@@ -474,7 +474,7 @@ class MorphManyDirectiveTest extends DBTestCase
         ])->assertJsonCount(3, 'data.task.hours.edges');
     }
 
-    public function relayTypeIsLimitedByMaxCountFromDirective(): void
+    public function testRelayTypeIsLimitedByMaxCountFromDirective(): void
     {
         config(['lighthouse.paginate_max_count' => 1]);
 
@@ -520,7 +520,7 @@ class MorphManyDirectiveTest extends DBTestCase
         );
     }
 
-    public function relayTypeIsLimitedToMaxCountFromConfig(): void
+    public function testRelayTypeIsLimitedToMaxCountFromConfig(): void
     {
         config(['lighthouse.paginate_max_count' => 2]);
 

--- a/tests/Integration/Schema/Directives/MorphManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/MorphManyDirectiveTest.php
@@ -85,10 +85,7 @@ class MorphManyDirectiveTest extends DBTestCase
             });
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryMorphManyRelationship(): void
+    public function testCanQueryMorphManyRelationship(): void
     {
         $this->schema = '
         type Post {
@@ -175,10 +172,7 @@ class MorphManyDirectiveTest extends DBTestCase
             ->assertJsonCount($this->taskHours->count(), 'data.task.hours');
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryMorphManyPaginator(): void
+    public function testCanQueryMorphManyPaginator(): void
     {
         $this->schema = '
         type Post {
@@ -235,9 +229,6 @@ class MorphManyDirectiveTest extends DBTestCase
         ])->assertJsonCount($this->postHours->count(), 'data.post.hours.data');
     }
 
-    /**
-     * @test
-     */
     public function paginatorTypeIsLimitedByMaxCountFromDirective(): void
     {
         config(['lighthouse.paginate_max_count' => 1]);
@@ -282,9 +273,6 @@ class MorphManyDirectiveTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
     public function paginatorTypeIsLimitedToMaxCountFromConfig(): void
     {
         config(['lighthouse.paginate_max_count' => 2]);
@@ -329,10 +317,7 @@ class MorphManyDirectiveTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itHandlesPaginationWithCountZero(): void
+    public function testHandlesPaginationWithCountZero(): void
     {
         $this->schema = '
         type Post {
@@ -379,10 +364,7 @@ class MorphManyDirectiveTest extends DBTestCase
         ])->assertErrorCategory(Error::CATEGORY_GRAPHQL);
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryMorphManyPaginatorWithADefaultCount(): void
+    public function testCanQueryMorphManyPaginatorWithADefaultCount(): void
     {
         $this->schema = '
         type Task {
@@ -438,10 +420,7 @@ class MorphManyDirectiveTest extends DBTestCase
         ])->assertJsonCount(3, 'data.task.hours.data');
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryMorphManyRelayConnection(): void
+    public function testCanQueryMorphManyRelayConnection(): void
     {
         $this->schema = '
         type Task {
@@ -495,9 +474,6 @@ class MorphManyDirectiveTest extends DBTestCase
         ])->assertJsonCount(3, 'data.task.hours.edges');
     }
 
-    /**
-     * @test
-     */
     public function relayTypeIsLimitedByMaxCountFromDirective(): void
     {
         config(['lighthouse.paginate_max_count' => 1]);
@@ -544,9 +520,6 @@ class MorphManyDirectiveTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
     public function relayTypeIsLimitedToMaxCountFromConfig(): void
     {
         config(['lighthouse.paginate_max_count' => 2]);
@@ -593,10 +566,7 @@ class MorphManyDirectiveTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryMorphManyRelayConnectionWithADefaultCount(): void
+    public function testCanQueryMorphManyRelayConnectionWithADefaultCount(): void
     {
         $this->schema = '
         type Task {

--- a/tests/Integration/Schema/Directives/MorphOneDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/MorphOneDirectiveTest.php
@@ -41,10 +41,7 @@ class MorphOneDirectiveTest extends DBTestCase
         $this->hour = $this->task->hours()->save(factory(Hour::class)->create());
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveMorphOneRelationship(): void
+    public function testCanResolveMorphOneRelationship(): void
     {
         $this->schema = '
         type Hour {
@@ -93,10 +90,7 @@ class MorphOneDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveMorphOneWithCustomName(): void
+    public function testCanResolveMorphOneWithCustomName(): void
     {
         $this->schema = '
         type Hour {

--- a/tests/Integration/Schema/Directives/MorphToDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/MorphToDirectiveTest.php
@@ -42,10 +42,7 @@ class MorphToDirectiveTest extends DBTestCase
         $this->hour = $this->task->hours()->save(factory(Hour::class)->create());
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveMorphToRelationship(): void
+    public function testCanResolveMorphToRelationship(): void
     {
         $this->schema = '
         type Hour {
@@ -94,10 +91,7 @@ class MorphToDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveMorphToWithCustomName(): void
+    public function testCanResolveMorphToWithCustomName(): void
     {
         $this->schema = '
         type Hour {
@@ -146,10 +140,7 @@ class MorphToDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveMorphToUsingInterfaces(): void
+    public function testCanResolveMorphToUsingInterfaces(): void
     {
         $post = factory(Post::class)->create([
             'user_id' => $this->user->id,

--- a/tests/Integration/Schema/Directives/PaginateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/PaginateDirectiveTest.php
@@ -11,10 +11,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 class PaginateDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itCanCreateQueryPaginators(): void
+    public function testCanCreateQueryPaginators(): void
     {
         factory(User::class, 10)->create();
 
@@ -57,10 +54,7 @@ class PaginateDirectiveTest extends DBTestCase
         ])->assertJsonCount(5, 'data.users.data');
     }
 
-    /**
-     * @test
-     */
-    public function itHandlesPaginationWithCountZero(): void
+    public function testHandlesPaginationWithCountZero(): void
     {
         $this->schema = '
         type User {
@@ -90,10 +84,7 @@ class PaginateDirectiveTest extends DBTestCase
         ->assertErrorCategory(Error::CATEGORY_GRAPHQL);
     }
 
-    /**
-     * @test
-     */
-    public function itCanSpecifyCustomBuilder(): void
+    public function testCanSpecifyCustomBuilder(): void
     {
         factory(User::class, 2)->create();
 
@@ -135,10 +126,7 @@ class PaginateDirectiveTest extends DBTestCase
         return User::orderBy('id', 'DESC');
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateQueryPaginatorsWithDifferentPages(): void
+    public function testCanCreateQueryPaginatorsWithDifferentPages(): void
     {
         $users = factory(User::class, 10)->create();
         $posts = factory(Post::class, 10)->create([
@@ -226,10 +214,7 @@ class PaginateDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateQueryConnections(): void
+    public function testCanCreateQueryConnections(): void
     {
         factory(User::class, 10)->create();
 
@@ -269,10 +254,7 @@ class PaginateDirectiveTest extends DBTestCase
         ])->assertJsonCount(5, 'data.users.edges');
     }
 
-    /**
-     * @test
-     */
-    public function itQueriesConnectionWithNoData(): void
+    public function testQueriesConnectionWithNoData(): void
     {
         $this->schema = '
         type User {
@@ -324,10 +306,7 @@ class PaginateDirectiveTest extends DBTestCase
         ])->assertJsonCount(0, 'data.users.edges');
     }
 
-    /**
-     * @test
-     */
-    public function itQueriesPaginationWithNoData(): void
+    public function testQueriesPaginationWithNoData(): void
     {
         $this->schema = '
         type User {
@@ -375,10 +354,7 @@ class PaginateDirectiveTest extends DBTestCase
         ])->assertJsonCount(0, 'data.users.data');
     }
 
-    /**
-     * @test
-     */
-    public function itPaginatesWhenDefinedInTypeExtension(): void
+    public function testPaginatesWhenDefinedInTypeExtension(): void
     {
         factory(User::class, 2)->create();
 
@@ -405,10 +381,7 @@ class PaginateDirectiveTest extends DBTestCase
         ')->assertJsonCount(1, 'data.users.data');
     }
 
-    /**
-     * @test
-     */
-    public function itCanHaveADefaultPaginationCount(): void
+    public function testCanHaveADefaultPaginationCount(): void
     {
         factory(User::class, 10)->create();
 
@@ -448,10 +421,7 @@ class PaginateDirectiveTest extends DBTestCase
         ])->assertJsonCount(5, 'data.users.data');
     }
 
-    /**
-     * @test
-     */
-    public function itIsLimitedToMaxCountFromConfig(): void
+    public function testIsLimitedToMaxCountFromConfig(): void
     {
         config(['lighthouse.paginate_max_count' => 5]);
 
@@ -504,10 +474,7 @@ class PaginateDirectiveTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itIsLimitedByMaxCountFromDirective(): void
+    public function testIsLimitedByMaxCountFromDirective(): void
     {
         config(['lighthouse.paginate_max_count' => 5]);
 

--- a/tests/Integration/Schema/Directives/SearchDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/SearchDirectiveTest.php
@@ -37,9 +37,6 @@ class SearchDirectiveTest extends DBTestCase
             ->andReturn($this->engine);
     }
 
-    /**
-     * @test
-     */
     public function canSearch(): void
     {
         $postA = factory(Post::class)->create([
@@ -90,9 +87,6 @@ class SearchDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
     public function canSearchWithCustomIndex(): void
     {
         $postA = factory(Post::class)->create([
@@ -160,10 +154,7 @@ class SearchDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itHandlesScoutBuilderPaginationArguments(): void
+    public function testHandlesScoutBuilderPaginationArguments(): void
     {
         $postA = factory(Post::class)->create([
             'title' => 'great title',

--- a/tests/Integration/Schema/Directives/SearchDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/SearchDirectiveTest.php
@@ -37,7 +37,7 @@ class SearchDirectiveTest extends DBTestCase
             ->andReturn($this->engine);
     }
 
-    public function canSearch(): void
+    public function testCanSearch(): void
     {
         $postA = factory(Post::class)->create([
             'title' => 'great title',
@@ -87,7 +87,7 @@ class SearchDirectiveTest extends DBTestCase
         ]);
     }
 
-    public function canSearchWithCustomIndex(): void
+    public function testCanSearchWithCustomIndex(): void
     {
         $postA = factory(Post::class)->create([
             'title' => 'great title',

--- a/tests/Integration/Schema/Directives/TrimDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/TrimDirectiveTest.php
@@ -6,10 +6,7 @@ use Tests\DBTestCase;
 
 class TrimDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itTrimsInput(): void
+    public function testTrimsInput(): void
     {
         $this->schema = '
         type Company {

--- a/tests/Integration/Schema/Directives/UpdateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/UpdateDirectiveTest.php
@@ -9,10 +9,7 @@ use Tests\Utils\Models\Category;
 
 class UpdateDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itCanUpdateFromFieldArguments(): void
+    public function testCanUpdateFromFieldArguments(): void
     {
         factory(Company::class)->create(['name' => 'foo']);
 
@@ -51,10 +48,7 @@ class UpdateDirectiveTest extends DBTestCase
         $this->assertSame('bar', Company::first()->name);
     }
 
-    /**
-     * @test
-     */
-    public function itCanUpdateFromInputObject(): void
+    public function testCanUpdateFromInputObject(): void
     {
         factory(Company::class)->create(['name' => 'foo']);
 
@@ -97,10 +91,7 @@ class UpdateDirectiveTest extends DBTestCase
         $this->assertSame('bar', Company::first()->name);
     }
 
-    /**
-     * @test
-     */
-    public function itCanUpdateWithCustomPrimaryKey(): void
+    public function testCanUpdateWithCustomPrimaryKey(): void
     {
         factory(Category::class)->create(['name' => 'foo']);
 
@@ -139,10 +130,7 @@ class UpdateDirectiveTest extends DBTestCase
         $this->assertSame('bar', Category::first()->name);
     }
 
-    /**
-     * @test
-     */
-    public function itDoesNotUpdateWithFailingRelationship(): void
+    public function testDoesNotUpdateWithFailingRelationship(): void
     {
         factory(User::class)->create(['name' => 'Original']);
 

--- a/tests/Integration/Schema/Directives/WithDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/WithDirectiveTest.php
@@ -34,10 +34,7 @@ class WithDirectiveTest extends DBTestCase
         $this->be($this->user);
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryARelationship(): void
+    public function testCanQueryARelationship(): void
     {
         $this->schema = '
         type User {

--- a/tests/Integration/Schema/NodeInterfaceTest.php
+++ b/tests/Integration/Schema/NodeInterfaceTest.php
@@ -34,10 +34,7 @@ class NodeInterfaceTest extends DBTestCase
         ],
     ];
 
-    /**
-     * @test
-     */
-    public function itCanResolveNodes(): void
+    public function testCanResolveNodes(): void
     {
         $this->schema = '
         type User @node(resolver: "Tests\\\Integration\\\Schema\\\NodeInterfaceTest@resolveNode") {
@@ -86,10 +83,7 @@ class NodeInterfaceTest extends DBTestCase
         return $this->testTuples[$id];
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveModelsNodes(): void
+    public function testCanResolveModelsNodes(): void
     {
         $this->schema = '
         type User @model {

--- a/tests/Integration/Schema/Source/SchemaSourceProviderTest.php
+++ b/tests/Integration/Schema/Source/SchemaSourceProviderTest.php
@@ -48,10 +48,7 @@ class SchemaSourceProviderTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
-    public function itCanSetRootPath(): void
+    public function testCanSetRootPath(): void
     {
         $this->filesystem->put('foo', 'bar');
 

--- a/tests/Integration/Schema/Types/InterfaceTest.php
+++ b/tests/Integration/Schema/Types/InterfaceTest.php
@@ -12,10 +12,7 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 class InterfaceTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itCanResolveInterfaceTypes(): void
+    public function testCanResolveInterfaceTypes(): void
     {
         // This creates one team with it
         factory(User::class)->create();
@@ -65,10 +62,7 @@ class InterfaceTest extends DBTestCase
         $this->assertArrayNotHasKey('id', $result->jsonGet('data.namedThings.1'));
     }
 
-    /**
-     * @test
-     */
-    public function itCanUseCustomTypeResolver(): void
+    public function testCanUseCustomTypeResolver(): void
     {
         $this->schema = '
         interface Nameable @interface(resolveType: "'.$this->qualifyTestResolver('resolveType').'"){
@@ -101,10 +95,7 @@ class InterfaceTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanListPossibleTypes(): void
+    public function testCanListPossibleTypes(): void
     {
         // This creates one team with it
         factory(User::class)->create();

--- a/tests/Integration/Schema/Types/UnionTest.php
+++ b/tests/Integration/Schema/Types/UnionTest.php
@@ -10,13 +10,12 @@ use Illuminate\Support\Collection;
 class UnionTest extends DBTestCase
 {
     /**
-     * @test
      * @dataProvider withAndWithoutCustomTypeResolver
      * @param  string  $schema
      * @param  string  $query
      * @return void
      */
-    public function itCanResolveUnionTypes(string $schema, string $query): void
+    public function testCanResolveUnionTypes(string $schema, string $query): void
     {
         // This creates a user with it
         factory(Post::class)->create(

--- a/tests/Integration/SoftDeletes/ForceDeleteDirectiveTest.php
+++ b/tests/Integration/SoftDeletes/ForceDeleteDirectiveTest.php
@@ -9,10 +9,7 @@ use Nuwave\Lighthouse\SoftDeletes\ForceDeleteDirective;
 
 class ForceDeleteDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itForceDeletesTaskAndReturnsIt(): void
+    public function testForceDeletesTaskAndReturnsIt(): void
     {
         factory(Task::class)->create();
 
@@ -43,10 +40,7 @@ class ForceDeleteDirectiveTest extends DBTestCase
         $this->assertCount(0, Task::withTrashed()->get());
     }
 
-    /**
-     * @test
-     */
-    public function itForceDeletesDeletedTaskAndReturnsIt(): void
+    public function testForceDeletesDeletedTaskAndReturnsIt(): void
     {
         $task = factory(Task::class)->create();
         $task->delete();
@@ -78,10 +72,7 @@ class ForceDeleteDirectiveTest extends DBTestCase
         $this->assertCount(0, Task::withTrashed()->get());
     }
 
-    /**
-     * @test
-     */
-    public function itForceDeletesMultipleTasksAndReturnsThem(): void
+    public function testForceDeletesMultipleTasksAndReturnsThem(): void
     {
         factory(Task::class, 2)->create();
 
@@ -107,10 +98,7 @@ class ForceDeleteDirectiveTest extends DBTestCase
         $this->assertCount(0, Task::withTrashed()->get());
     }
 
-    /**
-     * @test
-     */
-    public function itRejectsDefinitionWithNullableArgument(): void
+    public function testRejectsDefinitionWithNullableArgument(): void
     {
         $this->expectException(DirectiveException::class);
 
@@ -125,10 +113,7 @@ class ForceDeleteDirectiveTest extends DBTestCase
         ');
     }
 
-    /**
-     * @test
-     */
-    public function itRejectsDefinitionWithNoArgument(): void
+    public function testRejectsDefinitionWithNoArgument(): void
     {
         $this->expectException(DirectiveException::class);
 
@@ -143,10 +128,7 @@ class ForceDeleteDirectiveTest extends DBTestCase
         ');
     }
 
-    /**
-     * @test
-     */
-    public function itRejectsDefinitionWithMultipleArguments(): void
+    public function testRejectsDefinitionWithMultipleArguments(): void
     {
         $this->expectException(DirectiveException::class);
 
@@ -161,10 +143,7 @@ class ForceDeleteDirectiveTest extends DBTestCase
         ');
     }
 
-    /**
-     * @test
-     */
-    public function itRejectsUsingDirectiveWithNoSoftDeleteModels(): void
+    public function testRejectsUsingDirectiveWithNoSoftDeleteModels(): void
     {
         $this->expectExceptionMessage(ForceDeleteDirective::MODEL_NOT_USING_SOFT_DELETES);
         $this->buildSchema('

--- a/tests/Integration/SoftDeletes/RestoreDirectiveTest.php
+++ b/tests/Integration/SoftDeletes/RestoreDirectiveTest.php
@@ -9,10 +9,7 @@ use Nuwave\Lighthouse\Exceptions\DirectiveException;
 
 class RestoreDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itRestoresTaskAndReturnsIt(): void
+    public function testRestoresTaskAndReturnsIt(): void
     {
         $task = factory(Task::class)->create();
         $task->delete();
@@ -47,10 +44,7 @@ class RestoreDirectiveTest extends DBTestCase
         $this->assertCount(1, Task::withoutTrashed()->get());
     }
 
-    /**
-     * @test
-     */
-    public function itRestoresMultipleTasksAndReturnsThem(): void
+    public function testRestoresMultipleTasksAndReturnsThem(): void
     {
         $tasks = factory(Task::class, 2)->create();
         foreach ($tasks as $task) {
@@ -82,10 +76,7 @@ class RestoreDirectiveTest extends DBTestCase
         $this->assertCount(2, Task::withoutTrashed()->get());
     }
 
-    /**
-     * @test
-     */
-    public function itRejectsDefinitionWithNullableArgument(): void
+    public function testRejectsDefinitionWithNullableArgument(): void
     {
         $this->expectException(DirectiveException::class);
 
@@ -100,10 +91,7 @@ class RestoreDirectiveTest extends DBTestCase
         ');
     }
 
-    /**
-     * @test
-     */
-    public function itRejectsDefinitionWithNoArgument(): void
+    public function testRejectsDefinitionWithNoArgument(): void
     {
         $this->expectException(DirectiveException::class);
 
@@ -118,10 +106,7 @@ class RestoreDirectiveTest extends DBTestCase
         ');
     }
 
-    /**
-     * @test
-     */
-    public function itRejectsDefinitionWithMultipleArguments(): void
+    public function testRejectsDefinitionWithMultipleArguments(): void
     {
         $this->expectException(DirectiveException::class);
 
@@ -136,10 +121,7 @@ class RestoreDirectiveTest extends DBTestCase
         ');
     }
 
-    /**
-     * @test
-     */
-    public function itRejectsUsingDirectiveWithNoSoftDeleteModels(): void
+    public function testRejectsUsingDirectiveWithNoSoftDeleteModels(): void
     {
         $this->expectExceptionMessage(RestoreDirective::MODEL_NOT_USING_SOFT_DELETES);
 

--- a/tests/Integration/SoftDeletes/SoftDeletesAndTrashedDirectiveTest.php
+++ b/tests/Integration/SoftDeletes/SoftDeletesAndTrashedDirectiveTest.php
@@ -8,10 +8,7 @@ use Nuwave\Lighthouse\SoftDeletes\TrashedDirective;
 
 class SoftDeletesAndTrashedDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itCanBeUsedWithAllDirective(): void
+    public function testCanBeUsedWithAllDirective(): void
     {
         $tasks = factory(Task::class, 3)->create();
         $taskToRemove = $tasks[2];
@@ -74,10 +71,7 @@ class SoftDeletesAndTrashedDirectiveTest extends DBTestCase
         ')->assertJsonCount(2, 'data.tasks');
     }
 
-    /**
-     * @test
-     */
-    public function itCanBeUsedWithFindDirective(): void
+    public function testCanBeUsedWithFindDirective(): void
     {
         $taskToRemove = factory(Task::class)->create();
         $taskToRemove->delete();
@@ -152,10 +146,7 @@ class SoftDeletesAndTrashedDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanCanBeUsedWIthPaginateDirective(): void
+    public function testCanCanBeUsedWIthPaginateDirective(): void
     {
         $tasks = factory(Task::class, 3)->create();
         $taskToRemove = $tasks[2];
@@ -228,10 +219,7 @@ class SoftDeletesAndTrashedDirectiveTest extends DBTestCase
         ')->assertJsonCount(2, 'data.tasks.data');
     }
 
-    /**
-     * @test
-     */
-    public function itCanBeUsedNested(): void
+    public function testCanBeUsedNested(): void
     {
         $taskToRemove = factory(Task::class)->create();
         factory(Task::class, 2)->create(['user_id' => $taskToRemove->user->id]);
@@ -389,10 +377,7 @@ class SoftDeletesAndTrashedDirectiveTest extends DBTestCase
              ->assertJsonCount(2, 'data.user.tasksSimple');
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsIfModelDoesNotSupportSoftDeletesTrashed(): void
+    public function testThrowsIfModelDoesNotSupportSoftDeletesTrashed(): void
     {
         $this->schema = '
         type Query {
@@ -414,10 +399,7 @@ class SoftDeletesAndTrashedDirectiveTest extends DBTestCase
         ');
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsIfModelDoesNotSupportSoftDeletes(): void
+    public function testThrowsIfModelDoesNotSupportSoftDeletes(): void
     {
         $this->schema = '
         type Query {

--- a/tests/Integration/Subscriptions/BroadcastManagerTest.php
+++ b/tests/Integration/Subscriptions/BroadcastManagerTest.php
@@ -39,10 +39,7 @@ class BroadcastManagerTest extends TestCase
         $this->broadcastManager = app(BroadcastManager::class);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveDrivers(): void
+    public function testCanResolveDrivers(): void
     {
         $pusherDriver = $this->broadcastManager->driver('pusher');
         $this->assertInstanceOf(PusherBroadcaster::class, $pusherDriver);
@@ -51,10 +48,7 @@ class BroadcastManagerTest extends TestCase
         $this->assertInstanceOf(LogBroadcaster::class, $logDriver);
     }
 
-    /**
-     * @test
-     */
-    public function itCanExtendBroadcastManager(): void
+    public function testCanExtendBroadcastManager(): void
     {
         $broadcasterConfig = [];
 
@@ -97,10 +91,7 @@ class BroadcastManagerTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsIfDriverDoesNotImplementInterface(): void
+    public function testThrowsIfDriverDoesNotImplementInterface(): void
     {
         $this->broadcastManager->extend('foo', function () {
             return new class {

--- a/tests/Integration/Subscriptions/StorageManagerTest.php
+++ b/tests/Integration/Subscriptions/StorageManagerTest.php
@@ -108,10 +108,7 @@ class StorageManagerTest extends TestCase
         return $subscriber;
     }
 
-    /**
-     * @test
-     */
-    public function itCanStoreSubscribersInCache(): void
+    public function testCanStoreSubscribersInCache(): void
     {
         $subscriber1 = $this->subscriber('{ me }');
         $subscriber2 = $this->subscriber('{ viewer }');

--- a/tests/Integration/Subscriptions/SubscriptionTest.php
+++ b/tests/Integration/Subscriptions/SubscriptionTest.php
@@ -45,10 +45,7 @@ class SubscriptionTest extends TestCase
         ";
     }
 
-    /**
-     * @test
-     */
-    public function itSendsSubscriptionChannelInResponse(): void
+    public function testSendsSubscriptionChannelInResponse(): void
     {
         $response = $this->subscribe();
         $subscriber = app(StorageManager::class)->subscribersByTopic('ON_POST_CREATED')->first();
@@ -60,10 +57,7 @@ class SubscriptionTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itSendsSubscriptionChannelInBatchedResponse(): void
+    public function testSendsSubscriptionChannelInBatchedResponse(): void
     {
         $response = $this->postGraphQL([
             [
@@ -95,10 +89,7 @@ class SubscriptionTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanBroadcastSubscriptions(): void
+    public function testCanBroadcastSubscriptions(): void
     {
         $this->subscribe();
         $this->graphQL('
@@ -118,10 +109,7 @@ class SubscriptionTest extends TestCase
         $this->assertSame(['body' => 'Foobar'], $broadcasted['onPostCreated']);
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsWithMissingOperationName(): void
+    public function testThrowsWithMissingOperationName(): void
     {
         $this->graphQL('
         subscription {

--- a/tests/Integration/Support/DataLoader/ModelRelationLoaderPolymorphicTest.php
+++ b/tests/Integration/Support/DataLoader/ModelRelationLoaderPolymorphicTest.php
@@ -26,10 +26,7 @@ class ModelRelationLoaderPolymorphicTest extends DBTestCase
         });
     }
 
-    /**
-     * @test
-     */
-    public function itGetsPolymorphicRelationship(): void
+    public function testGetsPolymorphicRelationship(): void
     {
         /** @var \Tests\Utils\Models\Task $task */
         $task = Task::first();

--- a/tests/Integration/Support/DataLoader/ModelRelationLoaderTest.php
+++ b/tests/Integration/Support/DataLoader/ModelRelationLoaderTest.php
@@ -24,10 +24,7 @@ class ModelRelationLoaderTest extends DBTestCase
         });
     }
 
-    /**
-     * @test
-     */
-    public function itCanLoadRelationshipsWithLimitsOnCollection(): void
+    public function testCanLoadRelationshipsWithLimitsOnCollection(): void
     {
         // TODO refactor this as soon as Laravel fixes https://github.com/laravel/framework/issues/16217
 
@@ -43,10 +40,7 @@ class ModelRelationLoaderTest extends DBTestCase
         $this->assertEquals($users[2]->getKey(), $users[2]->tasks[0]->user_id);
     }
 
-    /**
-     * @test
-     */
-    public function itCanLoadCountOnCollection(): void
+    public function testCanLoadCountOnCollection(): void
     {
         $users = (new ModelRelationFetcher(User::all(), ['tasks']))
             ->reloadModelsWithRelationCount()
@@ -57,10 +51,7 @@ class ModelRelationLoaderTest extends DBTestCase
         $this->assertEquals($users[2]->tasks_count, 6);
     }
 
-    /**
-     * @test
-     */
-    public function itCanPaginateRelationshipOnCollection(): void
+    public function testCanPaginateRelationshipOnCollection(): void
     {
         $users = (new ModelRelationFetcher(User::all(), ['tasks']))
             ->loadRelationsForPage(2)
@@ -77,10 +68,7 @@ class ModelRelationLoaderTest extends DBTestCase
         $this->assertEquals($users[2]->getKey(), $users[2]->tasks[0]->user_id);
     }
 
-    /**
-     * @test
-     */
-    public function itCanHandleSoftDeletes(): void
+    public function testCanHandleSoftDeletes(): void
     {
         $user = User::first();
         $count = $user->tasks->count();

--- a/tests/Integration/Tracing/TracingExtensionTest.php
+++ b/tests/Integration/Tracing/TracingExtensionTest.php
@@ -21,10 +21,7 @@ SCHEMA;
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanAddTracingExtensionMetaToResult(): void
+    public function testCanAddTracingExtensionMetaToResult(): void
     {
         $this->graphQL('
         {
@@ -41,10 +38,7 @@ SCHEMA;
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanAddTracingExtensionMetaToBatchedResults(): void
+    public function testCanAddTracingExtensionMetaToBatchedResults(): void
     {
         $postData = [
             'query' => '

--- a/tests/Integration/ValidationTest.php
+++ b/tests/Integration/ValidationTest.php
@@ -82,10 +82,7 @@ class ValidationTest extends DBTestCase
         return Arr::get($args, 'email.emailAddress', 'no-email');
     }
 
-    /**
-     * @test
-     */
-    public function itRunsValidationBeforeCallingTheResolver(): void
+    public function testRunsValidationBeforeCallingTheResolver(): void
     {
         $shouldNotBeCalled = '@field(resolver: "'.$this->qualifyTestResolver('resolveDoNotCall').'")';
         $this->schema = '
@@ -128,10 +125,7 @@ class ValidationTest extends DBTestCase
         self::$callCount++;
     }
 
-    /**
-     * @test
-     */
-    public function itValidatesDifferentPathsIndividually(): void
+    public function testValidatesDifferentPathsIndividually(): void
     {
         $result = $this->graphQL('
         {
@@ -164,10 +158,7 @@ class ValidationTest extends DBTestCase
         ], $result);
     }
 
-    /**
-     * @test
-     */
-    public function itValidatesList(): void
+    public function testValidatesList(): void
     {
         $result = $this->graphQL('
         {
@@ -189,10 +180,7 @@ class ValidationTest extends DBTestCase
         ], $result);
     }
 
-    /**
-     * @test
-     */
-    public function itValidatesInputCount(): void
+    public function testValidatesInputCount(): void
     {
         $result = $this->graphQL('
         {
@@ -230,10 +218,7 @@ class ValidationTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itPassesIfNothingRequiredIsMissing(): void
+    public function testPassesIfNothingRequiredIsMissing(): void
     {
         $this->graphQL('
         {
@@ -246,10 +231,7 @@ class ValidationTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itEvaluatesArgDirectivesInDefinitionOrder(): void
+    public function testEvaluatesArgDirectivesInDefinitionOrder(): void
     {
         $validPasswordResult = $this->graphQL('
         {
@@ -274,10 +256,7 @@ class ValidationTest extends DBTestCase
         $this->assertValidationKeysSame(['password'], $invalidPasswordResult);
     }
 
-    /**
-     * @test
-     */
-    public function itEvaluatesConditionalValidation(): void
+    public function testEvaluatesConditionalValidation(): void
     {
         $validPasswordResult = $this->graphQL('
         {
@@ -300,10 +279,7 @@ class ValidationTest extends DBTestCase
         $this->assertValidationKeysSame(['password'], $invalidPasswordResult);
     }
 
-    /**
-     * @test
-     */
-    public function itEvaluatesInputArgValidation(): void
+    public function testEvaluatesInputArgValidation(): void
     {
         $result = $this->graphQL('
         {
@@ -318,10 +294,7 @@ class ValidationTest extends DBTestCase
         $this->assertValidationKeysSame(['bar'], $result);
     }
 
-    /**
-     * @test
-     */
-    public function itEvaluatesNonNullInputArgValidation(): void
+    public function testEvaluatesNonNullInputArgValidation(): void
     {
         $this->graphQL('
         {
@@ -359,10 +332,7 @@ class ValidationTest extends DBTestCase
         ], $invalidEmailResult);
     }
 
-    /**
-     * @test
-     */
-    public function itErrorsIfSomethingRequiredIsMissing(): void
+    public function testErrorsIfSomethingRequiredIsMissing(): void
     {
         $result = $this->graphQL('
         {
@@ -379,10 +349,7 @@ class ValidationTest extends DBTestCase
         ], $result);
     }
 
-    /**
-     * @test
-     */
-    public function itSetsArgumentsOnCustomValidationDirective(): void
+    public function testSetsArgumentsOnCustomValidationDirective(): void
     {
         $this->schema = '
         type Mutation {
@@ -435,10 +402,7 @@ class ValidationTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itIgnoresTheUserWeAreUpdating(): void
+    public function testIgnoresTheUserWeAreUpdating(): void
     {
         $this->schema = '
         type Mutation {
@@ -485,10 +449,7 @@ class ValidationTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCombinesFieldValidationAndArgumentValidation(): void
+    public function testCombinesFieldValidationAndArgumentValidation(): void
     {
         $this->markTestSkipped('Not implemented as of now as it would require a larger redo.');
 
@@ -523,10 +484,7 @@ class ValidationTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCombinesArgumentValidationByPausingAndResuming(): void
+    public function testCombinesArgumentValidationByPausingAndResuming(): void
     {
         $this->markTestSkipped('
         This should work once we can reliably depend upon repeatable directives.

--- a/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
+++ b/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
@@ -43,10 +43,7 @@ class WhereConstraintsDirectiveTest extends DBTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itAddsASingleWhereFilter(): void
+    public function testAddsASingleWhereFilter(): void
     {
         factory(User::class, 2)->create();
 
@@ -64,10 +61,7 @@ class WhereConstraintsDirectiveTest extends DBTestCase
         ')->assertJsonCount(1, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itOverwritesTheOperator(): void
+    public function testOverwritesTheOperator(): void
     {
         factory(User::class, 3)->create();
 
@@ -86,10 +80,7 @@ class WhereConstraintsDirectiveTest extends DBTestCase
         ')->assertJsonCount(2, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itAddsNestedAnd(): void
+    public function testAddsNestedAnd(): void
     {
         factory(User::class, 3)->create();
 
@@ -117,10 +108,7 @@ class WhereConstraintsDirectiveTest extends DBTestCase
         ')->assertJsonCount(1, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itAddsNestedOr(): void
+    public function testAddsNestedOr(): void
     {
         factory(User::class, 3)->create();
 
@@ -146,10 +134,7 @@ class WhereConstraintsDirectiveTest extends DBTestCase
         ')->assertJsonCount(2, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itAddsNestedNot(): void
+    public function testAddsNestedNot(): void
     {
         factory(User::class, 3)->create();
 
@@ -171,10 +156,7 @@ class WhereConstraintsDirectiveTest extends DBTestCase
         ')->assertJsonCount(2, 'data.users');
     }
 
-    /**
-     * @test
-     */
-    public function itRejectsInvalidColumnName(): void
+    public function testRejectsInvalidColumnName(): void
     {
         $this->graphQL('
         {
@@ -196,10 +178,7 @@ class WhereConstraintsDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itQueriesEmptyStrings(): void
+    public function testQueriesEmptyStrings(): void
     {
         factory(User::class, 3)->create();
 
@@ -231,10 +210,7 @@ class WhereConstraintsDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanQueryForNull(): void
+    public function testCanQueryForNull(): void
     {
         factory(User::class, 3)->create();
 
@@ -266,10 +242,7 @@ class WhereConstraintsDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itRequiresAValueForAColumn(): void
+    public function testRequiresAValueForAColumn(): void
     {
         $this->graphQL('
         {
@@ -286,10 +259,7 @@ class WhereConstraintsDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itOnlyAllowsWhitelistedColumns(): void
+    public function testOnlyAllowsWhitelistedColumns(): void
     {
         factory(User::class)->create();
 

--- a/tests/Unit/Console/IdeHelperCommandTest.php
+++ b/tests/Unit/Console/IdeHelperCommandTest.php
@@ -20,10 +20,7 @@ class IdeHelperCommandTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itGeneratesSchemaDirectives(): void
+    public function testGeneratesSchemaDirectives(): void
     {
         $this->artisan('lighthouse:ide-helper');
 
@@ -48,10 +45,7 @@ class IdeHelperCommandTest extends TestCase
         $this->assertContains(UnionDirective::class, $generated);
     }
 
-    /**
-     * @test
-     */
-    public function itDoesNotRequireCustomDirectives(): void
+    public function testDoesNotRequireCustomDirectives(): void
     {
         /** @var \Illuminate\Contracts\Config\Repository $config */
         $config = $this->app['config'];

--- a/tests/Unit/Events/ManipulateASTTest.php
+++ b/tests/Unit/Events/ManipulateASTTest.php
@@ -9,10 +9,7 @@ use Nuwave\Lighthouse\Schema\AST\PartialParser;
 
 class ManipulateASTTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itCanManipulateTheAST(): void
+    public function testCanManipulateTheAST(): void
     {
         $this->schema = '
         type Query {

--- a/tests/Unit/Execution/Utils/GlobalIdTest.php
+++ b/tests/Unit/Execution/Utils/GlobalIdTest.php
@@ -19,10 +19,7 @@ class GlobalIdTest extends TestCase
         $this->globalIdResolver = new GlobalId;
     }
 
-    /**
-     * @test
-     */
-    public function itCanHandleGlobalIds(): void
+    public function testCanHandleGlobalIds(): void
     {
         $globalId = $this->globalIdResolver->encode('User', 'asdf');
         $idParts = $this->globalIdResolver->decode($globalId);
@@ -30,20 +27,14 @@ class GlobalIdTest extends TestCase
         $this->assertSame(['User', 'asdf'], $idParts);
     }
 
-    /**
-     * @test
-     */
-    public function itCanDecodeJustTheId(): void
+    public function testCanDecodeJustTheId(): void
     {
         $globalId = $this->globalIdResolver->encode('User', 123);
 
         $this->assertSame('123', $this->globalIdResolver->decodeID($globalId));
     }
 
-    /**
-     * @test
-     */
-    public function itCanDecodeJustTheType(): void
+    public function testCanDecodeJustTheType(): void
     {
         $globalId = $this->globalIdResolver->encode('User', 123);
 

--- a/tests/Unit/Execution/Utils/SubscriptionTest.php
+++ b/tests/Unit/Execution/Utils/SubscriptionTest.php
@@ -56,10 +56,7 @@ class SubscriptionTest extends TestCase
         $this->app->instance(BroadcastsSubscriptions::class, $this->broadcaster->reveal());
     }
 
-    /**
-     * @test
-     */
-    public function itCanSendSubscriptionToBroadcaster(): void
+    public function testCanSendSubscriptionToBroadcaster(): void
     {
         $root = [
             'post' => [
@@ -76,10 +73,7 @@ class SubscriptionTest extends TestCase
         Subscription::broadcast(self::SUBSCRIPTION_FIELD, $root);
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsOnInvalidSubscriptionField(): void
+    public function testThrowsOnInvalidSubscriptionField(): void
     {
         $this->broadcaster->broadcast(Argument::any())->shouldNotBeCalled();
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/Schema/AST/ASTBuilderTest.php
+++ b/tests/Unit/Schema/AST/ASTBuilderTest.php
@@ -20,10 +20,7 @@ class ASTBuilderTest extends TestCase
         $this->astBuilder = app(ASTBuilder::class);
     }
 
-    /**
-     * @test
-     */
-    public function itCanMergeTypeExtensionFields(): void
+    public function testCanMergeTypeExtensionFields(): void
     {
         $this->schema = '
         type Query {
@@ -46,10 +43,7 @@ class ASTBuilderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itDoesNotAllowDuplicateFieldsOnTypeExtensions(): void
+    public function testDoesNotAllowDuplicateFieldsOnTypeExtensions(): void
     {
         $this->schema = '
         type Query {

--- a/tests/Unit/Schema/AST/ASTHelperTest.php
+++ b/tests/Unit/Schema/AST/ASTHelperTest.php
@@ -10,10 +10,7 @@ use Nuwave\Lighthouse\Exceptions\DefinitionException;
 
 class ASTHelperTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itThrowsWhenMergingUniqueNodeListWithCollision(): void
+    public function testThrowsWhenMergingUniqueNodeListWithCollision(): void
     {
         $objectType1 = PartialParser::objectTypeDefinition('
         type User {
@@ -35,10 +32,7 @@ class ASTHelperTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itMergesUniqueNodeListsWithOverwrite(): void
+    public function testMergesUniqueNodeListsWithOverwrite(): void
     {
         $objectType1 = PartialParser::objectTypeDefinition('
         type User {
@@ -69,10 +63,7 @@ class ASTHelperTest extends TestCase
         $this->assertCount(1, $firstNameField->directives);
     }
 
-    /**
-     * @test
-     */
-    public function itCanExtractStringArguments(): void
+    public function testCanExtractStringArguments(): void
     {
         $directive = PartialParser::directive('@foo(bar: "baz")');
         $this->assertSame(
@@ -81,10 +72,7 @@ class ASTHelperTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanExtractBooleanArguments(): void
+    public function testCanExtractBooleanArguments(): void
     {
         $directive = PartialParser::directive('@foo(bar: true)');
         $this->assertTrue(
@@ -92,10 +80,7 @@ class ASTHelperTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanExtractArrayArguments(): void
+    public function testCanExtractArrayArguments(): void
     {
         $directive = PartialParser::directive('@foo(bar: ["one", "two"])');
         $this->assertSame(
@@ -104,10 +89,7 @@ class ASTHelperTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanExtractObjectArguments(): void
+    public function testCanExtractObjectArguments(): void
     {
         $directive = PartialParser::directive('@foo(bar: { baz: "foobar" })');
         $this->assertSame(
@@ -116,10 +98,7 @@ class ASTHelperTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itReturnsNullForNonExistingArgumentOnDirective(): void
+    public function testReturnsNullForNonExistingArgumentOnDirective(): void
     {
         $directive = PartialParser::directive('@foo');
         $this->assertNull(
@@ -127,10 +106,7 @@ class ASTHelperTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itChecksWhetherTypeImplementsInterface(): void
+    public function testChecksWhetherTypeImplementsInterface(): void
     {
         $type = PartialParser::objectTypeDefinition('
             type Foo implements Bar {

--- a/tests/Unit/Schema/AST/DocumentASTTest.php
+++ b/tests/Unit/Schema/AST/DocumentASTTest.php
@@ -12,10 +12,7 @@ use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 
 class DocumentASTTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itParsesSimpleSchema(): void
+    public function testParsesSimpleSchema(): void
     {
         $documentAST = DocumentAST::fromSource('
         type Query {
@@ -29,10 +26,7 @@ class DocumentASTTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsOnInvalidSchema(): void
+    public function testThrowsOnInvalidSchema(): void
     {
         $this->expectException(ParseException::class);
         $this->expectExceptionMessageRegExp('/^Syntax Error/');
@@ -40,10 +34,7 @@ class DocumentASTTest extends TestCase
         DocumentAST::fromSource('foo');
     }
 
-    /**
-     * @test
-     */
-    public function itOverwritesDefinitionWithSameName(): void
+    public function testOverwritesDefinitionWithSameName(): void
     {
         $documentAST = DocumentAST::fromSource('
         type Query {
@@ -65,10 +56,7 @@ class DocumentASTTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanBeSerialized(): void
+    public function testCanBeSerialized(): void
     {
         $documentAST = DocumentAST::fromSource('
         type Query {

--- a/tests/Unit/Schema/AST/PartialParserTest.php
+++ b/tests/Unit/Schema/AST/PartialParserTest.php
@@ -12,10 +12,7 @@ use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 
 class PartialParserTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itParsesObjectType(): void
+    public function testParsesObjectType(): void
     {
         $this->assertInstanceOf(
             ObjectTypeDefinitionNode::class,
@@ -27,10 +24,7 @@ class PartialParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsForInvalidDefinition(): void
+    public function testThrowsForInvalidDefinition(): void
     {
         $this->expectException(SyntaxError::class);
         PartialParser::objectTypeDefinition('
@@ -38,10 +32,7 @@ class PartialParserTest extends TestCase
         ');
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsIfMultipleDefinitionsAreGiven(): void
+    public function testThrowsIfMultipleDefinitionsAreGiven(): void
     {
         $this->expectException(ParseException::class);
         PartialParser::objectTypeDefinition('
@@ -55,10 +46,7 @@ class PartialParserTest extends TestCase
         ');
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsIfDefinitionIsUnexpectedType(): void
+    public function testThrowsIfDefinitionIsUnexpectedType(): void
     {
         $this->expectException(ParseException::class);
         PartialParser::objectTypeDefinition('
@@ -68,10 +56,7 @@ class PartialParserTest extends TestCase
         ');
     }
 
-    /**
-     * @test
-     */
-    public function itParsesObjectTypesArray(): void
+    public function testParsesObjectTypesArray(): void
     {
         $objectTypes = PartialParser::objectTypeDefinitions(['
         type Foo {
@@ -88,10 +73,7 @@ class PartialParserTest extends TestCase
         $this->assertInstanceOf(ObjectTypeDefinitionNode::class, $objectTypes[1]);
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsOnInvalidTypeInObjectTypesArray(): void
+    public function testThrowsOnInvalidTypeInObjectTypesArray(): void
     {
         $this->expectException(ParseException::class);
         PartialParser::objectTypeDefinitions(['
@@ -105,10 +87,7 @@ class PartialParserTest extends TestCase
         ']);
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsOnMultipleDefinitionsInArrayItem(): void
+    public function testThrowsOnMultipleDefinitionsInArrayItem(): void
     {
         $this->expectException(ParseException::class);
         PartialParser::objectTypeDefinitions(['
@@ -122,10 +101,7 @@ class PartialParserTest extends TestCase
         ']);
     }
 
-    /**
-     * @test
-     */
-    public function itParsesOperationDefinition(): void
+    public function testParsesOperationDefinition(): void
     {
         $this->assertInstanceOf(
             OperationDefinitionNode::class,
@@ -137,10 +113,7 @@ class PartialParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itParsesArgument(): void
+    public function testParsesArgument(): void
     {
         $argumentNode = PartialParser::argument('key: "value"');
 

--- a/tests/Unit/Schema/AST/SchemaStitcherTest.php
+++ b/tests/Unit/Schema/AST/SchemaStitcherTest.php
@@ -57,10 +57,7 @@ class SchemaStitcherTest extends TestCase
         $this->filesystem->put(self::ROOT_SCHEMA_FILENAME, $schema);
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsIfRootSchemaIsNotFound(): void
+    public function testThrowsIfRootSchemaIsNotFound(): void
     {
         $this->expectException(FileNotFoundException::class);
         $this->expectExceptionMessageRegExp('/'.self::ROOT_SCHEMA_FILENAME.'/');
@@ -68,10 +65,7 @@ class SchemaStitcherTest extends TestCase
         $this->assertSchemaResultIsSame('');
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsIfSchemaImportIsNotFound(): void
+    public function testThrowsIfSchemaImportIsNotFound(): void
     {
         $this->expectException(FileNotFoundException::class);
         $this->expectExceptionMessageRegExp('/does-not-exist.graphql/');
@@ -85,10 +79,7 @@ EOT;
         $this->assertSchemaResultIsSame($foo);
     }
 
-    /**
-     * @test
-     */
-    public function itLeavesImportlessFileAsBefore(): void
+    public function testLeavesImportlessFileAsBefore(): void
     {
         $foo = <<<'EOT'
 foo
@@ -99,10 +90,7 @@ EOT;
         $this->assertSchemaResultIsSame($foo);
     }
 
-    /**
-     * @test
-     */
-    public function itReplacesImportWithFileContent(): void
+    public function testReplacesImportWithFileContent(): void
     {
         $this->putRootSchema(<<<'EOT'
 foo
@@ -125,10 +113,7 @@ EOT
         );
     }
 
-    /**
-     * @test
-     */
-    public function itImportsRecursively(): void
+    public function testImportsRecursively(): void
     {
         $this->putRootSchema(<<<'EOT'
 foo
@@ -158,10 +143,7 @@ EOT
         );
     }
 
-    /**
-     * @test
-     */
-    public function itImportsFromSubdirectory(): void
+    public function testImportsFromSubdirectory(): void
     {
         $this->putRootSchema(<<<'EOT'
 foo
@@ -185,10 +167,7 @@ EOT
         );
     }
 
-    /**
-     * @test
-     */
-    public function itKeepsIndententation(): void
+    public function testKeepsIndententation(): void
     {
         $this->putRootSchema(<<<'EOT'
     foo
@@ -211,10 +190,7 @@ EOT
         );
     }
 
-    /**
-     * @test
-     */
-    public function itImportsViaGlob(): void
+    public function testImportsViaGlob(): void
     {
         $this->putRootSchema(<<<'EOT'
 foo
@@ -244,10 +220,7 @@ EOT
         );
     }
 
-    /**
-     * @test
-     */
-    public function itAddsNewlineToTheEndOfImportedFile(): void
+    public function testAddsNewlineToTheEndOfImportedFile(): void
     {
         $this->putRootSchema(<<<'EOT'
 foo

--- a/tests/Unit/Schema/ClientDirectiveTest.php
+++ b/tests/Unit/Schema/ClientDirectiveTest.php
@@ -7,10 +7,7 @@ use GraphQL\Type\Definition\Directive;
 
 class ClientDirectiveTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itReturnsDefaultDirectivesInIntrospection(): void
+    public function testReturnsDefaultDirectivesInIntrospection(): void
     {
         $this->schema = $this->placeholderQuery();
 
@@ -22,10 +19,7 @@ class ClientDirectiveTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanDefineACustomClientDirective(): void
+    public function testCanDefineACustomClientDirective(): void
     {
         $this->schema = '
         "foo"

--- a/tests/Unit/Schema/Directives/AuthDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/AuthDirectiveTest.php
@@ -7,10 +7,7 @@ use Tests\Utils\Models\User;
 
 class AuthDirectiveTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itCanResolveAuthenticatedUser(): void
+    public function testCanResolveAuthenticatedUser(): void
     {
         $user = new User(['foo' => 'bar']);
         $this->be($user);
@@ -40,10 +37,7 @@ class AuthDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveAuthenticatedUserWithGuardArgument(): void
+    public function testCanResolveAuthenticatedUserWithGuardArgument(): void
     {
         $user = new User(['foo' => 'bar']);
 

--- a/tests/Unit/Schema/Directives/BaseDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/BaseDirectiveTest.php
@@ -22,10 +22,7 @@ use Tests\Utils\ModelsSecondary\Category as CategorySecondary;
  */
 class BaseDirectiveTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itDefaultsToFieldTypeForTheModelClass(): void
+    public function testDefaultsToFieldTypeForTheModelClass(): void
     {
         $directive = $this->constructFieldDirective('foo: User @dummy');
 
@@ -35,10 +32,7 @@ class BaseDirectiveTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsIfTheClassIsNotAModel(): void
+    public function testThrowsIfTheClassIsNotAModel(): void
     {
         $directive = $this->constructFieldDirective('foo: Exception @dummy');
 
@@ -46,10 +40,7 @@ class BaseDirectiveTest extends TestCase
         $directive->getModelClass();
     }
 
-    /**
-     * @test
-     */
-    public function itResolvesAModelThatIsNamedLikeABaseClass(): void
+    public function testResolvesAModelThatIsNamedLikeABaseClass(): void
     {
         $directive = $this->constructFieldDirective('foo: Closure @dummy');
 
@@ -59,10 +50,7 @@ class BaseDirectiveTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itPrefersThePrimaryModelNamespace(): void
+    public function testPrefersThePrimaryModelNamespace(): void
     {
         $directive = $this->constructFieldDirective('foo: Category @dummy');
 
@@ -72,10 +60,7 @@ class BaseDirectiveTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itAllowsOverwritingTheDefaultModel(): void
+    public function testAllowsOverwritingTheDefaultModel(): void
     {
         $directive = $this->constructFieldDirective('foo: OnlyHere @dummy(model: "Tests\\\Utils\\\ModelsSecondary\\\Category")');
 
@@ -85,10 +70,7 @@ class BaseDirectiveTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itResolvesFromTheSecondaryModelNamespace(): void
+    public function testResolvesFromTheSecondaryModelNamespace(): void
     {
         $directive = $this->constructFieldDirective('foo: OnlyHere @dummy');
 

--- a/tests/Unit/Schema/Directives/BcryptDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/BcryptDirectiveTest.php
@@ -6,10 +6,7 @@ use Tests\TestCase;
 
 class BcryptDirectiveTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itCanBcryptAnArgument(): void
+    public function testCanBcryptAnArgument(): void
     {
         $this->schema = '
         type Mutation {
@@ -50,10 +47,7 @@ class BcryptDirectiveTest extends TestCase
         $this->assertTrue(password_verify('123', $passwordFromQuery));
     }
 
-    /**
-     * @test
-     */
-    public function itCanBcryptAnArgumentInInputObjectAndArray(): void
+    public function testCanBcryptAnArgumentInInputObjectAndArray(): void
     {
         $this->schema = '
         type Query {

--- a/tests/Unit/Schema/Directives/CanDirectiveDbTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveDbTest.php
@@ -11,10 +11,7 @@ use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 
 class CanDirectiveDbTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itQueriesForSpecificModel(): void
+    public function testQueriesForSpecificModel(): void
     {
         $this->be(
             new User([
@@ -52,10 +49,7 @@ class CanDirectiveDbTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itFailsToFindSpecificModel(): void
+    public function testFailsToFindSpecificModel(): void
     {
         $this->be(
             new User([
@@ -86,10 +80,7 @@ class CanDirectiveDbTest extends DBTestCase
         ');
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsIfNotAuthorized(): void
+    public function testThrowsIfNotAuthorized(): void
     {
         $this->be(
             new User([
@@ -128,10 +119,7 @@ class CanDirectiveDbTest extends DBTestCase
         ")->assertErrorCategory(AuthorizationException::CATEGORY);
     }
 
-    /**
-     * @test
-     */
-    public function itCanHandleMultipleModels(): void
+    public function testCanHandleMultipleModels(): void
     {
         $user = User::create([
             'name' => UserPolicy::ADMIN,

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -9,10 +9,7 @@ use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 
 class CanDirectiveTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itThrowsIfNotAuthorized(): void
+    public function testThrowsIfNotAuthorized(): void
     {
         $this->be(new User);
 
@@ -37,10 +34,7 @@ class CanDirectiveTest extends TestCase
         ')->assertErrorCategory(AuthorizationException::CATEGORY);
     }
 
-    /**
-     * @test
-     */
-    public function itPassesAuthIfAuthorized(): void
+    public function testPassesAuthIfAuthorized(): void
     {
         $user = new User;
         $user->name = UserPolicy::ADMIN;
@@ -73,10 +67,7 @@ class CanDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itAcceptsGuestUser(): void
+    public function testAcceptsGuestUser(): void
     {
         if ((float) $this->app->version() < 5.7) {
             $this->markTestSkipped('Version less than 5.7 do not support guest user.');
@@ -109,10 +100,7 @@ class CanDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itPassesMultiplePolicies(): void
+    public function testPassesMultiplePolicies(): void
     {
         $user = new User;
         $user->name = UserPolicy::ADMIN;
@@ -145,10 +133,7 @@ class CanDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itProcessesTheArgsArgument(): void
+    public function testProcessesTheArgsArgument(): void
     {
         $this->schema = '
         type Query {

--- a/tests/Unit/Schema/Directives/ComplexityDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/ComplexityDirectiveTest.php
@@ -7,10 +7,7 @@ use Illuminate\Support\Arr;
 
 class ComplexityDirectiveTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itCanSetDefaultComplexityOnField(): void
+    public function testCanSetDefaultComplexityOnField(): void
     {
         $schema = $this->buildSchemaWithPlaceholderQuery('
         type User {
@@ -30,10 +27,7 @@ class ComplexityDirectiveTest extends TestCase
         $this->assertSame(100, $complexityFn(10, [config('lighthouse.pagination_amount_argument') => 10]));
     }
 
-    /**
-     * @test
-     */
-    public function itCanSetCustomComplexityResolver(): void
+    public function testCanSetCustomComplexityResolver(): void
     {
         $schema = $this->buildSchemaWithPlaceholderQuery('
         type User {
@@ -54,10 +48,7 @@ class ComplexityDirectiveTest extends TestCase
         $this->assertSame(100, $complexityFn(10, ['foo' => 10]));
     }
 
-    /**
-     * @test
-     */
-    public function itResolvesComplexityResolverThroughDefaultNamespace(): void
+    public function testResolvesComplexityResolverThroughDefaultNamespace(): void
     {
         $schema = $this->buildSchema('
         type Query {

--- a/tests/Unit/Schema/Directives/DeprecatedDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/DeprecatedDirectiveTest.php
@@ -9,10 +9,7 @@ use GraphQL\Type\Definition\Directive;
 
 class DeprecatedDirectiveTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itCanRemoveDeprecatedFieldsFromIntrospection(): void
+    public function testCanRemoveDeprecatedFieldsFromIntrospection(): void
     {
         $reason = 'Use `bar` field';
         $resolver = addslashes(Foo::class).'@bar';

--- a/tests/Unit/Schema/Directives/FieldDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/FieldDirectiveTest.php
@@ -9,10 +9,7 @@ use Nuwave\Lighthouse\Exceptions\DefinitionException;
 
 class FieldDirectiveTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itAssignsResolverFromCombinedDefinition(): void
+    public function testAssignsResolverFromCombinedDefinition(): void
     {
         $this->schema = '
         type Query {
@@ -31,10 +28,7 @@ class FieldDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itAssignsResolverWithInvokableClass(): void
+    public function testAssignsResolverWithInvokableClass(): void
     {
         $this->schema = '
         type Query {
@@ -53,10 +47,7 @@ class FieldDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveFieldWithMergedArgs(): void
+    public function testCanResolveFieldWithMergedArgs(): void
     {
         $this->schema = '
         type Query {
@@ -75,10 +66,7 @@ class FieldDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itUsesDefaultFieldNamespace(): void
+    public function testUsesDefaultFieldNamespace(): void
     {
         $this->schema = '
         type Query {
@@ -97,10 +85,7 @@ class FieldDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itUsesDefaultFieldNamespaceForInvokableClass(): void
+    public function testUsesDefaultFieldNamespaceForInvokableClass(): void
     {
         $this->schema = '
         type Query {
@@ -119,10 +104,7 @@ class FieldDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsAnErrorWhenNoClassFound(): void
+    public function testThrowsAnErrorWhenNoClassFound(): void
     {
         $this->expectException(DirectiveException::class);
         $this->expectExceptionMessage("No class 'bar' was found for directive 'field'");
@@ -140,10 +122,7 @@ class FieldDirectiveTest extends TestCase
         ');
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsAnErrorWhenClassIsntInvokable(): void
+    public function testThrowsAnErrorWhenClassIsntInvokable(): void
     {
         $this->expectException(DefinitionException::class);
         $this->expectExceptionMessage("Method '__invoke' does not exist on class 'Tests\Utils\Queries\Foo'");

--- a/tests/Unit/Schema/Directives/GlobalIdDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/GlobalIdDirectiveTest.php
@@ -20,10 +20,7 @@ class GlobalIdDirectiveTest extends TestCase
         $this->globalId = $this->app->make(GlobalId::class);
     }
 
-    /**
-     * @test
-     */
-    public function itDecodesGlobalId(): void
+    public function testDecodesGlobalId(): void
     {
         $this->schema = '
         type Query {
@@ -42,10 +39,7 @@ class GlobalIdDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itDecodesGlobalIds(): void
+    public function testDecodesGlobalIds(): void
     {
         $this->schema = "
         type Query {

--- a/tests/Unit/Schema/Directives/InjectDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/InjectDirectiveTest.php
@@ -7,10 +7,7 @@ use Tests\Utils\Models\User;
 
 class InjectDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itCanInjectDataFromContextIntoArgs(): void
+    public function testCanInjectDataFromContextIntoArgs(): void
     {
         $user = factory(User::class)->create();
         $this->be($user);

--- a/tests/Unit/Schema/Directives/MethodDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/MethodDirectiveTest.php
@@ -17,10 +17,7 @@ class MethodDirectiveTest extends TestCase
     }
     ';
 
-    /**
-     * @test
-     */
-    public function itWillCallAMethodToResolveField(): void
+    public function testWillCallAMethodToResolveField(): void
     {
         $this->graphQL('
         {
@@ -37,10 +34,7 @@ class MethodDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itWillCallAMethodWithArgsToResolveField(): void
+    public function testWillCallAMethodWithArgsToResolveField(): void
     {
         $this->graphQL('
         {

--- a/tests/Unit/Schema/Directives/MiddlewareDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/MiddlewareDirectiveTest.php
@@ -12,13 +12,12 @@ use Nuwave\Lighthouse\Exceptions\DirectiveException;
 class MiddlewareDirectiveTest extends TestCase
 {
     /**
-     * @test
      * @dataProvider fooMiddlewareQueries
      *
      * @param  string  $query
      * @return void
      */
-    public function itCallsFooMiddleware(string $query): void
+    public function testCallsFooMiddleware(string $query): void
     {
         $this->schema = '
         type Query {
@@ -58,10 +57,7 @@ class MiddlewareDirectiveTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     */
-    public function itWrapsExceptionFromMiddlewareInResponse(): void
+    public function testWrapsExceptionFromMiddlewareInResponse(): void
     {
         $this->schema = '
         type Query {
@@ -82,10 +78,7 @@ class MiddlewareDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itRunsAliasedMiddleware(): void
+    public function testRunsAliasedMiddleware(): void
     {
         /** @var \Illuminate\Routing\Router $router */
         $router = $this->app['router'];
@@ -110,10 +103,7 @@ class MiddlewareDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itRunsMiddlewareGroup(): void
+    public function testRunsMiddlewareGroup(): void
     {
         /** @var \Illuminate\Routing\Router $router */
         $router = $this->app['router'];
@@ -139,10 +129,7 @@ class MiddlewareDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itPassesOneFieldButThrowsInAnother(): void
+    public function testPassesOneFieldButThrowsInAnother(): void
     {
         $this->schema = '
         type Query {
@@ -175,10 +162,7 @@ class MiddlewareDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsWhenDefiningMiddlewareOnInvalidTypes(): void
+    public function testThrowsWhenDefiningMiddlewareOnInvalidTypes(): void
     {
         $this->expectException(DirectiveException::class);
         $this->buildSchemaWithPlaceholderQuery('
@@ -186,10 +170,7 @@ class MiddlewareDirectiveTest extends TestCase
         ');
     }
 
-    /**
-     * @test
-     */
-    public function itAddsMiddlewareDirectiveToFields(): void
+    public function testAddsMiddlewareDirectiveToFields(): void
     {
         $this->schema = '
         type Query @middleware(checks: ["auth", "Tests\\\Utils\\\Middleware\\\Authenticate", "api"]) {
@@ -216,10 +197,7 @@ class MiddlewareDirectiveTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itPrefersFieldMiddlewareOverTypeMiddleware(): void
+    public function testPrefersFieldMiddlewareOverTypeMiddleware(): void
     {
         $this->schema = '
         type Query @middleware(checks: ["auth"]) {

--- a/tests/Unit/Schema/Directives/NamespaceDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/NamespaceDirectiveTest.php
@@ -6,10 +6,7 @@ use Tests\TestCase;
 
 class NamespaceDirectiveTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itCanSetNamespaceOnField(): void
+    public function testCanSetNamespaceOnField(): void
     {
         $this->schema = '
         type Query {
@@ -28,10 +25,7 @@ class NamespaceDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanSetNamespaceFromType(): void
+    public function testCanSetNamespaceFromType(): void
     {
         $this->schema = '
         type Query @namespace(field: "Tests\\\Utils\\\QueriesSecondary") {
@@ -50,10 +44,7 @@ class NamespaceDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itPrefersFieldNamespaceOverTypeNamespace(): void
+    public function testPrefersFieldNamespaceOverTypeNamespace(): void
     {
         $this->schema = '
         type Query @namespace(field: "Tests\\\Utils\\\QueriesSecondary") {

--- a/tests/Unit/Schema/Directives/OrderByDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/OrderByDirectiveTest.php
@@ -19,10 +19,7 @@ class OrderByDirectiveTest extends DBTestCase
     }    
     ';
 
-    /**
-     * @test
-     */
-    public function itCanOrderByTheGivenFieldAndSortOrderASC(): void
+    public function testCanOrderByTheGivenFieldAndSortOrderASC(): void
     {
         factory(User::class)->create(['name' => 'B']);
         factory(User::class)->create(['name' => 'A']);
@@ -54,10 +51,7 @@ class OrderByDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanOrderByTheGivenFieldAndSortOrderDESC(): void
+    public function testCanOrderByTheGivenFieldAndSortOrderDESC(): void
     {
         factory(User::class)->create(['name' => 'B']);
         factory(User::class)->create(['name' => 'A']);
@@ -89,10 +83,7 @@ class OrderByDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanOrderByMultipleFields(): void
+    public function testCanOrderByMultipleFields(): void
     {
         factory(User::class)->create(['name' => 'B', 'team_id' => 2]);
         factory(User::class)->create(['name' => 'A', 'team_id' => 5]);
@@ -136,10 +127,7 @@ class OrderByDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsOnInvalidDefinition(): void
+    public function testThrowsOnInvalidDefinition(): void
     {
         $this->expectException(DefinitionException::class);
 

--- a/tests/Unit/Schema/Directives/PaginateDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/PaginateDirectiveTest.php
@@ -8,10 +8,7 @@ use GraphQL\Type\Definition\FieldDefinition;
 
 class PaginateDirectiveTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itCanAliasRelayToConnection(): void
+    public function testCanAliasRelayToConnection(): void
     {
         $connection = $this->getConnectionQueryField('connection');
         $relay = $this->getConnectionQueryField('relay');
@@ -35,10 +32,7 @@ class PaginateDirectiveTest extends TestCase
             ->getField('users');
     }
 
-    /**
-     * @test
-     */
-    public function itOnlyRegistersOneTypeForMultiplePaginators(): void
+    public function testOnlyRegistersOneTypeForMultiplePaginators(): void
     {
         $schema = $this->buildSchema('
         type User {
@@ -67,10 +61,7 @@ class PaginateDirectiveTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itRegistersPaginatorFromTypeExtensionField(): void
+    public function testRegistersPaginatorFromTypeExtensionField(): void
     {
         $schema = $this->buildSchemaWithPlaceholderQuery('
         type User {
@@ -96,10 +87,7 @@ class PaginateDirectiveTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itHasMaxCountInGeneratedCountDescription(): void
+    public function testHasMaxCountInGeneratedCountDescription(): void
     {
         config(['lighthouse.paginate_max_count' => 5]);
 
@@ -139,7 +127,7 @@ class PaginateDirectiveTest extends TestCase
         );
     }
 
-    public function itCanChangePaginationAmountArgument(): void
+    public function testCanChangePaginationAmountArgument(): void
     {
         config(['lighthouse.pagination_amount_argument' => 'first']);
 

--- a/tests/Unit/Schema/Directives/RenameDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/RenameDirectiveTest.php
@@ -7,10 +7,7 @@ use Nuwave\Lighthouse\Exceptions\DirectiveException;
 
 class RenameDirectiveTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itCanRenameAField(): void
+    public function testCanRenameAField(): void
     {
         $this->schema = "
         type Query {
@@ -42,10 +39,7 @@ class RenameDirectiveTest extends TestCase
         return new Bar;
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsAnExceptionIfNoAttributeDefined(): void
+    public function testThrowsAnExceptionIfNoAttributeDefined(): void
     {
         $this->expectException(DirectiveException::class);
 

--- a/tests/Unit/Schema/Directives/RulesDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/RulesDirectiveTest.php
@@ -73,10 +73,7 @@ class RulesDirectiveTest extends TestCase
         ";
     }
 
-    /**
-     * @test
-     */
-    public function itCanValidateQueryRootFieldArguments(): void
+    public function testCanValidateQueryRootFieldArguments(): void
     {
         $this->graphQL('
         {
@@ -119,10 +116,7 @@ class RulesDirectiveTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanReturnValidFieldsAndErrorMessagesForInvalidFields(): void
+    public function testCanReturnValidFieldsAndErrorMessagesForInvalidFields(): void
     {
         $this->graphQL('
         {
@@ -166,10 +160,7 @@ class RulesDirectiveTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanValidateRootMutationFieldArgs(): void
+    public function testCanValidateRootMutationFieldArgs(): void
     {
         $this->graphQL('
         mutation {
@@ -197,10 +188,7 @@ class RulesDirectiveTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itCanValidateArrayType(): void
+    public function testCanValidateArrayType(): void
     {
         $this->graphQL('
         {
@@ -261,10 +249,7 @@ class RulesDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itCanReturnCorrectValidationForInputObjects(): void
+    public function testCanReturnCorrectValidationForInputObjects(): void
     {
         $this->graphQL('
         {
@@ -313,10 +298,7 @@ class RulesDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itUsesCustomRuleClass(): void
+    public function testUsesCustomRuleClass(): void
     {
         $this->graphQL('
         mutation {

--- a/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
@@ -7,10 +7,7 @@ use Tests\Utils\Models\User;
 
 class SpreadDirectiveTest extends DBTestCase
 {
-    /**
-     * @test
-     */
-    public function itSpreadsTheInputIntoTheQuery(): void
+    public function testSpreadsTheInputIntoTheQuery(): void
     {
         factory(User::class, 2)->create();
 
@@ -45,10 +42,7 @@ class SpreadDirectiveTest extends DBTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
-    public function itIgnoresSpreadedInputIfNotGiven(): void
+    public function testIgnoresSpreadedInputIfNotGiven(): void
     {
         factory(User::class)->create();
 

--- a/tests/Unit/Schema/Directives/WhereJsonContainsDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/WhereJsonContainsDirectiveTest.php
@@ -26,10 +26,7 @@ class WhereJsonContainsDirectiveTest extends DBTestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function itCanApplyWhereJsonContainsFilter(): void
+    public function testCanApplyWhereJsonContainsFilter(): void
     {
         $nestedBar = \Safe\json_encode([
             'nested' => 'bar',

--- a/tests/Unit/Schema/Execution/ContextFactoryTest.php
+++ b/tests/Unit/Schema/Execution/ContextFactoryTest.php
@@ -48,10 +48,7 @@ class ContextFactoryTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
-    public function itCanGenerateCustomContext(): void
+    public function testCanGenerateCustomContext(): void
     {
         $this->schema = "
         type Query {

--- a/tests/Unit/Schema/Factories/DirectiveFactoryTest.php
+++ b/tests/Unit/Schema/Factories/DirectiveFactoryTest.php
@@ -27,10 +27,7 @@ class DirectiveFactoryTest extends TestCase
         parent::getEnvironmentSetUp($app);
     }
 
-    /**
-     * @test
-     */
-    public function itRegistersLighthouseDirectives(): void
+    public function testRegistersLighthouseDirectives(): void
     {
         $this->assertInstanceOf(
             FieldDirective::class,
@@ -38,10 +35,7 @@ class DirectiveFactoryTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itHydratesBaseDirectives(): void
+    public function testHydratesBaseDirectives(): void
     {
         $fieldDefinition = PartialParser::fieldDefinition('
             foo: String
@@ -58,10 +52,7 @@ class DirectiveFactoryTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itSkipsHydrationForNonBaseDirectives(): void
+    public function testSkipsHydrationForNonBaseDirectives(): void
     {
         $fieldDefinition = PartialParser::fieldDefinition('
             foo: String
@@ -85,20 +76,14 @@ class DirectiveFactoryTest extends TestCase
         $this->assertObjectNotHasAttribute('definitionNode', $directive);
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsIfDirectiveNameCanNotBeResolved(): void
+    public function testThrowsIfDirectiveNameCanNotBeResolved(): void
     {
         $this->expectException(DirectiveException::class);
 
         $this->directiveFactory->create('bar');
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateSingleDirective(): void
+    public function testCanCreateSingleDirective(): void
     {
         $fieldDefinition = PartialParser::fieldDefinition('
             foo: [Foo!]! @hasMany
@@ -108,10 +93,7 @@ class DirectiveFactoryTest extends TestCase
         $this->assertInstanceOf(FieldResolver::class, $resolver);
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsExceptionWhenMultipleFieldResolverDirectives(): void
+    public function testThrowsExceptionWhenMultipleFieldResolverDirectives(): void
     {
         $this->expectException(DirectiveException::class);
 
@@ -122,10 +104,7 @@ class DirectiveFactoryTest extends TestCase
         $this->directiveFactory->createSingleDirectiveOfType($fieldDefinition, FieldResolver::class);
     }
 
-    /**
-     * @test
-     */
-    public function itCanCreateMultipleDirectives(): void
+    public function testCanCreateMultipleDirectives(): void
     {
         $fieldDefinition = PartialParser::fieldDefinition('
             bar: String @can(if: ["viewBar"]) @event

--- a/tests/Unit/Schema/ResolverProviderTest.php
+++ b/tests/Unit/Schema/ResolverProviderTest.php
@@ -25,10 +25,7 @@ class ResolverProviderTest extends TestCase
         $this->resolverProvider = new ResolverProvider;
     }
 
-    /**
-     * @test
-     */
-    public function itGetsTheWebonyxDefaultResolverForNonRootFields(): void
+    public function testGetsTheWebonyxDefaultResolverForNonRootFields(): void
     {
         $fieldValue = $this->constructFieldValue('nonExisting: Int', 'NonRoot');
 
@@ -38,10 +35,7 @@ class ResolverProviderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itGetsTheConventionBasedDefaultResolverForRootFields(): void
+    public function testGetsTheConventionBasedDefaultResolverForRootFields(): void
     {
         $fieldValue = $this->constructFieldValue('foo: Int');
 
@@ -51,10 +45,7 @@ class ResolverProviderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itGetsTheConventionBasedDefaultResolverForRootFieldsWithInvoke(): void
+    public function testGetsTheConventionBasedDefaultResolverForRootFieldsWithInvoke(): void
     {
         $fieldValue = $this->constructFieldValue('fooInvoke: Int');
 
@@ -65,10 +56,9 @@ class ResolverProviderTest extends TestCase
     }
 
     /**
-     * @test
      * @deprecated will be changed in v5
      */
-    public function itGetsTheConventionBasedDefaultResolverForRootFieldsAndDefaultsToResolve(): void
+    public function testGetsTheConventionBasedDefaultResolverForRootFieldsAndDefaultsToResolve(): void
     {
         $fieldValue = $this->constructFieldValue('fooBar: String');
 
@@ -84,10 +74,7 @@ class ResolverProviderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itLooksAtMultipleNamespacesWhenLookingForDefaultFieldResolvers(): void
+    public function testLooksAtMultipleNamespacesWhenLookingForDefaultFieldResolvers(): void
     {
         $fieldValue = $this->constructFieldValue('baz: Int');
 
@@ -97,10 +84,7 @@ class ResolverProviderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsIfRootFieldHasNoResolver(): void
+    public function testThrowsIfRootFieldHasNoResolver(): void
     {
         $this->expectException(DefinitionException::class);
 

--- a/tests/Unit/Schema/SchemaBuilderTest.php
+++ b/tests/Unit/Schema/SchemaBuilderTest.php
@@ -11,10 +11,7 @@ use GraphQL\Type\Definition\InputObjectType;
 
 class SchemaBuilderTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itGeneratesValidSchema(): void
+    public function testGeneratesValidSchema(): void
     {
         $schema = $this->buildSchemaWithPlaceholderQuery('');
 
@@ -23,10 +20,7 @@ class SchemaBuilderTest extends TestCase
         $schema->assertValid();
     }
 
-    /**
-     * @test
-     */
-    public function itGeneratesWithEmptyQueryType(): void
+    public function testGeneratesWithEmptyQueryType(): void
     {
         $schema = $this->buildSchema('
         type Query
@@ -41,10 +35,7 @@ class SchemaBuilderTest extends TestCase
         $schema->assertValid();
     }
 
-    /**
-     * @test
-     */
-    public function itGeneratesWithEmptyMutationType(): void
+    public function testGeneratesWithEmptyMutationType(): void
     {
         $schema = $this->buildSchema('
         type Query
@@ -63,10 +54,7 @@ class SchemaBuilderTest extends TestCase
         $this->assertSame('foo', $foo->name);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveEnumTypes(): void
+    public function testCanResolveEnumTypes(): void
     {
         $schema = $this->buildSchemaWithPlaceholderQuery('
         "Role description"
@@ -89,10 +77,7 @@ class SchemaBuilderTest extends TestCase
         $this->assertSame('Company administrator.', $enumType->getValue('ADMIN')->description);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveInterfaceTypes(): void
+    public function testCanResolveInterfaceTypes(): void
     {
         $schema = $this->buildSchemaWithPlaceholderQuery('
         """
@@ -112,10 +97,7 @@ class SchemaBuilderTest extends TestCase
         $this->assertSame('bar is baz', $interfaceType->getField('bar')->description);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveObjectTypes(): void
+    public function testCanResolveObjectTypes(): void
     {
         $schema = $this->buildSchemaWithPlaceholderQuery('
         "asdf"
@@ -143,10 +125,7 @@ class SchemaBuilderTest extends TestCase
         $this->assertFalse($baz->defaultValue);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveInputObjectTypes(): void
+    public function testCanResolveInputObjectTypes(): void
     {
         $schema = $this->buildSchemaWithPlaceholderQuery('
         "bla"
@@ -167,10 +146,7 @@ class SchemaBuilderTest extends TestCase
         $this->assertSame(123, $inputObjectType->getField('bar')->defaultValue);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveMutations(): void
+    public function testCanResolveMutations(): void
     {
         $schema = $this->buildSchemaWithPlaceholderQuery('
         type Mutation {
@@ -185,10 +161,7 @@ class SchemaBuilderTest extends TestCase
         $this->assertSame('foo', $foo->name);
     }
 
-    /**
-     * @test
-     */
-    public function itCanResolveQueries(): void
+    public function testCanResolveQueries(): void
     {
         $schema = $this->buildSchemaWithPlaceholderQuery('');
 
@@ -199,10 +172,7 @@ class SchemaBuilderTest extends TestCase
         $this->assertSame('foo', $field->name);
     }
 
-    /**
-     * @test
-     */
-    public function itCanExtendObjectTypes(): void
+    public function testCanExtendObjectTypes(): void
     {
         $schema = $this->buildSchemaWithPlaceholderQuery('
         type Foo {
@@ -221,10 +191,7 @@ class SchemaBuilderTest extends TestCase
         $this->assertArrayHasKey('baz', $fields);
     }
 
-    /**
-     * @test
-     */
-    public function itCanExtendTypes(): void
+    public function testCanExtendTypes(): void
     {
         $schema = $this->buildSchemaWithPlaceholderQuery('
         type Foo {
@@ -243,10 +210,7 @@ class SchemaBuilderTest extends TestCase
         $this->assertSame('yo?', $type->getField('bar')->description);
     }
 
-    /**
-     * @test
-     */
-    public function itResolvesEnumDefaultValuesToInternalValues(): void
+    public function testResolvesEnumDefaultValuesToInternalValues(): void
     {
         $schema = $this->buildSchema('
         type Query {

--- a/tests/Unit/Schema/SecurityTest.php
+++ b/tests/Unit/Schema/SecurityTest.php
@@ -9,10 +9,7 @@ use GraphQL\Validator\Rules\DisableIntrospection;
 
 class SecurityTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itCanSetMaxComplexityThroughConfig(): void
+    public function testCanSetMaxComplexityThroughConfig(): void
     {
         config(['lighthouse.security.max_query_complexity' => 1]);
 
@@ -29,10 +26,7 @@ class SecurityTest extends TestCase
         $this->assertMaxQueryComplexityIs1();
     }
 
-    /**
-     * @test
-     */
-    public function itCanSetMaxDepthThroughConfig(): void
+    public function testCanSetMaxDepthThroughConfig(): void
     {
         config(['lighthouse.security.max_query_depth' => 1]);
 
@@ -50,10 +44,7 @@ class SecurityTest extends TestCase
         $this->assertMaxQueryDepthIs1();
     }
 
-    /**
-     * @test
-     */
-    public function itCanDisableIntrospectionThroughConfig(): void
+    public function testCanDisableIntrospectionThroughConfig(): void
     {
         config(['lighthouse.security.disable_introspection' => true]);
 

--- a/tests/Unit/Schema/TypeRegistryTest.php
+++ b/tests/Unit/Schema/TypeRegistryTest.php
@@ -29,10 +29,7 @@ class TypeRegistryTest extends TestCase
         $this->typeRegistry = app(TypeRegistry::class);
     }
 
-    /**
-     * @test
-     */
-    public function itSetsEnumValueThroughDirective(): void
+    public function testSetsEnumValueThroughDirective(): void
     {
         $enumNode = PartialParser::enumTypeDefinition('
         enum Role {
@@ -47,10 +44,7 @@ class TypeRegistryTest extends TestCase
         $this->assertSame(123, $enumType->getValue('ADMIN')->value);
     }
 
-    /**
-     * @test
-     */
-    public function itDefaultsEnumValueToItsName(): void
+    public function testDefaultsEnumValueToItsName(): void
     {
         $enumNode = PartialParser::enumTypeDefinition('
         enum Role {
@@ -65,10 +59,7 @@ class TypeRegistryTest extends TestCase
         $this->assertSame('EMPLOYEE', $enumType->getValue('EMPLOYEE')->value);
     }
 
-    /**
-     * @test
-     */
-    public function itCanTransformScalars(): void
+    public function testCanTransformScalars(): void
     {
         $scalarNode = PartialParser::scalarTypeDefinition('
         scalar Email
@@ -80,10 +71,7 @@ class TypeRegistryTest extends TestCase
         $this->assertSame('Email', $scalarType->name);
     }
 
-    /**
-     * @test
-     */
-    public function itCanPointToScalarClassThroughDirective(): void
+    public function testCanPointToScalarClassThroughDirective(): void
     {
         $scalarNode = PartialParser::scalarTypeDefinition('
         scalar DateTime @scalar(class: "Nuwave\\\Lighthouse\\\Schema\\\Types\\\Scalars\\\DateTime")
@@ -95,10 +83,7 @@ class TypeRegistryTest extends TestCase
         $this->assertSame('DateTime', $scalarType->name);
     }
 
-    /**
-     * @test
-     */
-    public function itCanPointToScalarClassThroughDirectiveWithoutNamespace(): void
+    public function testCanPointToScalarClassThroughDirectiveWithoutNamespace(): void
     {
         $scalarNode = PartialParser::scalarTypeDefinition('
         scalar SomeEmail @scalar(class: "Email")
@@ -110,10 +95,7 @@ class TypeRegistryTest extends TestCase
         $this->assertSame('SomeEmail', $scalarType->name);
     }
 
-    /**
-     * @test
-     */
-    public function itCanTransformInterfaces(): void
+    public function testCanTransformInterfaces(): void
     {
         $interfaceNode = PartialParser::interfaceTypeDefinition('
         interface Foo {
@@ -128,10 +110,7 @@ class TypeRegistryTest extends TestCase
         $this->assertArrayHasKey('bar', $interfaceType->getFields());
     }
 
-    /**
-     * @test
-     */
-    public function itResolvesInterfaceThoughNamespace(): void
+    public function testResolvesInterfaceThoughNamespace(): void
     {
         $interfaceNode = PartialParser::interfaceTypeDefinition('
         interface Nameable {
@@ -145,10 +124,7 @@ class TypeRegistryTest extends TestCase
         $this->assertSame('Nameable', $interfaceType->name);
     }
 
-    /**
-     * @test
-     */
-    public function itResolvesInterfaceThoughSecondaryNamespace(): void
+    public function testResolvesInterfaceThoughSecondaryNamespace(): void
     {
         $interfaceNode = PartialParser::interfaceTypeDefinition('
         interface Bar {
@@ -162,10 +138,7 @@ class TypeRegistryTest extends TestCase
         $this->assertSame('Bar', $interfaceType->name);
     }
 
-    /**
-     * @test
-     */
-    public function itCanTransformUnions(): void
+    public function testCanTransformUnions(): void
     {
         $unionNode = PartialParser::unionTypeDefinition('
         union Foo = Bar
@@ -178,10 +151,7 @@ class TypeRegistryTest extends TestCase
         $this->assertInstanceOf(Closure::class, $unionType->config['resolveType']);
     }
 
-    /**
-     * @test
-     */
-    public function itCanTransformObjectTypes(): void
+    public function testCanTransformObjectTypes(): void
     {
         $objectTypeNode = PartialParser::objectTypeDefinition('
         type User {
@@ -196,10 +166,7 @@ class TypeRegistryTest extends TestCase
         $this->assertArrayHasKey('foo', $objectType->getFields());
     }
 
-    /**
-     * @test
-     */
-    public function itCanTransformInputObjectTypes(): void
+    public function testCanTransformInputObjectTypes(): void
     {
         $inputNode = PartialParser::inputObjectTypeDefinition('
         input UserInput {

--- a/tests/Unit/Schema/Types/Scalars/DateTest.php
+++ b/tests/Unit/Schema/Types/Scalars/DateTest.php
@@ -13,13 +13,12 @@ use Nuwave\Lighthouse\Schema\Types\Scalars\Date;
 class DateTest extends TestCase
 {
     /**
-     * @test
      * @dataProvider invalidDateValues
      *
      * @param  mixed  $value
      * @return void
      */
-    public function itThrowsIfSerializingNonString($value): void
+    public function testThrowsIfSerializingNonString($value): void
     {
         $this->expectException(InvariantViolation::class);
 
@@ -27,13 +26,12 @@ class DateTest extends TestCase
     }
 
     /**
-     * @test
      * @dataProvider invalidDateValues
      *
      * @param  mixed  $value
      * @return void
      */
-    public function itThrowsIfParseValueNonString($value): void
+    public function testThrowsIfParseValueNonString($value): void
     {
         $this->expectException(Error::class);
 
@@ -58,10 +56,7 @@ class DateTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     */
-    public function itParsesValueString(): void
+    public function testParsesValueString(): void
     {
         $date = '2018-10-01';
         $this->assertEquals(
@@ -70,10 +65,7 @@ class DateTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itParsesLiteral(): void
+    public function testParsesLiteral(): void
     {
         $dateLiteral = new StringValueNode(
             ['value' => '2018-10-01']
@@ -86,10 +78,7 @@ class DateTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsIfParseLiteralNonString(): void
+    public function testThrowsIfParseLiteralNonString(): void
     {
         $this->expectException(Error::class);
 
@@ -98,10 +87,7 @@ class DateTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itSerializesCarbonInstance(): void
+    public function testSerializesCarbonInstance(): void
     {
         $now = now();
         $result = (new Date)->serialize($now);
@@ -112,10 +98,7 @@ class DateTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itSerializesValidDateString(): void
+    public function testSerializesValidDateString(): void
     {
         $date = '2018-10-01';
         $result = (new Date)->serialize($date);

--- a/tests/Unit/Schema/Types/Scalars/DateTimeTest.php
+++ b/tests/Unit/Schema/Types/Scalars/DateTimeTest.php
@@ -13,13 +13,12 @@ use Nuwave\Lighthouse\Schema\Types\Scalars\DateTime;
 class DateTimeTest extends TestCase
 {
     /**
-     * @test
      * @dataProvider invalidDateTimeValues
      *
      * @param  mixed  $value
      * @return void
      */
-    public function itThrowsIfSerializingNonString($value): void
+    public function testThrowsIfSerializingNonString($value): void
     {
         $this->expectException(InvariantViolation::class);
 
@@ -27,13 +26,12 @@ class DateTimeTest extends TestCase
     }
 
     /**
-     * @test
      * @dataProvider invalidDateTimeValues
      *
      * @param  mixed  $value
      * @return void
      */
-    public function itThrowsIfParseValueNonString($value): void
+    public function testThrowsIfParseValueNonString($value): void
     {
         $this->expectException(Error::class);
 
@@ -57,10 +55,7 @@ class DateTimeTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     */
-    public function itParsesValueString(): void
+    public function testParsesValueString(): void
     {
         $date = '2018-10-01 12:45:01';
         $this->assertEquals(
@@ -69,10 +64,7 @@ class DateTimeTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itParsesLiteral(): void
+    public function testParsesLiteral(): void
     {
         $dateLiteral = new StringValueNode(
             ['value' => '2018-10-01 12:45:01']
@@ -85,10 +77,7 @@ class DateTimeTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsIfParseLiteralNonString(): void
+    public function testThrowsIfParseLiteralNonString(): void
     {
         $this->expectException(Error::class);
 
@@ -97,10 +86,7 @@ class DateTimeTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itSerializesCarbonInstance(): void
+    public function testSerializesCarbonInstance(): void
     {
         $now = now();
         $result = (new DateTime)->serialize($now);
@@ -111,10 +97,7 @@ class DateTimeTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itSerializesValidDateTimeString(): void
+    public function testSerializesValidDateTimeString(): void
     {
         $date = '2018-10-01 12:45:01';
         $result = (new DateTime)->serialize($date);

--- a/tests/Unit/Schema/Types/Scalars/UploadTest.php
+++ b/tests/Unit/Schema/Types/Scalars/UploadTest.php
@@ -10,40 +10,28 @@ use Nuwave\Lighthouse\Schema\Types\Scalars\Upload;
 
 class UploadTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itThrowsIfSerializing(): void
+    public function testThrowsIfSerializing(): void
     {
         $this->expectException(InvariantViolation::class);
 
         (new Upload)->serialize('');
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsIfParsingLiteral(): void
+    public function testThrowsIfParsingLiteral(): void
     {
         $this->expectException(Error::class);
 
         (new Upload)->parseLiteral('');
     }
 
-    /**
-     * @test
-     */
-    public function itThrowsIfParsingValueNotFile(): void
+    public function testThrowsIfParsingValueNotFile(): void
     {
         $this->expectException(Error::class);
 
         (new Upload)->parseValue('not a file');
     }
 
-    /**
-     * @test
-     */
-    public function itParsesValidFiles(): void
+    public function testParsesValidFiles(): void
     {
         $value = UploadedFile::fake()
             ->create('my-file.jpg', 500);

--- a/tests/Unit/Subscriptions/Broadcast/BroadcastTest.php
+++ b/tests/Unit/Subscriptions/Broadcast/BroadcastTest.php
@@ -56,10 +56,7 @@ class BroadcastTest extends DBTestCase
         return $broadcast;
     }
 
-    /**
-     * @test
-     */
-    public function itBroadcastsFromPhp(): void
+    public function testBroadcastsFromPhp(): void
     {
         // Assert
         $broadcast = $this->withMockedBroadcasts();
@@ -80,10 +77,7 @@ class BroadcastTest extends DBTestCase
         Subscription::broadcast('taskUpdated', []);
     }
 
-    /**
-     * @test
-     */
-    public function itBroadcastsFromSchema(): void
+    public function testBroadcastsFromSchema(): void
     {
         // Assert
         $broadcast = $this->withMockedBroadcasts();

--- a/tests/Unit/Subscriptions/Iterators/SyncIteratorTest.php
+++ b/tests/Unit/Subscriptions/Iterators/SyncIteratorTest.php
@@ -26,10 +26,7 @@ class SyncIteratorTest extends TestCase
         $this->iterator = new SyncIterator;
     }
 
-    /**
-     * @test
-     */
-    public function itCanIterateOverItemsWithCallback(): void
+    public function testCanIterateOverItemsWithCallback(): void
     {
         $items = [];
 
@@ -43,10 +40,7 @@ class SyncIteratorTest extends TestCase
         $this->assertCount(3, $items);
     }
 
-    /**
-     * @test
-     */
-    public function itCanPassExceptionToHandler(): void
+    public function testCanPassExceptionToHandler(): void
     {
         /** @var \Exception|null $exception */
         $exception = null;


### PR DESCRIPTION
Just some internal refactoring.

This actually adds one test case that previously did not run because of the missing `@test` annotation.