### PR TITLE
Validate at schema build time that the `apply` argument `@rules` is an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `\Nuwave\Lighthouse\Support\Contracts\ArgResolver` directive interface https://github.com/nuwave/lighthouse/pull/899
 - Allow existing mutation directives `@create`, `@update`, `@upsert` and `@delete` to function
   as nested arg resolvers https://github.com/nuwave/lighthouse/pull/899
+- Validate at schema build time that the `apply` argument `@rules` is an array https://github.com/nuwave/lighthouse/pull/1092
 
 ### Changed
 

--- a/src/Schema/Directives/RulesDirective.php
+++ b/src/Schema/Directives/RulesDirective.php
@@ -94,7 +94,7 @@ SDL;
     ) {
         $rules = $this->directiveArgValue('apply');
 
-        if(!is_array($rules)) {
+        if (! is_array($rules)) {
             throw new DefinitionException("The apply argument of @rules on has to be an array, got: {$rules}");
         }
     }

--- a/src/Schema/Directives/RulesDirective.php
+++ b/src/Schema/Directives/RulesDirective.php
@@ -2,14 +2,20 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives;
 
+use GraphQL\Language\AST\FieldDefinitionNode;
+use GraphQL\Language\AST\InputValueDefinitionNode;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Illuminate\Support\Collection;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Support\Contracts\ArgDirective;
+use Nuwave\Lighthouse\Support\Contracts\ArgManipulator;
 use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
 use Nuwave\Lighthouse\Support\Contracts\HasArgumentPath as HasArgumentPathContract;
 use Nuwave\Lighthouse\Support\Contracts\ProvidesRules;
 use Nuwave\Lighthouse\Support\Traits\HasArgumentPath as HasArgumentPathTrait;
 
-class RulesDirective extends BaseDirective implements ArgDirective, ProvidesRules, HasArgumentPathContract, DefinedDirective
+class RulesDirective extends BaseDirective implements ArgDirective, ProvidesRules, HasArgumentPathContract, DefinedDirective, ArgManipulator
 {
     use HasArgumentPathTrait;
 
@@ -78,5 +84,18 @@ SDL;
                 return ["{$argumentPath}.{$rule}" => $message];
             })
             ->all();
+    }
+
+    public function manipulateArgDefinition(
+        DocumentAST &$documentAST,
+        InputValueDefinitionNode &$argDefinition,
+        FieldDefinitionNode &$parentField,
+        ObjectTypeDefinitionNode &$parentType
+    ) {
+        $rules = $this->directiveArgValue('apply');
+
+        if(!is_array($rules)) {
+            throw new DefinitionException("The apply argument of @rules on has to be an array, got: {$rules}");
+        }
     }
 }

--- a/tests/Unit/Schema/Directives/RulesDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/RulesDirectiveTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Schema\Directives;
 
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Tests\TestCase;
 use Tests\Utils\Rules\FooBarRule;
 
@@ -344,5 +345,15 @@ GRAPHQL)
                     FooBarRule::MESSAGE,
                 ],
             ]);
+    }
+
+    public function testRulesHaveToBeArray(): void
+    {
+        $this->expectException(DefinitionException::class);
+        $this->buildSchema(/** @lang GraphQL */'
+        type Query {
+            foo(bar: ID @rules(apply: 123)): ID
+        }
+        ');
     }
 }

--- a/tests/Unit/Schema/Directives/RulesDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/RulesDirectiveTest.php
@@ -350,7 +350,7 @@ GRAPHQL)
     public function testRulesHaveToBeArray(): void
     {
         $this->expectException(DefinitionException::class);
-        $this->buildSchema(/** @lang GraphQL */'
+        $this->buildSchema(/* @lang GraphQL */'
         type Query {
             foo(bar: ID @rules(apply: 123)): ID
         }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

**Changes**

This reifies the fact that passing rules as an array is the only valid syntax: `@rules(apply: ["min:3"])`.

**Breaking changes**

No, this only uncovers latent bugs.