### PR TITLE
Fix broken behaviour when using union types with schema caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `@upsert` directive and nested mutation operations to create or update a model
   regardless whether it exists https://github.com/nuwave/lighthouse/pull/1005
 
+### Fixed
+
+- Fix broken behaviour when using union types with schema caching https://github.com/nuwave/lighthouse/pull/1015 
+
 ## [4.4.2](https://github.com/nuwave/lighthouse/compare/v4.4.1...v4.4.2)
 
 ### Added

--- a/src/Schema/TypeRegistry.php
+++ b/src/Schema/TypeRegistry.php
@@ -8,7 +8,6 @@ use Nuwave\Lighthouse\Support\Utils;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\UnionType;
-use GraphQL\Language\AST\NamedTypeNode;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ScalarType;
 use Nuwave\Lighthouse\Support\Pipeline;
@@ -427,8 +426,8 @@ class TypeRegistry
                 $types = [];
 
                 // Might be a NodeList, so we can not use array_map()
-                foreach($unionDefinition->types as $type) {
-                    $types[]= $this->get($type->name->value);
+                foreach ($unionDefinition->types as $type) {
+                    $types[] = $this->get($type->name->value);
                 }
 
                 return $types;

--- a/src/Schema/TypeRegistry.php
+++ b/src/Schema/TypeRegistry.php
@@ -271,6 +271,8 @@ class TypeRegistry
             'fields' => $this->resolveFieldsFunction($objectDefinition),
             'interfaces' => function () use ($objectDefinition): array {
                 $interfaces = [];
+
+                // Might be a NodeList, so we can not use array_map()
                 foreach ($objectDefinition->interfaces as $interface) {
                     $interfaces [] = $this->get($interface->name->value);
                 }
@@ -292,6 +294,7 @@ class TypeRegistry
             $typeValue = new TypeValue($typeDefinition);
             $fields = [];
 
+            // Might be a NodeList, so we can not use array_map()
             foreach ($typeDefinition->fields as $fieldDefinition) {
                 /** @var \Nuwave\Lighthouse\Schema\Factories\FieldFactory $fieldFactory */
                 $fieldFactory = app(FieldFactory::class);
@@ -421,12 +424,14 @@ class TypeRegistry
             'name' => $nodeName,
             'description' => data_get($unionDefinition->description, 'value'),
             'types' => function () use ($unionDefinition): array {
-                return array_map(
-                    function (NamedTypeNode $type): Type {
-                        return $this->get($type->name->value);
-                    },
-                    $unionDefinition->types
-                );
+                $types = [];
+
+                // Might be a NodeList, so we can not use array_map()
+                foreach($unionDefinition->types as $type) {
+                    $types[]= $this->get($type->name->value);
+                }
+
+                return $types;
             },
             'resolveType' => $typeResolver,
         ]);

--- a/tests/Integration/SchemaCachingTest.php
+++ b/tests/Integration/SchemaCachingTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Integration;
+
+use Illuminate\Cache\CacheManager;
+use Illuminate\Cache\Repository;
+use Nuwave\Lighthouse\Schema\AST\ASTBuilder;
+use Tests\SerializingArrayStore;
+use Tests\TestCase;
+use Tests\Utils\Models\Comment;
+
+class SchemaCachingTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = $app['config'];
+
+        $config->set('lighthouse.cache.enable', true);
+
+        /** @var \Illuminate\Cache\CacheManager $cache */
+        $cache = $app->make(CacheManager::class);
+        $cache->extend('serializing-array', function(){
+            return new Repository(
+                new SerializingArrayStore()
+            );
+        });
+        $config->set('cache.stores.array.driver', 'serializing-array');
+    }
+
+    public function testSchemaCachingWithUnionType(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo: Foo @mock
+        }
+        
+        union Foo = Comment | Color
+        
+        type Comment {
+            bar: ID
+        }
+        
+        type Color {
+            id: ID
+        }
+        ';
+        $this->cacheSchema();
+
+        $this->mockResolver(function() {
+            return new Comment([
+                'bar' => 'bar'
+            ]);
+            $comment->id = 'bar';
+            return $comment;
+        });
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            foo {
+                ... on Comment {
+                    bar
+                }
+            }
+        }
+        ')->assertExactJson([
+            'data' => [
+                'foo' => [
+                    'bar' => 'bar'
+                ]
+            ]
+        ]);
+    }
+
+    protected function cacheSchema(): void
+    {
+        /** @var \Nuwave\Lighthouse\Schema\AST\ASTBuilder $astBuilder */
+        $astBuilder = app(ASTBuilder::class);
+        $astBuilder->documentAST();
+        $this->app->forgetInstance(ASTBuilder::class);
+    }
+}

--- a/tests/Integration/SchemaCachingTest.php
+++ b/tests/Integration/SchemaCachingTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Integration;
 
-use Illuminate\Cache\CacheManager;
-use Illuminate\Cache\Repository;
-use Nuwave\Lighthouse\Schema\AST\ASTBuilder;
-use Tests\SerializingArrayStore;
 use Tests\TestCase;
 use Tests\Utils\Models\Comment;
+use Illuminate\Cache\Repository;
+use Tests\SerializingArrayStore;
+use Illuminate\Cache\CacheManager;
+use Nuwave\Lighthouse\Schema\AST\ASTBuilder;
 
 class SchemaCachingTest extends TestCase
 {
@@ -22,7 +22,7 @@ class SchemaCachingTest extends TestCase
 
         /** @var \Illuminate\Cache\CacheManager $cache */
         $cache = $app->make(CacheManager::class);
-        $cache->extend('serializing-array', function(){
+        $cache->extend('serializing-array', function () {
             return new Repository(
                 new SerializingArrayStore()
             );
@@ -32,7 +32,7 @@ class SchemaCachingTest extends TestCase
 
     public function testSchemaCachingWithUnionType(): void
     {
-        $this->schema = /** @lang GraphQL */ '
+        $this->schema = /* @lang GraphQL */ '
         type Query {
             foo: Foo @mock
         }
@@ -49,15 +49,16 @@ class SchemaCachingTest extends TestCase
         ';
         $this->cacheSchema();
 
-        $this->mockResolver(function() {
+        $this->mockResolver(function () {
             return new Comment([
-                'bar' => 'bar'
+                'bar' => 'bar',
             ]);
             $comment->id = 'bar';
+
             return $comment;
         });
 
-        $this->graphQL(/** @lang GraphQL */ '
+        $this->graphQL(/* @lang GraphQL */ '
         {
             foo {
                 ... on Comment {
@@ -68,9 +69,9 @@ class SchemaCachingTest extends TestCase
         ')->assertExactJson([
             'data' => [
                 'foo' => [
-                    'bar' => 'bar'
-                ]
-            ]
+                    'bar' => 'bar',
+                ],
+            ],
         ]);
     }
 

--- a/tests/Integration/SchemaCachingTest.php
+++ b/tests/Integration/SchemaCachingTest.php
@@ -53,9 +53,6 @@ class SchemaCachingTest extends TestCase
             return new Comment([
                 'bar' => 'bar',
             ]);
-            $comment->id = 'bar';
-
-            return $comment;
         });
 
         $this->graphQL(/* @lang GraphQL */ '

--- a/tests/SerializingArrayStore.php
+++ b/tests/SerializingArrayStore.php
@@ -4,6 +4,12 @@ namespace Tests;
 
 use Illuminate\Cache\ArrayStore;
 
+/**
+ * A cache store used for testing.
+ *
+ * Works like Laravel's usual "array" store, expect
+ * it actually serializes/unserializes the values.
+ */
 class SerializingArrayStore extends ArrayStore
 {
     /**

--- a/tests/SerializingArrayStore.php
+++ b/tests/SerializingArrayStore.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Cache\ArrayStore;
+
+class SerializingArrayStore extends ArrayStore
+{
+    /**
+     * Retrieve an item from the cache by key.
+     *
+     * @param  string|array  $key
+     * @return mixed
+     */
+    public function get($key)
+    {
+        if (! isset($this->storage[$key])) {
+            return;
+        }
+
+        $item = $this->storage[$key];
+
+        $expiresAt = $item['expiresAt'] ?? 0;
+
+        if ($expiresAt !== 0 && $this->currentTime() > $expiresAt) {
+            $this->forget($key);
+
+            return;
+        }
+
+        return unserialize($item['value']);
+    }
+
+    /**
+     * Store an item in the cache for a given number of seconds.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function put($key, $value, $seconds)
+    {
+        $this->storage[$key] = [
+            'value' => serialize($value),
+            'expiresAt' => $this->calculateExpiration($seconds),
+        ];
+
+        return true;
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Updated the changelog

Fixes #1004

**Changes**

Fix broken behaviour when using union types with schema caching.

The test triggers the behaviour mentioned in #1004

```
PHPUnit 8.4.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.8 with Xdebug 2.7.2
Configuration: /var/www/phpunit.xml.dist

E                                                                   1 / 1 (100%)

Time: 7.09 seconds, Memory: 32.00 MB

There was 1 error:

1) Tests\Integration\SchemaCachingTest::testSchemaCachingWithUnionType
ErrorException: array_map(): Expected parameter 2 to be an array, object given

/var/www/src/Schema/TypeRegistry.php:428
```

**Breaking changes**

No
