### PR TITLE
Rework how @can directive fetches model (@softDeletes are not working)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.6.0...master)
 
+### Changed
+
+- Add ability to fetch soft deleted model within `@can` directive to validate permission using `@softDeletes` directive. https://github.com/nuwave/lighthouse/pull/1042
+
 ## [4.6.0](https://github.com/nuwave/lighthouse/compare/v4.5.3...v4.6.0)
 
 ### Added

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -481,8 +481,8 @@ directive @can(
 
 ### Examples
 
-You may specify an argument that is used to find a specific model
-instance against which the permissions should be checked.
+In `find` parameter you may specify an input argument which is used to find a specific model
+instance by primary key against which the permissions should be checked.
 
 ```graphql
 type Query {
@@ -497,6 +497,14 @@ class PostPolicy
     {
         return $user->id === $post->author_id;
     }
+}
+```
+
+It also works with soft deleted models in combination with `@softDeletes` directive.
+
+```graphql
+type Query {
+    post(id: ID @eq): Post @softDeletes @can(ability: "view", find: "id")
 }
 ```
 

--- a/src/Execution/Arguments/ArgumentSet.php
+++ b/src/Execution/Arguments/ArgumentSet.php
@@ -101,7 +101,7 @@ class ArgumentSet
                     return $directive instanceof ArgBuilderDirective;
                 });
 
-            if (!empty($directiveFilter)) {
+            if (! empty($directiveFilter)) {
                 $filteredDirectives = $filteredDirectives->filter($directiveFilter);
             }
 

--- a/src/Execution/Arguments/ArgumentSet.php
+++ b/src/Execution/Arguments/ArgumentSet.php
@@ -83,7 +83,7 @@ class ArgumentSet
      *
      * @return \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder
      */
-    public function enhanceBuilder($builder, array $scopes, $directiveFilter = null)
+    public function enhanceBuilder($builder, array $scopes, Closure $directiveFilter = null)
     {
         if (empty($directiveFilter)) {
             $directiveFilter = function (Directive $directive): bool {

--- a/src/Execution/Arguments/ArgumentSet.php
+++ b/src/Execution/Arguments/ArgumentSet.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Execution\Arguments;
 
+use Closure;
 use Nuwave\Lighthouse\Schema\Directives\SpreadDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective;
 use Nuwave\Lighthouse\Support\Contracts\Directive;
@@ -77,20 +78,14 @@ class ArgumentSet
     /**
      * Apply ArgBuilderDirectives and scopes to the builder.
      *
-     * @param \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder $builder
-     * @param string[] $scopes
-     * @param \Closure $directiveFilter
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $builder
+     * @param  string[]  $scopes
+     * @param  \Closure  $directiveFilter
      *
      * @return \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder
      */
     public function enhanceBuilder($builder, array $scopes, Closure $directiveFilter = null)
     {
-        if (empty($directiveFilter)) {
-            $directiveFilter = function (Directive $directive): bool {
-                return $directive instanceof ArgBuilderDirective;
-            };
-        }
-
         foreach ($this->arguments as $argument) {
             $value = $argument->toPlain();
 
@@ -100,12 +95,19 @@ class ArgumentSet
                 $value = $value->value;
             }
 
-            $argument
+            $filteredDirectives = $argument
                 ->directives
-                ->filter($directiveFilter)
-                ->each(function (ArgBuilderDirective $argBuilderDirective) use (&$builder, $value) {
-                    $builder = $argBuilderDirective->handleBuilder($builder, $value);
+                ->filter(function (Directive $directive): bool {
+                    return $directive instanceof ArgBuilderDirective;
                 });
+
+            if (!empty($directiveFilter)) {
+                $filteredDirectives = $filteredDirectives->filter($directiveFilter);
+            }
+
+            $filteredDirectives->each(function (ArgBuilderDirective $argBuilderDirective) use (&$builder, $value) {
+                $builder = $argBuilderDirective->handleBuilder($builder, $value);
+            });
 
             // TODO recurse deeper into the input to allow nested input objects to add filters
         }

--- a/src/Execution/Arguments/ArgumentSet.php
+++ b/src/Execution/Arguments/ArgumentSet.php
@@ -77,12 +77,20 @@ class ArgumentSet
     /**
      * Apply ArgBuilderDirectives and scopes to the builder.
      *
-     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $builder
-     * @param  string[]  $scopes
+     * @param \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder $builder
+     * @param string[] $scopes
+     * @param \Closure $directiveFilter
+     *
      * @return \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder
      */
-    public function enhanceBuilder($builder, array $scopes)
+    public function enhanceBuilder($builder, array $scopes, $directiveFilter = null)
     {
+        if (empty($directiveFilter)) {
+            $directiveFilter = function (Directive $directive): bool {
+                return $directive instanceof ArgBuilderDirective;
+            };
+        }
+
         foreach ($this->arguments as $argument) {
             $value = $argument->toPlain();
 
@@ -94,9 +102,7 @@ class ArgumentSet
 
             $argument
                 ->directives
-                ->filter(function (Directive $directive): bool {
-                    return $directive instanceof ArgBuilderDirective;
-                })
+                ->filter($directiveFilter)
                 ->each(function (ArgBuilderDirective $argBuilderDirective) use (&$builder, $value) {
                     $builder = $argBuilderDirective->handleBuilder($builder, $value);
                 });

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -82,7 +82,7 @@ SDL;
             $fieldValue->setResolver(
                 function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($previousResolver) {
                     if ($find = $this->directiveArgValue('find')) {
-                    $modelOrModels = $resolveInfo
+                        $modelOrModels = $resolveInfo
                             ->argumentSet
                             ->enhanceBuilder(
                                 $this->getModelClass()::query(),

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -8,7 +8,9 @@ use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Database\Eloquent\Model;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\SoftDeletes\TrashedDirective;
 use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
+use Nuwave\Lighthouse\Support\Contracts\Directive;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
@@ -80,7 +82,16 @@ SDL;
             $fieldValue->setResolver(
                 function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($previousResolver) {
                     if ($find = $this->directiveArgValue('find')) {
-                        $modelOrModels = $this->getModelClass()::findOrFail($args[$find]);
+                    $modelOrModels = $resolveInfo
+                            ->argumentSet
+                            ->enhanceBuilder(
+                                $this->getModelClass()::query(),
+                                $this->directiveArgValue('scopes', []),
+                                function (Directive $directive): bool {
+                                    return $directive instanceof TrashedDirective;
+                                }
+                            )
+                            ->findOrFail($args[$find]);
 
                         if ($modelOrModels instanceof Model) {
                             $modelOrModels = [$modelOrModels];

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -86,7 +86,7 @@ SDL;
                             ->argumentSet
                             ->enhanceBuilder(
                                 $this->getModelClass()::query(),
-                                $this->directiveArgValue('scopes', []),
+                                [],
                                 function (Directive $directive): bool {
                                     return $directive instanceof TrashedDirective;
                                 }

--- a/tests/Utils/Policies/AuthServiceProvider.php
+++ b/tests/Utils/Policies/AuthServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Tests\Utils\Policies;
 
 use Tests\Utils\Models\Post;
+use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
 
 class AuthServiceProvider extends \Illuminate\Foundation\Support\Providers\AuthServiceProvider
@@ -10,6 +11,7 @@ class AuthServiceProvider extends \Illuminate\Foundation\Support\Providers\AuthS
     protected $policies = [
         User::class => UserPolicy::class,
         Post::class => PostPolicy::class,
+        Task::class => TaskPolicy::class,
     ];
 
     public function boot(): void

--- a/tests/Utils/Policies/TaskPolicy.php
+++ b/tests/Utils/Policies/TaskPolicy.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Utils\Policies;
+
+use Tests\Utils\Models\User;
+
+class TaskPolicy
+{
+    const ADMIN = 'admin';
+
+    public function adminOnly(User $user): bool
+    {
+        return $user->name === self::ADMIN;
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

Using `@can` on softDeleted models is not working as expected. Within `@can` directive simple query builder gets created without respecting soft deleted models. `@softDeletes` directive ist also doesn't help here, as it is not processed in builder-creation

**Changes**

We should somehow rework, how `@can` fetches model for checking access. Take a look at line 83 in file `Nuwave\Lighthouse\Schema\Directives\CanDirective`. There is the problem. I tried to use following code:

```php
$resolveInfo
->argumentSet
->enhanceBuilder(
    $this->getModelClass()::query(),
    $this->directiveArgValue('scopes', [])
)
->findOrFail($args[$find]);
```

This piece is from `@find`, `@all` etc. directives. With given changes it works for my test, but failes the `testThrowsIfNotAuthorized` test with following error: 

```
Illuminate\Database\QueryException : SQLSTATE[42S22]: Column not found: 1054 Unknown column 'foo' in 'where clause' (SQL: select * from `posts` where `foo` = 1 and `posts`.`id` = 1 limit 1)
```

Currently I don't know how to fix it... =\ any ideas are welcome!

**Breaking changes**

There should be no breaking changes
