### PR TITLE
Use detailed `$description` property when generating `enum` values from a `BenSampo\Enum\Enum` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `@scope` directive for adding a scope to the query builder https://github.com/nuwave/lighthouse/pull/998
 
+### Changed
+
+- Using description of LaravelEnumType for more detail https://github.com/nuwave/lighthouse/pull/1027
+
 ## [4.5.3](https://github.com/nuwave/lighthouse/compare/v4.5.2...v4.5.3)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Using description of LaravelEnumType for more detail https://github.com/nuwave/lighthouse/pull/1027
+- Use detailed `$description` property when generating `enum` values from a `BenSampo\Enum\Enum` class  https://github.com/nuwave/lighthouse/pull/1027
 
 ## [4.5.3](https://github.com/nuwave/lighthouse/compare/v4.5.2...v4.5.3)
 

--- a/src/Schema/Types/LaravelEnumType.php
+++ b/src/Schema/Types/LaravelEnumType.php
@@ -41,7 +41,7 @@ class LaravelEnumType extends EnumType
                 function (Enum $enum): array {
                     return [
                         'name' => $enum->key,
-                        'value' => $enum->value,
+                        'value' => $enum,
                         'description' => $enum->description,
                     ];
                 },

--- a/src/Schema/Types/LaravelEnumType.php
+++ b/src/Schema/Types/LaravelEnumType.php
@@ -41,8 +41,8 @@ class LaravelEnumType extends EnumType
                 function (Enum $enum): array {
                     return [
                         'name' => $enum->key,
-                        'value' => $enum,
-                        'description' => "$enum->value",
+                        'value' => $enum->value,
+                        'description' => "$enum->description",
                     ];
                 },
                 $enumClass::getInstances()

--- a/src/Schema/Types/LaravelEnumType.php
+++ b/src/Schema/Types/LaravelEnumType.php
@@ -42,7 +42,7 @@ class LaravelEnumType extends EnumType
                     return [
                         'name' => $enum->key,
                         'value' => $enum->value,
-                        'description' => "$enum->description",
+                        'description' => $enum->description,
                     ];
                 },
                 $enumClass::getInstances()

--- a/src/Schema/Types/LaravelEnumType.php
+++ b/src/Schema/Types/LaravelEnumType.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Nuwave\Lighthouse\Schema\Types;
 
 use BenSampo\Enum\Enum;
-use InvalidArgumentException;
 use GraphQL\Type\Definition\EnumType;
+use InvalidArgumentException;
 
 /**
  * A convenience wrapper for registering enums programmatically.

--- a/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
+++ b/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Unit\Schema\Types;
 
-use Tests\TestCase;
-use Tests\Utils\LaravelEnums\UserType;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
-use PHPUnit\Framework\Constraint\Callback;
-use Tests\Utils\LaravelEnums\LocalizedUserType;
 use Nuwave\Lighthouse\Schema\Types\LaravelEnumType;
+use PHPUnit\Framework\Constraint\Callback;
+use Tests\TestCase;
+use Tests\Utils\LaravelEnums\LocalizedUserType;
+use Tests\Utils\LaravelEnums\UserType;
 
 class LaravelEnumTypeTest extends TestCase
 {

--- a/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
+++ b/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
@@ -3,10 +3,10 @@
 namespace Tests\Unit\Schema\Types;
 
 use Tests\TestCase;
-use Tests\Utils\LaravelEnums\LocalizedUserType;
 use Tests\Utils\LaravelEnums\UserType;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
 use PHPUnit\Framework\Constraint\Callback;
+use Tests\Utils\LaravelEnums\LocalizedUserType;
 use Nuwave\Lighthouse\Schema\Types\LaravelEnumType;
 
 class LaravelEnumTypeTest extends TestCase

--- a/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
+++ b/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Schema\Types;
 
 use Tests\TestCase;
+use Tests\Utils\LaravelEnums\LocalizedUserType;
 use Tests\Utils\LaravelEnums\UserType;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
 use PHPUnit\Framework\Constraint\Callback;
@@ -28,6 +29,13 @@ class LaravelEnumTypeTest extends TestCase
         $enumType = new LaravelEnumType(UserType::class, $customName);
 
         $this->assertSame($customName, $enumType->name);
+    }
+
+    public function testCustomDescription()
+    {
+        $enumType = new LaravelEnumType(LocalizedUserType::class);
+
+        $this->assertSame('Localize Moderator', $enumType->config['values']['Moderator']['description']);
     }
 
     public function testReceivesEnumInstanceInternally(): void

--- a/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
+++ b/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
@@ -31,7 +31,7 @@ class LaravelEnumTypeTest extends TestCase
         $this->assertSame($customName, $enumType->name);
     }
 
-    public function testCustomDescription()
+    public function testCustomDescription(): void
     {
         $enumType = new LaravelEnumType(LocalizedUserType::class);
 

--- a/tests/Utils/LaravelEnums/LocalizedUserType.php
+++ b/tests/Utils/LaravelEnums/LocalizedUserType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Utils\LaravelEnums;
+
+use BenSampo\Enum\Contracts\LocalizedEnum;
+use BenSampo\Enum\Enum;
+
+final class LocalizedUserType extends Enum implements LocalizedEnum
+{
+    const Administrator = 'ADMINISTRATOR';
+    const Moderator = 'MODERATOR';
+
+    public static function getDescription($value): string
+    {
+        if ($value === self::Moderator) {
+            return 'Localize Moderator';
+        }
+
+        return parent::getDescription($value);
+    }
+}

--- a/tests/Utils/LaravelEnums/LocalizedUserType.php
+++ b/tests/Utils/LaravelEnums/LocalizedUserType.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Utils\LaravelEnums;
 
-use BenSampo\Enum\Enum;
 use BenSampo\Enum\Contracts\LocalizedEnum;
+use BenSampo\Enum\Enum;
 
 final class LocalizedUserType extends Enum implements LocalizedEnum
 {

--- a/tests/Utils/LaravelEnums/LocalizedUserType.php
+++ b/tests/Utils/LaravelEnums/LocalizedUserType.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Utils\LaravelEnums;
 
-use BenSampo\Enum\Contracts\LocalizedEnum;
 use BenSampo\Enum\Enum;
+use BenSampo\Enum\Contracts\LocalizedEnum;
 
 final class LocalizedUserType extends Enum implements LocalizedEnum
 {


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Added Docs for all relevant versions
- [x] Updated the changelog

**Changes**
Description of LaravelEnumType should using `$enum->desciption` for more detail