### PR TITLE
Add fallback if ttl config is missing

### DIFF
--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -87,9 +87,11 @@ class ASTBuilder
 
         $cacheConfig = $this->configRepository->get('lighthouse.cache');
         if ($cacheConfig['enable']) {
-            $this->documentAST = app('cache')->remember(
+            /** @var \Illuminate\Contracts\Cache\Repository $cache */
+            $cache = app('cache');
+            $this->documentAST = $cache->remember(
                 $cacheConfig['key'],
-                $cacheConfig['ttl'],
+                $cacheConfig['ttl'] ?? null,
                 function (): DocumentAST {
                     return $this->build();
                 }

--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -91,6 +91,7 @@ class ASTBuilder
             $cache = app('cache');
             $this->documentAST = $cache->remember(
                 $cacheConfig['key'],
+                // TODO remove this fallback in v5
                 $cacheConfig['ttl'] ?? null,
                 function (): DocumentAST {
                     return $this->build();


### PR DESCRIPTION
This might happen when users upgrade to `v4`.

```
$ php artisan lighthouse:validate-schema

   ErrorException  : Undefined index: ttl

  at /builds/kt7nLJ3G/0/limes/limes-api/vendor/nuwave/lighthouse/src/Schema/AST/ASTBuilder.php:92
    88|         $cacheConfig = $this->configRepository->get('lighthouse.cache');
    89|         if ($cacheConfig['enable']) {
    90|             $this->documentAST = app('cache')->remember(
    91|                 $cacheConfig['key'],
  > 92|                 $cacheConfig['ttl'],
    93|                 function (): DocumentAST {
    94|                     return $this->build();
    95|                 }
    96|             );

  Exception trace:

  1   Illuminate\Foundation\Bootstrap\HandleExceptions::handleError("Undefined index: ttl", "/builds/kt7nLJ3G/0/limes/limes-api/vendor/nuwave/lighthouse/src/Schema/AST/ASTBuilder.php", [])
      /builds/kt7nLJ3G/0/limes/limes-api/vendor/nuwave/lighthouse/src/Schema/AST/ASTBuilder.php:92

  2   Nuwave\Lighthouse\Schema\AST\ASTBuilder::documentAST()
      /builds/kt7nLJ3G/0/limes/limes-api/vendor/nuwave/lighthouse/src/GraphQL.php:221

  Please use the argument -v to see more details.
```

By defaulting to `null`, a missing config key is handled gracefully.