### PR TITLE
[Feat] Added @count directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `@count` directive for counting a relationship https://github.com/nuwave/lighthouse/pull/984
 - Allow overwriting the name of Enum types created through `LaravelEnumType` https://github.com/nuwave/lighthouse/pull/968
 
 ### Changed

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -579,6 +579,30 @@ class ComplexityAnalyzer {
     }
 ```
 
+## Count
+
+Returns the count of a given relationship
+
+```
+type User  {
+    id: ID!
+    likes: Int! @count(relation: "likes")
+}
+```
+### Definition
+
+```graphql
+"""
+Resolve the field through a count.
+"""
+directive @count(
+  """
+  The relationship which you want to run the count on.
+  """
+  relation: String!
+) on FIELD_DEFINITION
+```
+
 ## @create
 
 Create a new Eloquent model with the given arguments.

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -581,7 +581,7 @@ class ComplexityAnalyzer {
 
 ## Count
 
-Returns the count of a given relationship or a model
+Returns the count of a given relationship or model.
 
 ```graphql
 type User  {

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -581,12 +581,18 @@ class ComplexityAnalyzer {
 
 ## Count
 
-Returns the count of a given relationship
+Returns the count of a given relationship or a model
 
-```
+```graphql
 type User  {
     id: ID!
     likes: Int! @count(relation: "likes")
+}
+```
+
+```graphql
+type Query {
+    categories: Int! @count(model: "Category")
 }
 ```
 ### Definition
@@ -599,7 +605,12 @@ directive @count(
   """
   The relationship which you want to run the count on.
   """
-  relation: String!
+  relation: String
+  
+  """
+  The model to run the count on.
+  """
+  model: String
 ) on FIELD_DEFINITION
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -579,7 +579,7 @@ class ComplexityAnalyzer {
     }
 ```
 
-## Count
+## @count
 
 Returns the count of a given relationship or model.
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -599,7 +599,7 @@ type Query {
 
 ```graphql
 """
-Resolve the field through a count.
+Returns the count of a given relationship or model.
 """
 directive @count(
   """

--- a/src/Schema/Directives/CountDirective.php
+++ b/src/Schema/Directives/CountDirective.php
@@ -50,15 +50,15 @@ SDL;
     {
         return $value->setResolver(
             function (?Model $model) {
+                // Fetch the count by relation
                 $relation = $this->directiveArgValue('relation');
-                $modelArg = $this->directiveArgValue('model');
-
                 if (! is_null($relation)) {
                     return $model->{$relation}()->count();
                 }
 
+                // Else we try to fetch by model.
+                $modelArg = $this->directiveArgValue('model');
                 if (! is_null($modelArg)) {
-
                     return $this->namespaceModelClass($modelArg)::count();
                 }
 

--- a/src/Schema/Directives/CountDirective.php
+++ b/src/Schema/Directives/CountDirective.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Directives;
+
+use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Database\Eloquent\Model;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
+use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+
+class CountDirective extends BaseDirective implements FieldResolver, DefinedDirective
+{
+
+    /**
+     * Name of the directive as used in the schema.
+     *
+     * @return string
+     */
+    public function name()
+    {
+        return 'count';
+    }
+
+    public static function definition(): string
+    {
+        return /* @lang GraphQL */ <<<'SDL'
+"""
+Resolve the field through a count.
+"""
+directive @count(
+  """
+  The relationship which you want to run the count on.
+  """
+  relation: String!
+) on FIELD_DEFINITION
+SDL;
+    }
+
+    /**
+     * Makes a simple count query for the relation.
+     *
+     * @param FieldValue $value
+     * @return FieldValue
+     */
+    public function resolveField(FieldValue $value)
+    {
+        return $value->setResolver(
+            function (Model $model, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) {
+                $relation = $this->directiveArgValue('relation', $this->definitionNode->name->value);
+
+                return $model->{$relation}()->count();
+            }
+        );
+    }
+}

--- a/src/Schema/Directives/CountDirective.php
+++ b/src/Schema/Directives/CountDirective.php
@@ -49,7 +49,7 @@ SDL;
     public function resolveField(FieldValue $value)
     {
         return $value->setResolver(
-            function (Model $model) {
+            function (?Model $model) {
                 $relation = $this->directiveArgValue('relation');
                 $modelArg = $this->directiveArgValue('model');
 
@@ -57,8 +57,9 @@ SDL;
                     return $model->{$relation}()->count();
                 }
 
-                if (! is_null($model)) {
-                    return $modelArg::count();
+                if (! is_null($modelArg)) {
+
+                    return $this->namespaceModelClass($modelArg)::count();
                 }
 
                 throw new DirectiveException(

--- a/src/Schema/Directives/CountDirective.php
+++ b/src/Schema/Directives/CountDirective.php
@@ -3,8 +3,8 @@
 namespace Nuwave\Lighthouse\Schema\Directives;
 
 use Illuminate\Database\Eloquent\Model;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
 
@@ -53,11 +53,11 @@ SDL;
                 $relation = $this->directiveArgValue('relation');
                 $modelArg = $this->directiveArgValue('model');
 
-                if(!is_null($relation)) {
+                if (! is_null($relation)) {
                     return $model->{$relation}()->count();
                 }
 
-                if (!is_null($model)) {
+                if (! is_null($model)) {
                     return $modelArg::count();
                 }
 

--- a/src/Schema/Directives/CountDirective.php
+++ b/src/Schema/Directives/CountDirective.php
@@ -2,16 +2,15 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives;
 
-use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Database\Eloquent\Model;
+use GraphQL\Type\Definition\ResolveInfo;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
 
 class CountDirective extends BaseDirective implements FieldResolver, DefinedDirective
 {
-
     /**
      * Name of the directive as used in the schema.
      *

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -20,14 +20,12 @@ abstract class DBTestCase extends TestCase
     {
         parent::getEnvironmentSetUp($app);
 
-        // Setup default database to use sqlite :memory:
-        $app['config']->set('database.default', 'testbench');
-        $app['config']->set('database.connections.testbench', [
-            'driver'   => 'sqlite',
-            'database' => ':memory:',
-            'prefix'   => '',
+        $app['config']->set('database.default', 'mysql');
+        $app['config']->set('database.connections.mysql', [
+            'driver' => 'mysql',
+            'database' => 'test',
+            'host' => env('TRAVIS') ? '127.0.0.1' : 'mysql',
+            'username' => 'root',
         ]);
-
-
     }
 }

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -20,12 +20,14 @@ abstract class DBTestCase extends TestCase
     {
         parent::getEnvironmentSetUp($app);
 
-        $app['config']->set('database.default', 'mysql');
-        $app['config']->set('database.connections.mysql', [
-            'driver' => 'mysql',
-            'database' => 'test',
-            'host' => env('TRAVIS') ? '127.0.0.1' : 'mysql',
-            'username' => 'root',
+        // Setup default database to use sqlite :memory:
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
         ]);
+
+
     }
 }

--- a/tests/Unit/Schema/Directives/CountDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CountDirectiveTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Unit\Schema\Directives;
+
+use Nuwave\Lighthouse\Exceptions\DirectiveException;
+use Tests\DBTestCase;
+use Tests\Utils\Models\Task;
+use Tests\Utils\Models\User;
+
+class CountDirectiveTest extends DBTestCase
+{
+    public function testCanResolveCountByModel(): void
+    {
+        factory(User::class)->times(3)->create();
+
+        $this->schema = '
+        type Query {
+            users: Int! @count(model: "User")
+        }
+        ';
+
+        $this->graphQL("
+        {
+            users
+        }
+        ")->assertJson([
+            'data' => [
+                'users' => 3
+            ]
+        ]);
+    }
+
+    public function testCanResolveCountByRelation(): void
+    {
+        /** @var User $user */
+        $user = factory(User::class)->create();
+
+        $user->tasks()->saveMany(
+            factory(Task::class)->times(4)->create()
+        );
+
+        $this->be($user);
+
+        $this->schema = '
+        type User {
+            taskCount: Int! @count(relation: "tasks")
+        }
+
+        type Query {
+            user: User @auth
+        }
+        ';
+
+        $this->graphQL("
+        {
+            user {
+                taskCount
+            }
+        }
+        ")->assertJson([
+            'data' => [
+                'user' => [
+                    'taskCount' => 4
+                ]
+            ]
+        ]);
+    }
+
+    public function testRequireRelationOrModelArgument()
+    {
+        $this->schema = '
+        type Query {
+            users: Int! @count
+        }
+        ';
+
+        $this->expectException(DirectiveException::class);
+        $this->graphQL("
+        {
+            users
+        }
+        ");
+    }
+}

--- a/tests/Unit/Schema/Directives/CountDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CountDirectiveTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Unit\Schema\Directives;
 
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
+use Nuwave\Lighthouse\Exceptions\DirectiveException;
 
 class CountDirectiveTest extends DBTestCase
 {
@@ -19,14 +19,14 @@ class CountDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL("
+        $this->graphQL('
         {
             users
         }
-        ")->assertJson([
+        ')->assertJson([
             'data' => [
-                'users' => 3
-            ]
+                'users' => 3,
+            ],
         ]);
     }
 
@@ -51,18 +51,18 @@ class CountDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL("
+        $this->graphQL('
         {
             user {
                 taskCount
             }
         }
-        ")->assertJson([
+        ')->assertJson([
             'data' => [
                 'user' => [
-                    'taskCount' => 4
-                ]
-            ]
+                    'taskCount' => 4,
+                ],
+            ],
         ]);
     }
 
@@ -75,10 +75,10 @@ class CountDirectiveTest extends DBTestCase
         ';
 
         $this->expectException(DirectiveException::class);
-        $this->graphQL("
+        $this->graphQL('
         {
             users
         }
-        ");
+        ');
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

You could do something close to this by using the paginator, however then you are forced to fetch at least one model, and also you are exposing data your might not wanna expose. This directive solves this by just having a simple count directive.

**Changes**

Adds a new directive for getting the count of a relation.

**Breaking changes**

New directive added, so shouldn't be breaking.
