### PR TITLE
Fix conversion of client directives after the schema was cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.5.1...master)
+## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.5.2...master)
+
+## [4.5.2](https://github.com/nuwave/lighthouse/compare/v4.5.1...v4.5.2)
+
+### Fixed
+
+- Fix conversion of client directives after the schema was cached https://github.com/nuwave/lighthouse/pull/1019
 
 ## [4.5.1](https://github.com/nuwave/lighthouse/compare/v4.5.0...v4.5.1)
 

--- a/src/Schema/Factories/ClientDirectiveFactory.php
+++ b/src/Schema/Factories/ClientDirectiveFactory.php
@@ -54,9 +54,10 @@ class ClientDirectiveFactory
             $arguments [] = new FieldArgument($fieldArgumentConfig);
         }
 
-        $locations = collect($directive->locations)->map(function (NameNode $location): string {
-            return $location->value;
-        });
+        $locations = [];
+        foreach ($directive->locations as $location) {
+            $locations[] = $location->value;
+        }
 
         return new Directive([
             'name' => $directive->name->value,

--- a/src/Schema/Factories/ClientDirectiveFactory.php
+++ b/src/Schema/Factories/ClientDirectiveFactory.php
@@ -54,15 +54,14 @@ class ClientDirectiveFactory
             $arguments [] = new FieldArgument($fieldArgumentConfig);
         }
 
+        $locations = collect($directive->locations)->map(function (NameNode $location): string {
+            return $location->value;
+        });
+
         return new Directive([
             'name' => $directive->name->value,
             'description' => data_get($directive->description, 'value'),
-            'locations' => array_map(
-                function (NameNode $location): string {
-                    return $location->value;
-                },
-                $directive->locations
-            ),
+            'locations' => $locations,
             'args' => $arguments,
             'astNode' => $directive,
         ]);

--- a/src/Schema/Factories/ClientDirectiveFactory.php
+++ b/src/Schema/Factories/ClientDirectiveFactory.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Schema\Factories;
 
-use GraphQL\Language\AST\NameNode;
 use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\FieldArgument;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;

--- a/src/Schema/Factories/ClientDirectiveFactory.php
+++ b/src/Schema/Factories/ClientDirectiveFactory.php
@@ -54,6 +54,7 @@ class ClientDirectiveFactory
         }
 
         $locations = [];
+        // Might be a NodeList, so we can not use array_map()
         foreach ($directive->locations as $location) {
             $locations[] = $location->value;
         }


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Added Docs for all relevant versions
- [x] Updated the changelog

Resolves #1018

**Changes**
Convert the array_map to a simple foreach because the mappable is not always a pure array.

**Breaking changes**
None.
