### PR TITLE
Improve error message when making an empty request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Remove the extra new line from the returned value when using `@globalId(decode: "ID")` https://github.com/nuwave/lighthouse/pull/982
-- Throw a syntax error instead of an exception when performing an empty request or a request with an empty query. https://github.com/nuwave/lighthouse/pull/989
+- Throw a syntax error instead of an exception when performing an empty request or a request with an empty query https://github.com/nuwave/lighthouse/pull/989
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Remove the extra new line from the returned value when using `@globalId(decode: "ID")` https://github.com/nuwave/lighthouse/pull/982
+- Throw a syntax error instead of an exception when performing an empty request or a request with an empty query. https://github.com/nuwave/lighthouse/pull/989
 
 ### Changed
 

--- a/src/Execution/BaseRequest.php
+++ b/src/Execution/BaseRequest.php
@@ -47,7 +47,7 @@ abstract class BaseRequest implements GraphQLRequest
      */
     public function query(): string
     {
-        return $this->fieldValue('query');
+        return $this->fieldValue('query') ?? '';
     }
 
     /**

--- a/tests/Integration/GraphQLTest.php
+++ b/tests/Integration/GraphQLTest.php
@@ -186,6 +186,40 @@ class GraphQLTest extends DBTestCase
         ]);
     }
 
+    public function testRejectsEmptyRequest(): void
+    {
+        $this->postGraphQL([])
+             ->assertStatus(200)
+             ->assertJson([
+                 [
+                     'errors' => [
+                         [
+                             'message' => 'Syntax Error: Unexpected <EOF>',
+                             'extensions' => [
+                                 'category' => 'graphql',
+                             ],
+                         ],
+                     ],
+                 ],
+             ]);
+    }
+
+    public function testRejectsEmptyQuery(): void
+    {
+        $this->graphQL('')
+             ->assertStatus(200)
+             ->assertJson([
+                 'errors' => [
+                     [
+                         'message' => 'Syntax Error: Unexpected <EOF>',
+                         'extensions' => [
+                             'category' => 'graphql',
+                         ],
+                     ],
+                 ],
+             ]);
+    }
+
     public function testRejectsInvalidQuery(): void
     {
         $result = $this->graphQL('


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Added Docs for all relevant versions
- [x] Updated the changelog

Fixes #730 and partially fixes #669.

**Changes**

Now `BaseRequest::query()` returns an empty string when `LighthouseRequest::fieldValue()` returns `null`, which causes a GraphQL syntax error when making an empty request instead of a `FatalThrowableError`.