### PR TITLE
Add Dark Theme for Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `syncWithoutDetaching` option for BelongsToMany and MorphToMany relationships https://github.com/nuwave/lighthouse/pull/1031
 - Add `injectArgs` option to `@can` directive to pass along client defined
   arguments to the policy check https://github.com/nuwave/lighthouse/pull/1043
+- Dark Mode support for Lighthouse Documentation when user `prefers-color-scheme` is set to `dark` https://github.com/nuwave/lighthouse/pull/1046
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `syncWithoutDetaching` option for BelongsToMany and MorphToMany relationships https://github.com/nuwave/lighthouse/pull/1031
 - Add `injectArgs` option to `@can` directive to pass along client defined
   arguments to the policy check https://github.com/nuwave/lighthouse/pull/1043
-- Dark Mode support for Lighthouse Documentation when user `prefers-color-scheme` is set to `dark` https://github.com/nuwave/lighthouse/pull/1046
 
 ### Changed
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -12,9 +12,16 @@ module.exports = {
             rel: 'stylesheet',
             type: 'text/css',
             href: 'https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,800,800i,900,900i'
-        },]
+        },],
+        ['link', {
+            rel: 'stylesheet',
+            type: 'text/css',
+            href: 'https://fonts.googleapis.com/css?family=Miriam+Libre:400,700'
+        },],
     ],
+    theme: 'default-prefers-color-scheme',
     themeConfig: {
+        defaultTheme: 'light',
         logo: '/logo.svg',
         editLinks: true, //  "Edit this page" at the bottom of each page
         lastUpdated: 'Last Updated', //  "Last Updated" at the bottom of each page

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -1,8 +1,12 @@
-@import url('https://fonts.googleapis.com/css?family=Miriam+Libre:400,700')
+:root
+    --bgColor #fbfbfb
+    --accentColor #a74ff4
+    --darken10AccentColor darken(#a74ff4, 10)
+    @media (prefers-color-scheme: dark)
+        --bgColor: #25272a;
 
 body
   font-family $secondaryFont !important
-  background-color #fbfbfb
 
 h1, h2, h3, h4, h5, h6
   font-family: $primaryFont, sans-serif

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,8 @@
         "@vuepress/plugin-back-to-top": "^1.1.0",
         "@vuepress/plugin-medium-zoom": "^1.1.0",
         "fs-extra": "^7.0.1",
-        "vuepress": "^1.0.3"
+        "vuepress": "^1.0.3",
+        "vuepress-theme-default-prefers-color-scheme": "^1.0.3"
     },
     "scripts": {
         "start": "vuepress dev .",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2205,6 +2205,13 @@ css-parse@~2.0.0:
   dependencies:
     css "^2.0.0"
 
+css-prefers-color-scheme@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz#6f830a2714199d4f0d0d0bb8a27916ed65cff1f4"
+  integrity sha512-MTu6+tMs9S3EUqzmqLXEcgNRbNkkD/TGFvowpeoWJn5Vfq7FMgsmRQs9X5NXAURiOBmOxm/lLjsDNXDE6k9bhg==
+  dependencies:
+    postcss "^7.0.5"
+
 css-select-base-adapter@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz#3b2ff4972cc362ab88561507a95408a1432135d7"
@@ -7099,6 +7106,13 @@ vuepress-plugin-container@^2.0.0:
   integrity sha512-SrGYYT7lkie7xlIlAVhn+9sDW42MytNCoxWL/2uDr+q9wZA4h1uYlQvfc2DVjy+FsM9PPPSslkeo/zCpYVY82g==
   dependencies:
     markdown-it-container "^2.0.0"
+
+vuepress-theme-default-prefers-color-scheme@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/vuepress-theme-default-prefers-color-scheme/-/vuepress-theme-default-prefers-color-scheme-1.0.3.tgz#85d5872a05b2cdc9ff3d22ba24380699f60fd3ad"
+  integrity sha512-CNu+opm+yvdObtzhxa2Mm4d3Ho9aM3NM17RKFpJ77soXeNX7muox+npKTSZiZwY685CFgFAJpSTm01/2f3aPCA==
+  dependencies:
+    css-prefers-color-scheme "^3.1.1"
 
 vuepress@^1.0.3:
   version "1.1.0"


### PR DESCRIPTION
- [x] ~~Added or updated tests~~
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Changes the Vuepress theme to be an extension of the default theme with dark mode support using prefers-color-scheme.

Other changes: 
- Switch to Vuepress theme with prefers-color-scheme / dark mode support
- Add CSS variables for lighthouse color scheme
- Migrate font @import into <head> declaration for performance

**Breaking changes**

Docs theme will change when using an OS & browser with dark mode support. Otherwise not that I'm aware of.
