### PR TITLE
Fix extra new line in GlobalId::decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Remove the extra new line from the returned value when using `@globalId(decode: "ID")`.
+- Remove the extra new line from the returned value when using `@globalId(decode: "ID")` https://github.com/nuwave/lighthouse/pull/982
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow overwriting the name of Enum types created through `LaravelEnumType` https://github.com/nuwave/lighthouse/pull/968
 
+### Fixed
+
+- Remove the extra new line from the returned value when using `@globalId(decode: "ID")`.
+
 ### Changed
 
 - Allow additional route configurations `prefix` and `domain` https://github.com/nuwave/lighthouse/pull/951

--- a/src/Execution/Utils/GlobalId.php
+++ b/src/Execution/Utils/GlobalId.php
@@ -51,7 +51,7 @@ class GlobalId implements GlobalIdContract
     {
         [$type, $id] = self::decode($globalID);
 
-        return $id;
+        return trim($id);
     }
 
     /**
@@ -64,6 +64,6 @@ class GlobalId implements GlobalIdContract
     {
         [$type, $id] = self::decode($globalID);
 
-        return $type;
+        return trim($type);
     }
 }


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Added Docs for all relevant versions
- [x] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behavior this PR introduces. -->

Trim return values from decodeID and decodeType.

I have the following schema.

```graphql
input UpdateCityInput {
  cityId: ID! @globalId(decode: "ID")
  ...
}
```

Sometimes the returned value has a new line at the end, for this reason, the Laravel find method does not find the record.

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->

None.