### PR TITLE
[Docs] Fix wrong definition in builder directive

### DIFF
--- a/docs/4.1/api-reference/directives.md
+++ b/docs/4.1/api-reference/directives.md
@@ -336,11 +336,11 @@ Use an argument to modify the query builder for a field.
 directive @builder(
   """
   Reference a method that is passed the query builder.
-  Consists of two parts: a class name and a method name, seperated by an `@` symbol.
+  Consists of two parts: a class name and a method name, separated by an `@` symbol.
   If you pass only a class name, the method name defaults to `__invoke`.
   """
   method: String!
-) on FIELD_DEFINITION
+) on ARGUMENT_DEFINITION
 ```
 
 ## @cache

--- a/docs/4.2/api-reference/directives.md
+++ b/docs/4.2/api-reference/directives.md
@@ -348,11 +348,11 @@ Use an argument to modify the query builder for a field.
 directive @builder(
   """
   Reference a method that is passed the query builder.
-  Consists of two parts: a class name and a method name, seperated by an `@` symbol.
+  Consists of two parts: a class name and a method name, separated by an `@` symbol.
   If you pass only a class name, the method name defaults to `__invoke`.
   """
   method: String!
-) on FIELD_DEFINITION
+) on ARGUMENT_DEFINITION
 ```
 
 ## @cache

--- a/docs/4.3/api-reference/directives.md
+++ b/docs/4.3/api-reference/directives.md
@@ -348,11 +348,11 @@ Use an argument to modify the query builder for a field.
 directive @builder(
   """
   Reference a method that is passed the query builder.
-  Consists of two parts: a class name and a method name, seperated by an `@` symbol.
+  Consists of two parts: a class name and a method name, separated by an `@` symbol.
   If you pass only a class name, the method name defaults to `__invoke`.
   """
   method: String!
-) on FIELD_DEFINITION
+) on ARGUMENT_DEFINITION
 ```
 
 ## @cache

--- a/docs/4.4/api-reference/directives.md
+++ b/docs/4.4/api-reference/directives.md
@@ -348,11 +348,11 @@ Use an argument to modify the query builder for a field.
 directive @builder(
   """
   Reference a method that is passed the query builder.
-  Consists of two parts: a class name and a method name, seperated by an `@` symbol.
+  Consists of two parts: a class name and a method name, separated by an `@` symbol.
   If you pass only a class name, the method name defaults to `__invoke`.
   """
   method: String!
-) on FIELD_DEFINITION
+) on ARGUMENT_DEFINITION
 ```
 
 ## @cache

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -348,11 +348,11 @@ Use an argument to modify the query builder for a field.
 directive @builder(
   """
   Reference a method that is passed the query builder.
-  Consists of two parts: a class name and a method name, seperated by an `@` symbol.
+  Consists of two parts: a class name and a method name, separated by an `@` symbol.
   If you pass only a class name, the method name defaults to `__invoke`.
   """
   method: String!
-) on FIELD_DEFINITION
+) on ARGUMENT_DEFINITION
 ```
 
 ## @cache

--- a/src/Schema/Directives/BuilderDirective.php
+++ b/src/Schema/Directives/BuilderDirective.php
@@ -26,11 +26,11 @@ Use an argument to modify the query builder for a field.
 directive @builder(
   """
   Reference a method that is passed the query builder.
-  Consists of two parts: a class name and a method name, seperated by an `@` symbol.
+  Consists of two parts: a class name and a method name, separated by an `@` symbol.
   If you pass only a class name, the method name defaults to `__invoke`.
   """
   method: String!
-) on FIELD_DEFINITION
+) on ARGUMENT_DEFINITION
 SDL;
     }
 


### PR DESCRIPTION
Looks like the builder directive was using the wrong definition as it is applied on arguments not on fields.