### PR TITLE
Add `INPUT_FIELD_DEFINITION` to allowed locations for the `@builder` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add `INPUT_FIELD_DEFINITION` to `builder` directive location https://github.com/nuwave/lighthouse/pull/1074
+- Add `INPUT_FIELD_DEFINITION` to allowed locations for the `@builder` directive https://github.com/nuwave/lighthouse/pull/1074
 
 ## [4.7.0](https://github.com/nuwave/lighthouse/compare/v4.6.0...v4.7.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/nuwave/lighthouse/compare/v4.7.0...master)
 
+### Changed
+
+- Add `INPUT_FIELD_DEFINITION` to `builder` directive location https://github.com/nuwave/lighthouse/pull/1074
+
 ## [4.7.0](https://github.com/nuwave/lighthouse/compare/v4.6.0...v4.7.0)
 
 ### Added

--- a/docs/4.1/api-reference/directives.md
+++ b/docs/4.1/api-reference/directives.md
@@ -340,7 +340,7 @@ directive @builder(
   If you pass only a class name, the method name defaults to `__invoke`.
   """
   method: String!
-) on ARGUMENT_DEFINITION
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 ## @cache

--- a/docs/4.2/api-reference/directives.md
+++ b/docs/4.2/api-reference/directives.md
@@ -352,7 +352,7 @@ directive @builder(
   If you pass only a class name, the method name defaults to `__invoke`.
   """
   method: String!
-) on ARGUMENT_DEFINITION
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 ## @cache

--- a/docs/4.3/api-reference/directives.md
+++ b/docs/4.3/api-reference/directives.md
@@ -352,7 +352,7 @@ directive @builder(
   If you pass only a class name, the method name defaults to `__invoke`.
   """
   method: String!
-) on ARGUMENT_DEFINITION
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 ## @cache

--- a/docs/4.4/api-reference/directives.md
+++ b/docs/4.4/api-reference/directives.md
@@ -352,7 +352,7 @@ directive @builder(
   If you pass only a class name, the method name defaults to `__invoke`.
   """
   method: String!
-) on ARGUMENT_DEFINITION
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 ## @cache

--- a/docs/4.5/api-reference/directives.md
+++ b/docs/4.5/api-reference/directives.md
@@ -352,7 +352,7 @@ directive @builder(
   If you pass only a class name, the method name defaults to `__invoke`.
   """
   method: String!
-) on ARGUMENT_DEFINITION
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 ## @cache

--- a/docs/4.6/api-reference/directives.md
+++ b/docs/4.6/api-reference/directives.md
@@ -352,7 +352,7 @@ directive @builder(
   If you pass only a class name, the method name defaults to `__invoke`.
   """
   method: String!
-) on ARGUMENT_DEFINITION
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 ## @cache

--- a/docs/4.7/api-reference/directives.md
+++ b/docs/4.7/api-reference/directives.md
@@ -352,7 +352,7 @@ directive @builder(
   If you pass only a class name, the method name defaults to `__invoke`.
   """
   method: String!
-) on ARGUMENT_DEFINITION
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 ## @cache

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -352,7 +352,7 @@ directive @builder(
   If you pass only a class name, the method name defaults to `__invoke`.
   """
   method: String!
-) on ARGUMENT_DEFINITION
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 ## @cache

--- a/src/Schema/Directives/BuilderDirective.php
+++ b/src/Schema/Directives/BuilderDirective.php
@@ -30,7 +30,7 @@ directive @builder(
   If you pass only a class name, the method name defaults to `__invoke`.
   """
   method: String!
-) on ARGUMENT_DEFINITION
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 SDL;
     }
 


### PR DESCRIPTION
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

**Changes**

Adds `INPUT_FIELD_DEFINITION ` to `@builder` directive location for use with `@spread`.
