### PR TITLE
Add `injectArgs` option to `@can` directive to pass along client defined   arguments to the policy check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `syncWithoutDetaching` option for BelongsToMany and MorphToMany relationships https://github.com/nuwave/lighthouse/pull/1031
+- Add `injectArgs` option to `@can` directive to pass along client defined
+  arguments to the policy check https://github.com/nuwave/lighthouse/pull/1043
 
 ### Changed
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -479,7 +479,7 @@ directive @can(
   """
   Pass input variables as arguments that are passed to `Gate::check`. 
   """
-  input: Boolean!
+  injectArgs: Boolean!
 ) on FIELD_DEFINITION
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -531,11 +531,11 @@ type Mutation {
 }
 ```
 
-You can pass the input variables as arguments to the policy setting `input` argument
+You can pass the input variables as arguments to the policy setting `injectArgs` argument
 ```graphql
 type Mutation {
     createPost(input: PostInput): Post
-        @can(ability: "create", input: "true")
+        @can(ability: "create", injectArgs: "true")
 }
 ```
 Now you will have access to `PostInput` values in the policy 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -476,6 +476,10 @@ directive @can(
   Additional arguments that are passed to `Gate::check`. 
   """
   args: [String!]
+  """
+  Pass input variables as arguments that are passed to `Gate::check`. 
+  """
+  input: Boolean!
 ) on FIELD_DEFINITION
 ```
 
@@ -526,6 +530,15 @@ type Mutation {
         @can(ability: "create", args: ["FROM_GRAPHQL"])
 }
 ```
+
+You can pass the input variables as arguments to the policy setting `input` argument
+```graphql
+type Mutation {
+    createPost(input: PostInput): Post
+        @can(ability: "create", input: "true")
+}
+```
+Now you will have access to `PostInput` values in the policy 
 
 Starting from Laravel 5.7, [authorization of guest users](https://laravel.com/docs/authorization#guest-users) is supported.
 Because of this, Lighthouse does **not** validate that the user is authenticated before passing it along to the policy.

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -459,6 +459,9 @@ class PostPolicy
 ```graphql
 """
 Check a Laravel Policy to ensure the current user is authorized to access a field.
+
+When `injectArgs` and `args` are used together, the client given
+arguments will be passed before the static args.
 """
 directive @can(
   """
@@ -471,22 +474,26 @@ directive @can(
   instance against which the permissions should be checked.
   """
   find: String
+
+  """
+  Pass along the client given input data as arguments to `Gate::check`. 
+  """
+  injectArgs: Boolean = false
+
+  """
+  Statically defined arguments that are passed to `Gate::check`.
   
+  You may pass pass arbitrary GraphQL literals,
+  e.g.: [1, 2, 3] or { foo: "bar" }
   """
-  Additional arguments that are passed to `Gate::check`. 
-  """
-  args: [String!]
-  """
-  Pass input variables as arguments that are passed to `Gate::check`. 
-  """
-  injectArgs: Boolean!
+  args: Mixed
 ) on FIELD_DEFINITION
 ```
 
 ### Examples
 
 In `find` parameter you may specify an input argument which is used to find a specific model
-instance by primary key against which the permissions should be checked.
+instance by primary key against which the permissions should be checked:
 
 ```graphql
 type Query {
@@ -504,7 +511,7 @@ class PostPolicy
 }
 ```
 
-It also works with soft deleted models in combination with `@softDeletes` directive.
+It also works with soft deleted models in combination with `@softDeletes` directive:
 
 ```graphql
 type Query {
@@ -522,7 +529,7 @@ type Mutation {
 }
 ```
 
-You can pass additional arguments to the policy checks by specifying them as `args`.
+You can pass additional arguments to the policy checks by specifying them as `args`:
 
 ```graphql
 type Mutation {
@@ -531,14 +538,17 @@ type Mutation {
 }
 ```
 
-You can pass the input variables as arguments to the policy setting `injectArgs` argument
+You can pass along the client given input data as arguments to the policy checks
+with the `injectArgs` argument:
+
 ```graphql
 type Mutation {
     createPost(input: PostInput): Post
         @can(ability: "create", injectArgs: "true")
 }
 ```
-Now you will have access to `PostInput` values in the policy 
+
+Now you will have access to `PostInput` values in the policy. 
 
 Starting from Laravel 5.7, [authorization of guest users](https://laravel.com/docs/authorization#guest-users) is supported.
 Because of this, Lighthouse does **not** validate that the user is authenticated before passing it along to the policy.

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -22,6 +22,11 @@ class CanDirective extends BaseDirective implements FieldMiddleware, DefinedDire
     protected $gate;
 
     /**
+     * @var array
+     */
+    protected $args;
+
+    /**
      * CanDirective constructor.
      * @param  \Illuminate\Contracts\Auth\Access\Gate  $gate
      * @return void
@@ -63,6 +68,11 @@ directive @can(
   Additional arguments that are passed to `Gate::check`. 
   """
   args: [String!]
+    """
+  Send input data as arguments to the policy. 
+  Set false by default
+  """
+  input: Boolean!
 ) on FIELD_DEFINITION
 SDL;
     }
@@ -81,6 +91,7 @@ SDL;
         return $next(
             $fieldValue->setResolver(
                 function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($previousResolver) {
+                    $this->args = $args;
                     if ($find = $this->directiveArgValue('find')) {
                         $modelOrModels = $resolveInfo
                             ->argumentSet
@@ -146,6 +157,9 @@ SDL;
      */
     protected function getAdditionalArguments(): array
     {
-        return (array) $this->directiveArgValue('args');
+        $directiveArgs = (array) $this->directiveArgValue('args');
+        $inputArgs = $this->directiveArgValue('input') === true ? [$this->args] : [];
+        
+        return array_merge($directiveArgs, $inputArgs);
     }
 }

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -7,6 +7,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Database\Eloquent\Model;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
+use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\SoftDeletes\TrashedDirective;
 use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
@@ -20,11 +21,6 @@ class CanDirective extends BaseDirective implements FieldMiddleware, DefinedDire
      * @var \Illuminate\Contracts\Auth\Access\Gate
      */
     protected $gate;
-
-    /**
-     * @var array
-     */
-    protected $args;
 
     /**
      * CanDirective constructor.
@@ -51,6 +47,9 @@ class CanDirective extends BaseDirective implements FieldMiddleware, DefinedDire
         return /* @lang GraphQL */ <<<'SDL'
 """
 Check a Laravel Policy to ensure the current user is authorized to access a field.
+
+When `injectArgs` and `args` are used together, the client given
+arguments will be passed before the static args.
 """
 directive @can(
   """
@@ -63,16 +62,19 @@ directive @can(
   instance against which the permissions should be checked.
   """
   find: String
-  
+
   """
-  Additional arguments that are passed to `Gate::check`. 
-  """
-  args: [String!]
-  """
-  Send input data as arguments to the policy. 
-  Set false by default
+  Pass along the client given input data as arguments to `Gate::check`. 
   """
   injectArgs: Boolean = false
+
+  """
+  Statically defined arguments that are passed to `Gate::check`.
+  
+  You may pass pass arbitrary GraphQL literals,
+  e.g.: [1, 2, 3] or { foo: "bar" }
+  """
+  args: Mixed
 ) on FIELD_DEFINITION
 SDL;
     }
@@ -91,59 +93,66 @@ SDL;
         return $next(
             $fieldValue->setResolver(
                 function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($previousResolver) {
-                    $this->args = $args;
-                    if ($find = $this->directiveArgValue('find')) {
-                        $modelOrModels = $resolveInfo
-                            ->argumentSet
-                            ->enhanceBuilder(
-                                $this->getModelClass()::query(),
-                                [],
-                                function (Directive $directive): bool {
-                                    return $directive instanceof TrashedDirective;
-                                }
-                            )
-                            ->findOrFail($args[$find]);
+                    $gate = $this->gate->forUser($context->user());
+                    $ability = $this->directiveArgValue('ability');
+                    $checkArguments = $this->buildCheckArguments($args);
 
-                        if ($modelOrModels instanceof Model) {
-                            $modelOrModels = [$modelOrModels];
-                        }
-
-                        /** @var \Illuminate\Database\Eloquent\Model $model */
-                        foreach ($modelOrModels as $model) {
-                            $this->authorize($context->user(), $model);
-                        }
-                    } else {
-                        $this->authorize($context->user(), $this->getModelClass());
+                    foreach ($this->modelsToCheck($resolveInfo->argumentSet, $args) as $model) {
+                        $this->authorize($gate, $ability, $model, $checkArguments);
                     }
 
-                    return call_user_func_array($previousResolver, func_get_args());
+                    return $previousResolver($root, $args, $context, $resolveInfo);
                 }
             )
         );
     }
 
     /**
-     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
+     * @param  \Nuwave\Lighthouse\Execution\Arguments\ArgumentSet  $argumentSet
+     * @param  array  $args
+     * @return iterable<Model|string>
+     *
+     * @throws \Nuwave\Lighthouse\Exceptions\DefinitionException
+     */
+    protected function modelsToCheck(ArgumentSet $argumentSet, array $args): iterable
+    {
+        if ($find = $this->directiveArgValue('find')) {
+            $modelOrModels = $argumentSet
+                ->enhanceBuilder(
+                    $this->getModelClass()::query(),
+                    [],
+                    function (Directive $directive): bool {
+                        return $directive instanceof TrashedDirective;
+                    }
+                )
+                ->findOrFail($args[$find]);
+
+            if ($modelOrModels instanceof Model) {
+                $modelOrModels = [$modelOrModels];
+            }
+
+            return $modelOrModels;
+        }
+
+        return [$this->getModelClass()];
+    }
+
+    /**
+     * @param  \Illuminate\Contracts\Auth\Access\Gate  $gate
+     * @param  string|string[]  $ability
      * @param  string|\Illuminate\Database\Eloquent\Model  $model
+     * @param  array  $arguments
      * @return void
      *
      * @throws \Nuwave\Lighthouse\Exceptions\AuthorizationException
      */
-    protected function authorize($user, $model): void
+    protected function authorize(Gate $gate, $ability, $model, array $arguments): void
     {
         // The signature of the second argument `$arguments` of `Gate::check`
         // should be [modelClassName, additionalArg, additionalArg...]
-        $arguments = $this->getAdditionalArguments();
         array_unshift($arguments, $model);
 
-        $can = $this->gate
-            ->forUser($user)
-            ->check(
-                $this->directiveArgValue('ability'),
-                $arguments
-            );
-
-        if (! $can) {
+        if (!$gate->check($ability, $arguments)) {
             throw new AuthorizationException(
                 "You are not authorized to access {$this->definitionNode->name->value}"
             );
@@ -153,15 +162,22 @@ SDL;
     /**
      * Additional arguments that are passed to `Gate::check`.
      *
+     * @param  array  $args
      * @return mixed[]
      */
-    protected function getAdditionalArguments(): array
+    protected function buildCheckArguments(array $args): array
     {
-        $directiveArgs = (array) $this->directiveArgValue('args');
-        $injectedArgs = $this->directiveArgValue('injectArgs') === true
-            ? $this->args
-            : [];
-        array_unshift($directiveArgs, $injectedArgs);
-        return $directiveArgs;
+        $checkArguments = [];
+
+        // The injected args come before the static args
+        if($this->directiveArgValue('injectArgs')) {
+            $checkArguments []= $args;
+        }
+
+        if($this->directiveHasArgument('args')) {
+            $checkArguments []= $this->directiveArgValue('args');
+        }
+
+        return $checkArguments;
     }
 }

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -68,11 +68,11 @@ directive @can(
   Additional arguments that are passed to `Gate::check`. 
   """
   args: [String!]
-    """
+  """
   Send input data as arguments to the policy. 
   Set false by default
   """
-  input: Boolean!
+  injectArgs: Boolean!
 ) on FIELD_DEFINITION
 SDL;
     }
@@ -158,8 +158,9 @@ SDL;
     protected function getAdditionalArguments(): array
     {
         $directiveArgs = (array) $this->directiveArgValue('args');
-        $inputArgs = $this->directiveArgValue('input') === true ? [$this->args] : [];
-
+        $inputArgs = $this->directiveArgValue('injectArgs') === true
+            ? [$this->args]
+            : [];
         return array_merge($directiveArgs, $inputArgs);
     }
 }

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -152,7 +152,7 @@ SDL;
         // should be [modelClassName, additionalArg, additionalArg...]
         array_unshift($arguments, $model);
 
-        if (!$gate->check($ability, $arguments)) {
+        if (! $gate->check($ability, $arguments)) {
             throw new AuthorizationException(
                 "You are not authorized to access {$this->definitionNode->name->value}"
             );
@@ -170,12 +170,12 @@ SDL;
         $checkArguments = [];
 
         // The injected args come before the static args
-        if($this->directiveArgValue('injectArgs')) {
-            $checkArguments []= $args;
+        if ($this->directiveArgValue('injectArgs')) {
+            $checkArguments [] = $args;
         }
 
-        if($this->directiveHasArgument('args')) {
-            $checkArguments []= $this->directiveArgValue('args');
+        if ($this->directiveHasArgument('args')) {
+            $checkArguments [] = $this->directiveArgValue('args');
         }
 
         return $checkArguments;

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -72,7 +72,7 @@ directive @can(
   Send input data as arguments to the policy. 
   Set false by default
   """
-  injectArgs: Boolean!
+  injectArgs: Boolean = false
 ) on FIELD_DEFINITION
 SDL;
     }
@@ -158,9 +158,10 @@ SDL;
     protected function getAdditionalArguments(): array
     {
         $directiveArgs = (array) $this->directiveArgValue('args');
-        $inputArgs = $this->directiveArgValue('injectArgs') === true
-            ? [$this->args]
+        $injectedArgs = $this->directiveArgValue('injectArgs') === true
+            ? $this->args
             : [];
-        return array_merge($directiveArgs, $inputArgs);
+        array_unshift($directiveArgs, $injectedArgs);
+        return $directiveArgs;
     }
 }

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -159,7 +159,7 @@ class CanDirectiveTest extends TestCase
     public function testInjectArgsPassesClientArgumentToPolicy(): void
     {
         $this->be(new User);
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /* @lang GraphQL */'
         type Query {
             user(foo: String): User!
                 @can(ability:"injectArgs", injectArgs: true)
@@ -190,7 +190,7 @@ class CanDirectiveTest extends TestCase
     public function testInjectedArgsAndStaticArgs(): void
     {
         $this->be(new User);
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /* @lang GraphQL */'
         type Query {
             user(foo: String): User!
                 @can(

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -171,8 +171,7 @@ class CanDirectiveTest extends TestCase
         }
         ';
 
-
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             user(foo: "bar"){
                 name
@@ -206,8 +205,7 @@ class CanDirectiveTest extends TestCase
         }
         ';
 
-
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             user(foo: "dynamic"){
                 name

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -187,6 +187,37 @@ class CanDirectiveTest extends TestCase
         ]);
     }
 
+    public function testWithArgsAndInjectArgsTogether(): void
+    {
+        $this->be(new User);
+        $this->schema = '
+        type Query {
+            user(foo: String): User!
+                @can(ability: "argsWithInjectedArgs", args: [{ argFoo: "argBar" }], injectArgs: true)
+                @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
+        }
+        
+        type User {
+            name: String
+        }
+        ';
+
+
+        $this->graphQL('
+        {
+            user(foo: "bar"){
+                name
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'user' => [
+                    'name' => 'foo',
+                ],
+            ],
+        ]);
+    }
+
     public function resolveUser(): User
     {
         $user = new User;

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -141,7 +141,7 @@ class CanDirectiveTest extends TestCase
                 @can(ability: "dependingOnArg", args: [false])
                 @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
         }
-
+        
         type User {
             name: String
         }
@@ -156,13 +156,13 @@ class CanDirectiveTest extends TestCase
         ')->assertErrorCategory(AuthorizationException::CATEGORY);
     }
 
-    public function testSendInputArgumentToPolicy(): void
+    public function testInjectArgsPassesClientArgumentToPolicy(): void
     {
         $this->be(new User);
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */'
         type Query {
             user(foo: String): User!
-                @can(ability:"severalArgs", injectArgs: true)
+                @can(ability:"injectArgs", injectArgs: true)
                 @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
         }
         
@@ -187,13 +187,17 @@ class CanDirectiveTest extends TestCase
         ]);
     }
 
-    public function testWithArgsAndInjectArgsTogether(): void
+    public function testInjectedArgsAndStaticArgs(): void
     {
         $this->be(new User);
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */'
         type Query {
             user(foo: String): User!
-                @can(ability: "argsWithInjectedArgs", args: [{ argFoo: "argBar" }], injectArgs: true)
+                @can(
+                    ability: "argsWithInjectedArgs"
+                    args: { foo: "static" }
+                    injectArgs: true
+                )
                 @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
         }
         
@@ -205,7 +209,7 @@ class CanDirectiveTest extends TestCase
 
         $this->graphQL('
         {
-            user(foo: "bar"){
+            user(foo: "dynamic"){
                 name
             }
         }

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -171,7 +171,7 @@ class CanDirectiveTest extends TestCase
         }
         ';
 
-        $this->graphQL(/** @lang GraphQL */ '
+        $this->graphQL(/* @lang GraphQL */ '
         {
             user(foo: "bar"){
                 name
@@ -205,7 +205,7 @@ class CanDirectiveTest extends TestCase
         }
         ';
 
-        $this->graphQL(/** @lang GraphQL */ '
+        $this->graphQL(/* @lang GraphQL */ '
         {
             user(foo: "dynamic"){
                 name

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -161,8 +161,8 @@ class CanDirectiveTest extends TestCase
         $this->be(new User);
         $this->schema = '
         type Query {
-            users(key1: String, key2: String, key3: String): [User]!
-                @can(ability:"severalArgs", input: true)
+            user(foo: String): User!
+                @can(ability:"severalArgs", injectArgs: true)
                 @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
         }
         
@@ -171,24 +171,20 @@ class CanDirectiveTest extends TestCase
         }
         ';
 
-        $variables = [
-            'key1' => 'foo',
-            'key2' => 'foo2',
-            'key3' => 'foo3',
-        ];
 
-        $this->postGraphQL(
-            [
-                'operationName' => 'Users',
-                'query' => 'query Users($key1: String, $key2: String, $key3: String) {
-                                users(key1: $key1, key2: $key2, key3: $key3) {
-                                    name
-                                }
-                            }
-                            ',
-                'variables' => $variables,
-            ]
-        )->assertOk();
+        $this->graphQL('
+        {
+            user(foo: "bar"){
+                name
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'user' => [
+                    'name' => 'foo',
+                ],
+            ],
+        ]);
     }
 
     public function resolveUser(): User

--- a/tests/Utils/Policies/UserPolicy.php
+++ b/tests/Utils/Policies/UserPolicy.php
@@ -35,6 +35,6 @@ class UserPolicy
 
     public function severalArgs($user, array $input): bool
     {
-        return $input['key1'] === 'foo' && $input['key2'] === 'foo2' && $input['key2'] === 'foo3';
+        return $input['foo'] === 'bar';
     }
 }

--- a/tests/Utils/Policies/UserPolicy.php
+++ b/tests/Utils/Policies/UserPolicy.php
@@ -32,4 +32,9 @@ class UserPolicy
     {
         return $pass;
     }
+
+    public function severalArgs($user, array $input): bool
+    {
+        return $input['key1'] === 'foo' && $input['key2'] === 'foo2' && $input['key2'] === 'foo3';
+    }
 }

--- a/tests/Utils/Policies/UserPolicy.php
+++ b/tests/Utils/Policies/UserPolicy.php
@@ -33,8 +33,13 @@ class UserPolicy
         return $pass;
     }
 
-    public function severalArgs($user, array $input): bool
+    public function severalArgs($user, array $injectedArgs): bool
     {
-        return $input['foo'] === 'bar';
+        return $injectedArgs['foo'] === 'bar';
+    }
+
+    public function argsWithInjectedArgs($user, array $injectedArgs, array $args): bool
+    {
+        return $args['argFoo'] === 'argBar' && $injectedArgs['foo'] === 'bar';
     }
 }

--- a/tests/Utils/Policies/UserPolicy.php
+++ b/tests/Utils/Policies/UserPolicy.php
@@ -33,13 +33,14 @@ class UserPolicy
         return $pass;
     }
 
-    public function severalArgs($user, array $injectedArgs): bool
+    public function injectArgs($user, array $injectedArgs): bool
     {
-        return $injectedArgs['foo'] === 'bar';
+        return $injectedArgs === ['foo' => 'bar'];
     }
 
-    public function argsWithInjectedArgs($user, array $injectedArgs, array $args): bool
+    public function argsWithInjectedArgs($user, array $injectedArgs, array $staticArgs): bool
     {
-        return $args['argFoo'] === 'argBar' && $injectedArgs['foo'] === 'bar';
+        return $injectedArgs === ['foo' => 'dynamic']
+            && $staticArgs === ['foo' => 'static'];
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions

Resolves #1002 
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
Added a new argument to avoid breaking changes with the current version.
Saying that I think `args` (getAdditionalArguments) is always a plain string, it doesn't have to much sense to me