### PR TITLE
Add OBJECT to the @middleware directive

### DIFF
--- a/docs/3.7/api-reference/directives.md
+++ b/docs/3.7/api-reference/directives.md
@@ -1254,18 +1254,11 @@ directive @method(
 
 ## @middleware
 
-Run Laravel middleware for a specific field. This can be handy to reuse existing
-middleware.
-
 ```graphql
-type Query {
-    users: [User!]! @middleware(checks: ["auth:api"]) @all
-}
-```
-
-### Definition
-
-```graphql
+"""
+Run Laravel middleware for a specific field or group of fields.
+This can be handy to reuse existing HTTP middleware.
+"""
 directive @middleware(      
   """
   Specify which middleware to run. 
@@ -1273,10 +1266,8 @@ directive @middleware(
   a middleware group - or any combination of them.
   """
   checks: [String!]
-) on FIELD_DEFINITION
+) on FIELD_DEFINITION | OBJECT
 ```
-
-### Examples
 
 You can define middleware just like you would in Laravel. Pass in either a fully qualified
 class name, an alias or a middleware group - or any combination of them.

--- a/docs/4.0/api-reference/directives.md
+++ b/docs/4.0/api-reference/directives.md
@@ -1283,18 +1283,11 @@ directive @method(
 
 ## @middleware
 
-Run Laravel middleware for a specific field. This can be handy to reuse existing
-middleware.
-
 ```graphql
-type Query {
-    users: [User!]! @middleware(checks: ["auth:api"]) @all
-}
-```
-
-### Definition
-
-```graphql
+"""
+Run Laravel middleware for a specific field or group of fields.
+This can be handy to reuse existing HTTP middleware.
+"""
 directive @middleware(      
   """
   Specify which middleware to run. 
@@ -1302,10 +1295,8 @@ directive @middleware(
   a middleware group - or any combination of them.
   """
   checks: [String!]
-) on FIELD_DEFINITION
+) on FIELD_DEFINITION | OBJECT
 ```
-
-### Examples
 
 You can define middleware just like you would in Laravel. Pass in either a fully qualified
 class name, an alias or a middleware group - or any combination of them.

--- a/docs/4.1/api-reference/directives.md
+++ b/docs/4.1/api-reference/directives.md
@@ -1294,18 +1294,11 @@ directive @method(
 
 ## @middleware
 
-Run Laravel middleware for a specific field. This can be handy to reuse existing
-middleware.
-
 ```graphql
-type Query {
-    users: [User!]! @middleware(checks: ["auth:api"]) @all
-}
-```
-
-### Definition
-
-```graphql
+"""
+Run Laravel middleware for a specific field or group of fields.
+This can be handy to reuse existing HTTP middleware.
+"""
 directive @middleware(      
   """
   Specify which middleware to run. 
@@ -1313,10 +1306,8 @@ directive @middleware(
   a middleware group - or any combination of them.
   """
   checks: [String!]
-) on FIELD_DEFINITION
+) on FIELD_DEFINITION | OBJECT
 ```
-
-### Examples
 
 You can define middleware just like you would in Laravel. Pass in either a fully qualified
 class name, an alias or a middleware group - or any combination of them.

--- a/docs/4.2/api-reference/directives.md
+++ b/docs/4.2/api-reference/directives.md
@@ -1339,18 +1339,11 @@ directive @method(
 
 ## @middleware
 
-Run Laravel middleware for a specific field. This can be handy to reuse existing
-middleware.
-
 ```graphql
-type Query {
-    users: [User!]! @middleware(checks: ["auth:api"]) @all
-}
-```
-
-### Definition
-
-```graphql
+"""
+Run Laravel middleware for a specific field or group of fields.
+This can be handy to reuse existing HTTP middleware.
+"""
 directive @middleware(      
   """
   Specify which middleware to run. 
@@ -1358,10 +1351,8 @@ directive @middleware(
   a middleware group - or any combination of them.
   """
   checks: [String!]
-) on FIELD_DEFINITION
+) on FIELD_DEFINITION | OBJECT
 ```
-
-### Examples
 
 You can define middleware just like you would in Laravel. Pass in either a fully qualified
 class name, an alias or a middleware group - or any combination of them.

--- a/docs/4.3/api-reference/directives.md
+++ b/docs/4.3/api-reference/directives.md
@@ -1377,18 +1377,11 @@ directive @method(
 
 ## @middleware
 
-Run Laravel middleware for a specific field. This can be handy to reuse existing
-middleware.
-
 ```graphql
-type Query {
-    users: [User!]! @middleware(checks: ["auth:api"]) @all
-}
-```
-
-### Definition
-
-```graphql
+"""
+Run Laravel middleware for a specific field or group of fields.
+This can be handy to reuse existing HTTP middleware.
+"""
 directive @middleware(      
   """
   Specify which middleware to run. 
@@ -1396,10 +1389,8 @@ directive @middleware(
   a middleware group - or any combination of them.
   """
   checks: [String!]
-) on FIELD_DEFINITION
+) on FIELD_DEFINITION | OBJECT
 ```
-
-### Examples
 
 You can define middleware just like you would in Laravel. Pass in either a fully qualified
 class name, an alias or a middleware group - or any combination of them.

--- a/docs/4.4/api-reference/directives.md
+++ b/docs/4.4/api-reference/directives.md
@@ -1413,18 +1413,11 @@ directive @method(
 
 ## @middleware
 
-Run Laravel middleware for a specific field. This can be handy to reuse existing
-middleware.
-
 ```graphql
-type Query {
-    users: [User!]! @middleware(checks: ["auth:api"]) @all
-}
-```
-
-### Definition
-
-```graphql
+"""
+Run Laravel middleware for a specific field or group of fields.
+This can be handy to reuse existing HTTP middleware.
+"""
 directive @middleware(      
   """
   Specify which middleware to run. 
@@ -1432,10 +1425,8 @@ directive @middleware(
   a middleware group - or any combination of them.
   """
   checks: [String!]
-) on FIELD_DEFINITION
+) on FIELD_DEFINITION | OBJECT
 ```
-
-### Examples
 
 You can define middleware just like you would in Laravel. Pass in either a fully qualified
 class name, an alias or a middleware group - or any combination of them.

--- a/docs/4.5/api-reference/directives.md
+++ b/docs/4.5/api-reference/directives.md
@@ -1413,18 +1413,11 @@ directive @method(
 
 ## @middleware
 
-Run Laravel middleware for a specific field. This can be handy to reuse existing
-middleware.
-
 ```graphql
-type Query {
-    users: [User!]! @middleware(checks: ["auth:api"]) @all
-}
-```
-
-### Definition
-
-```graphql
+"""
+Run Laravel middleware for a specific field or group of fields.
+This can be handy to reuse existing HTTP middleware.
+"""
 directive @middleware(      
   """
   Specify which middleware to run. 
@@ -1432,10 +1425,8 @@ directive @middleware(
   a middleware group - or any combination of them.
   """
   checks: [String!]
-) on FIELD_DEFINITION
+) on FIELD_DEFINITION | OBJECT
 ```
-
-### Examples
 
 You can define middleware just like you would in Laravel. Pass in either a fully qualified
 class name, an alias or a middleware group - or any combination of them.

--- a/docs/4.6/api-reference/directives.md
+++ b/docs/4.6/api-reference/directives.md
@@ -1413,18 +1413,11 @@ directive @method(
 
 ## @middleware
 
-Run Laravel middleware for a specific field. This can be handy to reuse existing
-middleware.
-
 ```graphql
-type Query {
-    users: [User!]! @middleware(checks: ["auth:api"]) @all
-}
-```
-
-### Definition
-
-```graphql
+"""
+Run Laravel middleware for a specific field or group of fields.
+This can be handy to reuse existing HTTP middleware.
+"""
 directive @middleware(      
   """
   Specify which middleware to run. 
@@ -1432,10 +1425,8 @@ directive @middleware(
   a middleware group - or any combination of them.
   """
   checks: [String!]
-) on FIELD_DEFINITION
+) on FIELD_DEFINITION | OBJECT
 ```
-
-### Examples
 
 You can define middleware just like you would in Laravel. Pass in either a fully qualified
 class name, an alias or a middleware group - or any combination of them.

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -1444,18 +1444,11 @@ directive @method(
 
 ## @middleware
 
-Run Laravel middleware for a specific field. This can be handy to reuse existing
-middleware.
-
 ```graphql
-type Query {
-    users: [User!]! @middleware(checks: ["auth:api"]) @all
-}
-```
-
-### Definition
-
-```graphql
+"""
+Run Laravel middleware for a specific field or group of fields.
+This can be handy to reuse existing HTTP middleware.
+"""
 directive @middleware(      
   """
   Specify which middleware to run. 
@@ -1463,10 +1456,8 @@ directive @middleware(
   a middleware group - or any combination of them.
   """
   checks: [String!]
-) on FIELD_DEFINITION
+) on FIELD_DEFINITION | OBJECT
 ```
-
-### Examples
 
 You can define middleware just like you would in Laravel. Pass in either a fully qualified
 class name, an alias or a middleware group - or any combination of them.

--- a/src/Schema/Directives/MiddlewareDirective.php
+++ b/src/Schema/Directives/MiddlewareDirective.php
@@ -83,7 +83,7 @@ directive @middleware(
   a middleware group - or any combination of them.
   """
   checks: [String!]
-) on FIELD_DEFINITION
+) on FIELD_DEFINITION | OBJECT
 SDL;
     }
 

--- a/src/Schema/Directives/MiddlewareDirective.php
+++ b/src/Schema/Directives/MiddlewareDirective.php
@@ -76,9 +76,13 @@ class MiddlewareDirective extends BaseDirective implements FieldMiddleware, Type
     public static function definition(): string
     {
         return /* @lang GraphQL */ <<<'SDL'
-directive @middleware(      
+"""
+Run Laravel middleware for a specific field or group of fields.
+This can be handy to reuse existing HTTP middleware.
+"""
+directive @middleware(
   """
-  Specify which middleware to run. 
+  Specify which middleware to run.
   Pass in either a fully qualified class name, an alias or
   a middleware group - or any combination of them.
   """


### PR DESCRIPTION
In some IDEs such as PHPStorm, when the middleware directive is used when extending the Query type for example, and error is shown because the directive is only defined on FIELD_DEFINITION.

Example: given the following

```
extend type Query @middleware(checks: ["auth:api"]) {}
```

The error shown is `Query' [@1:1] tried to use a directive 'middleware' in the 'OBJECT' location but that is illegal`

Adding OBJECT to the definition fixes this.
