### PR TITLE
Handle arrays of namespaces in generator commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use detailed `$description` property when generating `enum` values from a `BenSampo\Enum\Enum` class  https://github.com/nuwave/lighthouse/pull/1027
 
+### Fixed
+
+- Handle arrays of namespaces in generator commands https://github.com/nuwave/lighthouse/pull/1033
+
 ## [4.5.3](https://github.com/nuwave/lighthouse/compare/v4.5.2...v4.5.3)
 
 ### Fixed

--- a/src/Console/InterfaceCommand.php
+++ b/src/Console/InterfaceCommand.php
@@ -25,15 +25,9 @@ class InterfaceCommand extends LighthouseGeneratorCommand
      */
     protected $type = 'Interface';
 
-    /**
-     * Get the default namespace for the class.
-     *
-     * @param  string  $rootNamespace
-     * @return string
-     */
-    protected function getDefaultNamespace($rootNamespace): string
+    protected function namespaceConfigKey(): string
     {
-        return config('lighthouse.namespaces.interfaces');
+        return 'interfaces';
     }
 
     /**

--- a/src/Console/LighthouseGeneratorCommand.php
+++ b/src/Console/LighthouseGeneratorCommand.php
@@ -19,4 +19,68 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
     {
         return ucfirst(trim($this->argument('name')));
     }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace): string
+    {
+        $namespaces = config('lighthouse.namespaces.' . $this->namespaceConfigKey());
+
+        return static::commonNamespace((array) $namespaces);
+    }
+
+    /**
+     * Get the config key that holds the default namespaces for the class.
+     *
+     * @return string
+     */
+    abstract protected function namespaceConfigKey(): string;
+
+    /**
+     * Find the common namespace of a list of namespaces.
+     *
+     * For example, ['App\\Foo\\A', 'App\\Foo\\B'] would return 'App\\Foo'.
+     *
+     * @param  string[]  $namespaces
+     * @return string
+     */
+    public static function commonNamespace(array $namespaces): string
+    {
+        if($namespaces === []) {
+            return '';
+        }
+
+        if(count($namespaces) === 1) {
+            return reset($namespaces);
+        }
+
+        // If the strings are sorted, any prefix common to all strings
+        // will be common to the sorted first and last strings.
+        // All the strings in the middle can be ignored.
+        sort($namespaces);
+
+        $first = explode('\\', reset($namespaces));
+        $last = explode('\\', end($namespaces));
+
+        $matching = [];
+        foreach($first as $i => $part) {
+            // We ran out of elements to compare, so we reached the maximum common length
+            if(!isset($last[$i])) {
+                break;
+            }
+
+            // We found an element that differs
+            if($last[$i] !== $part) {
+                break;
+            }
+
+            $matching []= $part;
+        }
+
+        return implode('\\', $matching);
+    }
 }

--- a/src/Console/LighthouseGeneratorCommand.php
+++ b/src/Console/LighthouseGeneratorCommand.php
@@ -28,7 +28,7 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace): string
     {
-        $namespaces = config('lighthouse.namespaces.' . $this->namespaceConfigKey());
+        $namespaces = config('lighthouse.namespaces.'.$this->namespaceConfigKey());
 
         return static::commonNamespace((array) $namespaces);
     }
@@ -50,11 +50,11 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
      */
     public static function commonNamespace(array $namespaces): string
     {
-        if($namespaces === []) {
+        if ($namespaces === []) {
             return '';
         }
 
-        if(count($namespaces) === 1) {
+        if (count($namespaces) === 1) {
             return reset($namespaces);
         }
 
@@ -67,18 +67,18 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
         $last = explode('\\', end($namespaces));
 
         $matching = [];
-        foreach($first as $i => $part) {
+        foreach ($first as $i => $part) {
             // We ran out of elements to compare, so we reached the maximum common length
-            if(!isset($last[$i])) {
+            if (! isset($last[$i])) {
                 break;
             }
 
             // We found an element that differs
-            if($last[$i] !== $part) {
+            if ($last[$i] !== $part) {
                 break;
             }
 
-            $matching []= $part;
+            $matching [] = $part;
         }
 
         return implode('\\', $matching);

--- a/src/Console/MutationCommand.php
+++ b/src/Console/MutationCommand.php
@@ -25,15 +25,9 @@ class MutationCommand extends LighthouseGeneratorCommand
      */
     protected $type = 'Mutation';
 
-    /**
-     * Get the default namespace for the class.
-     *
-     * @param  string  $rootNamespace
-     * @return string
-     */
-    protected function getDefaultNamespace($rootNamespace): string
+    protected function namespaceConfigKey(): string
     {
-        return config('lighthouse.namespaces.mutations');
+        return 'mutations';
     }
 
     /**

--- a/src/Console/QueryCommand.php
+++ b/src/Console/QueryCommand.php
@@ -25,15 +25,9 @@ class QueryCommand extends LighthouseGeneratorCommand
      */
     protected $type = 'Query';
 
-    /**
-     * Get the default namespace for the class.
-     *
-     * @param  string  $rootNamespace
-     * @return string
-     */
-    protected function getDefaultNamespace($rootNamespace): string
+    protected function namespaceConfigKey(): string
     {
-        return config('lighthouse.namespaces.queries');
+        return 'queries';
     }
 
     /**

--- a/src/Console/ScalarCommand.php
+++ b/src/Console/ScalarCommand.php
@@ -25,15 +25,9 @@ class ScalarCommand extends LighthouseGeneratorCommand
      */
     protected $type = 'Scalar';
 
-    /**
-     * Get the default namespace for the class.
-     *
-     * @param  string  $rootNamespace
-     * @return string
-     */
-    protected function getDefaultNamespace($rootNamespace): string
+    protected function namespaceConfigKey(): string
     {
-        return config('lighthouse.namespaces.scalars');
+        return 'scalars';
     }
 
     /**

--- a/src/Console/SubscriptionCommand.php
+++ b/src/Console/SubscriptionCommand.php
@@ -25,15 +25,9 @@ class SubscriptionCommand extends LighthouseGeneratorCommand
      */
     protected $type = 'Subscription';
 
-    /**
-     * Get the default namespace for the class.
-     *
-     * @param  string  $rootNamespace
-     * @return string
-     */
-    protected function getDefaultNamespace($rootNamespace): string
+    protected function namespaceConfigKey(): string
     {
-        return config('lighthouse.namespaces.subscriptions');
+        return 'subscriptions';
     }
 
     /**

--- a/src/Console/UnionCommand.php
+++ b/src/Console/UnionCommand.php
@@ -25,15 +25,9 @@ class UnionCommand extends LighthouseGeneratorCommand
      */
     protected $type = 'Union';
 
-    /**
-     * Get the default namespace for the class.
-     *
-     * @param  string  $rootNamespace
-     * @return string
-     */
-    protected function getDefaultNamespace($rootNamespace): string
+    protected function namespaceConfigKey(): string
     {
-        return config('lighthouse.namespaces.unions');
+        return 'unions';
     }
 
     /**

--- a/tests/Unit/Console/LighthouseGeneratorCommandTest.php
+++ b/tests/Unit/Console/LighthouseGeneratorCommandTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit\Console;
+
+use Nuwave\Lighthouse\Console\LighthouseGeneratorCommand;
+use Tests\TestCase;
+
+class LighthouseGeneratorCommandTest extends TestCase
+{
+    public function testCommonNamespaceSingle(): void
+    {
+        $namespace = 'App\\Foo';
+
+        $this->assertSame(
+            $namespace,
+            LighthouseGeneratorCommand::commonNamespace([$namespace])
+        );
+    }
+
+    public function testCommonNamespaceMultiple(): void
+    {
+        $this->assertSame(
+            'App',
+            LighthouseGeneratorCommand::commonNamespace(['App\\Foo', 'App\\Bar', 'App\\Foo\\Bar'])
+        );
+        $this->assertSame(
+            '',
+            LighthouseGeneratorCommand::commonNamespace(['Foo', 'Bar'])
+        );
+    }
+
+    public function testCommonNamespaceNone(): void
+    {
+        $this->assertSame(
+            '',
+            LighthouseGeneratorCommand::commonNamespace([])
+        );
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated the changelog

Resolves https://github.com/nuwave/lighthouse/issues/1029

**Changes**

When the configuration holds an array of namespaces, the generator commands currently fail with:

```
QueryCommand::getDefaultNamespace() must be of the type string, array returned
```

This handles the case of multiple default namespaces by identifying the common part of all configured namespaces and uses that to generate the class.

Just like Laravel generator commands, sub-namespaces can be added:

```
php artisan lighthouse:query Sub\\Foo
```

**Breaking changes**

No
