### PR TITLE
Fix Post's author relation

### DIFF
--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -307,9 +307,9 @@ naming - the type name `Post` is also the name of our Model - and the use of ser
 We add additional type definitions that clearly define the shape of our data: 
 
 ```graphql
-type Query{
+type Query {
     posts: [Post!]! @all
-    post (id: Int! @eq): Post @find
+    post(id: Int! @eq): Post @find
 }
 
 type User {
@@ -329,7 +329,7 @@ type Post {
     comments: [Comment!]! @hasMany
 }
 
-type Comment{
+type Comment {
     id: ID!
     reply: String!
     post: Post! @belongsTo

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -190,7 +190,7 @@ class CreatePostsTable extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
-            $table->unsignedInteger('user_id');
+            $table->unsignedInteger('author_id');
             $table->string('title');
             $table->string('content');
             $table->timestamps();
@@ -278,7 +278,7 @@ class User extends Authenticatable
 
     public function posts(): HasMany
     {
-        return $this->hasMany(Post::class);
+        return $this->hasMany(Post::class, 'author_id');
     }
 }
 ```


### PR DESCRIPTION
The Post's relation `author` does not work unless you specify the `$foreignKey`. Without it, it will try to guess the foreign key based on the method name (author) so it  will try to find `author_id` instead.

The linked repo does not seem to match the tutorial: https://github.com/nuwave/lighthouse-tutorial/blame/master/app/Post.php#L9-L12

N/A

- ~[ ] Added or updated tests~
- ~[ ] Added Docs for all relevant versions~
- ~[ ] Updated CHANGELOG.md~

**Changes**

Fixed relation issue in tutorial.

**Breaking changes**

N/A
