### PR TITLE
Handle nullable input objects in TypedArgs conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.5.2...master)
 
+### Fixed
+
+- Handle `null` being passed to a nullable argument that is an input object type https://github.com/nuwave/lighthouse/pull/1021
+
 ## [4.5.2](https://github.com/nuwave/lighthouse/compare/v4.5.1...v4.5.2)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.5.2...master)
+## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.5.3...master)
+
+## [4.5.3](https://github.com/nuwave/lighthouse/compare/v4.5.2...v4.5.3)
 
 ### Fixed
 

--- a/src/Execution/Arguments/TypedArgs.php
+++ b/src/Execution/Arguments/TypedArgs.php
@@ -181,6 +181,11 @@ class TypedArgs
      */
     protected function wrapWithNamedType($value, NamedType $namedType)
     {
+        // As GraphQL does not allow empty input objects, we return null as is
+        if ($value === null) {
+            return $value;
+        }
+
         // This might be null if the type is
         // - created outside of the schema string
         // - one of the built in types
@@ -193,9 +198,9 @@ class TypedArgs
             $subArgumentSet->arguments = $this->wrapArgs($value, $typeDef->fields);
 
             return $subArgumentSet;
-        } else {
-            // Otherwise, we just return the value as is and are down with that subtree
-            return $value;
         }
+
+        // Otherwise, we just return the value as is and are down with that subtree
+        return $value;
     }
 }

--- a/src/Execution/Arguments/TypedArgs.php
+++ b/src/Execution/Arguments/TypedArgs.php
@@ -183,7 +183,7 @@ class TypedArgs
     {
         // As GraphQL does not allow empty input objects, we return null as is
         if ($value === null) {
-            return null;
+            return;
         }
 
         // This might be null if the type is

--- a/src/Execution/Arguments/TypedArgs.php
+++ b/src/Execution/Arguments/TypedArgs.php
@@ -183,7 +183,7 @@ class TypedArgs
     {
         // As GraphQL does not allow empty input objects, we return null as is
         if ($value === null) {
-            return $value;
+            return null;
         }
 
         // This might be null if the type is

--- a/tests/Unit/Execution/Arguments/TypedArgsTest.php
+++ b/tests/Unit/Execution/Arguments/TypedArgsTest.php
@@ -46,7 +46,7 @@ class TypedArgsTest extends TestCase
 
         $bar = $argumentSet->arguments['bar'];
         $this->assertInstanceOf(Argument::class, $bar);
-        $this->assertSame(null, $bar->value);
+        $this->assertNull($bar->value);
     }
 
     public function testNullableInputObject(): void
@@ -69,7 +69,7 @@ class TypedArgsTest extends TestCase
 
         $bar = $argumentSet->arguments['bar'];
         $this->assertInstanceOf(Argument::class, $bar);
-        $this->assertSame(null, $bar->value);
+        $this->assertNull($bar->value);
     }
 
     protected function rootQueryArgumentSet(array $args): ArgumentSet

--- a/tests/Unit/Execution/Arguments/TypedArgsTest.php
+++ b/tests/Unit/Execution/Arguments/TypedArgsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Execution\Arguments;
 
+use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Tests\TestCase;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Schema\AST\ASTBuilder;
@@ -18,21 +19,9 @@ class TypedArgsTest extends TestCase
         }
         ';
 
-        /** @var \Nuwave\Lighthouse\Schema\AST\ASTBuilder $astBuilder */
-        $astBuilder = $this->app->make(ASTBuilder::class);
-        $documentAST = $astBuilder->documentAST();
-        /** @var \Nuwave\Lighthouse\Execution\Arguments\TypedArgs $typedArgs */
-        $typedArgs = $this->app->make(TypedArgs::class);
-
-        /** @var \GraphQL\Language\AST\ObjectTypeDefinitionNode $queryType */
-        $queryType = $documentAST->types['Query'];
-
-        $argumentSet = $typedArgs->fromField(
-            [
-                'bar' => 123,
-            ],
-            ASTHelper::firstByName($queryType->fields, 'foo')
-        );
+        $argumentSet = $this->rootQueryArgumentSet([
+            'bar' => 123,
+        ]);
 
         $this->assertCount(1, $argumentSet->arguments);
 
@@ -49,6 +38,42 @@ class TypedArgsTest extends TestCase
         }
         ';
 
+        $argumentSet = $this->rootQueryArgumentSet([
+            'bar' => null,
+        ]);
+
+        $this->assertCount(1, $argumentSet->arguments);
+
+        $bar = $argumentSet->arguments['bar'];
+        $this->assertInstanceOf(Argument::class, $bar);
+        $this->assertSame(null, $bar->value);
+    }
+
+    public function testNullableInputObject(): void
+    {
+        $this->schema = '
+        type Query {
+            foo(bar: Bar): Int
+        }
+        
+        input Bar {
+            baz: ID
+        }
+        ';
+
+        $argumentSet = $this->rootQueryArgumentSet([
+            'bar' => null,
+        ]);
+
+        $this->assertCount(1, $argumentSet->arguments);
+
+        $bar = $argumentSet->arguments['bar'];
+        $this->assertInstanceOf(Argument::class, $bar);
+        $this->assertSame(null, $bar->value);
+    }
+
+    protected function rootQueryArgumentSet(array $args): ArgumentSet
+    {
         /** @var \Nuwave\Lighthouse\Schema\AST\ASTBuilder $astBuilder */
         $astBuilder = $this->app->make(ASTBuilder::class);
         $documentAST = $astBuilder->documentAST();
@@ -58,17 +83,9 @@ class TypedArgsTest extends TestCase
         /** @var \GraphQL\Language\AST\ObjectTypeDefinitionNode $queryType */
         $queryType = $documentAST->types['Query'];
 
-        $argumentSet = $typedArgs->fromField(
-            [
-                'bar' => null,
-            ],
+        return $typedArgs->fromField(
+            $args,
             ASTHelper::firstByName($queryType->fields, 'foo')
         );
-
-        $this->assertCount(1, $argumentSet->arguments);
-
-        $bar = $argumentSet->arguments['bar'];
-        $this->assertInstanceOf(Argument::class, $bar);
-        $this->assertSame(null, $bar->value);
     }
 }

--- a/tests/Unit/Execution/Arguments/TypedArgsTest.php
+++ b/tests/Unit/Execution/Arguments/TypedArgsTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Unit\Execution\Arguments;
 
-use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Tests\TestCase;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Schema\AST\ASTBuilder;
 use Nuwave\Lighthouse\Execution\Arguments\Argument;
 use Nuwave\Lighthouse\Execution\Arguments\TypedArgs;
+use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 
 class TypedArgsTest extends TestCase
 {


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Updated the changelog

**Changes**

Converting client-given args to an `ArgumentSet` fails when `null` is given for an argument that is defined as an `input`.

Added a failing test:

```
1) Tests\Unit\Execution\Arguments\TypedArgsTest::testNullableInputObject
TypeError: Argument 1 passed to Nuwave\Lighthouse\Execution\Arguments\TypedArgs::wrapArgs() must be of the type array, null given, called in /var/www/src/Execution/Arguments/TypedArgs.php on line 193

/var/www/src/Execution/Arguments/TypedArgs.php:91
```

It works now.

**Breaking changes**

No