### PR TITLE
Throw DefinitionException when missing a type in the type registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add ability to fetch soft deleted model within `@can` directive to validate permissions
   using `@softDeletes` directive. https://github.com/nuwave/lighthouse/pull/1042
 - Improve the error message for missing field resolvers by offering a solution https://github.com/nuwave/lighthouse/pull/1045
+- Throw `DefinitionException` when missing a type in the type registry https://github.com/nuwave/lighthouse/pull/1066
 
 ## [4.6.0](https://github.com/nuwave/lighthouse/compare/v4.5.3...v4.6.0)
 

--- a/src/Schema/TypeRegistry.php
+++ b/src/Schema/TypeRegistry.php
@@ -99,7 +99,7 @@ class TypeRegistry
     {
         if (! isset($this->types[$name])) {
             $typeDefinition = $this->documentAST->types[$name] ?? null;
-            if(!$typeDefinition) {
+            if (! $typeDefinition) {
                 throw new DefinitionException(<<<EOL
 Lighthouse failed while trying to load a type: $name
 

--- a/src/Schema/TypeRegistry.php
+++ b/src/Schema/TypeRegistry.php
@@ -92,13 +92,24 @@ class TypeRegistry
      *
      * @param  string  $name
      * @return \GraphQL\Type\Definition\Type
+     *
+     * @throws \Nuwave\Lighthouse\Exceptions\DefinitionException
      */
     public function get(string $name): Type
     {
         if (! isset($this->types[$name])) {
-            $this->types[$name] = $this->handle(
-                $this->documentAST->types[$name]
-            );
+            $typeDefinition = $this->documentAST->types[$name] ?? null;
+            if(!$typeDefinition) {
+                throw new DefinitionException(<<<EOL
+Lighthouse failed while trying to load a type: $name
+
+Make sure the type is present in your schema definition.
+
+EOL
+                );
+            }
+
+            $this->types[$name] = $this->handle($typeDefinition);
         }
 
         return $this->types[$name];

--- a/tests/Unit/Schema/TypeRegistryTest.php
+++ b/tests/Unit/Schema/TypeRegistryTest.php
@@ -9,6 +9,7 @@ use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\UnionType;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\AST\PartialParser;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
 use Tests\TestCase;
@@ -179,5 +180,11 @@ class TypeRegistryTest extends TestCase
         $this->assertInstanceOf(InputObjectType::class, $inputObjectType);
         $this->assertSame('UserInput', $inputObjectType->name);
         $this->assertArrayHasKey('foo', $inputObjectType->getFields());
+    }
+
+    public function testThrowsWhenMissingType(): void
+    {
+        $this->expectException(DefinitionException::class);
+        $this->typeRegistry->get('ThisTypeDoesNotExist');
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

**Changes**

Throw a descriptive error instead of getting an `Undefined index`.

**Breaking changes**

No.
