### PR TITLE
Handle `null` being passed to a nullable argument that is a list of type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.5.0...master)
+## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.5.1...master)
+
+## [4.5.1](https://github.com/nuwave/lighthouse/compare/v4.5.0...v4.5.1)
+
+### Fixed
+
+- Handle `null` being passed to a nullable argument that is a list of type https://github.com/nuwave/lighthouse/pull/1016
 
 ## [4.5.0](https://github.com/nuwave/lighthouse/compare/v4.4.2...v4.5.0)
 

--- a/src/Execution/Arguments/TypedArgs.php
+++ b/src/Execution/Arguments/TypedArgs.php
@@ -152,13 +152,13 @@ class TypedArgs
                 }
 
                 return $values;
-            } else {
-                // This case happens if `null` is passed
-                return $this->wrapWithNamedType($valueOrValues, $typeInList);
             }
-        } else {
-            return $this->wrapWithNamedType($valueOrValues, $type);
+
+            // This case happens if `null` is passed
+            return $this->wrapWithNamedType($valueOrValues, $typeInList);
         }
+
+        return $this->wrapWithNamedType($valueOrValues, $type);
     }
 
     /**

--- a/src/Execution/Arguments/TypedArgs.php
+++ b/src/Execution/Arguments/TypedArgs.php
@@ -145,12 +145,17 @@ class TypedArgs
         if ($type instanceof ListType) {
             $typeInList = $type->type;
 
-            $values = [];
-            foreach ($valueOrValues as $singleValue) {
-                $values [] = $this->wrapWithNamedType($singleValue, $typeInList);
-            }
+            if(is_array($valueOrValues)) {
+                $values = [];
+                foreach ($valueOrValues as $singleValue) {
+                    $values [] = $this->wrapWithNamedType($singleValue, $typeInList);
+                }
 
-            return $values;
+                return $values;
+            } else {
+                // This case happens if `null` is passed
+                return $this->wrapWithNamedType($valueOrValues, $typeInList);
+            }
         } else {
             return $this->wrapWithNamedType($valueOrValues, $type);
         }

--- a/src/Execution/Arguments/TypedArgs.php
+++ b/src/Execution/Arguments/TypedArgs.php
@@ -145,7 +145,7 @@ class TypedArgs
         if ($type instanceof ListType) {
             $typeInList = $type->type;
 
-            if(is_array($valueOrValues)) {
+            if (is_array($valueOrValues)) {
                 $values = [];
                 foreach ($valueOrValues as $singleValue) {
                     $values [] = $this->wrapWithNamedType($singleValue, $typeInList);

--- a/tests/Unit/Execution/Arguments/TypedArgsTest.php
+++ b/tests/Unit/Execution/Arguments/TypedArgsTest.php
@@ -40,4 +40,35 @@ class TypedArgsTest extends TestCase
         $this->assertInstanceOf(Argument::class, $bar);
         $this->assertSame(123, $bar->value);
     }
+
+    public function testNullableList(): void
+    {
+        $this->schema = '
+        type Query {
+            foo(bar: [Int!]): Int
+        }
+        ';
+
+        /** @var \Nuwave\Lighthouse\Schema\AST\ASTBuilder $astBuilder */
+        $astBuilder = $this->app->make(ASTBuilder::class);
+        $documentAST = $astBuilder->documentAST();
+        /** @var \Nuwave\Lighthouse\Execution\Arguments\TypedArgs $typedArgs */
+        $typedArgs = $this->app->make(TypedArgs::class);
+
+        /** @var \GraphQL\Language\AST\ObjectTypeDefinitionNode $queryType */
+        $queryType = $documentAST->types['Query'];
+
+        $argumentSet = $typedArgs->fromField(
+            [
+                'bar' => null,
+            ],
+            ASTHelper::firstByName($queryType->fields, 'foo')
+        );
+
+        $this->assertCount(1, $argumentSet->arguments);
+
+        $bar = $argumentSet->arguments['bar'];
+        $this->assertInstanceOf(Argument::class, $bar);
+        $this->assertSame(null, $bar->value);
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Updated the changelog

**Changes**

The new `TypedArgs` wrapper produced an error when a client passes `null` as the value of an argument that is defined as a list of type.

Failing test:

```
PHPUnit 8.4.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.9 with Xdebug 2.7.2
Configuration: /projects/lighthouse/phpunit.xml.dist

.E                                                                  2 / 2 (100%)

Time: 1.29 seconds, Memory: 28.00 MB

There was 1 error:

1) Tests\Unit\Execution\Arguments\TypedArgsTest::testNullableList
ErrorException: Invalid argument supplied for foreach()

/projects/lighthouse/src/Execution/Arguments/TypedArgs.php:149
```

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->

No