### PR TITLE
Avoid old dependencies in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_install:
 install:
   - if [[ $LARAVEL = '5.5.*' ]]; then composer remove --dev nunomaduro/larastan --no-update; fi
   - composer require "illuminate/contracts:${LARAVEL}" --no-interaction --prefer-dist --no-interaction --no-suggest
-  - composer update
 
 script: vendor/bin/phpunit --colors=always --verbose
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
 install:
   - if [[ $LARAVEL = '5.5.*' ]]; then composer remove --dev nunomaduro/larastan --no-update; fi
   - composer require "illuminate/contracts:${LARAVEL}" --no-interaction --prefer-dist --no-interaction --no-suggest
+  - composer update
 
 script: vendor/bin/phpunit --colors=always --verbose
 

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "orchestra/database": "3.5.* || 3.6.* || 3.7.* || 3.8.* || 3.9.* || ^4.0",
         "orchestra/testbench": "3.5.* || 3.6.* || 3.7.* || 3.8.* || 3.9.* || ^4.0",
         "phpbench/phpbench": "@dev",
+        "phpunit/phpunit": "^6.5 || ^7.5 || ^8.4",
         "pusher/pusher-php-server": "^3.2"
     },
     "suggest": {


### PR DESCRIPTION
Sometime in the last few weeks, travis seems to have changed and now defaults to lower dependencies. This causes a test failure when running against Laravel `5.5.*`.

```
0.16s$ if [[ $LARAVEL = '5.5.*' ]]; then composer remove --dev nunomaduro/larastan --no-update; fi
install.2
61.81s$ composer require "illuminate/contracts:${LARAVEL}" --no-interaction --prefer-dist --no-interaction --no-suggest
36.16s$ vendor/bin/phpunit --colors=always --verbose
PHPUnit 6.0.8 by Sebastian Bergmann and contributors.
Runtime:       PHP 7.1.27
Configuration: /home/travis/build/nuwave/lighthouse/phpunit.xml.dist
...............................................................  63 / 527 ( 11%)
..EE..S..................................................E..... 126 / 527 ( 23%)
......................................E........................ 189 / 527 ( 35%)
................E.............................................. 252 / 527 ( 47%)
............................................................... 315 / 527 ( 59%)
...............................................E............... 378 / 527 ( 71%)
....................................E.......................... 441 / 527 ( 83%)
................S.........S..E................................. 504 / 527 ( 95%)
...........SS..........                                         527 / 527 (100%)
Time: 36.05 seconds, Memory: 48.00MB
There were 8 errors:
1) Tests\Unit\Schema\Directives\BcryptDirectiveTest::testCanBcryptAnArgument
TypeError: Return value of Tests\TestCase::mockResolver() must be an instance of PHPUnit\Framework\MockObject\Builder\InvocationMocker, instance of PHPUnit_Framework_MockObject_Builder_InvocationMocker returned
```
