### PR TITLE
Add INPUT_FIELD_DEFINITION to orderBy directive location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   using `@softDeletes` directive. https://github.com/nuwave/lighthouse/pull/1042
 - Improve the error message for missing field resolvers by offering a solution https://github.com/nuwave/lighthouse/pull/1045
 - Throw `DefinitionException` when missing a type in the type registry https://github.com/nuwave/lighthouse/pull/1066
+- Add `INPUT_FIELD_DEFINITION` to `orderBy` directive location https://github.com/nuwave/lighthouse/pull/1069
 
 ## [4.6.0](https://github.com/nuwave/lighthouse/compare/v4.5.3...v4.6.0)
 

--- a/docs/3.7/api-reference/directives.md
+++ b/docs/3.7/api-reference/directives.md
@@ -1433,7 +1433,7 @@ type Query {
 ### Definition
 
 ```graphql
-directive @orderBy on ARGUMENT_DEFINITION
+directive @orderBy on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 The `OrderByClause` input is automatically added to the schema,
@@ -1469,6 +1469,38 @@ Querying a field that has an `orderBy` argument looks like this:
 ```
 
 You may pass more than one sorting option to add a secondary ordering.
+
+### Input Definition Example
+
+The `@orderBy` directive can also be applied inside an input field definition when used in conjunction with the [`@spread`](#spread) directive. See below for example: 
+
+```graphql
+type Query{
+    posts(filter: PostFilterInput @spread): Posts
+}
+
+input PostFilterInput {
+    orderBy: [OrderByClause!] @orderBy
+}
+```
+
+And usage example:
+
+```graphql
+{
+    posts(filter: {
+        orderBy: [
+            {
+                field: "postedAt"
+                order: ASC
+            }    
+        ]       
+    }) {
+        title
+    }
+}
+```
+
 
 ## @paginate
 

--- a/docs/4.0/api-reference/directives.md
+++ b/docs/4.0/api-reference/directives.md
@@ -1498,7 +1498,7 @@ type Query {
 ### Definition
 
 ```graphql
-directive @orderBy on ARGUMENT_DEFINITION
+directive @orderBy on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 The `OrderByClause` input is automatically added to the schema,
@@ -1534,6 +1534,38 @@ Querying a field that has an `orderBy` argument looks like this:
 ```
 
 You may pass more than one sorting option to add a secondary ordering.
+
+### Input Definition Example
+
+The `@orderBy` directive can also be applied inside an input field definition when used in conjunction with the [`@spread`](#spread) directive. See below for example: 
+
+```graphql
+type Query{
+    posts(filter: PostFilterInput @spread): Posts
+}
+
+input PostFilterInput {
+    orderBy: [OrderByClause!] @orderBy
+}
+```
+
+And usage example:
+
+```graphql
+{
+    posts(filter: {
+        orderBy: [
+            {
+                field: "postedAt"
+                order: ASC
+            }    
+        ]       
+    }) {
+        title
+    }
+}
+```
+
 
 ## @paginate
 

--- a/docs/4.1/api-reference/directives.md
+++ b/docs/4.1/api-reference/directives.md
@@ -1513,7 +1513,7 @@ type Query {
 """
 Sort a result list by one or more given fields.
 """
-directive @orderBy on ARGUMENT_DEFINITION
+directive @orderBy on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 The `OrderByClause` input is automatically added to the schema,
@@ -1549,6 +1549,38 @@ Querying a field that has an `orderBy` argument looks like this:
 ```
 
 You may pass more than one sorting option to add a secondary ordering.
+
+### Input Definition Example
+
+The `@orderBy` directive can also be applied inside an input field definition when used in conjunction with the [`@spread`](#spread) directive. See below for example: 
+
+```graphql
+type Query{
+    posts(filter: PostFilterInput @spread): Posts
+}
+
+input PostFilterInput {
+    orderBy: [OrderByClause!] @orderBy
+}
+```
+
+And usage example:
+
+```graphql
+{
+    posts(filter: {
+        orderBy: [
+            {
+                field: "postedAt"
+                order: ASC
+            }    
+        ]       
+    }) {
+        title
+    }
+}
+```
+
 
 ## @paginate
 

--- a/docs/4.2/api-reference/directives.md
+++ b/docs/4.2/api-reference/directives.md
@@ -1695,7 +1695,7 @@ type Query {
 ### Definition
 
 ```graphql
-directive @orderBy on ARGUMENT_DEFINITION
+directive @orderBy on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 The `OrderByClause` input is automatically added to the schema,
@@ -1731,6 +1731,38 @@ Querying a field that has an `orderBy` argument looks like this:
 ```
 
 You may pass more than one sorting option to add a secondary ordering.
+
+### Input Definition Example
+
+The `@orderBy` directive can also be applied inside an input field definition when used in conjunction with the [`@spread`](#spread) directive. See below for example: 
+
+```graphql
+type Query{
+    posts(filter: PostFilterInput @spread): Posts
+}
+
+input PostFilterInput {
+    orderBy: [OrderByClause!] @orderBy
+}
+```
+
+And usage example:
+
+```graphql
+{
+    posts(filter: {
+        orderBy: [
+            {
+                field: "postedAt"
+                order: ASC
+            }    
+        ]       
+    }) {
+        title
+    }
+}
+```
+
 
 ## @paginate
 

--- a/docs/4.3/api-reference/directives.md
+++ b/docs/4.3/api-reference/directives.md
@@ -1733,7 +1733,7 @@ type Query {
 ### Definition
 
 ```graphql
-directive @orderBy on ARGUMENT_DEFINITION
+directive @orderBy on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 The `OrderByClause` input is automatically added to the schema,
@@ -1769,6 +1769,38 @@ Querying a field that has an `orderBy` argument looks like this:
 ```
 
 You may pass more than one sorting option to add a secondary ordering.
+
+### Input Definition Example
+
+The `@orderBy` directive can also be applied inside an input field definition when used in conjunction with the [`@spread`](#spread) directive. See below for example: 
+
+```graphql
+type Query{
+    posts(filter: PostFilterInput @spread): Posts
+}
+
+input PostFilterInput {
+    orderBy: [OrderByClause!] @orderBy
+}
+```
+
+And usage example:
+
+```graphql
+{
+    posts(filter: {
+        orderBy: [
+            {
+                field: "postedAt"
+                order: ASC
+            }    
+        ]       
+    }) {
+        title
+    }
+}
+```
+
 
 ## @paginate
 

--- a/docs/4.4/api-reference/directives.md
+++ b/docs/4.4/api-reference/directives.md
@@ -1809,7 +1809,7 @@ type Query {
 ### Definition
 
 ```graphql
-directive @orderBy on ARGUMENT_DEFINITION
+directive @orderBy on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 The `OrderByClause` input is automatically added to the schema,
@@ -1845,6 +1845,38 @@ Querying a field that has an `orderBy` argument looks like this:
 ```
 
 You may pass more than one sorting option to add a secondary ordering.
+
+### Input Definition Example
+
+The `@orderBy` directive can also be applied inside an input field definition when used in conjunction with the [`@spread`](#spread) directive. See below for example: 
+
+```graphql
+type Query{
+    posts(filter: PostFilterInput @spread): Posts
+}
+
+input PostFilterInput {
+    orderBy: [OrderByClause!] @orderBy
+}
+```
+
+And usage example:
+
+```graphql
+{
+    posts(filter: {
+        orderBy: [
+            {
+                field: "postedAt"
+                order: ASC
+            }    
+        ]       
+    }) {
+        title
+    }
+}
+```
+
 
 ## @paginate
 

--- a/docs/4.5/api-reference/directives.md
+++ b/docs/4.5/api-reference/directives.md
@@ -1809,7 +1809,7 @@ type Query {
 ### Definition
 
 ```graphql
-directive @orderBy on ARGUMENT_DEFINITION
+directive @orderBy on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 The `OrderByClause` input is automatically added to the schema,
@@ -1845,6 +1845,38 @@ Querying a field that has an `orderBy` argument looks like this:
 ```
 
 You may pass more than one sorting option to add a secondary ordering.
+
+### Input Definition Example
+
+The `@orderBy` directive can also be applied inside an input field definition when used in conjunction with the [`@spread`](#spread) directive. See below for example: 
+
+```graphql
+type Query{
+    posts(filter: PostFilterInput @spread): Posts
+}
+
+input PostFilterInput {
+    orderBy: [OrderByClause!] @orderBy
+}
+```
+
+And usage example:
+
+```graphql
+{
+    posts(filter: {
+        orderBy: [
+            {
+                field: "postedAt"
+                order: ASC
+            }    
+        ]       
+    }) {
+        title
+    }
+}
+```
+
 
 ## @paginate
 

--- a/docs/4.6/api-reference/directives.md
+++ b/docs/4.6/api-reference/directives.md
@@ -1809,7 +1809,7 @@ type Query {
 ### Definition
 
 ```graphql
-directive @orderBy on ARGUMENT_DEFINITION
+directive @orderBy on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 The `OrderByClause` input is automatically added to the schema,
@@ -1845,6 +1845,38 @@ Querying a field that has an `orderBy` argument looks like this:
 ```
 
 You may pass more than one sorting option to add a secondary ordering.
+
+### Input Definition Example
+
+The `@orderBy` directive can also be applied inside an input field definition when used in conjunction with the [`@spread`](#spread) directive. See below for example: 
+
+```graphql
+type Query{
+    posts(filter: PostFilterInput @spread): Posts
+}
+
+input PostFilterInput {
+    orderBy: [OrderByClause!] @orderBy
+}
+```
+
+And usage example:
+
+```graphql
+{
+    posts(filter: {
+        orderBy: [
+            {
+                field: "postedAt"
+                order: ASC
+            }    
+        ]       
+    }) {
+        title
+    }
+}
+```
+
 
 ## @paginate
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -1840,7 +1840,7 @@ type Query {
 ### Definition
 
 ```graphql
-directive @orderBy on ARGUMENT_DEFINITION
+directive @orderBy on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 The `OrderByClause` input is automatically added to the schema,
@@ -1876,6 +1876,37 @@ Querying a field that has an `orderBy` argument looks like this:
 ```
 
 You may pass more than one sorting option to add a secondary ordering.
+
+### Input Definition Example
+
+The `@orderBy` directive can also be applied inside an input field definition when used in conjunction with the [`@spread`](#spread) directive. See below for example: 
+
+```graphql
+type Query{
+    posts(filter: PostFilterInput @spread): Posts
+}
+
+input PostFilterInput {
+    orderBy: [OrderByClause!] @orderBy
+}
+```
+
+And usage example:
+
+```graphql
+{
+    posts(filter: {
+        orderBy: [
+            {
+                field: "postedAt"
+                order: ASC
+            }    
+        ]       
+    }) {
+        title
+    }
+}
+```
 
 ## @paginate
 

--- a/src/Schema/Directives/OrderByDirective.php
+++ b/src/Schema/Directives/OrderByDirective.php
@@ -31,7 +31,7 @@ class OrderByDirective implements ArgBuilderDirective, ArgDirectiveForArray, Arg
 """
 Sort a result list by one or more given fields.
 """
-directive @orderBy on ARGUMENT_DEFINITION
+directive @orderBy on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 SDL;
     }
 


### PR DESCRIPTION
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

Resolves #1048 

**Changes**

Adds `INPUT_FIELD_DEFINITION` to the directive location for `orderBy` directive and provides example on how to use.

**Breaking changes**

None.
