### PR TITLE
Add `@upsert` directive and nested mutation operations to create or update a model   regardless whether it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.4.0...master)
 
+### Added
+- Add `@upsert` directive for mutations and nested mutations https://github.com/nuwave/lighthouse/pull/1005
+
 ## [4.4.0](https://github.com/nuwave/lighthouse/compare/v4.3.0...v4.4.0)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `@upsert` directive for mutations and nested mutations https://github.com/nuwave/lighthouse/pull/1005
+- Add `@upsert` directive and nested mutation operations to create or update a model
+  regardless whether it exists https://github.com/nuwave/lighthouse/pull/1005
 
 ## [4.4.0](https://github.com/nuwave/lighthouse/compare/v4.3.0...v4.4.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.4.0...master)
 
 ### Added
+
 - Add `@upsert` directive for mutations and nested mutations https://github.com/nuwave/lighthouse/pull/1005
 
 ## [4.4.0](https://github.com/nuwave/lighthouse/compare/v4.3.0...v4.4.0)

--- a/docs/4.4/api-reference/directives.md
+++ b/docs/4.4/api-reference/directives.md
@@ -2541,6 +2541,64 @@ type Mutation {
 }
 ```
 
+## @upsert
+
+Create or update an Eloquent model with the input values of the field.
+
+```graphql
+type Mutation {
+    upsertPost(id: ID!, content: String): Post @upsert
+}
+```
+
+### Definition
+
+```graphql
+"""
+Create or update an Eloquent model with the input values of the field.
+"""
+directive @upsert(
+  """
+  Specify the class name of the model to use.
+  This is only needed when the default model resolution does not work.
+  """
+  model: String
+
+  """
+  Set to `true` to use global ids for finding the model.
+  If set to `false`, regular non-global ids are used.
+  """
+  globalId: Boolean = false
+) on FIELD_DEFINITION
+```
+
+### Examples
+
+Lighthouse uses the argument `id` to fetch the model by its primary key if exists.
+If the model doesn't exist it will create it using the primary key indicated.
+This will work even if your model has a differently named primary key,
+so you can keep your schema simple and independent of your database structure.
+
+If you want your schema to directly reflect your database schema,
+you can also use the name of the underlying primary key.
+This is not recommended as it makes client-side caching more difficult
+and couples your schema to the underlying implementation.
+
+```graphql
+type Mutation {
+    upsertPost(post_id: ID!, content: String): Post @upsert
+}
+```
+
+If the name of the Eloquent model does not match the return type of the field,
+or is located in a non-default namespace, set it with the `model` argument.
+
+```graphql
+type Mutation {
+    upsertAuthor(id: ID!, name: String): Author @upsert(model: "App\\User")
+}
+```
+
 ## @where
 
 Use an input value as a [where filter](https://laravel.com/docs/queries#where-clauses).

--- a/docs/4.4/api-reference/directives.md
+++ b/docs/4.4/api-reference/directives.md
@@ -2541,64 +2541,6 @@ type Mutation {
 }
 ```
 
-## @upsert
-
-Create or update an Eloquent model with the input values of the field.
-
-```graphql
-type Mutation {
-    upsertPost(id: ID!, content: String): Post @upsert
-}
-```
-
-### Definition
-
-```graphql
-"""
-Create or update an Eloquent model with the input values of the field.
-"""
-directive @upsert(
-  """
-  Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
-  """
-  model: String
-
-  """
-  Set to `true` to use global ids for finding the model.
-  If set to `false`, regular non-global ids are used.
-  """
-  globalId: Boolean = false
-) on FIELD_DEFINITION
-```
-
-### Examples
-
-Lighthouse uses the argument `id` to fetch the model by its primary key if exists.
-If the model doesn't exist it will create it using the primary key indicated.
-This will work even if your model has a differently named primary key,
-so you can keep your schema simple and independent of your database structure.
-
-If you want your schema to directly reflect your database schema,
-you can also use the name of the underlying primary key.
-This is not recommended as it makes client-side caching more difficult
-and couples your schema to the underlying implementation.
-
-```graphql
-type Mutation {
-    upsertPost(post_id: ID!, content: String): Post @upsert
-}
-```
-
-If the name of the Eloquent model does not match the return type of the field,
-or is located in a non-default namespace, set it with the `model` argument.
-
-```graphql
-type Mutation {
-    upsertAuthor(id: ID!, name: String): Author @upsert(model: "App\\User")
-}
-```
-
 ## @where
 
 Use an input value as a [where filter](https://laravel.com/docs/queries#where-clauses).

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2581,28 +2581,13 @@ directive @upsert(
 
 ### Examples
 
-Lighthouse uses the argument `id` to fetch the model by its primary key if exists.
-If the model doesn't exist it will create it using the primary key indicated.
-This will work even if your model has a differently named primary key,
-so you can keep your schema simple and independent of your database structure.
 
-If you want your schema to directly reflect your database schema,
-you can also use the name of the underlying primary key.
-This is not recommended as it makes client-side caching more difficult
-and couples your schema to the underlying implementation.
+Lighthouse will try to to fetch the model by its primary key, just like [`@update`](#update).
+If the model doesn't exist, it will be created using the given `id`.
 
 ```graphql
 type Mutation {
     upsertPost(post_id: ID!, content: String): Post @upsert
-}
-```
-
-If the name of the Eloquent model does not match the return type of the field,
-or is located in a non-default namespace, set it with the `model` argument.
-
-```graphql
-type Mutation {
-    upsertAuthor(id: ID!, name: String): Author @upsert(model: "App\\User")
 }
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2548,6 +2548,64 @@ type Mutation {
 }
 ```
 
+## @upsert
+
+Create or update an Eloquent model with the input values of the field.
+
+```graphql
+type Mutation {
+    upsertPost(id: ID!, content: String): Post @upsert
+}
+```
+
+### Definition
+
+```graphql
+"""
+Create or update an Eloquent model with the input values of the field.
+"""
+directive @upsert(
+  """
+  Specify the class name of the model to use.
+  This is only needed when the default model resolution does not work.
+  """
+  model: String
+
+  """
+  Set to `true` to use global ids for finding the model.
+  If set to `false`, regular non-global ids are used.
+  """
+  globalId: Boolean = false
+) on FIELD_DEFINITION
+```
+
+### Examples
+
+Lighthouse uses the argument `id` to fetch the model by its primary key if exists.
+If the model doesn't exist it will create it using the primary key indicated.
+This will work even if your model has a differently named primary key,
+so you can keep your schema simple and independent of your database structure.
+
+If you want your schema to directly reflect your database schema,
+you can also use the name of the underlying primary key.
+This is not recommended as it makes client-side caching more difficult
+and couples your schema to the underlying implementation.
+
+```graphql
+type Mutation {
+    upsertPost(post_id: ID!, content: String): Post @upsert
+}
+```
+
+If the name of the Eloquent model does not match the return type of the field,
+or is located in a non-default namespace, set it with the `model` argument.
+
+```graphql
+type Mutation {
+    upsertAuthor(id: ID!, name: String): Author @upsert(model: "App\\User")
+}
+```
+
 ## @where
 
 Use an input value as a [where filter](https://laravel.com/docs/queries#where-clauses).

--- a/docs/master/eloquent/getting-started.md
+++ b/docs/master/eloquent/getting-started.md
@@ -218,6 +218,56 @@ may fail to find the model you provided and return `null`:
 }
 ```
 
+## Upsert
+
+You can create or update a model with the [@upsert](../api-reference/directives.md#upsert) directive.
+
+```graphql
+type Mutation {
+  upsertUser(id: ID!, name: String!, email: String): User @upsert
+}
+```
+
+Since upsert can create or update your data you must have all the minimum fields for a creation as required.
+For example the `id` is going to be always mandatory.
+
+```graphql
+mutation {
+  upsertUser(id: "123" name: "Hillary"){
+    id
+    name
+    email
+  }
+}
+```
+
+```json
+{
+  "data": {
+    "upsertUser": {
+      "id": "123",
+      "name": "Hillary",
+      "email": null
+    }
+  }
+}
+```
+
+Due to upsert does a create or update, it produces an idempotent result. This means that you can execute it
+as many times as you want, that it will produce always the same result.
+
+```json
+{
+  "data": {
+    "upsertUser": {
+      "id": "123",
+      "name": "Hillary",
+      "email": null
+    }
+  }
+}
+```
+
 ## Delete
 
 Deleting models is a breeze using the [@delete](../api-reference/directives.md#delete) directive. Dangerously easy.

--- a/docs/master/eloquent/getting-started.md
+++ b/docs/master/eloquent/getting-started.md
@@ -253,21 +253,6 @@ mutation {
 }
 ```
 
-Due to upsert does a create or update, it produces an idempotent result. This means that you can execute it
-as many times as you want, that it will produce always the same result.
-
-```json
-{
-  "data": {
-    "upsertUser": {
-      "id": "123",
-      "name": "Hillary",
-      "email": null
-    }
-  }
-}
-```
-
 ## Delete
 
 Deleting models is a breeze using the [@delete](../api-reference/directives.md#delete) directive. Dangerously easy.

--- a/docs/master/eloquent/getting-started.md
+++ b/docs/master/eloquent/getting-started.md
@@ -220,7 +220,8 @@ may fail to find the model you provided and return `null`:
 
 ## Upsert
 
-You can create or update a model with the [@upsert](../api-reference/directives.md#upsert) directive.
+Use the [@upsert](../api-reference/directives.md#upsert) directive to update a model with 
+a given `id` or create it if it does not exist. 
 
 ```graphql
 type Mutation {
@@ -229,7 +230,7 @@ type Mutation {
 ```
 
 Since upsert can create or update your data you must have all the minimum fields for a creation as required.
-For example the `id` is going to be always mandatory.
+The `id` is always required and must be marked as fillable in the model.
 
 ```graphql
 mutation {

--- a/docs/master/eloquent/nested-mutations.md
+++ b/docs/master/eloquent/nested-mutations.md
@@ -70,7 +70,7 @@ input CreateAuthorRelation {
 }
 ```
 
-There are 3 possible operations that you can expose on a `BelongsTo` relationship when creating:
+You can expose the following operations on a `BelongsTo` relationship when creating:
 - `connect` it to an existing model
 - `create` a new related model and attach it
 - `update` an existing model and attach it
@@ -505,7 +505,7 @@ mutation {
 }
 ```
 
-Updates on BelongsToMany relations may expose up to 7 nested operations.
+Updates on BelongsToMany relations may expose the following nested operations.
 
 ```graphql
 type Mutation {

--- a/docs/master/eloquent/nested-mutations.md
+++ b/docs/master/eloquent/nested-mutations.md
@@ -212,8 +212,8 @@ The `author` relationship will only be disconnected if the value of the variable
 }
 ```
 
-When issuing an upsert you will have all the update options, so the behaviour is the same. In the case that
-you create a new model it will have the same behaviour than an update that doesn't have any connected model.
+When issuing an `upsert`, you may expose the same nested operations as an `update`.
+In case a new model is created, they will simply be ignored.
 
 ```graphql
 mutation UpdatePost($disconnectAuthor: Boolean){
@@ -326,7 +326,6 @@ When updating a `User`, further nested operations become possible.
 It is up to you which ones you want to expose through the schema definition.
 
 The following example covers the full range of possible operations:
-`create`, `update` and `delete`.
 
 ```graphql
 type Mutation {
@@ -391,8 +390,8 @@ mutation {
 }
 ```
 
-The behaviour when you are upserting is a mix between updating and creating and it won't fail
-if the model exists or not because it will produce the needed action (update or create) in every case.
+The behaviour for `upsert` is a mix between updating and creating,
+it will produce the needed action regardless of whether the model exists or not.
 
 ## Belongs To Many
 
@@ -505,7 +504,7 @@ mutation {
 }
 ```
 
-Updates on BelongsToMany relations may expose the following nested operations.
+Updates on `BelongsToMany` relations may expose the following nested operations:
 
 ```graphql
 type Mutation {
@@ -740,7 +739,7 @@ mutation {
 You can either use `connect` or `sync` during creation. 
 
 When you want to create a new tag while creating the task,
-you need use the `create` operation to provide an array of `CreateTagInput` 
+you need to use the `create` operation to provide an array of `CreateTagInput` 
 or use the `upsert` operation to provide an array of `UpsertTagInput`:
 
 ```graphql

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -329,7 +329,7 @@ class MutationExecutor
     /**
      * Execute an update mutation.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model $modelInstance
      *         An empty instance of the model that should be updated
      * @param  \Illuminate\Support\Collection  $args
      *         The corresponding slice of the input arguments for updating this model
@@ -337,16 +337,16 @@ class MutationExecutor
      *         If we are in a nested update, we can use this to associate the new model to its parent
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public static function executeUpdate(Model $model, Collection $args, ?Relation $parentRelation = null): Model
+    public static function executeUpdate(Model $modelInstance, Collection $args, ?Relation $parentRelation = null): Model
     {
         $id = $args->pull('id')
             ?? $args->pull(
-                $model->getKeyName()
+                $modelInstance->getKeyName()
             );
 
-        $model = $model->newQuery()->findOrFail($id);
+        $modelInstance = $modelInstance->newQuery()->findOrFail($id);
 
-        return self::executeUpdateWithLoadedModel($model, $args, $parentRelation);
+        return self::executeUpdateWithLoadedModel($modelInstance, $args, $parentRelation);
     }
 
     /**

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -155,6 +155,14 @@ class MutationExecutor
                 $relation->associate($belongsToModel);
             }
 
+            if (isset($nestedOperations['upsert'])) {
+                $belongsToModel = self::executeUpsert(
+                    $relation->getModel()->newInstance(),
+                    new Collection($nestedOperations['upsert'])
+                );
+                $relation->associate($belongsToModel);
+            }
+
             if (isset($nestedOperations['connect'])) {
                 $relation->associate($nestedOperations['connect']);
             }

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -14,7 +14,6 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
@@ -417,13 +416,12 @@ class MutationExecutor
                 $model->getKeyName()
             );
 
-        try {
-            $model = $model->newQuery()->findOrFail($id);
-
-            return self::executeUpdateWithLoadedModel($model, $args, $parentRelation);
-        } catch (ModelNotFoundException $e) {
-            return self::executeCreate($model, $args, $parentRelation);
+        $modelInstance = $model->newQuery()->find($id);
+        if($modelInstance) {
+            return self::executeUpdateWithLoadedModel($modelInstance, $args, $parentRelation);
         }
+
+        return self::executeCreate($model, $args, $parentRelation);
     }
 
     /**

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -417,7 +417,7 @@ class MutationExecutor
             );
 
         $modelInstance = $model->newQuery()->find($id);
-        if($modelInstance) {
+        if ($modelInstance) {
             return self::executeUpdateWithLoadedModel($modelInstance, $args, $parentRelation);
         }
 

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -6,7 +6,6 @@ use ReflectionClass;
 use ReflectionNamedType;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
@@ -15,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
@@ -316,16 +316,16 @@ class MutationExecutor
     {
         return $args->partition(
             function ($value, string $key) use ($modelReflection, $relationClass): bool {
-                if (!$modelReflection->hasMethod($key)) {
+                if (! $modelReflection->hasMethod($key)) {
                     return false;
                 }
 
                 $relationMethodCandidate = $modelReflection->getMethod($key);
-                if (!$returnType = $relationMethodCandidate->getReturnType()) {
+                if (! $returnType = $relationMethodCandidate->getReturnType()) {
                     return false;
                 }
 
-                if (!$returnType instanceof ReflectionNamedType) {
+                if (! $returnType instanceof ReflectionNamedType) {
                     return false;
                 }
 
@@ -355,6 +355,7 @@ class MutationExecutor
 
         try {
             $model = $model->newQuery()->findOrFail($id);
+
             return self::executeUpdateWithLoadedModel($model, $args, $parentRelation);
         } catch (ModelNotFoundException $e) {
             return self::executeCreate($model, $args, $parentRelation);

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -58,13 +58,7 @@ class MutationExecutor
             }
 
             if (isset($nestedOperations['upsert'])) {
-                (new Collection($nestedOperations['upsert']))->each(function ($singleValues) use ($relation): void {
-                    self::executeUpsert(
-                        $relation->getModel()->newInstance(),
-                        new Collection($singleValues),
-                        $relation
-                    );
-                });
+                self::handleMultiRelationUpsert(new Collection($nestedOperations['upsert']), $relation);
             }
         };
         $hasMany->each($createOneToMany);
@@ -79,11 +73,7 @@ class MutationExecutor
             }
 
             if (isset($nestedOperations['upsert'])) {
-                self::executeUpsert(
-                    $relation->getModel()->newInstance(),
-                    new Collection($nestedOperations['upsert']),
-                    $relation
-                );
+                self::handleSingleRelationUpsert(new Collection($nestedOperations['upsert']), $relation);
             }
         };
         $hasOne->each($createOneToOne);
@@ -102,23 +92,11 @@ class MutationExecutor
             }
 
             if (isset($nestedOperations['update'])) {
-                (new Collection($nestedOperations['update']))->each(function ($singleValues) use ($relation): void {
-                    self::executeUpdate(
-                        $relation->getModel()->newInstance(),
-                        new Collection($singleValues),
-                        $relation
-                    );
-                });
+                self::handleMultiRelationUpdate(new Collection($nestedOperations['update']), $relation);
             }
 
             if (isset($nestedOperations['upsert'])) {
-                (new Collection($nestedOperations['upsert']))->each(function ($singleValues) use ($relation): void {
-                    self::executeUpsert(
-                        $relation->getModel()->newInstance(),
-                        new Collection($singleValues),
-                        $relation
-                    );
-                });
+                self::handleMultiRelationUpsert(new Collection($nestedOperations['upsert']), $relation);
             }
 
             if (isset($nestedOperations['connect'])) {
@@ -288,6 +266,67 @@ class MutationExecutor
     }
 
     /**
+     * Handle the update with multiple relations.
+     *
+     * @param  \Illuminate\Support\Collection  $multiValues
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+     * @return void
+     */
+    protected static function handleMultiRelationUpdate(Collection $multiValues, $relation): void
+    {
+        $multiValues->each(function ($singleValues) use ($relation): void {
+            self::handleSingleRelationUpdate(new Collection($singleValues), $relation);
+        });
+    }
+
+    /**
+     * Handle the update with a single relation.
+     *
+     * @param  \Illuminate\Support\Collection  $singleValues
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+     * @return void
+     */
+    protected static function handleSingleRelationUpdate(Collection $singleValues, Relation $relation): void
+    {
+        self::executeUpdate(
+            $relation->getModel()->newInstance(),
+            new Collection($singleValues),
+            $relation
+        );
+    }
+
+
+    /**
+     * Handle the upsert with multiple relations.
+     *
+     * @param  \Illuminate\Support\Collection  $multiValues
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+     * @return void
+     */
+    protected static function handleMultiRelationUpsert(Collection $multiValues, $relation): void
+    {
+        $multiValues->each(function ($singleValues) use ($relation): void {
+            self::handleSingleRelationUpsert(new Collection($singleValues), $relation);
+        });
+    }
+
+    /**
+     * Handle the upsert with a single relation.
+     *
+     * @param  \Illuminate\Support\Collection  $singleValues
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+     * @return void
+     */
+    protected static function handleSingleRelationUpsert(Collection $singleValues, Relation $relation): void
+    {
+        self::executeUpsert(
+            $relation->getModel()->newInstance(),
+            new Collection($singleValues),
+            $relation
+        );
+    }
+
+    /**
      * Execute an update mutation.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -427,23 +466,11 @@ class MutationExecutor
             }
 
             if (isset($nestedOperations['update'])) {
-                (new Collection($nestedOperations['update']))->each(function ($singleValues) use ($relation): void {
-                    self::executeUpdate(
-                        $relation->getModel()->newInstance(),
-                        new Collection($singleValues),
-                        $relation
-                    );
-                });
+                self::handleMultiRelationUpdate(new Collection($nestedOperations['update']), $relation);
             }
 
             if (isset($nestedOperations['upsert'])) {
-                (new Collection($nestedOperations['upsert']))->each(function ($singleValues) use ($relation): void {
-                    self::executeUpsert(
-                        $relation->getModel()->newInstance(),
-                        new Collection($singleValues),
-                        $relation
-                    );
-                });
+                self::handleMultiRelationUpsert(new Collection($nestedOperations['upsert']), $relation);
             }
 
             if (isset($nestedOperations['delete'])) {
@@ -462,19 +489,11 @@ class MutationExecutor
             }
 
             if (isset($nestedOperations['update'])) {
-                self::executeUpdate(
-                    $relation->getModel()->newInstance(),
-                    new Collection($nestedOperations['update']),
-                    $relation
-                );
+                self::handleSingleRelationUpdate(new Collection($nestedOperations['update']), $relation);
             }
 
             if (isset($nestedOperations['upsert'])) {
-                self::executeUpsert(
-                    $relation->getModel()->newInstance(),
-                    new Collection($nestedOperations['upsert']),
-                    $relation
-                );
+                self::handleSingleRelationUpsert(new Collection($nestedOperations['upsert']), $relation);
             }
 
             if (isset($nestedOperations['delete'])) {
@@ -497,23 +516,11 @@ class MutationExecutor
             }
 
             if (isset($nestedOperations['update'])) {
-                (new Collection($nestedOperations['update']))->each(function ($singleValues) use ($relation): void {
-                    self::executeUpdate(
-                        $relation->getModel()->newInstance(),
-                        new Collection($singleValues),
-                        $relation
-                    );
-                });
+                self::handleMultiRelationUpdate(new Collection($nestedOperations['update']), $relation);
             }
 
             if (isset($nestedOperations['upsert'])) {
-                (new Collection($nestedOperations['upsert']))->each(function ($singleValues) use ($relation): void {
-                    self::executeUpsert(
-                        $relation->getModel()->newInstance(),
-                        new Collection($singleValues),
-                        $relation
-                    );
-                });
+                self::handleMultiRelationUpsert(new Collection($nestedOperations['upsert']), $relation);
             }
 
             if (isset($nestedOperations['delete'])) {

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -295,7 +295,6 @@ class MutationExecutor
         );
     }
 
-
     /**
      * Handle the upsert with multiple relations.
      *

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -411,8 +411,8 @@ class MutationExecutor
      */
     public static function executeUpsert(Model $model, Collection $args, ?Relation $parentRelation = null): Model
     {
-        $id = $args->pull('id')
-            ?? $args->pull(
+        $id = $args->get('id')
+            ?? $args->get(
                 $model->getKeyName()
             );
 

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -109,6 +109,223 @@ class MutationExecutor
     }
 
     /**
+     * Execute an update mutation.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model $model
+     *         An empty instance of the model that should be updated
+     * @param  \Illuminate\Support\Collection  $args
+     *         The corresponding slice of the input arguments for updating this model
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation|null  $parentRelation
+     *         If we are in a nested update, we can use this to associate the new model to its parent
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public static function executeUpdate(Model $model, Collection $args, ?Relation $parentRelation = null): Model
+    {
+        // Remove the ID from the arguments, as we do not need to set it
+        $id = $args->pull('id')
+            ?? $args->pull(
+                $model->getKeyName()
+            );
+
+        $model = $model->newQuery()->findOrFail($id);
+
+        return self::executeUpdateWithLoadedModel($model, $args, $parentRelation);
+    }
+
+    /**
+     * Execute an upsert mutation.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     *         An empty instance of the model that should be created or updated
+     * @param \Illuminate\Support\Collection $args
+     *         The corresponding slice of the input arguments for creating or updating this model
+     * @param \Illuminate\Database\Eloquent\Relations\Relation|null $parentRelation
+     *         If we are in a nested upsert, we can use this to associate the new model to its parent
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public static function executeUpsert(Model $model, Collection $args, ?Relation $parentRelation = null): Model
+    {
+        $id = $args->get('id')
+            // We keep
+            ?? $args->get(
+                $model->getKeyName()
+            );
+
+        $modelInstance = $model->newQuery()->find($id);
+        if ($modelInstance) {
+            return self::executeUpdateWithLoadedModel($modelInstance, $args, $parentRelation);
+        }
+
+        return self::executeCreate($model, $args, $parentRelation);
+    }
+
+    /**
+     * Execute an update mutation over a loaded model.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     *         An empty instance of the model that should be updated
+     * @param \Illuminate\Support\Collection $args
+     *         The corresponding slice of the input arguments for updating this model
+     * @param \Illuminate\Database\Eloquent\Relations\Relation|null $parentRelation
+     *         If we are in a nested update, we can use this to associate the new model to its parent
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    protected static function executeUpdateWithLoadedModel(Model $model, Collection $args, ?Relation $parentRelation): Model
+    {
+        $reflection = new ReflectionClass($model);
+
+        [$hasMany, $remaining] = self::partitionArgsByRelationType($reflection, $args, HasMany::class);
+
+        [$morphMany, $remaining] = self::partitionArgsByRelationType($reflection, $remaining, MorphMany::class);
+
+        [$hasOne, $remaining] = self::partitionArgsByRelationType($reflection, $remaining, HasOne::class);
+
+        [$morphOne, $remaining] = self::partitionArgsByRelationType($reflection, $remaining, MorphOne::class);
+
+        [$belongsToMany, $remaining] = self::partitionArgsByRelationType($reflection, $remaining, BelongsToMany::class);
+
+        [$morphToMany, $remaining] = self::partitionArgsByRelationType($reflection, $remaining, MorphToMany::class);
+
+        $model = self::saveModelWithPotentialParent($model, $remaining, $parentRelation);
+
+        $updateOneToMany = function (array $nestedOperations, string $relationName) use ($model): void {
+            /** @var \Illuminate\Database\Eloquent\Relations\HasMany|\Illuminate\Database\Eloquent\Relations\MorphMany $relation */
+            $relation = $model->{$relationName}();
+
+            if (isset($nestedOperations['create'])) {
+                self::handleMultiRelationCreate(new Collection($nestedOperations['create']), $relation);
+            }
+
+            if (isset($nestedOperations['update'])) {
+                self::handleMultiRelationUpdate(new Collection($nestedOperations['update']), $relation);
+            }
+
+            if (isset($nestedOperations['upsert'])) {
+                self::handleMultiRelationUpsert(new Collection($nestedOperations['upsert']), $relation);
+            }
+
+            if (isset($nestedOperations['delete'])) {
+                $relation->getModel()::destroy($nestedOperations['delete']);
+            }
+        };
+        $hasMany->each($updateOneToMany);
+        $morphMany->each($updateOneToMany);
+
+        $updateOneToOne = function (array $nestedOperations, string $relationName) use ($model): void {
+            /** @var \Illuminate\Database\Eloquent\Relations\HasOne|\Illuminate\Database\Eloquent\Relations\MorphOne $relation */
+            $relation = $model->{$relationName}();
+
+            if (isset($nestedOperations['create'])) {
+                self::handleSingleRelationCreate(new Collection($nestedOperations['create']), $relation);
+            }
+
+            if (isset($nestedOperations['update'])) {
+                self::handleSingleRelationUpdate(new Collection($nestedOperations['update']), $relation);
+            }
+
+            if (isset($nestedOperations['upsert'])) {
+                self::handleSingleRelationUpsert(new Collection($nestedOperations['upsert']), $relation);
+            }
+
+            if (isset($nestedOperations['delete'])) {
+                $relation->getModel()::destroy($nestedOperations['delete']);
+            }
+        };
+        $hasOne->each($updateOneToOne);
+        $morphOne->each($updateOneToOne);
+
+        $updateManyToMany = function (array $nestedOperations, string $relationName) use ($model): void {
+            /** @var \Illuminate\Database\Eloquent\Relations\BelongsToMany|\Illuminate\Database\Eloquent\Relations\MorphToMany $relation */
+            $relation = $model->{$relationName}();
+
+            if (isset($nestedOperations['sync'])) {
+                $relation->sync($nestedOperations['sync']);
+            }
+
+            if (isset($nestedOperations['create'])) {
+                self::handleMultiRelationCreate(new Collection($nestedOperations['create']), $relation);
+            }
+
+            if (isset($nestedOperations['update'])) {
+                self::handleMultiRelationUpdate(new Collection($nestedOperations['update']), $relation);
+            }
+
+            if (isset($nestedOperations['upsert'])) {
+                self::handleMultiRelationUpsert(new Collection($nestedOperations['upsert']), $relation);
+            }
+
+            if (isset($nestedOperations['delete'])) {
+                $relation->detach($nestedOperations['delete']);
+                $relation->getModel()::destroy($nestedOperations['delete']);
+            }
+
+            if (isset($nestedOperations['connect'])) {
+                $relation->attach($nestedOperations['connect']);
+            }
+
+            if (isset($nestedOperations['disconnect'])) {
+                $relation->detach($nestedOperations['disconnect']);
+            }
+        };
+        $belongsToMany->each($updateManyToMany);
+        $morphToMany->each($updateManyToMany);
+
+        return $model;
+    }
+
+    /**
+     * Extract all the arguments that correspond to a relation of a certain type on the model.
+     *
+     * For example, if the args input looks like this:
+     *
+     * [
+     *  'comments' =>
+     *    ['foo' => 'Bar'],
+     *  'name' => 'Ralf',
+     * ]
+     *
+     * and the model has a method "comments" that returns a HasMany relationship,
+     * the result will be:
+     * [
+     *   [
+     *    'comments' =>
+     *      ['foo' => 'Bar'],
+     *   ],
+     *   [
+     *    'name' => 'Ralf',
+     *   ]
+     * ]
+     *
+     * @param  \ReflectionClass  $modelReflection
+     * @param  \Illuminate\Support\Collection  $args
+     * @param  string  $relationClass
+     * @return \Illuminate\Support\Collection  [relationshipArgs, remainingArgs]
+     */
+    protected static function partitionArgsByRelationType(ReflectionClass $modelReflection, Collection $args, string $relationClass): Collection
+    {
+        return $args->partition(
+            function ($value, string $key) use ($modelReflection, $relationClass): bool {
+                if (! $modelReflection->hasMethod($key)) {
+                    return false;
+                }
+
+                $relationMethodCandidate = $modelReflection->getMethod($key);
+                if (! $returnType = $relationMethodCandidate->getReturnType()) {
+                    return false;
+                }
+
+                if (! $returnType instanceof ReflectionNamedType) {
+                    return false;
+                }
+
+                return is_a($returnType->getName(), $relationClass, true);
+            }
+        );
+    }
+
+    /**
      * Save a model that maybe has a parent.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -322,220 +539,5 @@ class MutationExecutor
             new Collection($singleValues),
             $relation
         );
-    }
-
-    /**
-     * Execute an update mutation.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model $modelInstance
-     *         An empty instance of the model that should be updated
-     * @param  \Illuminate\Support\Collection  $args
-     *         The corresponding slice of the input arguments for updating this model
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation|null  $parentRelation
-     *         If we are in a nested update, we can use this to associate the new model to its parent
-     * @return \Illuminate\Database\Eloquent\Model
-     */
-    public static function executeUpdate(Model $modelInstance, Collection $args, ?Relation $parentRelation = null): Model
-    {
-        $id = $args->pull('id')
-            ?? $args->pull(
-                $modelInstance->getKeyName()
-            );
-
-        $modelInstance = $modelInstance->newQuery()->findOrFail($id);
-
-        return self::executeUpdateWithLoadedModel($modelInstance, $args, $parentRelation);
-    }
-
-    /**
-     * Extract all the arguments that correspond to a relation of a certain type on the model.
-     *
-     * For example, if the args input looks like this:
-     *
-     * [
-     *  'comments' =>
-     *    ['foo' => 'Bar'],
-     *  'name' => 'Ralf',
-     * ]
-     *
-     * and the model has a method "comments" that returns a HasMany relationship,
-     * the result will be:
-     * [
-     *   [
-     *    'comments' =>
-     *      ['foo' => 'Bar'],
-     *   ],
-     *   [
-     *    'name' => 'Ralf',
-     *   ]
-     * ]
-     *
-     * @param  \ReflectionClass  $modelReflection
-     * @param  \Illuminate\Support\Collection  $args
-     * @param  string  $relationClass
-     * @return \Illuminate\Support\Collection  [relationshipArgs, remainingArgs]
-     */
-    protected static function partitionArgsByRelationType(ReflectionClass $modelReflection, Collection $args, string $relationClass): Collection
-    {
-        return $args->partition(
-            function ($value, string $key) use ($modelReflection, $relationClass): bool {
-                if (! $modelReflection->hasMethod($key)) {
-                    return false;
-                }
-
-                $relationMethodCandidate = $modelReflection->getMethod($key);
-                if (! $returnType = $relationMethodCandidate->getReturnType()) {
-                    return false;
-                }
-
-                if (! $returnType instanceof ReflectionNamedType) {
-                    return false;
-                }
-
-                return is_a($returnType->getName(), $relationClass, true);
-            }
-        );
-    }
-
-    /**
-     * Execute an upsert mutation.
-     *
-     * @param \Illuminate\Database\Eloquent\Model $model
-     *         An empty instance of the model that should be created or updated
-     * @param \Illuminate\Support\Collection $args
-     *         The corresponding slice of the input arguments for creating or updating this model
-     * @param \Illuminate\Database\Eloquent\Relations\Relation|null $parentRelation
-     *         If we are in a nested upsert, we can use this to associate the new model to its parent
-     *
-     * @return \Illuminate\Database\Eloquent\Model
-     */
-    public static function executeUpsert(Model $model, Collection $args, ?Relation $parentRelation = null): Model
-    {
-        $id = $args->get('id')
-            ?? $args->get(
-                $model->getKeyName()
-            );
-
-        $modelInstance = $model->newQuery()->find($id);
-        if ($modelInstance) {
-            return self::executeUpdateWithLoadedModel($modelInstance, $args, $parentRelation);
-        }
-
-        return self::executeCreate($model, $args, $parentRelation);
-    }
-
-    /**
-     * Execute an update mutation over a loaded model.
-     *
-     * @param \Illuminate\Database\Eloquent\Model $model
-     *         An empty instance of the model that should be updated
-     * @param \Illuminate\Support\Collection $args
-     *         The corresponding slice of the input arguments for updating this model
-     * @param \Illuminate\Database\Eloquent\Relations\Relation|null $parentRelation
-     *         If we are in a nested update, we can use this to associate the new model to its parent
-     *
-     * @return \Illuminate\Database\Eloquent\Model
-     */
-    protected static function executeUpdateWithLoadedModel(Model $model, Collection $args, ?Relation $parentRelation): Model
-    {
-        $reflection = new ReflectionClass($model);
-
-        [$hasMany, $remaining] = self::partitionArgsByRelationType($reflection, $args, HasMany::class);
-
-        [$morphMany, $remaining] = self::partitionArgsByRelationType($reflection, $remaining, MorphMany::class);
-
-        [$hasOne, $remaining] = self::partitionArgsByRelationType($reflection, $remaining, HasOne::class);
-
-        [$morphOne, $remaining] = self::partitionArgsByRelationType($reflection, $remaining, MorphOne::class);
-
-        [$belongsToMany, $remaining] = self::partitionArgsByRelationType($reflection, $remaining, BelongsToMany::class);
-
-        [$morphToMany, $remaining] = self::partitionArgsByRelationType($reflection, $remaining, MorphToMany::class);
-
-        $model = self::saveModelWithPotentialParent($model, $remaining, $parentRelation);
-
-        $updateOneToMany = function (array $nestedOperations, string $relationName) use ($model): void {
-            /** @var \Illuminate\Database\Eloquent\Relations\HasMany|\Illuminate\Database\Eloquent\Relations\MorphMany $relation */
-            $relation = $model->{$relationName}();
-
-            if (isset($nestedOperations['create'])) {
-                self::handleMultiRelationCreate(new Collection($nestedOperations['create']), $relation);
-            }
-
-            if (isset($nestedOperations['update'])) {
-                self::handleMultiRelationUpdate(new Collection($nestedOperations['update']), $relation);
-            }
-
-            if (isset($nestedOperations['upsert'])) {
-                self::handleMultiRelationUpsert(new Collection($nestedOperations['upsert']), $relation);
-            }
-
-            if (isset($nestedOperations['delete'])) {
-                $relation->getModel()::destroy($nestedOperations['delete']);
-            }
-        };
-        $hasMany->each($updateOneToMany);
-        $morphMany->each($updateOneToMany);
-
-        $updateOneToOne = function (array $nestedOperations, string $relationName) use ($model): void {
-            /** @var \Illuminate\Database\Eloquent\Relations\HasOne|\Illuminate\Database\Eloquent\Relations\MorphOne $relation */
-            $relation = $model->{$relationName}();
-
-            if (isset($nestedOperations['create'])) {
-                self::handleSingleRelationCreate(new Collection($nestedOperations['create']), $relation);
-            }
-
-            if (isset($nestedOperations['update'])) {
-                self::handleSingleRelationUpdate(new Collection($nestedOperations['update']), $relation);
-            }
-
-            if (isset($nestedOperations['upsert'])) {
-                self::handleSingleRelationUpsert(new Collection($nestedOperations['upsert']), $relation);
-            }
-
-            if (isset($nestedOperations['delete'])) {
-                $relation->getModel()::destroy($nestedOperations['delete']);
-            }
-        };
-        $hasOne->each($updateOneToOne);
-        $morphOne->each($updateOneToOne);
-
-        $updateManyToMany = function (array $nestedOperations, string $relationName) use ($model): void {
-            /** @var \Illuminate\Database\Eloquent\Relations\BelongsToMany|\Illuminate\Database\Eloquent\Relations\MorphToMany $relation */
-            $relation = $model->{$relationName}();
-
-            if (isset($nestedOperations['sync'])) {
-                $relation->sync($nestedOperations['sync']);
-            }
-
-            if (isset($nestedOperations['create'])) {
-                self::handleMultiRelationCreate(new Collection($nestedOperations['create']), $relation);
-            }
-
-            if (isset($nestedOperations['update'])) {
-                self::handleMultiRelationUpdate(new Collection($nestedOperations['update']), $relation);
-            }
-
-            if (isset($nestedOperations['upsert'])) {
-                self::handleMultiRelationUpsert(new Collection($nestedOperations['upsert']), $relation);
-            }
-
-            if (isset($nestedOperations['delete'])) {
-                $relation->detach($nestedOperations['delete']);
-                $relation->getModel()::destroy($nestedOperations['delete']);
-            }
-
-            if (isset($nestedOperations['connect'])) {
-                $relation->attach($nestedOperations['connect']);
-            }
-
-            if (isset($nestedOperations['disconnect'])) {
-                $relation->detach($nestedOperations['disconnect']);
-            }
-        };
-        $belongsToMany->each($updateManyToMany);
-        $morphToMany->each($updateManyToMany);
-
-        return $model;
     }
 }

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -56,6 +56,16 @@ class MutationExecutor
             if (isset($nestedOperations['create'])) {
                 self::handleMultiRelationCreate(new Collection($nestedOperations['create']), $relation);
             }
+
+            if (isset($nestedOperations['upsert'])) {
+                (new Collection($nestedOperations['upsert']))->each(function ($singleValues) use ($relation): void {
+                    self::executeUpsert(
+                        $relation->getModel()->newInstance(),
+                        new Collection($singleValues),
+                        $relation
+                    );
+                });
+            }
         };
         $hasMany->each($createOneToMany);
         $morphMany->each($createOneToMany);
@@ -125,7 +135,7 @@ class MutationExecutor
     {
         $reflection = new ReflectionClass($model);
 
-        // Extract $morphTo first, as MorphTo extends BelongsTo
+        // Extract $morphTo first, as MorphTo extends
         [$morphTo, $remaining] = self::partitionArgsByRelationType(
             $reflection,
             $args,
@@ -414,6 +424,16 @@ class MutationExecutor
             if (isset($nestedOperations['update'])) {
                 (new Collection($nestedOperations['update']))->each(function ($singleValues) use ($relation): void {
                     self::executeUpdate(
+                        $relation->getModel()->newInstance(),
+                        new Collection($singleValues),
+                        $relation
+                    );
+                });
+            }
+
+            if (isset($nestedOperations['upsert'])) {
+                (new Collection($nestedOperations['upsert']))->each(function ($singleValues) use ($relation): void {
+                    self::executeUpsert(
                         $relation->getModel()->newInstance(),
                         new Collection($singleValues),
                         $relation

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -465,6 +465,16 @@ class MutationExecutor
                 });
             }
 
+            if (isset($nestedOperations['upsert'])) {
+                (new Collection($nestedOperations['upsert']))->each(function ($singleValues) use ($relation): void {
+                    self::executeUpsert(
+                        $relation->getModel()->newInstance(),
+                        new Collection($singleValues),
+                        $relation
+                    );
+                });
+            }
+
             if (isset($nestedOperations['delete'])) {
                 $relation->detach($nestedOperations['delete']);
                 $relation->getModel()::destroy($nestedOperations['delete']);

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -400,7 +400,8 @@ class MutationExecutor
      *
      * @return \Illuminate\Database\Eloquent\Model
      */
-    protected static function executeUpdateWithLoadedModel(Model $model, Collection $args, ?Relation $parentRelation): Model {
+    protected static function executeUpdateWithLoadedModel(Model $model, Collection $args, ?Relation $parentRelation): Model
+    {
         $reflection = new ReflectionClass($model);
 
         [$hasMany, $remaining] = self::partitionArgsByRelationType($reflection, $args, HasMany::class);

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -338,11 +338,11 @@ class MutationExecutor
      * Execute an upsert mutation.
      *
      * @param \Illuminate\Database\Eloquent\Model $model
-     *         An empty instance of the model that should be updated
+     *         An empty instance of the model that should be created or updated
      * @param \Illuminate\Support\Collection $args
-     *         The corresponding slice of the input arguments for updating this model
+     *         The corresponding slice of the input arguments for creating or updating this model
      * @param \Illuminate\Database\Eloquent\Relations\Relation|null $parentRelation
-     *         If we are in a nested update, we can use this to associate the new model to its parent
+     *         If we are in a nested upsert, we can use this to associate the new model to its parent
      *
      * @return \Illuminate\Database\Eloquent\Model
      */

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -77,6 +77,14 @@ class MutationExecutor
             if (isset($nestedOperations['create'])) {
                 self::handleSingleRelationCreate(new Collection($nestedOperations['create']), $relation);
             }
+
+            if (isset($nestedOperations['upsert'])) {
+                self::executeUpsert(
+                    $relation->getModel()->newInstance(),
+                    new Collection($nestedOperations['upsert']),
+                    $relation
+                );
+            }
         };
         $hasOne->each($createOneToOne);
         $morphOne->each($createOneToOne);
@@ -460,6 +468,14 @@ class MutationExecutor
                 self::executeUpdate(
                     $relation->getModel()->newInstance(),
                     new Collection($nestedOperations['update']),
+                    $relation
+                );
+            }
+
+            if (isset($nestedOperations['upsert'])) {
+                self::executeUpsert(
+                    $relation->getModel()->newInstance(),
+                    new Collection($nestedOperations['upsert']),
                     $relation
                 );
             }

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -143,7 +143,7 @@ class MutationExecutor
     {
         $reflection = new ReflectionClass($model);
 
-        // Extract $morphTo first, as MorphTo extends
+        // Extract $morphTo first, as MorphTo extends BelongsTo
         [$morphTo, $remaining] = self::partitionArgsByRelationType(
             $reflection,
             $args,
@@ -400,11 +400,7 @@ class MutationExecutor
      *
      * @return \Illuminate\Database\Eloquent\Model
      */
-    protected static function executeUpdateWithLoadedModel(
-        Model $model,
-        Collection $args,
-        ?Relation $parentRelation
-    ): Model {
+    protected static function executeUpdateWithLoadedModel(Model $model, Collection $args, ?Relation $parentRelation): Model {
         $reflection = new ReflectionClass($model);
 
         [$hasMany, $remaining] = self::partitionArgsByRelationType($reflection, $args, HasMany::class);

--- a/src/Schema/Directives/CreateDirective.php
+++ b/src/Schema/Directives/CreateDirective.php
@@ -2,10 +2,10 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Nuwave\Lighthouse\Execution\MutationExecutor;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class CreateDirective extends MutationExecutorDirective
 {

--- a/src/Schema/Directives/CreateDirective.php
+++ b/src/Schema/Directives/CreateDirective.php
@@ -5,34 +5,12 @@ namespace Nuwave\Lighthouse\Schema\Directives;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Nuwave\Lighthouse\Execution\MutationExecutor;
-use Illuminate\Database\Eloquent\Relations\Relation;
 
 class CreateDirective extends MutationExecutorDirective
 {
-    /**
-     * Name of the directive.
-     *
-     * @return string
-     */
     public function name(): string
     {
         return 'create';
-    }
-
-    /**
-     * Execute a create mutation.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     *         An empty instance of the model that should be created
-     * @param  \Illuminate\Support\Collection  $args
-     *         The corresponding slice of the input arguments for creating this model
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation|null  $parentRelation
-     *         If we are in a nested create, we can use this to associate the new model to its parent
-     * @return \Illuminate\Database\Eloquent\Model
-     */
-    protected function executeMutation(Model $model, Collection $args, ?Relation $parentRelation = null): Model
-    {
-        return MutationExecutor::executeCreate($model, $args, $parentRelation);
     }
 
     public static function definition(): string
@@ -49,5 +27,10 @@ directive @create(
   model: String
 ) on FIELD_DEFINITION
 SDL;
+    }
+
+    protected function executeMutation(Model $model, Collection $args): Model
+    {
+        return MutationExecutor::executeCreate($model, $args);
     }
 }

--- a/src/Schema/Directives/MutationExecutorDirective.php
+++ b/src/Schema/Directives/MutationExecutorDirective.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Directives;
+
+use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Collection;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
+use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
+use Nuwave\Lighthouse\Support\Contracts\GlobalId;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+
+abstract class MutationExecutorDirective extends BaseDirective implements FieldResolver, DefinedDirective
+{
+    /**
+     * @var \Illuminate\Database\DatabaseManager
+     */
+    protected $databaseManager;
+
+    /**
+     * The GlobalId resolver.
+     *
+     * @var \Nuwave\Lighthouse\Support\Contracts\GlobalId
+     */
+    protected $globalId;
+
+    /**
+     * UpdateDirective constructor.
+     *
+     * @param  \Illuminate\Database\DatabaseManager  $databaseManager
+     * @param  \Nuwave\Lighthouse\Support\Contracts\GlobalId  $globalId
+     * @return void
+     */
+    public function __construct(DatabaseManager $databaseManager, GlobalId $globalId)
+    {
+        $this->databaseManager = $databaseManager;
+        $this->globalId = $globalId;
+    }
+
+    /**
+     * Resolve the field directive.
+     *
+     * @param  \Nuwave\Lighthouse\Schema\Values\FieldValue  $fieldValue
+     * @return \Nuwave\Lighthouse\Schema\Values\FieldValue
+     */
+    public function resolveField(FieldValue $fieldValue): FieldValue
+    {
+        return $fieldValue->setResolver(
+            function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo): Model {
+                $modelClass = $this->getModelClass();
+                /** @var \Illuminate\Database\Eloquent\Model $model */
+                $model = new $modelClass;
+
+                $executeMutation = function () use ($model, $args): Model {
+                    return $this->executeMutation($model, new Collection($args))->refresh();
+                };
+
+                return config('lighthouse.transactional_mutations', true)
+                    ? $this->databaseManager->connection($model->getConnectionName())->transaction($executeMutation)
+                    : $executeMutation();
+            }
+        );
+    }
+
+    abstract protected function executeMutation(Model $model, Collection $args, ?Relation $parentRelation = null): Model;
+}

--- a/src/Schema/Directives/MutationExecutorDirective.php
+++ b/src/Schema/Directives/MutationExecutorDirective.php
@@ -51,8 +51,9 @@ abstract class MutationExecutorDirective extends BaseDirective implements FieldR
     {
         return $fieldValue->setResolver(
             function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo): Model {
+                $modelClass = $this->getModelClass();
                 /** @var \Illuminate\Database\Eloquent\Model $model */
-                $model = new ($this->getModelClass());
+                $model = new $modelClass;
 
                 $executeMutation = function () use ($model, $args): Model {
                     return $this

--- a/src/Schema/Directives/MutationExecutorDirective.php
+++ b/src/Schema/Directives/MutationExecutorDirective.php
@@ -2,16 +2,16 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives;
 
+use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Model;
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Database\DatabaseManager;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
-use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 use Nuwave\Lighthouse\Support\Contracts\GlobalId;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
 
 abstract class MutationExecutorDirective extends BaseDirective implements FieldResolver, DefinedDirective
 {

--- a/src/Schema/Directives/UpdateDirective.php
+++ b/src/Schema/Directives/UpdateDirective.php
@@ -5,34 +5,12 @@ namespace Nuwave\Lighthouse\Schema\Directives;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Nuwave\Lighthouse\Execution\MutationExecutor;
-use Illuminate\Database\Eloquent\Relations\Relation;
 
 class UpdateDirective extends MutationExecutorDirective
 {
-    /**
-     * Name of the directive.
-     *
-     * @return string
-     */
     public function name(): string
     {
         return 'update';
-    }
-
-    /**
-     * Execute an update mutation.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model $modelInstance
-     *         An empty instance of the model that should be updated
-     * @param  \Illuminate\Support\Collection  $args
-     *         The corresponding slice of the input arguments for updating this model
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation|null  $parentRelation
-     *         If we are in a nested update, we can use this to associate the new model to its parent
-     * @return \Illuminate\Database\Eloquent\Model
-     */
-    protected function executeMutation(Model $model, Collection $args, ?Relation $parentRelation = null): Model
-    {
-        return MutationExecutor::executeUpdate($model, new Collection($args))->refresh();
     }
 
     public static function definition(): string
@@ -55,5 +33,10 @@ directive @update(
   globalId: Boolean = false
 ) on FIELD_DEFINITION
 SDL;
+    }
+
+    protected function executeMutation(Model $model, Collection $args): Model
+    {
+        return MutationExecutor::executeUpdate($model, $args);
     }
 }

--- a/src/Schema/Directives/UpdateDirective.php
+++ b/src/Schema/Directives/UpdateDirective.php
@@ -2,10 +2,10 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives;
 
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Nuwave\Lighthouse\Execution\MutationExecutor;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class UpdateDirective extends MutationExecutorDirective
 {

--- a/src/Schema/Directives/UpdateDirective.php
+++ b/src/Schema/Directives/UpdateDirective.php
@@ -2,42 +2,13 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\DatabaseManager;
-use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Execution\MutationExecutor;
-use Nuwave\Lighthouse\Support\Contracts\GlobalId;
-use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
-use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
 
-class UpdateDirective extends BaseDirective implements FieldResolver, DefinedDirective
+class UpdateDirective extends MutationExecutorDirective
 {
-    /**
-     * @var \Illuminate\Database\DatabaseManager
-     */
-    protected $databaseManager;
-
-    /**
-     * The GlobalId resolver.
-     *
-     * @var \Nuwave\Lighthouse\Support\Contracts\GlobalId
-     */
-    protected $globalId;
-
-    /**
-     * UpdateDirective constructor.
-     *
-     * @param  \Illuminate\Database\DatabaseManager  $databaseManager
-     * @param  \Nuwave\Lighthouse\Support\Contracts\GlobalId  $globalId
-     * @return void
-     */
-    public function __construct(DatabaseManager $databaseManager, GlobalId $globalId)
-    {
-        $this->databaseManager = $databaseManager;
-        $this->globalId = $globalId;
-    }
-
     /**
      * Name of the directive.
      *
@@ -46,6 +17,22 @@ class UpdateDirective extends BaseDirective implements FieldResolver, DefinedDir
     public function name(): string
     {
         return 'update';
+    }
+
+    /**
+     * Execute an update mutation.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model $modelInstance
+     *         An empty instance of the model that should be updated
+     * @param  \Illuminate\Support\Collection  $args
+     *         The corresponding slice of the input arguments for updating this model
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation|null  $parentRelation
+     *         If we are in a nested update, we can use this to associate the new model to its parent
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    protected function executeMutation(Model $model, Collection $args, ?Relation $parentRelation = null): Model
+    {
+        return MutationExecutor::executeUpdate($model, new Collection($args))->refresh();
     }
 
     public static function definition(): string
@@ -68,34 +55,5 @@ directive @update(
   globalId: Boolean = false
 ) on FIELD_DEFINITION
 SDL;
-    }
-
-    /**
-     * Resolve the field directive.
-     *
-     * @param  \Nuwave\Lighthouse\Schema\Values\FieldValue  $fieldValue
-     * @return \Nuwave\Lighthouse\Schema\Values\FieldValue
-     */
-    public function resolveField(FieldValue $fieldValue): FieldValue
-    {
-        return $fieldValue->setResolver(
-            function ($root, array $args): Model {
-                $modelClass = $this->getModelClass();
-                /** @var \Illuminate\Database\Eloquent\Model $model */
-                $model = new $modelClass;
-
-                if ($this->directiveArgValue('globalId', false)) {
-                    $args['id'] = $this->globalId->decodeId($args['id']);
-                }
-
-                $executeMutation = function () use ($model, $args): Model {
-                    return MutationExecutor::executeUpdate($model, new Collection($args))->refresh();
-                };
-
-                return config('lighthouse.transactional_mutations', true)
-                    ? $this->databaseManager->connection($model->getConnectionName())->transaction($executeMutation)
-                    : $executeMutation();
-            }
-        );
     }
 }

--- a/src/Schema/Directives/UpsertDirective.php
+++ b/src/Schema/Directives/UpsertDirective.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Directives;
+
+use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\DatabaseManager;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Execution\MutationExecutor;
+use Nuwave\Lighthouse\Support\Contracts\GlobalId;
+use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
+use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
+
+class UpsertDirective extends BaseDirective implements FieldResolver, DefinedDirective
+{
+    /**
+     * @var \Illuminate\Database\DatabaseManager
+     */
+    protected $databaseManager;
+
+    /**
+     * The GlobalId resolver.
+     *
+     * @var \Nuwave\Lighthouse\Support\Contracts\GlobalId
+     */
+    protected $globalId;
+
+    /**
+     * UpdateDirective constructor.
+     *
+     * @param  \Illuminate\Database\DatabaseManager  $databaseManager
+     * @param  \Nuwave\Lighthouse\Support\Contracts\GlobalId  $globalId
+     * @return void
+     */
+    public function __construct(DatabaseManager $databaseManager, GlobalId $globalId)
+    {
+        $this->databaseManager = $databaseManager;
+        $this->globalId = $globalId;
+    }
+
+    /**
+     * Name of the directive.
+     *
+     * @return string
+     */
+    public function name(): string
+    {
+        return 'upsert';
+    }
+
+    public static function definition(): string
+    {
+        return /* @lang GraphQL */ <<<'SDL'
+"""
+Create or update an Eloquent model with the input values of the field.
+"""
+directive @upsert(
+  """
+  Specify the class name of the model to use.
+  This is only needed when the default model resolution does not work.
+  """
+  model: String
+
+  """
+  Set to `true` to use global ids for finding the model.
+  If set to `false`, regular non-global ids are used.
+  """
+  globalId: Boolean = false
+) on FIELD_DEFINITION
+SDL;
+    }
+
+    /**
+     * Resolve the field directive.
+     *
+     * @param  \Nuwave\Lighthouse\Schema\Values\FieldValue  $fieldValue
+     * @return \Nuwave\Lighthouse\Schema\Values\FieldValue
+     */
+    public function resolveField(FieldValue $fieldValue): FieldValue
+    {
+        return $fieldValue->setResolver(
+            function ($root, array $args): Model {
+                $modelClass = $this->getModelClass();
+                /** @var \Illuminate\Database\Eloquent\Model $model */
+                $model = new $modelClass;
+
+                if ($this->directiveArgValue('globalId', false)) {
+                    $args['id'] = $this->globalId->decodeId($args['id']);
+                }
+
+                $executeMutation = function () use ($model, $args): Model {
+                    return MutationExecutor::executeUpsert($model, new Collection($args))->refresh();
+                };
+
+                return config('lighthouse.transactional_mutations', true)
+                    ? $this->databaseManager->connection($model->getConnectionName())->transaction($executeMutation)
+                    : $executeMutation();
+            }
+        );
+    }
+}

--- a/src/Schema/Directives/UpsertDirective.php
+++ b/src/Schema/Directives/UpsertDirective.php
@@ -26,7 +26,7 @@ class UpsertDirective extends BaseDirective implements FieldResolver, DefinedDir
     protected $globalId;
 
     /**
-     * UpdateDirective constructor.
+     * UpsertDirective constructor.
      *
      * @param  \Illuminate\Database\DatabaseManager  $databaseManager
      * @param  \Nuwave\Lighthouse\Support\Contracts\GlobalId  $globalId

--- a/src/Schema/Directives/UpsertDirective.php
+++ b/src/Schema/Directives/UpsertDirective.php
@@ -2,10 +2,10 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives;
 
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Nuwave\Lighthouse\Execution\MutationExecutor;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class UpsertDirective extends MutationExecutorDirective
 {

--- a/src/Schema/Directives/UpsertDirective.php
+++ b/src/Schema/Directives/UpsertDirective.php
@@ -5,35 +5,12 @@ namespace Nuwave\Lighthouse\Schema\Directives;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Nuwave\Lighthouse\Execution\MutationExecutor;
-use Illuminate\Database\Eloquent\Relations\Relation;
 
 class UpsertDirective extends MutationExecutorDirective
 {
-    /**
-     * Name of the directive.
-     *
-     * @return string
-     */
     public function name(): string
     {
         return 'upsert';
-    }
-
-    /**
-     * Execute an upsert mutation.
-     *
-     * @param \Illuminate\Database\Eloquent\Model $model
-     *         An empty instance of the model that should be created or updated
-     * @param \Illuminate\Support\Collection $args
-     *         The corresponding slice of the input arguments for creating or updating this model
-     * @param \Illuminate\Database\Eloquent\Relations\Relation|null $parentRelation
-     *         If we are in a nested upsert, we can use this to associate the new model to its parent
-     *
-     * @return \Illuminate\Database\Eloquent\Model
-     */
-    protected function executeMutation(Model $model, Collection $args, ?Relation $parentRelation = null): Model
-    {
-        return MutationExecutor::executeUpsert($model, new Collection($args))->refresh();
     }
 
     public static function definition(): string
@@ -56,5 +33,10 @@ directive @upsert(
   globalId: Boolean = false
 ) on FIELD_DEFINITION
 SDL;
+    }
+
+    protected function executeMutation(Model $model, Collection $args): Model
+    {
+        return MutationExecutor::executeUpsert($model, $args);
     }
 }

--- a/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
@@ -545,7 +545,6 @@ class BelongsToManyTest extends DBTestCase
         $this->assertCount(0, $role->users);
     }
 
-
     public function testCanUpsertWithBelongsToManyOnNonExistentData(): void
     {
         $this->graphQL('

--- a/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
@@ -370,7 +370,7 @@ class BelongsToManyTest extends DBTestCase
         $this->assertSame('is_user', $role->name);
     }
 
-    public function actionsOverExistingDataProvider()
+    public function existingModelMutations()
     {
         return [
             ['Update action' => 'update'],
@@ -379,7 +379,7 @@ class BelongsToManyTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpdateWithBelongsToMany(string $action): void
     {
@@ -442,7 +442,7 @@ class BelongsToManyTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanDeleteWithBelongsToMany(string $action): void
     {
@@ -495,7 +495,7 @@ class BelongsToManyTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanConnectWithBelongsToMany(string $action): void
     {
@@ -544,7 +544,7 @@ class BelongsToManyTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanSyncWithBelongsToMany(string $action): void
     {
@@ -593,7 +593,7 @@ class BelongsToManyTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanDisconnectWithBelongsToMany(string $action): void
     {
@@ -719,7 +719,7 @@ class BelongsToManyTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanDisconnectAllRelatedModelsOnEmptySync(string $action): void
     {

--- a/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
@@ -372,14 +372,16 @@ class BelongsToManyTest extends DBTestCase
 
     public function actionsOverExistingDataProvider()
     {
-        yield ['Update action' => 'update'];
-        yield ['Upsert action' => 'upsert'];
+        return [
+            ['Update action' => 'update'],
+            ['Upsert action' => 'upsert'],
+        ];
     }
 
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpdateWithBelongsToMany($action): void
+    public function testCanUpdateWithBelongsToMany(string $action): void
     {
         factory(Role::class)
             ->create([
@@ -442,7 +444,7 @@ class BelongsToManyTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanDeleteWithBelongsToMany($action): void
+    public function testCanDeleteWithBelongsToMany(string $action): void
     {
         factory(Role::class)
             ->create([
@@ -495,7 +497,7 @@ class BelongsToManyTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanConnectWithBelongsToMany($action): void
+    public function testCanConnectWithBelongsToMany(string $action): void
     {
         factory(User::class)->create();
         factory(Role::class)
@@ -544,7 +546,7 @@ class BelongsToManyTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanSyncWithBelongsToMany($action): void
+    public function testCanSyncWithBelongsToMany(string $action): void
     {
         factory(User::class)->create();
         factory(Role::class)
@@ -593,7 +595,7 @@ class BelongsToManyTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanDisconnectWithBelongsToMany($action): void
+    public function testCanDisconnectWithBelongsToMany(string $action): void
     {
         factory(Role::class)
             ->create()
@@ -719,7 +721,7 @@ class BelongsToManyTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanDisconnectAllRelatedModelsOnEmptySync($action): void
+    public function testCanDisconnectAllRelatedModelsOnEmptySync(string $action): void
     {
         /** @var User $user */
         $user = factory(User::class)->create();

--- a/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
@@ -133,11 +133,11 @@ class BelongsToManyTest extends DBTestCase
                 name: "is_user"
                 users: {
                     upsert: [{
-                        id: 1
+                        id: 10
                         name: "user1"
                     },
                     {
-                        id: 2
+                        id: 20
                         name: "user2"
                     }]
                 }
@@ -157,11 +157,11 @@ class BelongsToManyTest extends DBTestCase
                     'name' => 'is_user',
                     'users' => [
                         [
-                            'id' => '1',
+                            'id' => '10',
                             'name' => 'user1',
                         ],
                         [
-                            'id' => '2',
+                            'id' => '20',
                             'name' => 'user2',
                         ],
                     ],

--- a/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
@@ -397,14 +397,16 @@ class BelongsToTest extends DBTestCase
 
     public function actionsOverExistingDataProvider()
     {
-        yield ['Update action' => 'update'];
-        yield ['Upsert action' => 'upsert'];
+        return [
+            ['Update action' => 'update'],
+            ['Upsert action' => 'upsert'],
+        ];
     }
 
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpdateAndDisconnectBelongsTo($action): void
+    public function testCanUpdateAndDisconnectBelongsTo(string $action): void
     {
         factory(Task::class)->create();
 
@@ -489,7 +491,7 @@ class BelongsToTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpdateAndDeleteBelongsTo($action): void
+    public function testCanUpdateAndDeleteBelongsTo(string $action): void
     {
         factory(Task::class)->create();
 
@@ -574,7 +576,7 @@ class BelongsToTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testDoesNotDeleteOrDisconnectOnFalsyValues($action): void
+    public function testDoesNotDeleteOrDisconnectOnFalsyValues(string $action): void
     {
         factory(Task::class)->create();
 

--- a/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
@@ -395,7 +395,7 @@ class BelongsToTest extends DBTestCase
         ]);
     }
 
-    public function actionsOverExistingDataProvider()
+    public function existingModelMutations()
     {
         return [
             ['Update action' => 'update'],
@@ -404,7 +404,7 @@ class BelongsToTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpdateAndDisconnectBelongsTo(string $action): void
     {
@@ -489,7 +489,7 @@ class BelongsToTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpdateAndDeleteBelongsTo(string $action): void
     {
@@ -574,7 +574,7 @@ class BelongsToTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testDoesNotDeleteOrDisconnectOnFalsyValues(string $action): void
     {

--- a/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
@@ -35,6 +35,7 @@ class BelongsToTest extends DBTestCase
         connect: ID
         create: CreateUserInput
         update: UpdateUserInput
+        upsert: UpsertUserInput
     }
     
     input CreateUserInput {
@@ -151,6 +152,39 @@ class BelongsToTest extends DBTestCase
                 name: "foo"
                 user: {
                     create: {
+                        name: "New User"
+                    }
+                }
+            }) {
+                id
+                name
+                user {
+                    id
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'createTask' => [
+                    'id' => '1',
+                    'name' => 'foo',
+                    'user' => [
+                        'id' => '1',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testCanUpsertWithNewBelongsTo(): void
+    {
+        $this->graphQL('
+        mutation {
+            createTask(input: {
+                name: "foo"
+                user: {
+                    upsert: {
+                        id: 1
                         name: "New User"
                     }
                 }

--- a/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
@@ -415,11 +415,11 @@ class BelongsToTest extends DBTestCase
     {
         factory(User::class)->create();
 
-        $this->graphQL("
+        $this->graphQL('
         mutation {
             upsertTask(input: {
                 id: 1
-                name: \"foo\"
+                name: "foo"
                 user: {
                     disconnect: true
                 }
@@ -431,7 +431,7 @@ class BelongsToTest extends DBTestCase
                 }
             }
         }
-        ")->assertJson([
+        ')->assertJson([
             'data' => [
                 'upsertTask' => [
                     'id' => '1',

--- a/tests/Integration/Execution/MutationExecutor/HasManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasManyTest.php
@@ -33,6 +33,7 @@ class HasManyTest extends DBTestCase
     
     input CreateTaskRelation {
         create: [CreateTaskInput!]
+        upsert: [UpsertTaskInput!]
     }
     
     input CreateTaskInput {
@@ -84,6 +85,43 @@ class HasManyTest extends DBTestCase
                 name: "foo"
                 tasks: {
                     create: [{
+                        name: "bar"
+                    }]
+                }
+            }) {
+                id
+                name
+                tasks {
+                    id
+                    name
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'createUser' => [
+                    'id' => '1',
+                    'name' => 'foo',
+                    'tasks' => [
+                        [
+                            'id' => '1',
+                            'name' => 'bar',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testCanUpsertWithNewHasMany(): void
+    {
+        $this->graphQL('
+        mutation {
+            createUser(input: {
+                name: "foo"
+                tasks: {
+                    upsert: [{
+                        id: 1
                         name: "bar"
                     }]
                 }

--- a/tests/Integration/Execution/MutationExecutor/HasManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasManyTest.php
@@ -190,14 +190,16 @@ class HasManyTest extends DBTestCase
 
     public function actionsOverExistingDataProvider()
     {
-        yield ['Update action' => 'update'];
-        yield ['Upsert action' => 'upsert'];
+        return [
+            ['Update action' => 'update'],
+            ['Upsert action' => 'upsert'],
+        ];
     }
 
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanCreateHasMany($action): void
+    public function testCanCreateHasMany(string $action): void
     {
         factory(User::class)->create();
 
@@ -239,7 +241,7 @@ class HasManyTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpdateHasMany($action): void
+    public function testCanUpdateHasMany(string $action): void
     {
         factory(User::class)
             ->create()
@@ -287,7 +289,7 @@ class HasManyTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpsertHasMany($action): void
+    public function testCanUpsertHasMany(string $action): void
     {
         factory(User::class)
             ->create()
@@ -335,7 +337,7 @@ class HasManyTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanDeleteHasMany($action): void
+    public function testCanDeleteHasMany(string $action): void
     {
         factory(User::class)
             ->create()

--- a/tests/Integration/Execution/MutationExecutor/HasManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasManyTest.php
@@ -188,7 +188,7 @@ class HasManyTest extends DBTestCase
         ]);
     }
 
-    public function actionsOverExistingDataProvider()
+    public function existingModelMutations()
     {
         return [
             ['Update action' => 'update'],
@@ -197,7 +197,7 @@ class HasManyTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanCreateHasMany(string $action): void
     {
@@ -239,7 +239,7 @@ class HasManyTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpdateHasMany(string $action): void
     {
@@ -287,7 +287,7 @@ class HasManyTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpsertHasMany(string $action): void
     {
@@ -335,7 +335,7 @@ class HasManyTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanDeleteHasMany(string $action): void
     {

--- a/tests/Integration/Execution/MutationExecutor/HasOneTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasOneTest.php
@@ -185,14 +185,16 @@ class HasOneTest extends DBTestCase
 
     public function actionsOverExistingDataProvider()
     {
-        yield ['Update action' => 'update'];
-        yield ['Upsert action' => 'upsert'];
+        return [
+            ['Update action' => 'update'],
+            ['Upsert action' => 'upsert'],
+        ];
     }
 
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpdateWithNewHasOne($action): void
+    public function testCanUpdateWithNewHasOne(string $action): void
     {
         factory(Task::class)->create();
 
@@ -232,7 +234,7 @@ class HasOneTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpdateAndUpdateHasOne($action): void
+    public function testCanUpdateAndUpdateHasOne(string $action): void
     {
         factory(Task::class)
             ->create()
@@ -278,7 +280,7 @@ class HasOneTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpdateAndUpsertHasOne($action): void
+    public function testCanUpdateAndUpsertHasOne(string $action): void
     {
         factory(Task::class)
             ->create()
@@ -324,7 +326,7 @@ class HasOneTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpdateAndDeleteHasOne($action): void
+    public function testCanUpdateAndDeleteHasOne(string $action): void
     {
         factory(Task::class)
             ->create()

--- a/tests/Integration/Execution/MutationExecutor/HasOneTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasOneTest.php
@@ -183,7 +183,7 @@ class HasOneTest extends DBTestCase
         ]);
     }
 
-    public function actionsOverExistingDataProvider()
+    public function existingModelMutations()
     {
         return [
             ['Update action' => 'update'],
@@ -192,7 +192,7 @@ class HasOneTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpdateWithNewHasOne(string $action): void
     {
@@ -232,7 +232,7 @@ class HasOneTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpdateAndUpdateHasOne(string $action): void
     {
@@ -278,7 +278,7 @@ class HasOneTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpdateAndUpsertHasOne(string $action): void
     {
@@ -324,7 +324,7 @@ class HasOneTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpdateAndDeleteHasOne(string $action): void
     {

--- a/tests/Integration/Execution/MutationExecutor/HasOneTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasOneTest.php
@@ -33,7 +33,8 @@ class HasOneTest extends DBTestCase
     }
     
     input CreatePostRelation {
-        create: CreatePostInput!
+        create: CreatePostInput
+        upsert: UpsertPostInput
     }
     
     input CreatePostInput {
@@ -85,6 +86,41 @@ class HasOneTest extends DBTestCase
                 name: "foo"
                 post: {
                     create: {
+                        title: "bar"
+                    }
+                }
+            }) {
+                id
+                name
+                post {
+                    id
+                    title
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'createTask' => [
+                    'id' => '1',
+                    'name' => 'foo',
+                    'post' => [
+                        'id' => '1',
+                        'title' => 'bar',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testCanUpsertWithNewHasOne(): void
+    {
+        $this->graphQL('
+        mutation {
+            createTask(input: {
+                name: "foo"
+                post: {
+                    upsert: {
+                        id: 1
                         title: "bar"
                     }
                 }

--- a/tests/Integration/Execution/MutationExecutor/MorphManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphManyTest.php
@@ -147,14 +147,16 @@ class MorphManyTest extends DBTestCase
 
     public function actionsOverExistingDataProvider()
     {
-        yield ['Update action' => 'update'];
-        yield ['Upsert action' => 'upsert'];
+        return [
+            ['Update action' => 'update'],
+            ['Upsert action' => 'upsert'],
+        ];
     }
 
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpdateWithNewMorphMany($action): void
+    public function testCanUpdateWithNewMorphMany(string $action): void
     {
         factory(Task::class)->create();
 
@@ -194,7 +196,7 @@ class MorphManyTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpdateAndUpdateMorphMany($action): void
+    public function testCanUpdateAndUpdateMorphMany(string $action): void
     {
         factory(Task::class)
             ->create()
@@ -240,7 +242,7 @@ class MorphManyTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpdateAndUpsertMorphMany($action): void
+    public function testCanUpdateAndUpsertMorphMany(string $action): void
     {
         factory(Task::class)
             ->create()
@@ -286,7 +288,7 @@ class MorphManyTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpdateAndDeleteMorphMany($action): void
+    public function testCanUpdateAndDeleteMorphMany(string $action): void
     {
         factory(Task::class)
             ->create()

--- a/tests/Integration/Execution/MutationExecutor/MorphManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphManyTest.php
@@ -145,7 +145,7 @@ class MorphManyTest extends DBTestCase
         ]);
     }
 
-    public function actionsOverExistingDataProvider()
+    public function existingModelMutations()
     {
         return [
             ['Update action' => 'update'],
@@ -154,7 +154,7 @@ class MorphManyTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpdateWithNewMorphMany(string $action): void
     {
@@ -194,7 +194,7 @@ class MorphManyTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpdateAndUpdateMorphMany(string $action): void
     {
@@ -240,7 +240,7 @@ class MorphManyTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpdateAndUpsertMorphMany(string $action): void
     {
@@ -286,7 +286,7 @@ class MorphManyTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpdateAndDeleteMorphMany(string $action): void
     {

--- a/tests/Integration/Execution/MutationExecutor/MorphOneTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphOneTest.php
@@ -143,14 +143,16 @@ class MorphOneTest extends DBTestCase
 
     public function actionsOverExistingDataProvider()
     {
-        yield ['Update action' => 'update'];
-        yield ['Upsert action' => 'upsert'];
+        return [
+            ['Update action' => 'update'],
+            ['Upsert action' => 'upsert'],
+        ];
     }
 
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpdateWithNewMorphOne($action): void
+    public function testCanUpdateWithNewMorphOne(string $action): void
     {
         factory(Task::class)->create();
 
@@ -188,7 +190,7 @@ class MorphOneTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpdateWithUpsertMorphOne($action): void
+    public function testCanUpdateWithUpsertMorphOne(string $action): void
     {
         factory(Task::class)->create();
 
@@ -227,7 +229,7 @@ class MorphOneTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpdateAndUpdateMorphOne($action): void
+    public function testCanUpdateAndUpdateMorphOne(string $action): void
     {
         factory(Task::class)
             ->create()
@@ -271,7 +273,7 @@ class MorphOneTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testCanUpdateAndDeleteMorphOne($action): void
+    public function testCanUpdateAndDeleteMorphOne(string $action): void
     {
         factory(Task::class)
             ->create()

--- a/tests/Integration/Execution/MutationExecutor/MorphOneTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphOneTest.php
@@ -22,6 +22,7 @@ class MorphOneTest extends DBTestCase
     type Mutation {
         createTask(input: CreateTaskInput! @spread): Task @create
         updateTask(input: UpdateTaskInput! @spread): Task @update
+        upsertTask(input: UpsertTaskInput! @spread): Task @upsert
     }
     
     input CreateTaskInput {
@@ -30,7 +31,8 @@ class MorphOneTest extends DBTestCase
     }
     
     input CreateHourRelation {
-        create: CreateHourInput!
+        create: CreateHourInput
+        upsert: UpsertHourInput
     }
     
     input CreateHourInput {
@@ -46,10 +48,29 @@ class MorphOneTest extends DBTestCase
     input UpdateHourRelation {
         create: CreateHourInput
         update: UpdateHourInput
+        upsert: UpsertHourInput
         delete: ID
     }
     
     input UpdateHourInput {
+        id: ID!
+        weekday: Int
+    }
+
+    input UpsertTaskInput {
+        id: ID!
+        name: String
+        hour: UpsertHourRelation
+    }
+
+    input UpsertHourRelation {
+        create: CreateHourInput
+        update: UpdateHourInput
+        upsert: UpsertHourInput
+        delete: ID
+    }
+
+    input UpsertHourInput {
         id: ID!
         weekday: Int
     }
@@ -87,57 +108,14 @@ class MorphOneTest extends DBTestCase
         ]);
     }
 
-    public function testCanUpdateWithNewMorphOne(): void
+    public function testCanCreateWithUpsertMorphOne(): void
     {
-        factory(Task::class)->create();
-
         $this->graphQL('
         mutation {
-            updateTask(input: {
-                id: 1
+            createTask(input: {
                 name: "foo"
                 hour: {
-                    create: {
-                        weekday: 3
-                    }
-                }
-            }) {
-                id
-                name
-                hour {
-                    weekday
-                }
-            }
-        }
-        ')->assertJson([
-            'data' => [
-                'updateTask' => [
-                    'id' => '1',
-                    'name' => 'foo',
-                    'hour' => [
-                        'weekday' => 3,
-                    ],
-                ],
-            ],
-        ]);
-    }
-
-    public function testCanUpdateAndUpdateMorphOne(): void
-    {
-        factory(Task::class)
-            ->create()
-            ->hour()
-            ->save(
-                factory(Hour::class)->create()
-            );
-
-        $this->graphQL('
-        mutation {
-            updateTask(input: {
-                id: 1
-                name: "foo"
-                hour: {
-                    update: {
+                    upsert: {
                         id: 1
                         weekday: 3
                     }
@@ -152,7 +130,7 @@ class MorphOneTest extends DBTestCase
         }
         ')->assertJson([
             'data' => [
-                'updateTask' => [
+                'createTask' => [
                     'id' => '1',
                     'name' => 'foo',
                     'hour' => [
@@ -163,7 +141,93 @@ class MorphOneTest extends DBTestCase
         ]);
     }
 
-    public function testCanUpdateAndDeleteMorphOne(): void
+    public function actionsOverExistingDataProvider()
+    {
+        yield ['Update action' => 'update'];
+        yield ['Upsert action' => 'upsert'];
+    }
+
+    /**
+     * @dataProvider actionsOverExistingDataProvider
+     */
+    public function testCanUpdateWithNewMorphOne($action): void
+    {
+        factory(Task::class)->create();
+
+        $this->graphQL("
+        mutation {
+            ${action}Task(input: {
+                id: 1
+                name: \"foo\"
+                hour: {
+                    create: {
+                        weekday: 3
+                    }
+                }
+            }) {
+                id
+                name
+                hour {
+                    weekday
+                }
+            }
+        }
+        ")->assertJson([
+            'data' => [
+                "${action}Task" => [
+                    'id' => '1',
+                    'name' => 'foo',
+                    'hour' => [
+                        'weekday' => 3,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @dataProvider actionsOverExistingDataProvider
+     */
+    public function testCanUpdateWithUpsertMorphOne($action): void
+    {
+        factory(Task::class)->create();
+
+        $this->graphQL("
+        mutation {
+            ${action}Task(input: {
+                id: 1
+                name: \"foo\"
+                hour: {
+                    upsert: {
+                        id: 1
+                        weekday: 3
+                    }
+                }
+            }) {
+                id
+                name
+                hour {
+                    weekday
+                }
+            }
+        }
+        ")->assertJson([
+            'data' => [
+                "${action}Task" => [
+                    'id' => '1',
+                    'name' => 'foo',
+                    'hour' => [
+                        'weekday' => 3,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @dataProvider actionsOverExistingDataProvider
+     */
+    public function testCanUpdateAndUpdateMorphOne($action): void
     {
         factory(Task::class)
             ->create()
@@ -172,11 +236,55 @@ class MorphOneTest extends DBTestCase
                 factory(Hour::class)->create()
             );
 
-        $this->graphQL('
+        $this->graphQL("
         mutation {
-            updateTask(input: {
+            ${action}Task(input: {
                 id: 1
-                name: "foo"
+                name: \"foo\"
+                hour: {
+                    update: {
+                        id: 1
+                        weekday: 3
+                    }
+                }
+            }) {
+                id
+                name
+                hour {
+                    weekday
+                }
+            }
+        }
+        ")->assertJson([
+            'data' => [
+                "${action}Task" => [
+                    'id' => '1',
+                    'name' => 'foo',
+                    'hour' => [
+                        'weekday' => 3,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @dataProvider actionsOverExistingDataProvider
+     */
+    public function testCanUpdateAndDeleteMorphOne($action): void
+    {
+        factory(Task::class)
+            ->create()
+            ->hour()
+            ->save(
+                factory(Hour::class)->create()
+            );
+
+        $this->graphQL("
+        mutation {
+            ${action}Task(input: {
+                id: 1
+                name: \"foo\"
                 hour: {
                     delete: 1
                 }
@@ -188,9 +296,9 @@ class MorphOneTest extends DBTestCase
                 }
             }
         }
-        ')->assertJson([
+        ")->assertJson([
             'data' => [
-                'updateTask' => [
+                "${action}Task" => [
                     'id' => '1',
                     'name' => 'foo',
                     'hour' => null,

--- a/tests/Integration/Execution/MutationExecutor/MorphOneTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphOneTest.php
@@ -141,7 +141,7 @@ class MorphOneTest extends DBTestCase
         ]);
     }
 
-    public function actionsOverExistingDataProvider()
+    public function existingModelMutations()
     {
         return [
             ['Update action' => 'update'],
@@ -150,7 +150,7 @@ class MorphOneTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpdateWithNewMorphOne(string $action): void
     {
@@ -188,7 +188,7 @@ class MorphOneTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpdateWithUpsertMorphOne(string $action): void
     {
@@ -227,7 +227,7 @@ class MorphOneTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpdateAndUpdateMorphOne(string $action): void
     {
@@ -271,7 +271,7 @@ class MorphOneTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testCanUpdateAndDeleteMorphOne(string $action): void
     {

--- a/tests/Integration/Execution/MutationExecutor/MorphToManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToManyTest.php
@@ -10,6 +10,7 @@ class MorphToManyTest extends DBTestCase
     protected $schema = '
     type Mutation {
         createTask(input: CreateTaskInput! @spread): Task @create
+        upsertTask(input: UpsertTaskInput! @spread): Task @upsert
     }
     
     input CreateTaskInput {
@@ -19,6 +20,7 @@ class MorphToManyTest extends DBTestCase
     
     input CreateTagRelation {
         create: [CreateTagInput!]
+        upsert: [UpsertTagInput!]
         sync: [ID!]
         connect: [ID!]
     }
@@ -26,7 +28,25 @@ class MorphToManyTest extends DBTestCase
     input CreateTagInput {
         name: String!
     }
-    
+
+    input UpsertTaskInput {
+        id: ID!
+        name: String!
+        tags: UpsertTagRelation
+    }
+
+    input UpsertTagRelation {
+        create: [CreateTagInput!]
+        upsert: [UpsertTagInput!]
+        sync: [ID!]
+        connect: [ID!]
+    }
+
+    input UpsertTagInput {
+        id: ID!
+        name: String!
+    }
+
     type Task {
         id: ID!
         name: String!
@@ -69,6 +89,37 @@ class MorphToManyTest extends DBTestCase
         ]);
     }
 
+    public function testCanUpsertATaskWithExistingTagsByUsingConnect(): void
+    {
+        $id = factory(Tag::class)->create(['name' => 'php'])->id;
+
+        $this->graphQL('
+        mutation {
+            upsertTask(input: {
+                id: 1
+                name: "Finish tests"
+                tags: {
+                    connect: [1]
+                }
+            }) {
+                tags{
+                    id
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'upsertTask' => [
+                    'tags' => [
+                        [
+                            'id' => $id,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
     public function testCanCreateATaskWithExistingTagsByUsingSync(): void
     {
         $id = factory(Tag::class)->create(['name' => 'php'])->id;
@@ -89,6 +140,37 @@ class MorphToManyTest extends DBTestCase
         ')->assertJson([
             'data' => [
                 'createTask' => [
+                    'tags' => [
+                        [
+                            'id' => $id,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testCanUpsertATaskWithExistingTagsByUsingSync(): void
+    {
+        $id = factory(Tag::class)->create(['name' => 'php'])->id;
+
+        $this->graphQL('
+        mutation {
+            upsertTask(input: {
+                id: 1
+                name: "Finish tests"
+                tags: {
+                    sync: [1]
+                }
+            }) {
+                tags {
+                    id
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'upsertTask' => [
                     'tags' => [
                         [
                             'id' => $id,
@@ -122,6 +204,77 @@ class MorphToManyTest extends DBTestCase
         ')->assertJson([
             'data' => [
                 'createTask' => [
+                    'tags' => [
+                        [
+                            'id' => 1,
+                            'name' => 'php',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testCanUpsertANewTagRelationByUsingCreate(): void
+    {
+        $this->graphQL('
+        mutation {
+            upsertTask(input: {
+                id: 1
+                name: "Finish tests"
+                tags: {
+                    create: [
+                        {
+                            name: "php"
+                        }
+                    ]
+                }
+            }) {
+                tags {
+                    id
+                    name
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'upsertTask' => [
+                    'tags' => [
+                        [
+                            'id' => 1,
+                            'name' => 'php',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testCanUpsertANewTagRelationByUsingUpsert(): void
+    {
+        $this->graphQL('
+        mutation {
+            upsertTask(input: {
+                id: 1
+                name: "Finish tests"
+                tags: {
+                    upsert: [
+                        {
+                            id: 1
+                            name: "php"
+                        }
+                    ]
+                }
+            }) {
+                tags {
+                    id
+                    name
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'upsertTask' => [
                     'tags' => [
                         [
                             'id' => 1,

--- a/tests/Integration/Execution/MutationExecutor/MorphToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToTest.php
@@ -145,7 +145,7 @@ class MorphToTest extends DBTestCase
         ]);
     }
 
-    public function actionsOverExistingDataProvider()
+    public function existingModelMutations()
     {
         return [
             ['Update action' => 'update'],
@@ -154,7 +154,7 @@ class MorphToTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testDisconnectsMorphTo(string $action): void
     {
@@ -191,7 +191,7 @@ class MorphToTest extends DBTestCase
     }
 
     /**
-     * @dataProvider actionsOverExistingDataProvider
+     * @dataProvider existingModelMutations
      */
     public function testDeletesMorphTo(string $action): void
     {

--- a/tests/Integration/Execution/MutationExecutor/MorphToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToTest.php
@@ -147,14 +147,16 @@ class MorphToTest extends DBTestCase
 
     public function actionsOverExistingDataProvider()
     {
-        yield ['Update action' => 'update'];
-        yield ['Upsert action' => 'upsert'];
+        return [
+            ['Update action' => 'update'],
+            ['Upsert action' => 'upsert'],
+        ];
     }
 
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testDisconnectsMorphTo($action): void
+    public function testDisconnectsMorphTo(string $action): void
     {
         /** @var \Tests\Utils\Models\Task $task */
         $task = factory(Task::class)->create(['name' => 'first_task']);
@@ -191,7 +193,7 @@ class MorphToTest extends DBTestCase
     /**
      * @dataProvider actionsOverExistingDataProvider
      */
-    public function testDeletesMorphTo($action): void
+    public function testDeletesMorphTo(string $action): void
     {
         /** @var \Tests\Utils\Models\Task $task */
         $task = factory(Task::class)->create(['name' => 'first_task']);

--- a/tests/Integration/Schema/Directives/UpdateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/UpdateDirectiveTest.php
@@ -45,6 +45,7 @@ class UpdateDirectiveTest extends DBTestCase
                 ],
             ],
         ]);
+
         $this->assertSame('bar', Company::first()->name);
     }
 
@@ -88,6 +89,7 @@ class UpdateDirectiveTest extends DBTestCase
                 ],
             ],
         ]);
+
         $this->assertSame('bar', Company::first()->name);
     }
 
@@ -127,6 +129,7 @@ class UpdateDirectiveTest extends DBTestCase
                 ],
             ],
         ]);
+
         $this->assertSame('bar', Category::first()->name);
     }
 
@@ -186,6 +189,7 @@ class UpdateDirectiveTest extends DBTestCase
             }
         }
         ')->assertJsonCount(1, 'errors');
+
         $this->assertSame('Original', User::first()->name);
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

Resolves #995 

**Changes**

## Upsert

Use the [@upsert](../api-reference/directives.md#upsert) directive to update a model with 
a given `id` or create it if it does not exist. 

```graphql
type Mutation {
  upsertUser(id: ID!, name: String!, email: String): User @upsert
}
```

Since upsert can create or update your data you must have all the minimum fields for a creation as required.
The `id` is always required and must be marked as fillable in the model.

```graphql
mutation {
  upsertUser(id: "123" name: "Hillary"){
    id
    name
    email
  }
}
```

```json
{
  "data": {
    "upsertUser": {
      "id": "123",
      "name": "Hillary",
      "email": null
    }
  }
}
```

## Nested mutations

You can now expose a nested operation `upsert` in all nested mutations that support the `update` operation.

**Breaking changes**

\-
