### PR TITLE
Fix text color on code blocks when light color scheme is explicitly set

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -2,6 +2,7 @@
     --bgColor #fbfbfb
     --accentColor #a74ff4
     --darken10AccentColor darken(#a74ff4, 10)
+    --preTextColor white
     @media (prefers-color-scheme: dark)
         --bgColor: #25272a;
 


### PR DESCRIPTION
**Changes**

Fixes `pre` / `code` text color when light color scheme is explicitly set
