### PR TITLE
Speed up tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
     "require-dev": {
         "bensampo/laravel-enum": "^1.22",
         "haydenpierce/class-finder": "^0.4.0",
-        "johnkary/phpunit-speedtrap": "^3.1",
         "laravel/lumen-framework": "5.5.* || 5.6.* || 5.7.* || 5.8.* || ^6.0",
         "laravel/scout": "^4.0 || ^5.0 || ^6.0 || ^7.0",
         "localheinz/composer-normalize": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "require-dev": {
         "bensampo/laravel-enum": "^1.22",
         "haydenpierce/class-finder": "^0.4.0",
+        "johnkary/phpunit-speedtrap": "^3.1",
         "laravel/lumen-framework": "5.5.* || 5.6.* || 5.7.* || 5.8.* || ^6.0",
         "laravel/scout": "^4.0 || ^5.0 || ^6.0 || ^7.0",
         "localheinz/composer-normalize": "^1.3",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,4 +23,7 @@
             <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
+    <listeners>
+        <listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />
+    </listeners>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,7 +23,4 @@
             <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
-    <listeners>
-        <listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />
-    </listeners>
 </phpunit>

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -12,17 +12,17 @@ abstract class DBTestCase extends TestCase
     {
         parent::setUp();
 
-        if(! static::$migrated) {
-            $this->artisan('migrate:fresh --realpath --path ' .__DIR__.'/database/migrations');
+        if (! static::$migrated) {
+            $this->artisan('migrate:fresh --realpath --path '.__DIR__.'/database/migrations');
 
             static::$migrated = true;
         }
 
         // Ensure we start from a clean slate each time
         // We cannot use transactions, as they do not reset autoincrement
-        foreach(DB::select('SHOW TABLES') as $table) {
+        foreach (DB::select('SHOW TABLES') as $table) {
             DB::table($table->Tables_in_test)->truncate();
-        };
+        }
 
         $this->withFactories(__DIR__.'/database/factories');
     }

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -13,7 +13,11 @@ abstract class DBTestCase extends TestCase
         parent::setUp();
 
         if (! static::$migrated) {
-            $this->artisan('migrate:fresh --realpath --path '.__DIR__.'/database/migrations');
+            $this->artisan('migrate:fresh', [
+                '--realpath' => true,
+                '-path' => __DIR__.'/database/migrations'
+            ]);
+
 
             static::$migrated = true;
         }

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -15,9 +15,8 @@ abstract class DBTestCase extends TestCase
         if (! static::$migrated) {
             $this->artisan('migrate:fresh', [
                 '--realpath' => true,
-                '-path' => __DIR__.'/database/migrations'
+                '-path' => __DIR__.'/database/migrations',
             ]);
-
 
             static::$migrated = true;
         }

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -15,7 +15,7 @@ abstract class DBTestCase extends TestCase
         if (! static::$migrated) {
             $this->artisan('migrate:fresh', [
                 '--realpath' => true,
-                '-path' => __DIR__.'/database/migrations',
+                '--path' => __DIR__.'/database/migrations',
             ]);
 
             static::$migrated = true;

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -13,9 +13,10 @@ abstract class DBTestCase extends TestCase
         parent::setUp();
 
         if (! static::$migrated) {
+            // We have to use this instead of --realpath as long as Laravel 5.5 is supported
+            $this->app->setBasePath(__DIR__);
             $this->artisan('migrate:fresh', [
-                '--realpath' => true,
-                '--path' => __DIR__.'/database/migrations',
+                '--path' => 'database/migrations',
             ]);
 
             static::$migrated = true;

--- a/tests/Integration/Console/IdeHelperCommandTest.php
+++ b/tests/Integration/Console/IdeHelperCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Console;
+namespace Tests\Integration\Console;
 
 use Tests\TestCase;
 use Nuwave\Lighthouse\Console\IdeHelperCommand;

--- a/tests/Integration/Console/IdeHelperCommandTest.php
+++ b/tests/Integration/Console/IdeHelperCommandTest.php
@@ -16,10 +16,16 @@ class IdeHelperCommandTest extends TestCase
         $config = $app['config'];
 
         $config->set('lighthouse.namespaces.directives', [
-            'Tests\\Unit\\Console',
+            // Contains an overwritten UnionDirective
+            'Tests\\Integration\\Console',
+            // We need to ensure this does not throw an error
+            'Empty\\Because\\The\\User\\Has\\Not\\Created\\Custom\\Directives\\Yet',
         ]);
     }
 
+    /**
+     * This test is pretty slow, so we put it all in one test method.
+     */
     public function testGeneratesSchemaDirectives(): void
     {
         $this->artisan('lighthouse:ide-helper');
@@ -43,19 +49,5 @@ class IdeHelperCommandTest extends TestCase
             'Overwrites definitions through custom namespaces'
         );
         $this->assertContains(UnionDirective::class, $generated);
-    }
-
-    public function testDoesNotRequireCustomDirectives(): void
-    {
-        /** @var \Illuminate\Contracts\Config\Repository $config */
-        $config = $this->app['config'];
-
-        $config->set('lighthouse.namespaces.directives', [
-            'Empty\\Because\\The\\User\\Has\\Not\\Created\\Custom\\Directives\\Yet',
-        ]);
-
-        $this->artisan('lighthouse:ide-helper');
-
-        $this->assertFileExists(IdeHelperCommand::filePath());
     }
 }

--- a/tests/Integration/Console/UnionDirective.php
+++ b/tests/Integration/Console/UnionDirective.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Console;
+namespace Tests\Integration\Console;
 
 use Nuwave\Lighthouse\Support\Contracts\Directive;
 use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;

--- a/tests/Integration/Schema/Directives/CanDirectiveDBTest.php
+++ b/tests/Integration/Schema/Directives/CanDirectiveDBTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Schema\Directives;
+namespace Tests\Integration\Schema\Directives;
 
 use Tests\DBTestCase;
 use Tests\Utils\Models\Post;
@@ -9,7 +9,7 @@ use Tests\Utils\Policies\UserPolicy;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 
-class CanDirectiveDbTest extends DBTestCase
+class CanDirectiveDBTest extends DBTestCase
 {
     public function testQueriesForSpecificModel(): void
     {

--- a/tests/Integration/Schema/Directives/CountDirectiveDBTest.php
+++ b/tests/Integration/Schema/Directives/CountDirectiveDBTest.php
@@ -5,7 +5,6 @@ namespace Tests\Integration\Schema\Directives;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
-use Nuwave\Lighthouse\Exceptions\DirectiveException;
 
 class CountDirectiveDBTest extends DBTestCase
 {

--- a/tests/Integration/Schema/Directives/CountDirectiveDBTest.php
+++ b/tests/Integration/Schema/Directives/CountDirectiveDBTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Integration\Schema\Directives;
+
+use Tests\DBTestCase;
+use Tests\Utils\Models\Task;
+use Tests\Utils\Models\User;
+use Nuwave\Lighthouse\Exceptions\DirectiveException;
+
+class CountDirectiveDBTest extends DBTestCase
+{
+    public function testCanResolveCountByModel(): void
+    {
+        factory(User::class)->times(3)->create();
+
+        $this->schema = '
+        type Query {
+            users: Int! @count(model: "User")
+        }
+        ';
+
+        $this->graphQL('
+        {
+            users
+        }
+        ')->assertJson([
+            'data' => [
+                'users' => 3,
+            ],
+        ]);
+    }
+
+    public function testCanResolveCountByRelation(): void
+    {
+        /** @var User $user */
+        $user = factory(User::class)->create();
+
+        $user->tasks()->saveMany(
+            factory(Task::class)->times(4)->create()
+        );
+
+        $this->be($user);
+
+        $this->schema = '
+        type User {
+            taskCount: Int! @count(relation: "tasks")
+        }
+
+        type Query {
+            user: User @auth
+        }
+        ';
+
+        $this->graphQL('
+        {
+            user {
+                taskCount
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'user' => [
+                    'taskCount' => 4,
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Integration/Schema/Directives/InjectDirectiveDBTest.php
+++ b/tests/Integration/Schema/Directives/InjectDirectiveDBTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Tests\Unit\Schema\Directives;
+namespace Tests\Integration\Schema\Directives;
 
 use Tests\DBTestCase;
 use Tests\Utils\Models\User;
 
-class InjectDirectiveTest extends DBTestCase
+class InjectDirectiveDBTest extends DBTestCase
 {
     public function testCanInjectDataFromContextIntoArgs(): void
     {

--- a/tests/Integration/Schema/Directives/OrderByDirectiveDBTest.php
+++ b/tests/Integration/Schema/Directives/OrderByDirectiveDBTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Tests\Unit\Schema\Directives;
+namespace Tests\Integration\Schema\Directives;
 
 use Tests\DBTestCase;
 use Tests\Utils\Models\User;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 
-class OrderByDirectiveTest extends DBTestCase
+class OrderByDirectiveDBTest extends DBTestCase
 {
     protected $schema = '
     type Query {

--- a/tests/Integration/Schema/Directives/PaginateDirectiveDBTest.php
+++ b/tests/Integration/Schema/Directives/PaginateDirectiveDBTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Integration\Schema\Directives;
 
 use Tests\DBTestCase;
-use GraphQL\Error\Error;
 use Tests\Utils\Models\Post;
 use Tests\Utils\Models\User;
 use Tests\Utils\Models\Comment;
@@ -65,7 +64,7 @@ class PaginateDirectiveDBTest extends DBTestCase
         }
         
         type Query {
-            users: [User!]! @paginate(builder: "' .$this->qualifyTestResolver('builder').'")
+            users: [User!]! @paginate(builder: "'.$this->qualifyTestResolver('builder').'")
         }
         ';
 

--- a/tests/Integration/Schema/Directives/PaginateDirectiveDBTest.php
+++ b/tests/Integration/Schema/Directives/PaginateDirectiveDBTest.php
@@ -9,11 +9,11 @@ use Tests\Utils\Models\User;
 use Tests\Utils\Models\Comment;
 use Illuminate\Database\Eloquent\Builder;
 
-class PaginateDirectiveTest extends DBTestCase
+class PaginateDirectiveDBTest extends DBTestCase
 {
     public function testCanCreateQueryPaginators(): void
     {
-        factory(User::class, 10)->create();
+        factory(User::class, 3)->create();
 
         $this->schema = '
         type User {
@@ -28,7 +28,7 @@ class PaginateDirectiveTest extends DBTestCase
 
         $this->graphQL('
         {
-            users(first: 5) {
+            users(first: 2) {
                 paginatorInfo {
                     count
                     total
@@ -44,44 +44,14 @@ class PaginateDirectiveTest extends DBTestCase
             'data' => [
                 'users' => [
                     'paginatorInfo' => [
-                        'count' => 5,
-                        'total' => 10,
+                        'count' => 2,
+                        'total' => 3,
                         'currentPage' => 1,
                     ],
                     'data' => [],
                 ],
             ],
-        ])->assertJsonCount(5, 'data.users.data');
-    }
-
-    public function testHandlesPaginationWithCountZero(): void
-    {
-        $this->schema = '
-        type User {
-            id: ID!
-            name: String!
-        }
-        
-        type Query {
-            users: [User!] @paginate
-        }
-        ';
-
-        $this->graphQL('
-        {
-            users(first: 0) {
-                data {
-                    id
-                }
-            }
-        }
-        ')
-        ->assertJson([
-            'data' => [
-                'users' => null,
-            ],
-        ])
-        ->assertErrorCategory(Error::CATEGORY_GRAPHQL);
+        ])->assertJsonCount(2, 'data.users.data');
     }
 
     public function testCanSpecifyCustomBuilder(): void
@@ -95,7 +65,7 @@ class PaginateDirectiveTest extends DBTestCase
         }
         
         type Query {
-            users: [User!]! @paginate(builder: "Tests\\\Integration\\\Schema\\\Directives\\\PaginateDirectiveTest@builder")
+            users: [User!]! @paginate(builder: "' .$this->qualifyTestResolver('builder').'")
         }
         ';
 
@@ -128,11 +98,11 @@ class PaginateDirectiveTest extends DBTestCase
 
     public function testCanCreateQueryPaginatorsWithDifferentPages(): void
     {
-        $users = factory(User::class, 10)->create();
-        $posts = factory(Post::class, 10)->create([
+        $users = factory(User::class, 3)->create();
+        $posts = factory(Post::class, 3)->create([
             'user_id' => $users->first()->id,
         ]);
-        factory(Comment::class, 10)->create([
+        factory(Comment::class, 3)->create([
             'post_id' => $posts->first()->id,
         ]);
 
@@ -159,7 +129,7 @@ class PaginateDirectiveTest extends DBTestCase
 
         $this->graphQL('
         {
-            users(first: 3, page: 1) {
+            users(first: 2, page: 1) {
                 paginatorInfo {
                     count
                     total
@@ -216,7 +186,7 @@ class PaginateDirectiveTest extends DBTestCase
 
     public function testCanCreateQueryConnections(): void
     {
-        factory(User::class, 10)->create();
+        factory(User::class, 3)->create();
 
         $this->schema = '
         type User {
@@ -231,7 +201,7 @@ class PaginateDirectiveTest extends DBTestCase
 
         $this->graphQL('
         {
-            users(first: 5) {
+            users(first: 2) {
                 pageInfo {
                     hasNextPage
                 }
@@ -251,7 +221,7 @@ class PaginateDirectiveTest extends DBTestCase
                     ],
                 ],
             ],
-        ])->assertJsonCount(5, 'data.users.edges');
+        ])->assertJsonCount(2, 'data.users.edges');
     }
 
     public function testQueriesConnectionWithNoData(): void
@@ -383,7 +353,7 @@ class PaginateDirectiveTest extends DBTestCase
 
     public function testCanHaveADefaultPaginationCount(): void
     {
-        factory(User::class, 10)->create();
+        factory(User::class, 3)->create();
 
         $this->schema = '
         type User {
@@ -392,7 +362,7 @@ class PaginateDirectiveTest extends DBTestCase
         }
         
         type Query {
-            users: [User!]! @paginate(defaultCount: 5)
+            users: [User!]! @paginate(defaultCount: 2)
         }
         ';
 
@@ -414,109 +384,10 @@ class PaginateDirectiveTest extends DBTestCase
             'data' => [
                 'users' => [
                     'paginatorInfo' => [
-                        'count' => 5,
+                        'count' => 2,
                     ],
                 ],
             ],
-        ])->assertJsonCount(5, 'data.users.data');
-    }
-
-    public function testIsLimitedToMaxCountFromConfig(): void
-    {
-        config(['lighthouse.paginate_max_count' => 5]);
-
-        factory(User::class, 10)->create();
-
-        $this->schema = '
-        type User {
-            id: ID!
-            name: String!
-        }
-        
-        type Query {
-            users1: [User!]! @paginate
-            users2: [User!]! @paginate(type: "relay")
-        }
-        ';
-
-        $resultFromDefaultPagination = $this->graphQL('
-        {
-            users1(first: 10) {
-                data {
-                    id
-                    name
-                }
-            }
-        }
-        ');
-
-        $this->assertSame(
-            'Maximum number of 5 requested items exceeded. Fetch smaller chunks.',
-            $resultFromDefaultPagination->jsonGet('errors.0.message')
-        );
-
-        $resultFromRelayPagination = $this->graphQL('
-        {
-            users2(first: 10) {
-                edges {
-                    node {
-                        id
-                        name
-                    }
-                }
-            }
-        }
-        ');
-
-        $this->assertSame(
-            'Maximum number of 5 requested items exceeded. Fetch smaller chunks.',
-            $resultFromRelayPagination->jsonGet('errors.0.message')
-        );
-    }
-
-    public function testIsLimitedByMaxCountFromDirective(): void
-    {
-        config(['lighthouse.paginate_max_count' => 5]);
-
-        factory(User::class, 10)->create();
-
-        $this->schema = '
-        type User {
-            id: ID!
-            name: String!
-        }
-        
-        type Query {
-            users1: [User!]! @paginate(maxCount: 6)
-            users2: [User!]! @paginate(maxCount: 10)
-        }
-        ';
-
-        $result = $this->graphQL('
-        {
-            users1(first: 10) {
-                data {
-                    id
-                    name
-                }
-            }
-        }
-        ');
-
-        $this->assertSame(
-            'Maximum number of 6 requested items exceeded. Fetch smaller chunks.',
-            $result->jsonGet('errors.0.message')
-        );
-
-        $this->graphQL('
-        {
-            users2(first: 10) {
-                data {
-                    id
-                    name
-                }
-            }
-        }
-        ')->assertJsonCount(10, 'data.users2.data');
+        ])->assertJsonCount(2, 'data.users.data');
     }
 }

--- a/tests/Integration/Schema/Directives/SpreadDirectiveDBTest.php
+++ b/tests/Integration/Schema/Directives/SpreadDirectiveDBTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Integration\Schema\Directives;
+
+use Tests\DBTestCase;
+use Tests\Utils\Models\User;
+
+class SpreadDirectiveDBTest extends DBTestCase
+{
+    public function testSpreadsTheInputIntoTheQuery(): void
+    {
+        factory(User::class, 2)->create();
+
+        $this->schema = '
+        type Query {
+            user(input: UserInput @spread): User @first
+        }
+
+        type User {
+            id: ID
+        }
+
+        input UserInput {
+            id: ID @eq
+        }
+        ';
+
+        $this->graphQL('
+        {
+            user(input: {
+                id: 2
+            }) {
+                id
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'user' => [
+                    'id' => 2,
+                ],
+            ],
+        ]);
+    }
+
+    public function testIgnoresSpreadedInputIfNotGiven(): void
+    {
+        factory(User::class)->create();
+
+        $this->schema = '
+        type Query {
+            user(input: UserInput @spread): User @first
+        }
+
+        type User {
+            id: ID
+        }
+
+        input UserInput {
+            id: ID @eq
+        }
+        ';
+
+        $this->graphQL('
+        {
+            user {
+                id
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'user' => [
+                    'id' => 1,
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Integration/Schema/Directives/WhereJsonContainsDirectiveDBTest.php
+++ b/tests/Integration/Schema/Directives/WhereJsonContainsDirectiveDBTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Tests\Unit\Schema\Directives;
+namespace Tests\Integration\Schema\Directives;
 
 use Tests\DBTestCase;
 use Tests\Utils\Models\User;
 
-class WhereJsonContainsDirectiveTest extends DBTestCase
+class WhereJsonContainsDirectiveDBTest extends DBTestCase
 {
     protected $schema = '
     type Query {

--- a/tests/Integration/Schema/Types/LaravelEnumTypeDBTest.php
+++ b/tests/Integration/Schema/Types/LaravelEnumTypeDBTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Schema\Types;
+namespace Tests\Integration\Schema\Types;
 
 use Tests\DBTestCase;
 use Tests\Utils\Models\User;
@@ -8,7 +8,7 @@ use Tests\Utils\LaravelEnums\UserType;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
 use Nuwave\Lighthouse\Schema\Types\LaravelEnumType;
 
-class LaravelEnumTypeDbTest extends DBTestCase
+class LaravelEnumTypeDBTest extends DBTestCase
 {
     /**
      * @var \Nuwave\Lighthouse\Schema\TypeRegistry

--- a/tests/Integration/Subscriptions/Broadcast/BroadcastDBTest.php
+++ b/tests/Integration/Subscriptions/Broadcast/BroadcastDBTest.php
@@ -1,15 +1,14 @@
 <?php
 
-namespace Tests\Unit\Subscriptions\Broadcast;
+namespace Tests\Integration\Subscriptions\Broadcast;
 
 use Tests\DBTestCase;
-use Mockery\MockInterface;
 use Tests\Utils\Models\Task;
 use Nuwave\Lighthouse\Execution\Utils\Subscription;
 use Nuwave\Lighthouse\Subscriptions\SubscriptionBroadcaster;
 use Nuwave\Lighthouse\Subscriptions\SubscriptionServiceProvider;
 
-class BroadcastTest extends DBTestCase
+class BroadcastDBTest extends DBTestCase
 {
     protected $schema = '
     type Task {
@@ -45,24 +44,12 @@ class BroadcastTest extends DBTestCase
         factory(Task::class, 1)->create();
     }
 
-    /**
-     * @return MockInterface
-     */
-    public function withMockedBroadcasts(): MockInterface
-    {
-        $broadcast = \Mockery::mock(SubscriptionBroadcaster::class);
-        $this->app->instance(SubscriptionBroadcaster::class, $broadcast);
-
-        return $broadcast;
-    }
-
     public function testBroadcastsFromPhp(): void
     {
-        // Assert
-        $broadcast = $this->withMockedBroadcasts();
-        $broadcast->shouldReceive('broadcast')->once();
+        $this->mock(SubscriptionBroadcaster::class)
+            ->shouldReceive('broadcast')
+            ->once();
 
-        // Subscribe to event
         $this->postGraphQL([
             'query' => '
                 subscription UserUpdated {
@@ -73,17 +60,15 @@ class BroadcastTest extends DBTestCase
             ',
         ]);
 
-        // Broadcast
         Subscription::broadcast('taskUpdated', []);
     }
 
     public function testBroadcastsFromSchema(): void
     {
-        // Assert
-        $broadcast = $this->withMockedBroadcasts();
-        $broadcast->shouldReceive('broadcast')->once();
+        $this->mock(SubscriptionBroadcaster::class)
+            ->shouldReceive('broadcast')
+            ->once();
 
-        // Subscribe to event
         $this->postGraphQL([
             'query' => '
                 subscription TaskUpdated {
@@ -94,7 +79,6 @@ class BroadcastTest extends DBTestCase
             ',
         ]);
 
-        // Broadcast
         $this->postGraphQL([
             'query' => '
                 mutation {

--- a/tests/Integration/Subscriptions/Broadcast/BroadcastDBTest.php
+++ b/tests/Integration/Subscriptions/Broadcast/BroadcastDBTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Integration\Subscriptions\Broadcast;
 
 use Tests\DBTestCase;
+use Mockery\MockInterface;
 use Tests\Utils\Models\Task;
 use Nuwave\Lighthouse\Execution\Utils\Subscription;
 use Nuwave\Lighthouse\Subscriptions\SubscriptionBroadcaster;
@@ -44,9 +45,17 @@ class BroadcastDBTest extends DBTestCase
         factory(Task::class, 1)->create();
     }
 
+    public function withMockedBroadcasts(): MockInterface
+    {
+        $broadcast = \Mockery::mock(SubscriptionBroadcaster::class);
+        $this->app->instance(SubscriptionBroadcaster::class, $broadcast);
+
+        return $broadcast;
+    }
+
     public function testBroadcastsFromPhp(): void
     {
-        $this->mock(SubscriptionBroadcaster::class)
+        $this->withMockedBroadcasts(SubscriptionBroadcaster::class)
             ->shouldReceive('broadcast')
             ->once();
 
@@ -65,7 +74,7 @@ class BroadcastDBTest extends DBTestCase
 
     public function testBroadcastsFromSchema(): void
     {
-        $this->mock(SubscriptionBroadcaster::class)
+        $this->withMockedBroadcasts(SubscriptionBroadcaster::class)
             ->shouldReceive('broadcast')
             ->once();
 

--- a/tests/Integration/Subscriptions/Broadcast/BroadcastDBTest.php
+++ b/tests/Integration/Subscriptions/Broadcast/BroadcastDBTest.php
@@ -55,7 +55,7 @@ class BroadcastDBTest extends DBTestCase
 
     public function testBroadcastsFromPhp(): void
     {
-        $this->withMockedBroadcasts(SubscriptionBroadcaster::class)
+        $this->withMockedBroadcasts()
             ->shouldReceive('broadcast')
             ->once();
 
@@ -74,7 +74,7 @@ class BroadcastDBTest extends DBTestCase
 
     public function testBroadcastsFromSchema(): void
     {
-        $this->withMockedBroadcasts(SubscriptionBroadcaster::class)
+        $this->withMockedBroadcasts()
             ->shouldReceive('broadcast')
             ->once();
 

--- a/tests/Unit/Events/BuildSchemaStringTest.php
+++ b/tests/Unit/Events/BuildSchemaStringTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Integration\Events;
+namespace Tests\Unit\Events;
 
 use Tests\TestCase;
 use Nuwave\Lighthouse\Events\BuildSchemaString;

--- a/tests/Unit/Events/ManipulateResultTest.php
+++ b/tests/Unit/Events/ManipulateResultTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Integration\Events;
+namespace Tests\Unit\Events;
 
 use Tests\TestCase;
 use Tests\Utils\Queries\Foo;

--- a/tests/Unit/Events/RegisterDirectiveNamespacesTest.php
+++ b/tests/Unit/Events/RegisterDirectiveNamespacesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Integration\Events;
+namespace Tests\Unit\Events;
 
 use Tests\TestCase;
 use Tests\Utils\Directives\FooDirective;

--- a/tests/Unit/Schema/Directives/CountDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CountDirectiveTest.php
@@ -2,70 +2,11 @@
 
 namespace Tests\Unit\Schema\Directives;
 
-use Tests\DBTestCase;
-use Tests\Utils\Models\Task;
-use Tests\Utils\Models\User;
+use Tests\TestCase;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;
 
-class CountDirectiveTest extends DBTestCase
+class CountDirectiveTest extends TestCase
 {
-    public function testCanResolveCountByModel(): void
-    {
-        factory(User::class)->times(3)->create();
-
-        $this->schema = '
-        type Query {
-            users: Int! @count(model: "User")
-        }
-        ';
-
-        $this->graphQL('
-        {
-            users
-        }
-        ')->assertJson([
-            'data' => [
-                'users' => 3,
-            ],
-        ]);
-    }
-
-    public function testCanResolveCountByRelation(): void
-    {
-        /** @var User $user */
-        $user = factory(User::class)->create();
-
-        $user->tasks()->saveMany(
-            factory(Task::class)->times(4)->create()
-        );
-
-        $this->be($user);
-
-        $this->schema = '
-        type User {
-            taskCount: Int! @count(relation: "tasks")
-        }
-
-        type Query {
-            user: User @auth
-        }
-        ';
-
-        $this->graphQL('
-        {
-            user {
-                taskCount
-            }
-        }
-        ')->assertJson([
-            'data' => [
-                'user' => [
-                    'taskCount' => 4,
-                ],
-            ],
-        ]);
-    }
-
     public function testRequireRelationOrModelArgument()
     {
         $this->schema = '

--- a/tests/Unit/Schema/Directives/PaginateDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/PaginateDirectiveTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit\Schema\Directives;
 
-use GraphQL\Error\Error;
 use Tests\TestCase;
+use GraphQL\Error\Error;
 use GraphQL\Type\Definition\FieldArgument;
 use GraphQL\Type\Definition\FieldDefinition;
 

--- a/tests/Unit/Schema/Directives/PaginateDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/PaginateDirectiveTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Schema\Directives;
 
+use GraphQL\Error\Error;
 use Tests\TestCase;
 use GraphQL\Type\Definition\FieldArgument;
 use GraphQL\Type\Definition\FieldDefinition;
@@ -147,5 +148,119 @@ class PaginateDirectiveTest extends TestCase
             FieldArgument::class,
             $queryType->getField('defaultPaginated')->getArg('first')
         );
+    }
+
+    public function testIsLimitedByMaxCountFromDirective(): void
+    {
+        config(['lighthouse.paginate_max_count' => 5]);
+
+        $this->schema = '
+        type User {
+            id: ID!
+            name: String!
+        }
+        
+        type Query {
+            users1: [User!]! @paginate(maxCount: 6)
+            users2: [User!]! @paginate(maxCount: 10)
+        }
+        ';
+
+        $result = $this->graphQL('
+        {
+            users1(first: 10) {
+                data {
+                    id
+                    name
+                }
+            }
+        }
+        ');
+
+        $this->assertSame(
+            'Maximum number of 6 requested items exceeded. Fetch smaller chunks.',
+            $result->jsonGet('errors.0.message')
+        );
+    }
+
+    public function testIsLimitedToMaxCountFromConfig(): void
+    {
+        config(['lighthouse.paginate_max_count' => 5]);
+
+        $this->schema = '
+        type User {
+            id: ID!
+            name: String!
+        }
+        
+        type Query {
+            users1: [User!]! @paginate
+            users2: [User!]! @paginate(type: "relay")
+        }
+        ';
+
+        $resultFromDefaultPagination = $this->graphQL('
+        {
+            users1(first: 10) {
+                data {
+                    id
+                    name
+                }
+            }
+        }
+        ');
+
+        $this->assertSame(
+            'Maximum number of 5 requested items exceeded. Fetch smaller chunks.',
+            $resultFromDefaultPagination->jsonGet('errors.0.message')
+        );
+
+        $resultFromRelayPagination = $this->graphQL('
+        {
+            users2(first: 10) {
+                edges {
+                    node {
+                        id
+                        name
+                    }
+                }
+            }
+        }
+        ');
+
+        $this->assertSame(
+            'Maximum number of 5 requested items exceeded. Fetch smaller chunks.',
+            $resultFromRelayPagination->jsonGet('errors.0.message')
+        );
+    }
+
+    public function testThrowsWhenPaginationWithCountZeroIsRequested(): void
+    {
+        $this->schema = '
+        type User {
+            id: ID!
+            name: String!
+        }
+        
+        type Query {
+            users: [User!] @paginate
+        }
+        ';
+
+        $this->graphQL('
+        {
+            users(first: 0) {
+                data {
+                    id
+                }
+            }
+        }
+        ')
+        ->assertJson([
+            'data' => [
+                'users' => null,
+            ],
+        ])
+        ->assertErrorCategory(Error::CATEGORY_GRAPHQL);
     }
 }

--- a/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
@@ -6,7 +6,6 @@ use Tests\TestCase;
 
 class SpreadDirectiveTest extends TestCase
 {
-
     public function testNestedSpread(): void
     {
         $this->mockResolver()

--- a/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
@@ -2,78 +2,10 @@
 
 namespace Tests\Unit\Schema\Directives;
 
-use Tests\DBTestCase;
-use Tests\Utils\Models\User;
+use Tests\TestCase;
 
-class SpreadDirectiveTest extends DBTestCase
+class SpreadDirectiveTest extends TestCase
 {
-    public function testSpreadsTheInputIntoTheQuery(): void
-    {
-        factory(User::class, 2)->create();
-
-        $this->schema = '
-        type Query {
-            user(input: UserInput @spread): User @first
-        }
-
-        type User {
-            id: ID
-        }
-
-        input UserInput {
-            id: ID @eq
-        }
-        ';
-
-        $this->graphQL('
-        {
-            user(input: {
-                id: 2
-            }) {
-                id
-            }
-        }
-        ')->assertJson([
-            'data' => [
-                'user' => [
-                    'id' => 2,
-                ],
-            ],
-        ]);
-    }
-
-    public function testIgnoresSpreadedInputIfNotGiven(): void
-    {
-        factory(User::class)->create();
-
-        $this->schema = '
-        type Query {
-            user(input: UserInput @spread): User @first
-        }
-
-        type User {
-            id: ID
-        }
-
-        input UserInput {
-            id: ID @eq
-        }
-        ';
-
-        $this->graphQL('
-        {
-            user {
-                id
-            }
-        }
-        ')->assertJson([
-            'data' => [
-                'user' => [
-                    'id' => 1,
-                ],
-            ],
-        ]);
-    }
 
     public function testNestedSpread(): void
     {

--- a/tests/Unit/Schema/Source/SchemaSourceProviderTest.php
+++ b/tests/Unit/Schema/Source/SchemaSourceProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Integration\Schema\Source;
+namespace Tests\Unit\Schema\Source;
 
 use Tests\TestCase;
 use League\Flysystem\Filesystem;

--- a/tests/Unit/Subscriptions/BroadcastManagerTest.php
+++ b/tests/Unit/Subscriptions/BroadcastManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Integration\Subscriptions;
+namespace Tests\Unit\Subscriptions;
 
 use Tests\TestCase;
 use Illuminate\Http\Request;

--- a/tests/Unit/Subscriptions/StorageManagerTest.php
+++ b/tests/Unit/Subscriptions/StorageManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Integration\Subscriptions;
+namespace Tests\Unit\Subscriptions;
 
 use Tests\TestCase;
 use GraphQL\Utils\AST;


### PR DESCRIPTION
I was getting annoyed.

- Add https://github.com/johnkary/phpunit-speedtrap for measuring slow tests
- Truncate inbetween DB tests instead of migrating
- Move all DB tests into Integration suite
- Split/combine some tests

In my local environment, that brings the execution time for all tests down from +4min to about 2min.