### PR TITLE
Add `syncWithoutDetaching` option for BelongsToMany and MorphToMany relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `@scope` directive for adding a scope to the query builder https://github.com/nuwave/lighthouse/pull/998
+- Add `syncWithoutDetaching` option for BelongsToMany relationships
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.6.0...master)
 
+### Added
+
+- Add `syncWithoutDetaching` option for BelongsToMany relationships https://github.com/nuwave/lighthouse/pull/1031
+
 ### Changed
 
 - Add ability to fetch soft deleted model within `@can` directive to validate permission using `@softDeletes` directive. https://github.com/nuwave/lighthouse/pull/1042
@@ -16,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `@scope` directive for adding a scope to the query builder https://github.com/nuwave/lighthouse/pull/998
-- Add `syncWithoutDetaching` option for BelongsToMany relationships
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `syncWithoutDetaching` option for BelongsToMany relationships https://github.com/nuwave/lighthouse/pull/1031
+- Add `syncWithoutDetaching` option for BelongsToMany and MorphToMany relationships https://github.com/nuwave/lighthouse/pull/1031
 
 ### Changed
 

--- a/docs/master/eloquent/nested-mutations.md
+++ b/docs/master/eloquent/nested-mutations.md
@@ -523,6 +523,7 @@ input UpdateAuthorRelation {
   update: [UpdateAuthorInput!]
   upsert: [UpsertAuthorInput!]
   sync: [ID!]
+  syncWithoutDetaching: [ID!]
   delete: [ID!]
   disconnect: [ID!]
 }

--- a/src/Execution/MutationExecutor.php
+++ b/src/Execution/MutationExecutor.php
@@ -86,6 +86,10 @@ class MutationExecutor
                 $relation->sync($nestedOperations['sync']);
             }
 
+            if (isset($nestedOperations['syncWithoutDetaching'])) {
+                $relation->syncWithoutDetaching($nestedOperations['syncWithoutDetaching']);
+            }
+
             if (isset($nestedOperations['create'])) {
                 self::handleMultiRelationCreate(new Collection($nestedOperations['create']), $relation);
             }
@@ -242,6 +246,10 @@ class MutationExecutor
 
             if (isset($nestedOperations['sync'])) {
                 $relation->sync($nestedOperations['sync']);
+            }
+
+            if (isset($nestedOperations['syncWithoutDetaching'])) {
+                $relation->syncWithoutDetaching($nestedOperations['syncWithoutDetaching']);
             }
 
             if (isset($nestedOperations['create'])) {

--- a/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
@@ -133,8 +133,8 @@ class BelongsToManyTest extends DBTestCase
                     'users' => [
                         [
                             'id' => '2',
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
                 'updateRole' => [
                     'id' => '1',
@@ -144,9 +144,9 @@ class BelongsToManyTest extends DBTestCase
                         ],
                         [
                             'id' => '2',
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
         ]);
     }

--- a/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
@@ -24,6 +24,7 @@ class BelongsToManyTest extends DBTestCase
         createRole(input: CreateRoleInput! @spread): Role @create
         updateRole(input: UpdateRoleInput! @spread): Role @update
         upsertRole(input: UpsertRoleInput! @spread): Role @upsert
+        createUser(input: CreateUserInput! @spread): User @create
     }
 
     input CreateRoleInput {
@@ -55,6 +56,7 @@ class BelongsToManyTest extends DBTestCase
         delete: [ID!]
         connect: [ID!]
         sync: [ID!]
+        syncWithoutDetaching: [ID!]
         disconnect: [ID!]
     }
     
@@ -84,6 +86,70 @@ class BelongsToManyTest extends DBTestCase
         name: String
     }
     '.self::PLACEHOLDER_QUERY;
+
+    public function testCanSyncWithoutDetaching(): void
+    {
+        $this->graphQL('
+        mutation {
+            createUser(input: {
+                name: "user1"
+            }) {
+                id
+            }
+            createRole(input: {
+                name: "foobar"
+                users: {
+                    create: [
+                        {
+                            name: "user2"
+                        }
+                    ]
+                }
+            }) {
+                id
+                users {
+                    id
+                }
+            }
+            updateRole(input: {
+                id: 1
+                users: {
+                    syncWithoutDetaching: [1]
+                }
+            }) {
+                id
+                users {
+                    id
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'createUser' => [
+                    'id' => '1',
+                ],
+                'createRole' => [
+                    'id' => '1',
+                    'users' => [
+                        [
+                            'id' => '2',
+                        ]
+                    ]
+                ],
+                'updateRole' => [
+                    'id' => '1',
+                    'users' => [
+                        [
+                            'id' => '1',
+                        ],
+                        [
+                            'id' => '2',
+                        ]
+                    ]
+                ]
+            ],
+        ]);
+    }
 
     public function testCanCreateWithNewBelongsToMany(): void
     {


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

**Changes**

Adds support for `syncWithoutDetaching` method on BelongsToMany relationships.

**Breaking changes**

Should be no breaking changes.
