### PR TITLE
Unify PHPDoc comments

### DIFF
--- a/benchmarks/ASTUnserializationBench.php
+++ b/benchmarks/ASTUnserializationBench.php
@@ -10,8 +10,7 @@ use Nuwave\Lighthouse\Schema\AST\DocumentAST;
  */
 class ASTUnserializationBench
 {
-    const SCHEMA = /* @lang GraphQL */
-        <<<'SCHEMA'
+    const SCHEMA = /** @lang GraphQL */ <<<'SCHEMA'
 type Query {
   query1: String
   query2: String

--- a/docs/3.7/testing/phpunit.md
+++ b/docs/3.7/testing/phpunit.md
@@ -139,7 +139,7 @@ helper method.
 ```php
 $this->multipartGraphQL(
     [
-        'operations' => /* @lang JSON */
+        'operations' => /** @lang JSON */
             '
             {
                 "query": "mutation Upload($file: Upload!) { upload(file: $file) }",
@@ -148,7 +148,7 @@ $this->multipartGraphQL(
                 }
             }
         ',
-        'map' => /* @lang JSON */
+        'map' => /** @lang JSON */
             '
             {
                 "0": ["variables.file"]

--- a/docs/4.0/testing/phpunit.md
+++ b/docs/4.0/testing/phpunit.md
@@ -139,7 +139,7 @@ helper method.
 ```php
 $this->multipartGraphQL(
     [
-        'operations' => /* @lang JSON */
+        'operations' => /** @lang JSON */
             '
             {
                 "query": "mutation Upload($file: Upload!) { upload(file: $file) }",
@@ -148,7 +148,7 @@ $this->multipartGraphQL(
                 }
             }
         ',
-        'map' => /* @lang JSON */
+        'map' => /** @lang JSON */
             '
             {
                 "0": ["variables.file"]

--- a/docs/4.1/testing/phpunit.md
+++ b/docs/4.1/testing/phpunit.md
@@ -139,7 +139,7 @@ helper method.
 ```php
 $this->multipartGraphQL(
     [
-        'operations' => /* @lang JSON */
+        'operations' => /** @lang JSON */
             '
             {
                 "query": "mutation Upload($file: Upload!) { upload(file: $file) }",
@@ -148,7 +148,7 @@ $this->multipartGraphQL(
                 }
             }
         ',
-        'map' => /* @lang JSON */
+        'map' => /** @lang JSON */
             '
             {
                 "0": ["variables.file"]

--- a/docs/4.2/testing/phpunit.md
+++ b/docs/4.2/testing/phpunit.md
@@ -139,7 +139,7 @@ helper method.
 ```php
 $this->multipartGraphQL(
     [
-        'operations' => /* @lang JSON */
+        'operations' => /** @lang JSON */
             '
             {
                 "query": "mutation Upload($file: Upload!) { upload(file: $file) }",
@@ -148,7 +148,7 @@ $this->multipartGraphQL(
                 }
             }
         ',
-        'map' => /* @lang JSON */
+        'map' => /** @lang JSON */
             '
             {
                 "0": ["variables.file"]

--- a/docs/4.3/testing/phpunit.md
+++ b/docs/4.3/testing/phpunit.md
@@ -139,7 +139,7 @@ helper method.
 ```php
 $this->multipartGraphQL(
     [
-        'operations' => /* @lang JSON */
+        'operations' => /** @lang JSON */
             '
             {
                 "query": "mutation Upload($file: Upload!) { upload(file: $file) }",
@@ -148,7 +148,7 @@ $this->multipartGraphQL(
                 }
             }
         ',
-        'map' => /* @lang JSON */
+        'map' => /** @lang JSON */
             '
             {
                 "0": ["variables.file"]

--- a/docs/4.4/testing/phpunit.md
+++ b/docs/4.4/testing/phpunit.md
@@ -139,7 +139,7 @@ helper method.
 ```php
 $this->multipartGraphQL(
     [
-        'operations' => /* @lang JSON */
+        'operations' => /** @lang JSON */
             '
             {
                 "query": "mutation Upload($file: Upload!) { upload(file: $file) }",
@@ -148,7 +148,7 @@ $this->multipartGraphQL(
                 }
             }
         ',
-        'map' => /* @lang JSON */
+        'map' => /** @lang JSON */
             '
             {
                 "0": ["variables.file"]

--- a/docs/4.5/testing/phpunit.md
+++ b/docs/4.5/testing/phpunit.md
@@ -139,7 +139,7 @@ helper method.
 ```php
 $this->multipartGraphQL(
     [
-        'operations' => /* @lang JSON */
+        'operations' => /** @lang JSON */
             '
             {
                 "query": "mutation Upload($file: Upload!) { upload(file: $file) }",
@@ -148,7 +148,7 @@ $this->multipartGraphQL(
                 }
             }
         ',
-        'map' => /* @lang JSON */
+        'map' => /** @lang JSON */
             '
             {
                 "0": ["variables.file"]

--- a/docs/4.6/testing/phpunit.md
+++ b/docs/4.6/testing/phpunit.md
@@ -139,7 +139,7 @@ helper method.
 ```php
 $this->multipartGraphQL(
     [
-        'operations' => /* @lang JSON */
+        'operations' => /** @lang JSON */
             '
             {
                 "query": "mutation Upload($file: Upload!) { upload(file: $file) }",
@@ -148,7 +148,7 @@ $this->multipartGraphQL(
                 }
             }
         ',
-        'map' => /* @lang JSON */
+        'map' => /** @lang JSON */
             '
             {
                 "0": ["variables.file"]

--- a/docs/4.7/testing/phpunit.md
+++ b/docs/4.7/testing/phpunit.md
@@ -139,7 +139,7 @@ helper method.
 ```php
 $this->multipartGraphQL(
     [
-        'operations' => /* @lang JSON */
+        'operations' => /** @lang JSON */
             '
             {
                 "query": "mutation Upload($file: Upload!) { upload(file: $file) }",
@@ -148,7 +148,7 @@ $this->multipartGraphQL(
                 }
             }
         ',
-        'map' => /* @lang JSON */
+        'map' => /** @lang JSON */
             '
             {
                 "0": ["variables.file"]

--- a/docs/master/custom-directives/argument-directives.md
+++ b/docs/master/custom-directives/argument-directives.md
@@ -31,7 +31,7 @@ class TrimDirective extends BaseDirective implements ArgTransformerDirective, De
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Run the `trim` function on an input value.
 """
@@ -140,7 +140,7 @@ class EqDirective extends BaseDirective implements ArgBuilderDirective, DefinedD
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 directive @eq(  
   """
   Specify the database column to compare. 
@@ -232,7 +232,7 @@ class ModelArgsDirective extends BaseDirective implements ArgManipulator, Define
      */
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Automatically generates an input argument based on a type.
 """

--- a/docs/master/testing/phpunit.md
+++ b/docs/master/testing/phpunit.md
@@ -136,7 +136,7 @@ helper method.
 ```php
 $this->multipartGraphQL(
     [
-        'operations' => /* @lang JSON */
+        'operations' => /** @lang JSON */
             '
             {
                 "query": "mutation Upload($file: Upload!) { upload(file: $file) }",
@@ -145,7 +145,7 @@ $this->multipartGraphQL(
                 }
             }
         ',
-        'map' => /* @lang JSON */
+        'map' => /** @lang JSON */
             '
             {
                 "0": ["variables.file"]

--- a/src/Defer/DeferrableDirective.php
+++ b/src/Defer/DeferrableDirective.php
@@ -21,7 +21,7 @@ class DeferrableDirective extends BaseDirective implements DefinedDirective, Fie
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Do not use this directive directly, it is automatically added to the schema
 when using the defer extension.

--- a/src/Execution/Arguments/NestedOneToOne.php
+++ b/src/Execution/Arguments/NestedOneToOne.php
@@ -26,7 +26,7 @@ class NestedOneToOne implements ArgResolver
         /** @var \Illuminate\Database\Eloquent\Relations\HasOne|\Illuminate\Database\Eloquent\Relations\MorphOne $relation */
         $relation = $parent->{$this->relationName}();
 
-        /* @var \Nuwave\Lighthouse\Execution\Arguments\Argument|null $create */
+        /** @var \Nuwave\Lighthouse\Execution\Arguments\Argument|null $create */
         if (isset($args->arguments['create'])) {
             $saveModel = new ResolveNested(new SaveModel($relation));
 

--- a/src/OrderBy/OrderByDirective.php
+++ b/src/OrderBy/OrderByDirective.php
@@ -19,7 +19,7 @@ class OrderByDirective extends BaseDirective implements ArgBuilderDirective, Arg
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Sort a result list by one or more given columns.
 """

--- a/src/Schema/Directives/AllDirective.php
+++ b/src/Schema/Directives/AllDirective.php
@@ -13,7 +13,7 @@ class AllDirective extends BaseDirective implements DefinedDirective, FieldResol
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 directive @all(
   """
   Specify the class name of the model to use.

--- a/src/Schema/Directives/AuthDirective.php
+++ b/src/Schema/Directives/AuthDirective.php
@@ -28,7 +28,7 @@ class AuthDirective extends BaseDirective implements DefinedDirective, FieldReso
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Return the currently authenticated user as the result of a query.
 """

--- a/src/Schema/Directives/BcryptDirective.php
+++ b/src/Schema/Directives/BcryptDirective.php
@@ -9,7 +9,7 @@ class BcryptDirective extends BaseDirective implements ArgTransformerDirective, 
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Run the `bcrypt` function on the argument it is defined on.
 """

--- a/src/Schema/Directives/BelongsToDirective.php
+++ b/src/Schema/Directives/BelongsToDirective.php
@@ -9,7 +9,7 @@ class BelongsToDirective extends RelationDirective implements FieldResolver, Def
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Resolves a field through the Eloquent `BelongsTo` relationship.
 """

--- a/src/Schema/Directives/BelongsToManyDirective.php
+++ b/src/Schema/Directives/BelongsToManyDirective.php
@@ -10,7 +10,7 @@ class BelongsToManyDirective extends RelationDirective implements FieldResolver,
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Resolves a field through the Eloquent `BelongsToMany` relationship.
 """

--- a/src/Schema/Directives/BroadcastDirective.php
+++ b/src/Schema/Directives/BroadcastDirective.php
@@ -13,7 +13,7 @@ class BroadcastDirective extends BaseDirective implements FieldMiddleware, Defin
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 directive @broadcast(
   """
   Name of the subscription that should be retriggered as a result of this operation..

--- a/src/Schema/Directives/BuilderDirective.php
+++ b/src/Schema/Directives/BuilderDirective.php
@@ -9,7 +9,7 @@ class BuilderDirective extends BaseDirective implements ArgBuilderDirective, Def
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Use an argument to modify the query builder for a field.
 """

--- a/src/Schema/Directives/CacheDirective.php
+++ b/src/Schema/Directives/CacheDirective.php
@@ -37,7 +37,7 @@ class CacheDirective extends BaseDirective implements FieldMiddleware, DefinedDi
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Cache the result of a resolver.
 """

--- a/src/Schema/Directives/CacheKeyDirective.php
+++ b/src/Schema/Directives/CacheKeyDirective.php
@@ -9,7 +9,7 @@ class CacheKeyDirective extends BaseDirective implements Directive, DefinedDirec
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Specify the field to use as a key when creating a cache.
 """

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -34,7 +34,7 @@ class CanDirective extends BaseDirective implements FieldMiddleware, DefinedDire
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Check a Laravel Policy to ensure the current user is authorized to access a field.
 

--- a/src/Schema/Directives/ComplexityDirective.php
+++ b/src/Schema/Directives/ComplexityDirective.php
@@ -13,7 +13,7 @@ class ComplexityDirective extends BaseDirective implements FieldMiddleware, Defi
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Customize the calculation of a fields complexity score before execution.
 """

--- a/src/Schema/Directives/CountDirective.php
+++ b/src/Schema/Directives/CountDirective.php
@@ -12,7 +12,7 @@ class CountDirective extends BaseDirective implements FieldResolver, DefinedDire
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Returns the count of a given relationship or model.
 """

--- a/src/Schema/Directives/CreateDirective.php
+++ b/src/Schema/Directives/CreateDirective.php
@@ -9,7 +9,7 @@ class CreateDirective extends MutationExecutorDirective
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Create a new Eloquent model with the given arguments.
 """

--- a/src/Schema/Directives/DeleteDirective.php
+++ b/src/Schema/Directives/DeleteDirective.php
@@ -20,7 +20,7 @@ class DeleteDirective extends ModifyModelExistenceDirective implements DefinedDi
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Delete one or more models by their ID.
 The field must have a single non-null argument that may be a list.

--- a/src/Schema/Directives/DeprecatedDirective.php
+++ b/src/Schema/Directives/DeprecatedDirective.php
@@ -12,7 +12,7 @@ class DeprecatedDirective extends BaseDirective implements FieldMiddleware, Defi
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Marks an element of a GraphQL schema as no longer supported.
 """

--- a/src/Schema/Directives/EnumDirective.php
+++ b/src/Schema/Directives/EnumDirective.php
@@ -8,7 +8,7 @@ class EnumDirective extends BaseDirective implements DefinedDirective
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Assign an internal value to an enum key.
 When dealing with the Enum type in your code,

--- a/src/Schema/Directives/EqDirective.php
+++ b/src/Schema/Directives/EqDirective.php
@@ -9,7 +9,7 @@ class EqDirective extends BaseDirective implements ArgBuilderDirective, DefinedD
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 directive @eq(
   """
   Specify the database column to compare.

--- a/src/Schema/Directives/EventDirective.php
+++ b/src/Schema/Directives/EventDirective.php
@@ -28,7 +28,7 @@ class EventDirective extends BaseDirective implements FieldMiddleware, DefinedDi
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Fire an event after a mutation has taken place.
 It requires the `dispatch` argument that should be

--- a/src/Schema/Directives/FieldDirective.php
+++ b/src/Schema/Directives/FieldDirective.php
@@ -13,7 +13,7 @@ class FieldDirective extends BaseDirective implements FieldResolver, DefinedDire
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Assign a resolver function to a field.
 """

--- a/src/Schema/Directives/FindDirective.php
+++ b/src/Schema/Directives/FindDirective.php
@@ -14,7 +14,7 @@ class FindDirective extends BaseDirective implements FieldResolver, DefinedDirec
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Find a model based on the arguments provided.
 """

--- a/src/Schema/Directives/FirstDirective.php
+++ b/src/Schema/Directives/FirstDirective.php
@@ -13,7 +13,7 @@ class FirstDirective extends BaseDirective implements FieldResolver, DefinedDire
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Get the first query result from a collection of Eloquent models.
 """

--- a/src/Schema/Directives/GlobalIdDirective.php
+++ b/src/Schema/Directives/GlobalIdDirective.php
@@ -32,7 +32,7 @@ class GlobalIdDirective extends BaseDirective implements FieldMiddleware, ArgTra
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Converts between IDs/types and global IDs.
 When used upon a field, it encodes,

--- a/src/Schema/Directives/GuardDirective.php
+++ b/src/Schema/Directives/GuardDirective.php
@@ -37,7 +37,7 @@ class GuardDirective extends BaseDirective implements FieldMiddleware, TypeManip
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Run authentication through one or more guards.
 This is run per field and may allow unauthenticated

--- a/src/Schema/Directives/HasManyDirective.php
+++ b/src/Schema/Directives/HasManyDirective.php
@@ -10,7 +10,7 @@ class HasManyDirective extends RelationDirective implements FieldResolver, Field
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Corresponds to [the Eloquent relationship HasMany](https://laravel.com/docs/eloquent-relationships#one-to-many).
 """

--- a/src/Schema/Directives/HasOneDirective.php
+++ b/src/Schema/Directives/HasOneDirective.php
@@ -9,7 +9,7 @@ class HasOneDirective extends RelationDirective implements FieldResolver, Define
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Corresponds to [the Eloquent relationship HasOne](https://laravel.com/docs/eloquent-relationships#one-to-one).
 """

--- a/src/Schema/Directives/InDirective.php
+++ b/src/Schema/Directives/InDirective.php
@@ -9,7 +9,7 @@ class InDirective extends BaseDirective implements ArgBuilderDirective, DefinedD
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 directive @in(
   """
   Specify the database column to compare.

--- a/src/Schema/Directives/InjectDirective.php
+++ b/src/Schema/Directives/InjectDirective.php
@@ -15,7 +15,7 @@ class InjectDirective extends BaseDirective implements FieldMiddleware, DefinedD
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 directive @inject(
   """
   A path to the property of the context that will be injected.

--- a/src/Schema/Directives/InterfaceDirective.php
+++ b/src/Schema/Directives/InterfaceDirective.php
@@ -8,7 +8,7 @@ class InterfaceDirective extends BaseDirective implements DefinedDirective
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Use a custom resolver to determine the concrete type of an interface.
 """

--- a/src/Schema/Directives/LazyLoadDirective.php
+++ b/src/Schema/Directives/LazyLoadDirective.php
@@ -15,7 +15,7 @@ class LazyLoadDirective extends BaseDirective implements DefinedDirective, Field
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Perform a [lazy eager load](https://laravel.com/docs/eloquent-relationships#lazy-eager-loading)
 on the relations of a list of models.

--- a/src/Schema/Directives/MethodDirective.php
+++ b/src/Schema/Directives/MethodDirective.php
@@ -12,7 +12,7 @@ class MethodDirective extends BaseDirective implements FieldResolver, DefinedDir
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Call a method with a given `name` on the class that represents a type to resolve a field.
 Use this if the data is not accessible as an attribute (e.g. `$model->myData`).

--- a/src/Schema/Directives/MiddlewareDirective.php
+++ b/src/Schema/Directives/MiddlewareDirective.php
@@ -59,7 +59,7 @@ class MiddlewareDirective extends BaseDirective implements FieldMiddleware, Type
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Run Laravel middleware for a specific field or group of fields.
 This can be handy to reuse existing HTTP middleware.

--- a/src/Schema/Directives/ModelClassDirective.php
+++ b/src/Schema/Directives/ModelClassDirective.php
@@ -9,7 +9,7 @@ class ModelClassDirective extends BaseDirective implements DefinedDirective, Dir
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Map a model class to an object type.
 This can be used when the name of the model differs from the name of the type.

--- a/src/Schema/Directives/ModelDirective.php
+++ b/src/Schema/Directives/ModelDirective.php
@@ -6,7 +6,7 @@ class ModelDirective extends NodeDirective
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Enable fetching an Eloquent model by its global id through the `node` query.
 

--- a/src/Schema/Directives/MorphManyDirective.php
+++ b/src/Schema/Directives/MorphManyDirective.php
@@ -15,7 +15,7 @@ class MorphManyDirective extends RelationDirective implements FieldResolver, Fie
      */
     public static function definition()
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Corresponds to [Eloquent's MorphMany-Relationship](https://laravel.com/docs/5.8/eloquent-relationships#one-to-one-polymorphic-relations).
 """

--- a/src/Schema/Directives/MorphOneDirective.php
+++ b/src/Schema/Directives/MorphOneDirective.php
@@ -14,7 +14,7 @@ class MorphOneDirective extends RelationDirective implements FieldResolver, Defi
      */
     public static function definition()
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Corresponds to [Eloquent's MorphOne-Relationship](https://laravel.com/docs/5.8/eloquent-relationships#one-to-one-polymorphic-relations).
 """

--- a/src/Schema/Directives/MorphToDirective.php
+++ b/src/Schema/Directives/MorphToDirective.php
@@ -14,7 +14,7 @@ class MorphToDirective extends RelationDirective implements FieldResolver, Defin
      */
     public static function definition()
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Corresponds to [Eloquent's MorphTo-Relationship](https://laravel.com/docs/5.8/eloquent-relationships#one-to-one-polymorphic-relations).
 """

--- a/src/Schema/Directives/NamespaceDirective.php
+++ b/src/Schema/Directives/NamespaceDirective.php
@@ -25,7 +25,7 @@ class NamespaceDirective extends BaseDirective implements TypeManipulator, TypeE
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Redefine the default namespaces used in other directives.
 The arguments are a map from directive names to namespaces.

--- a/src/Schema/Directives/NeqDirective.php
+++ b/src/Schema/Directives/NeqDirective.php
@@ -9,7 +9,7 @@ class NeqDirective extends BaseDirective implements ArgBuilderDirective, Defined
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Place a not equals operator `!=` on an Eloquent query.
 """

--- a/src/Schema/Directives/NestDirective.php
+++ b/src/Schema/Directives/NestDirective.php
@@ -11,7 +11,7 @@ class NestDirective extends BaseDirective implements ArgResolver
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 A no-op nested arg resolver that delegates all calls
 to the ArgResolver directives attached to the children.

--- a/src/Schema/Directives/NodeDirective.php
+++ b/src/Schema/Directives/NodeDirective.php
@@ -32,7 +32,7 @@ class NodeDirective extends BaseDirective implements TypeMiddleware, TypeManipul
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Register a type for Relay's global object identification.
 When used without any arguments, Lighthouse will attempt

--- a/src/Schema/Directives/NotInDirective.php
+++ b/src/Schema/Directives/NotInDirective.php
@@ -9,7 +9,7 @@ class NotInDirective extends BaseDirective implements ArgBuilderDirective, Defin
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Filter a column by an array using a `whereNotIn` clause.
 """

--- a/src/Schema/Directives/PaginateDirective.php
+++ b/src/Schema/Directives/PaginateDirective.php
@@ -20,7 +20,7 @@ class PaginateDirective extends BaseDirective implements FieldResolver, FieldMan
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Query multiple entries as a paginated list.
 """

--- a/src/Schema/Directives/RenameDirective.php
+++ b/src/Schema/Directives/RenameDirective.php
@@ -11,7 +11,7 @@ class RenameDirective extends BaseDirective implements FieldResolver, DefinedDir
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Change the internally used name of a field or argument.
 This does not change the schema from a client perspective.

--- a/src/Schema/Directives/RulesDirective.php
+++ b/src/Schema/Directives/RulesDirective.php
@@ -21,7 +21,7 @@ class RulesDirective extends BaseDirective implements ArgDirective, ProvidesRule
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Validate an argument using [Laravel built-in validation](https://laravel.com/docs/validation).
 """

--- a/src/Schema/Directives/RulesForArrayDirective.php
+++ b/src/Schema/Directives/RulesForArrayDirective.php
@@ -16,7 +16,7 @@ class RulesForArrayDirective extends BaseDirective implements ArgDirectiveForArr
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Run validation on an array itself, using [Laravel built-in validation](https://laravel.com/docs/validation).
 """

--- a/src/Schema/Directives/ScalarDirective.php
+++ b/src/Schema/Directives/ScalarDirective.php
@@ -8,7 +8,7 @@ class ScalarDirective extends BaseDirective implements DefinedDirective
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Reference a class implementing a scalar definition.
 """

--- a/src/Schema/Directives/ScopeDirective.php
+++ b/src/Schema/Directives/ScopeDirective.php
@@ -11,7 +11,7 @@ class ScopeDirective extends BaseDirective implements ArgBuilderDirective, Defin
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Adds a scope to the query builder.
 The scope method will receive the client-given value of the argument as the second parameter.

--- a/src/Schema/Directives/SearchDirective.php
+++ b/src/Schema/Directives/SearchDirective.php
@@ -9,7 +9,7 @@ class SearchDirective extends BaseDirective implements ArgBuilderDirective, Defi
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Perform a full-text by the given input value.
 """

--- a/src/Schema/Directives/SpreadDirective.php
+++ b/src/Schema/Directives/SpreadDirective.php
@@ -9,7 +9,7 @@ class SpreadDirective extends BaseDirective implements ArgDirective, DefinedDire
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Merge the fields of a nested input object into the arguments of its parent
 when processing the field arguments given by a client.

--- a/src/Schema/Directives/SubscriptionDirective.php
+++ b/src/Schema/Directives/SubscriptionDirective.php
@@ -17,7 +17,7 @@ class SubscriptionDirective extends BaseDirective implements Directive, DefinedD
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Reference a class to handle the broadcasting of a subscription to clients.
 The given class must extend `\Nuwave\Lighthouse\Schema\Types\GraphQLSubscription`.

--- a/src/Schema/Directives/TrimDirective.php
+++ b/src/Schema/Directives/TrimDirective.php
@@ -9,7 +9,7 @@ class TrimDirective extends BaseDirective implements ArgTransformerDirective, De
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Run the `trim` function on an input value.
 """

--- a/src/Schema/Directives/UnionDirective.php
+++ b/src/Schema/Directives/UnionDirective.php
@@ -8,7 +8,7 @@ class UnionDirective extends BaseDirective implements DefinedDirective
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Use a custom function to determine the concrete type of unions.
 """

--- a/src/Schema/Directives/UpdateDirective.php
+++ b/src/Schema/Directives/UpdateDirective.php
@@ -10,7 +10,7 @@ class UpdateDirective extends MutationExecutorDirective
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Update an Eloquent model with the input values of the field.
 """

--- a/src/Schema/Directives/UpsertDirective.php
+++ b/src/Schema/Directives/UpsertDirective.php
@@ -10,7 +10,7 @@ class UpsertDirective extends MutationExecutorDirective
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Create or update an Eloquent model with the input values of the field.
 """

--- a/src/Schema/Directives/WhereBetweenDirective.php
+++ b/src/Schema/Directives/WhereBetweenDirective.php
@@ -9,7 +9,7 @@ class WhereBetweenDirective extends BaseDirective implements ArgBuilderDirective
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Verify that a column\'s value is between two values.
 The type of the input value this is defined upon should be

--- a/src/Schema/Directives/WhereDirective.php
+++ b/src/Schema/Directives/WhereDirective.php
@@ -9,7 +9,7 @@ class WhereDirective extends BaseDirective implements ArgBuilderDirective, Defin
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Use an input value as a [where filter](https://laravel.com/docs/queries#where-clauses).
 """

--- a/src/Schema/Directives/WhereJsonContainsDirective.php
+++ b/src/Schema/Directives/WhereJsonContainsDirective.php
@@ -9,7 +9,7 @@ class WhereJsonContainsDirective extends BaseDirective implements ArgBuilderDire
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Use an input value as a [whereJsonContains filter](https://laravel.com/docs/queries#json-where-clauses).
 """

--- a/src/Schema/Directives/WhereNotBetweenDirective.php
+++ b/src/Schema/Directives/WhereNotBetweenDirective.php
@@ -9,7 +9,7 @@ class WhereNotBetweenDirective extends BaseDirective implements ArgBuilderDirect
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Verify that a column\'s value lies outside of two values.
 The type of the input value this is defined upon should be

--- a/src/Schema/Directives/WithDirective.php
+++ b/src/Schema/Directives/WithDirective.php
@@ -17,7 +17,7 @@ class WithDirective extends RelationDirective implements FieldMiddleware, Define
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Eager-load an Eloquent relation.
 """

--- a/src/SoftDeletes/ForceDeleteDirective.php
+++ b/src/SoftDeletes/ForceDeleteDirective.php
@@ -14,7 +14,7 @@ class ForceDeleteDirective extends ModifyModelExistenceDirective
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Permanently remove one or more soft deleted models by their ID.
 The field must have a single non-null argument that may be a list.

--- a/src/SoftDeletes/RestoreDirective.php
+++ b/src/SoftDeletes/RestoreDirective.php
@@ -16,7 +16,7 @@ class RestoreDirective extends ModifyModelExistenceDirective implements DefinedD
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Un-delete one or more soft deleted models by their ID.
 The field must have a single non-null argument that may be a list.

--- a/src/SoftDeletes/SoftDeletesDirective.php
+++ b/src/SoftDeletes/SoftDeletesDirective.php
@@ -15,7 +15,7 @@ class SoftDeletesDirective extends BaseDirective implements FieldManipulator, De
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Allows to filter if trashed elements should be fetched.
 This manipulates the schema by adding the argument
@@ -33,7 +33,7 @@ SDL;
      */
     public function manipulateFieldDefinition(DocumentAST &$documentAST, FieldDefinitionNode &$fieldDefinition, ObjectTypeDefinitionNode &$parentType): void
     {
-        $softDeletesArgument = PartialParser::inputValueDefinition(/* @lang GraphQL */ <<<'SDL'
+        $softDeletesArgument = PartialParser::inputValueDefinition(/** @lang GraphQL */ <<<'SDL'
 """
 Allows to filter if trashed elements should be fetched.
 """

--- a/src/SoftDeletes/TrashedDirective.php
+++ b/src/SoftDeletes/TrashedDirective.php
@@ -16,7 +16,7 @@ class TrashedDirective extends BaseDirective implements ArgBuilderDirective, Def
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Allows to filter if trashed elements should be fetched.
 """

--- a/src/Testing/MockDirective.php
+++ b/src/Testing/MockDirective.php
@@ -33,7 +33,7 @@ class MockDirective extends BaseDirective implements FieldResolver, DefinedDirec
      */
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Allows you to easily hook up a resolver for an endpoint.
 """

--- a/src/Tracing/TracingDirective.php
+++ b/src/Tracing/TracingDirective.php
@@ -31,7 +31,7 @@ class TracingDirective extends BaseDirective implements FieldMiddleware, Defined
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Do not use this directive directly, it is automatically added to the schema
 when using the tracing extension.

--- a/src/WhereConstraints/WhereConstraintsDirective.php
+++ b/src/WhereConstraints/WhereConstraintsDirective.php
@@ -35,7 +35,7 @@ class WhereConstraintsDirective extends BaseDirective implements ArgBuilderDirec
 
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Add a dynamically client-controlled WHERE constraint to a fields query.
 The argument it is defined on may have any name but **must** be

--- a/tests/Integration/Console/UnionDirective.php
+++ b/tests/Integration/Console/UnionDirective.php
@@ -10,7 +10,7 @@ class UnionDirective extends BaseDirective implements Directive, DefinedDirectiv
 {
     public static function definition(): string
     {
-        return /* @lang GraphQL */ <<<'SDL'
+        return /** @lang GraphQL */ <<<'SDL'
 """
 Some other definition then the original.
 """

--- a/tests/Integration/CustomDefaultResolverTest.php
+++ b/tests/Integration/CustomDefaultResolverTest.php
@@ -9,7 +9,7 @@ class CustomDefaultResolverTest extends TestCase
 {
     const CUSTOM_RESOLVER_RESULT = 123;
 
-    protected $schema = /** @lang GraphQL */'
+    protected $schema = /** @lang GraphQL */ '
     type Query {
         foo: Foo @field(resolver: "Tests\\\\Integration\\\\CustomDefaultResolverTest@resolve")
     }

--- a/tests/Integration/Defer/DeferDBTest.php
+++ b/tests/Integration/Defer/DeferDBTest.php
@@ -41,7 +41,7 @@ class DeferDBTest extends DBTestCase
             return $user;
         });
 
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Company {
             name: String!
         }
@@ -61,7 +61,7 @@ class DeferDBTest extends DBTestCase
             $queries++;
         });
 
-        $chunks = $this->getStreamedChunks(/* @lang GraphQL */ '
+        $chunks = $this->getStreamedChunks(/** @lang GraphQL */ '
         {
             user {
                 email
@@ -96,7 +96,7 @@ class DeferDBTest extends DBTestCase
             return $user;
         });
 
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Company {
             name: String!
             users: [User] @hasMany
@@ -117,7 +117,7 @@ class DeferDBTest extends DBTestCase
             $queries++;
         });
 
-        $chunks = $this->getStreamedChunks(/* @lang GraphQL */ '
+        $chunks = $this->getStreamedChunks(/** @lang GraphQL */ '
         {
             user {
                 email
@@ -172,7 +172,7 @@ class DeferDBTest extends DBTestCase
             return $companies;
         });
 
-        $this->schema = /* @lang GraphQL */ '
+        $this->schema = /** @lang GraphQL */ '
         type Company {
             name: String!
             users: [User] @hasMany
@@ -193,7 +193,7 @@ class DeferDBTest extends DBTestCase
             $queries++;
         });
 
-        $chunks = $this->getStreamedChunks(/* @lang GraphQL */ '
+        $chunks = $this->getStreamedChunks(/** @lang GraphQL */ '
         {
             companies {
                 name

--- a/tests/Integration/Defer/DeferTest.php
+++ b/tests/Integration/Defer/DeferTest.php
@@ -168,7 +168,7 @@ class DeferTest extends TestCase
             ],
         ];
 
-        $this->schema = /** @lang GraphQL */"
+        $this->schema = /** @lang GraphQL */ "
         type User {
             name: String!
             parent: User
@@ -236,7 +236,7 @@ class DeferTest extends TestCase
             ],
         ];
 
-        $this->schema = /** @lang GraphQL */"
+        $this->schema = /** @lang GraphQL */ "
         type Post {
             title: String
             author: User
@@ -297,7 +297,7 @@ class DeferTest extends TestCase
             ],
         ];
 
-        $this->schema = /** @lang GraphQL */"
+        $this->schema = /** @lang GraphQL */ "
         type Comment {
             message: String
         }
@@ -598,7 +598,7 @@ class DeferTest extends TestCase
             'name' => 'John Doe',
         ];
 
-        $this->schema = /** @lang GraphQL */"
+        $this->schema = /** @lang GraphQL */ "
         type User {
             name: String!
             parent: User
@@ -638,7 +638,7 @@ class DeferTest extends TestCase
             ],
         ];
 
-        $this->schema = /** @lang GraphQL */"
+        $this->schema = /** @lang GraphQL */ "
         type User {
             name: String!
             parent: User
@@ -674,7 +674,7 @@ class DeferTest extends TestCase
             ],
         ];
 
-        $this->schema = /** @lang GraphQL */"
+        $this->schema = /** @lang GraphQL */ "
         type User {
             name: String!
             parent: User @field(resolver: \"{$this->qualifyTestResolver('throw')}\")

--- a/tests/Integration/Execution/BuilderTest.php
+++ b/tests/Integration/Execution/BuilderTest.php
@@ -28,7 +28,7 @@ class BuilderTest extends DBTestCase
 
     public function testCanAttachEqFilterToQuery(): void
     {
-        $this->schema .= /** @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type Query {
             users(id: ID @eq): [User!]! @all
         }
@@ -49,7 +49,7 @@ class BuilderTest extends DBTestCase
 
     public function testCanAttachEqFilterFromInputObject(): void
     {
-        $this->schema .= /** @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type Query {
             users(input: UserInput! @spread): [User!]! @all
         }
@@ -217,7 +217,7 @@ class BuilderTest extends DBTestCase
 
     public function testCanUseInputObjectsForWhereBetweenFilter(): void
     {
-        $this->schema .= /** @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type Query {
             users(
                 created: TimeRange @whereBetween(key: "created_at")

--- a/tests/Integration/Execution/DataLoader/RelationBatchLoaderTest.php
+++ b/tests/Integration/Execution/DataLoader/RelationBatchLoaderTest.php
@@ -13,7 +13,7 @@ use Tests\Utils\Models\User;
 
 class RelationBatchLoaderTest extends DBTestCase
 {
-    protected $schema = /* @lang GraphQL */ '
+    protected $schema = /** @lang GraphQL */ '
     type Task {
         id: ID
         name: String
@@ -49,7 +49,7 @@ class RelationBatchLoaderTest extends DBTestCase
 
     public function testCanResolveBatchedFieldsFromBatchedRequests(): void
     {
-        $query = /* @lang GraphQL */ '
+        $query = /** @lang GraphQL */ '
         query User($id: ID!) {
             user(id: $id) {
                 email
@@ -96,7 +96,7 @@ class RelationBatchLoaderTest extends DBTestCase
         });
 
         $this
-            ->graphQL(/* @lang GraphQL */ '
+            ->graphQL(/** @lang GraphQL */ '
             {
                 users {
                     email
@@ -148,7 +148,7 @@ class RelationBatchLoaderTest extends DBTestCase
             'many'
         );
 
-        $this->schema = /* @lang GraphQL */ '
+        $this->schema = /** @lang GraphQL */ '
         type Task {
             name: String
         }
@@ -164,7 +164,7 @@ class RelationBatchLoaderTest extends DBTestCase
         }
         ';
 
-        $query = /* @lang GraphQL */ '
+        $query = /** @lang GraphQL */ '
         query User($id: ID!, $ids: [ID!]!) {
             user(id: $id) {
                 email
@@ -198,7 +198,7 @@ class RelationBatchLoaderTest extends DBTestCase
     public function testTwoBatchloadedQueriesWithDifferentResults(): void
     {
         $this
-            ->graphQL(/* @lang GraphQL */'
+            ->graphQL(/** @lang GraphQL */ '
             {
                 user(id: 1) {
                     tasks {
@@ -226,7 +226,7 @@ class RelationBatchLoaderTest extends DBTestCase
             ]);
 
         $this
-            ->graphQL(/* @lang GraphQL */'
+            ->graphQL(/** @lang GraphQL */ '
             {
                 user(id: 2) {
                     tasks {

--- a/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
@@ -9,7 +9,7 @@ use Tests\Utils\Models\User;
 
 class BelongsToManyTest extends DBTestCase
 {
-    protected $schema = /** @lang GraphQL */'
+    protected $schema = /** @lang GraphQL */ '
     type Role {
         id: ID!
         name: String

--- a/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
@@ -8,7 +8,7 @@ use Tests\Utils\Models\User;
 
 class BelongsToTest extends DBTestCase
 {
-    protected $schema = /* @lang GraphQL */'
+    protected $schema = /** @lang GraphQL */ '
     type Task {
         id: ID!
         name: String!
@@ -83,7 +83,7 @@ class BelongsToTest extends DBTestCase
     {
         factory(User::class)->create();
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createTask(input: {
                 name: "foo"
@@ -115,7 +115,7 @@ class BelongsToTest extends DBTestCase
     {
         factory(User::class)->create();
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             upsertTask(input: {
                 id: 1
@@ -146,7 +146,7 @@ class BelongsToTest extends DBTestCase
 
     public function testCanCreateWithNewBelongsTo(): void
     {
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createTask(input: {
                 name: "foo"
@@ -178,7 +178,7 @@ class BelongsToTest extends DBTestCase
 
     public function testCanUpsertWithNewBelongsTo(): void
     {
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createTask(input: {
                 name: "foo"
@@ -244,7 +244,7 @@ GRAPHQL
 
     public function testCanUpsertUsingCreateWithNewBelongsTo(): void
     {
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             upsertTask(input: {
                 id: 1
@@ -277,7 +277,7 @@ GRAPHQL
 
     public function testCanUpsertUsingCreateWithNewUpsertBelongsTo(): void
     {
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             upsertTask(input: {
                 id: 1
@@ -315,7 +315,7 @@ GRAPHQL
             'name' => 'foo',
         ]);
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createTask(input: {
                 name: "foo"
@@ -354,7 +354,7 @@ GRAPHQL
             'name' => 'foo',
         ]);
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             upsertTask(input: {
                 id: 1
@@ -394,7 +394,7 @@ GRAPHQL
             'name' => 'foo',
         ]);
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             upsertTask(input: {
                 id: 1
@@ -445,7 +445,7 @@ GRAPHQL
         $task = factory(Task::class)->create();
         $task->user()->create();
 
-        $this->graphQL(/* @lang GraphQL */ "
+        $this->graphQL(/** @lang GraphQL */ "
         mutation {
             ${action}Task(input: {
                 id: 1
@@ -490,7 +490,7 @@ GRAPHQL
             factory(Task::class)->make()
         );
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             upsertTask(input: {
                 id: 1
@@ -538,7 +538,7 @@ GRAPHQL
             factory(Task::class)->make()
         );
 
-        $this->graphQL(/* @lang GraphQL */ "
+        $this->graphQL(/** @lang GraphQL */ "
         mutation {
             ${action}Task(input: {
                 id: 1
@@ -579,7 +579,7 @@ GRAPHQL
     {
         factory(User::class)->create();
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             upsertTask(input: {
                 id: 1
@@ -627,7 +627,7 @@ GRAPHQL
             factory(Task::class)->make()
         );
 
-        $this->graphQL(/* @lang GraphQL */ "
+        $this->graphQL(/** @lang GraphQL */ "
         mutation {
             ${action}Task(input: {
                 id: 1

--- a/tests/Integration/Execution/MutationExecutor/HasOneTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasOneTest.php
@@ -8,7 +8,7 @@ use Tests\Utils\Models\Task;
 
 class HasOneTest extends DBTestCase
 {
-    protected $schema = /* @lang GraphQL */ '
+    protected $schema = /** @lang GraphQL */ '
     type Task {
         id: ID!
         name: String!

--- a/tests/Integration/FileUploadTest.php
+++ b/tests/Integration/FileUploadTest.php
@@ -8,7 +8,7 @@ use Tests\Utils\Queries\Foo;
 
 class FileUploadTest extends TestCase
 {
-    protected $schema = /* @lang GraphQL */'
+    protected $schema = /** @lang GraphQL */ '
     scalar Upload @scalar(class: "Nuwave\\\\Lighthouse\\\\Schema\\\\Types\\\\Scalars\\\\Upload")
 
     type Mutation {
@@ -23,7 +23,7 @@ class FileUploadTest extends TestCase
     {
         $this->multipartGraphQL(
             [
-                'operations' => /* @lang JSON */'
+                'operations' => /** @lang JSON */ '
                     {
                         "query": "mutation Upload($file: Upload!) { upload(file: $file) }",
                         "variables": {
@@ -31,7 +31,7 @@ class FileUploadTest extends TestCase
                         }
                     }
                 ',
-                'map' => /* @lang JSON */'
+                'map' => /** @lang JSON */ '
                     {
                         "0": ["variables.file"]
                     }
@@ -54,7 +54,7 @@ class FileUploadTest extends TestCase
     {
         $this->multipartGraphQL(
             [
-                'operations' => /* @lang JSON */'
+                'operations' => /** @lang JSON */ '
                     [
                         {
                             "query": "mutation Upload($file: Upload!) { upload(file: $file) }",
@@ -70,7 +70,7 @@ class FileUploadTest extends TestCase
                         }
                     ]
                 ',
-                'map' => /* @lang JSON */'
+                'map' => /** @lang JSON */ '
                     {
                         "0": ["0.variables.file"],
                         "1": ["1.variables.file"]
@@ -99,13 +99,13 @@ class FileUploadTest extends TestCase
     {
         $this->multipartGraphQL(
             [
-                'operations' => /* @lang JSON */ '
+                'operations' => /** @lang JSON */ '
                     {
                         "query": "{ foo }",
                         "variables": {}
                     }
                 ',
-                'map' => /* @lang JSON */'{}',
+                'map' => /** @lang JSON */ '{}',
             ],
             []
         )->assertJson([

--- a/tests/Integration/GraphQLTest.php
+++ b/tests/Integration/GraphQLTest.php
@@ -9,7 +9,7 @@ use Tests\Utils\Queries\Foo;
 
 class GraphQLTest extends TestCase
 {
-    protected $schema = /* @lang GraphQL */ '
+    protected $schema = /** @lang GraphQL */ '
     type Query {
         foo: Int
         bar: String
@@ -19,7 +19,7 @@ class GraphQLTest extends TestCase
     public function testResolvesQueryViaPostRequest(): void
     {
         $this
-            ->graphQL(/* @lang GraphQL */ '
+            ->graphQL(/** @lang GraphQL */ '
             {
                 foo
             }
@@ -38,7 +38,7 @@ class GraphQLTest extends TestCase
                 'graphql?'
                 .http_build_query(
                     [
-                        'query' => /* @lang GraphQL */ '
+                        'query' => /** @lang GraphQL */ '
                         {
                             foo
                         }
@@ -56,7 +56,7 @@ class GraphQLTest extends TestCase
     public function testResolvesNamedOperation(): void
     {
         $this->postGraphQL([
-            'query' => /* @lang GraphQL */ '
+            'query' => /** @lang GraphQL */ '
                 query Foo {
                     foo
                 }
@@ -92,7 +92,7 @@ class GraphQLTest extends TestCase
 
     public function testRejectsEmptyQuery(): void
     {
-        $this->graphQL(/* @lang GraphQL */ '')
+        $this->graphQL(/** @lang GraphQL */ '')
              ->assertStatus(200)
              ->assertJson([
                  'errors' => [
@@ -109,7 +109,7 @@ class GraphQLTest extends TestCase
     public function testRejectsInvalidQuery(): void
     {
         $result = $this
-            ->graphQL(/* @lang GraphQL */ '
+            ->graphQL(/** @lang GraphQL */ '
             {
                 nonExistingField
             }
@@ -133,14 +133,14 @@ class GraphQLTest extends TestCase
             throw new Error($message);
         });
 
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo: ID @mock
         }
         ';
 
         $this
-            ->graphQL(/* @lang GraphQL */ '
+            ->graphQL(/** @lang GraphQL */ '
             {
                 foo
             }
@@ -160,8 +160,8 @@ class GraphQLTest extends TestCase
     public function testIgnoresInvalidJSONVariables(): void
     {
         $result = $this->postGraphQL([
-            'query' => /* @lang GraphQL */ '{}',
-            'variables' => /* @lang JSON */ '{}',
+            'query' => /** @lang GraphQL */ '{}',
+            'variables' => /** @lang JSON */ '{}',
         ]);
 
         $result->assertStatus(200);
@@ -172,14 +172,14 @@ class GraphQLTest extends TestCase
         $this
             ->postGraphQL([
                 [
-                    'query' => /* @lang GraphQL */ '
+                    'query' => /** @lang GraphQL */ '
                         {
                             foo
                         }
                         ',
                 ],
                 [
-                    'query' => /* @lang GraphQL */ '
+                    'query' => /** @lang GraphQL */ '
                         {
                             bar
                         }

--- a/tests/Integration/MultipleRequestsTest.php
+++ b/tests/Integration/MultipleRequestsTest.php
@@ -8,13 +8,13 @@ class MultipleRequestsTest extends TestCase
 {
     public function testCanFireMultipleRequestsInOneTest(): void
     {
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             return(this: String!): String @field(resolver:"'.$this->qualifyTestResolver().'")
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             return(this: "foo")
         }
@@ -24,7 +24,7 @@ class MultipleRequestsTest extends TestCase
             ],
         ]);
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             return(this: "bar")
         }

--- a/tests/Integration/Schema/Directives/BelongsToManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/BelongsToManyDirectiveTest.php
@@ -104,7 +104,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
 
     public function testCanQueryBelongsToManyPaginator(): void
     {
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type User {
             roles: [Role!]! @belongsToMany(type: "paginator")
         }
@@ -151,7 +151,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
 
     public function testCanQueryBelongsToManyRelayConnection(): void
     {
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type User {
             roles: [Role!]! @belongsToMany(type: "relay")
         }
@@ -196,7 +196,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
 
     public function testCanQueryBelongsToManyRelayConnectionWithCustomEdgeUsingDirective(): void
     {
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type User {
             roles: [Role!]! @belongsToMany(type: "relay", edgeType: "CustomRoleEdge")
         }
@@ -247,7 +247,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
 
     public function testThrowsExceptionForInvalidEdgeTypeFromDirective(): void
     {
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type User {
             roles: [Role!]! @belongsToMany(type: "relay", edgeType: "CustomRoleEdge")
         }
@@ -282,7 +282,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
 
     public function testCanQueryBelongsToManyRelayConnectionWithCustomMagicEdge(): void
     {
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type User {
             roles: [Role!]! @belongsToMany(type: "relay")
         }
@@ -336,7 +336,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
 
     public function testCanQueryBelongsToManyNestedRelationships(): void
     {
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type User {
             id: Int!
             roles: [Role!]! @belongsToMany(type: "relay")

--- a/tests/Integration/Schema/Directives/CreateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/CreateDirectiveTest.php
@@ -11,7 +11,7 @@ class CreateDirectiveTest extends DBTestCase
 {
     public function testCanCreateFromFieldArguments(): void
     {
-        $this->schema .= /* @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type Company {
             id: ID!
             name: String!
@@ -22,7 +22,7 @@ class CreateDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createCompany(name: "foo") {
                 id
@@ -41,7 +41,7 @@ class CreateDirectiveTest extends DBTestCase
 
     public function testCanCreateFromInputObject(): void
     {
-        $this->schema .= /* @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type Company {
             id: ID!
             name: String!
@@ -56,7 +56,7 @@ class CreateDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createCompany(input: {
                 name: "foo"
@@ -77,7 +77,7 @@ class CreateDirectiveTest extends DBTestCase
 
     public function testCreatesAnEntryWithDatabaseDefaultsAndReturnsItImmediately(): void
     {
-        $this->schema .= /* @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type Mutation {
             createTag(name: String): Tag @create
         }
@@ -88,7 +88,7 @@ class CreateDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createTag(name: "foobar"){
                 name
@@ -111,7 +111,7 @@ class CreateDirectiveTest extends DBTestCase
 
         $this->app['config']->set('app.debug', false);
 
-        $this->schema .= /* @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type Task {
             id: ID!
             name: String!
@@ -142,7 +142,7 @@ class CreateDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createUser(input: {
                 name: "foo"
@@ -178,7 +178,7 @@ class CreateDirectiveTest extends DBTestCase
         $this->app['config']->set('app.debug', false);
         config(['lighthouse.transactional_mutations' => false]);
 
-        $this->schema .= /* @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type Task {
             id: ID!
             name: String!
@@ -209,7 +209,7 @@ class CreateDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createUser(input: {
                 name: "foo"
@@ -244,7 +244,7 @@ class CreateDirectiveTest extends DBTestCase
 
     public function testDoesNotFailWhenPropertyNameMatchesModelsNativeMethods(): void
     {
-        $this->schema .= /* @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type Task {
             id: ID!
             name: String!
@@ -276,7 +276,7 @@ class CreateDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createUser(input: {
                 name: "foo"
@@ -307,7 +307,7 @@ class CreateDirectiveTest extends DBTestCase
 
     public function testNestedArgResolverHasMany(): void
     {
-        $this->schema .= /* @lang GraphQL */ '
+        $this->schema .= /** @lang GraphQL */ '
         type Mutation {
             createUser(input: CreateUserInput! @spread): User @create
         }
@@ -331,7 +331,7 @@ class CreateDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createUser(input: {
                 name: "foo"
@@ -361,7 +361,7 @@ class CreateDirectiveTest extends DBTestCase
 
     public function testNestedArgResolverBelongsTo(): void
     {
-        $this->schema .= /* @lang GraphQL */ '
+        $this->schema .= /** @lang GraphQL */ '
         type Mutation {
             createTask(input: CreateTaskInput! @spread): Task @create
         }
@@ -385,7 +385,7 @@ class CreateDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createTask(input: {
                 name: "task"
@@ -413,7 +413,7 @@ class CreateDirectiveTest extends DBTestCase
 
     public function testCanCreateTwice(): void
     {
-        $this->schema .= /* @lang GraphQL */ '
+        $this->schema .= /** @lang GraphQL */ '
         type Task {
             id: ID!
             name: String!
@@ -443,7 +443,7 @@ class CreateDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */'
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createUser(input: {
                 name: "foo"
@@ -464,7 +464,7 @@ class CreateDirectiveTest extends DBTestCase
             ],
         ]);
 
-        $this->graphQL(/* @lang GraphQL */'
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createUser(input: {
                 name: "bar"

--- a/tests/Integration/Schema/Directives/DeleteDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/DeleteDirectiveTest.php
@@ -71,7 +71,7 @@ class DeleteDirectiveTest extends DBTestCase
     {
         $this->expectException(DefinitionException::class);
 
-        $this->buildSchema(/* @lang GraphQL */ '
+        $this->buildSchema(/** @lang GraphQL */ '
         type User {
             id: ID!
             name: String
@@ -87,7 +87,7 @@ class DeleteDirectiveTest extends DBTestCase
     {
         $this->expectException(DefinitionException::class);
 
-        $this->buildSchema(/* @lang GraphQL */ '
+        $this->buildSchema(/** @lang GraphQL */ '
         type User {
             id: ID!
         }
@@ -102,7 +102,7 @@ class DeleteDirectiveTest extends DBTestCase
     {
         $this->expectException(DefinitionException::class);
 
-        $this->buildSchema(/* @lang GraphQL */ '
+        $this->buildSchema(/** @lang GraphQL */ '
         type User {
             id: ID!
         }
@@ -117,7 +117,7 @@ class DeleteDirectiveTest extends DBTestCase
     {
         $this->expectException(DefinitionException::class);
 
-        $this->buildSchema(/* @lang GraphQL */ '
+        $this->buildSchema(/** @lang GraphQL */ '
         type Query {
             updateUser(deleteTasks: Tasks @delete): User @update
         }
@@ -135,7 +135,7 @@ class DeleteDirectiveTest extends DBTestCase
             'user_id' => 1,
         ]);
 
-        $this->schema = /* @lang GraphQL */ '
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             updateUser(
                 id: Int
@@ -153,7 +153,7 @@ class DeleteDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             updateUser(id: 1, deleteTasks: [2]) {
                 id
@@ -184,7 +184,7 @@ class DeleteDirectiveTest extends DBTestCase
             factory(Post::class)->make()
         );
 
-        $this->schema = /* @lang GraphQL */ '
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             updateTask(
                 id: Int
@@ -202,7 +202,7 @@ class DeleteDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             updateTask(id: 1, deletePost: false) {
                 id
@@ -222,7 +222,7 @@ class DeleteDirectiveTest extends DBTestCase
             ],
         ]);
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             updateTask(id: 1, deletePost: true) {
                 id
@@ -250,7 +250,7 @@ class DeleteDirectiveTest extends DBTestCase
             'user_id' => 1,
         ]);
 
-        $this->schema = /* @lang GraphQL */ '
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             updateTask(
                 id: Int
@@ -268,7 +268,7 @@ class DeleteDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             updateTask(id: 1, deleteUser: true) {
                 id

--- a/tests/Integration/Schema/Directives/NestDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/NestDirectiveTest.php
@@ -8,7 +8,7 @@ class NestDirectiveTest extends DBTestCase
 {
     public function testNestDelegates(): void
     {
-        $this->schema .= /* @lang GraphQL */ '
+        $this->schema .= /** @lang GraphQL */ '
         type Mutation {
             createUser(
                 name: String
@@ -34,7 +34,7 @@ class NestDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createUser(
                 name: "foo"

--- a/tests/Integration/Schema/Directives/ScopeDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ScopeDirectiveTest.php
@@ -28,7 +28,7 @@ class ScopeDirectiveTest extends DBTestCase
 
         $this->be($user);
 
-        $this->schema = /* @lang GraphQL */ '
+        $this->schema = /** @lang GraphQL */ '
         type User {
             tasks(tags: [String!] @scope(name: "whereTags")): [Task!]! @hasMany
         }
@@ -49,7 +49,7 @@ class ScopeDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */'
+        $this->graphQL(/** @lang GraphQL */ '
         {
             user {
                 tasks(tags: ["Lighthouse"]) {
@@ -72,7 +72,7 @@ class ScopeDirectiveTest extends DBTestCase
 
     public function testCanThrowExceptionOnInvalidScope(): void
     {
-        $this->schema = /* @lang GraphQL */ '
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             tasks(
                 name: String @scope(name: "nonExistantScope")
@@ -85,7 +85,7 @@ class ScopeDirectiveTest extends DBTestCase
         ';
 
         $this->expectException(DefinitionException::class);
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             tasks(name: "Lighthouse rocks") {
                 id

--- a/tests/Integration/Schema/Directives/UpdateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/UpdateDirectiveTest.php
@@ -139,7 +139,7 @@ class UpdateDirectiveTest extends DBTestCase
     {
         factory(User::class)->create(['name' => 'Original']);
 
-        $this->schema .= /* @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type Task {
             id: ID!
             name: String!
@@ -171,7 +171,7 @@ class UpdateDirectiveTest extends DBTestCase
         ';
 
         $this->expectException(QueryException::class);
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             updateUser(input: {
                 id: 1
@@ -202,7 +202,7 @@ class UpdateDirectiveTest extends DBTestCase
             'id' => 3,
         ]);
 
-        $this->schema .= /* @lang GraphQL */ '
+        $this->schema .= /** @lang GraphQL */ '
         type Mutation {
             updateUser(input: UpdateUserInput! @spread): User @update
         }
@@ -229,7 +229,7 @@ class UpdateDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             updateUser(input: {
                 id: 1

--- a/tests/Integration/Schema/Directives/UpsertDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/UpsertDirectiveTest.php
@@ -16,7 +16,7 @@ class UpsertDirectiveTest extends DBTestCase
             'name' => 'old',
         ]);
 
-        $this->schema .= /* @lang GraphQL */ '
+        $this->schema .= /** @lang GraphQL */ '
         type Mutation {
             updateUser(input: UpdateUserInput! @spread): User @update
         }
@@ -43,7 +43,7 @@ class UpsertDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             updateUser(input: {
                 id: 1

--- a/tests/Integration/SchemaCachingTest.php
+++ b/tests/Integration/SchemaCachingTest.php
@@ -32,7 +32,7 @@ class SchemaCachingTest extends TestCase
 
     public function testSchemaCachingWithUnionType(): void
     {
-        $this->schema = /* @lang GraphQL */ '
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo: Foo @mock
         }
@@ -55,7 +55,7 @@ class SchemaCachingTest extends TestCase
             ]);
         });
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             foo {
                 ... on Comment {

--- a/tests/Integration/SoftDeletes/ForceDeleteDirectiveTest.php
+++ b/tests/Integration/SoftDeletes/ForceDeleteDirectiveTest.php
@@ -102,7 +102,7 @@ class ForceDeleteDirectiveTest extends DBTestCase
     {
         $this->expectException(DefinitionException::class);
 
-        $this->buildSchema(/* @lang GraphQL */ '
+        $this->buildSchema(/** @lang GraphQL */ '
         type Task {
             id: ID!
         }
@@ -117,7 +117,7 @@ class ForceDeleteDirectiveTest extends DBTestCase
     {
         $this->expectException(DefinitionException::class);
 
-        $this->buildSchema(/* @lang GraphQL */ '
+        $this->buildSchema(/** @lang GraphQL */ '
         type Task {
             id: ID!
         }
@@ -132,7 +132,7 @@ class ForceDeleteDirectiveTest extends DBTestCase
     {
         $this->expectException(DefinitionException::class);
 
-        $this->buildSchema(/* @lang GraphQL */ '
+        $this->buildSchema(/** @lang GraphQL */ '
         type Task {
             id: ID!
         }
@@ -146,7 +146,7 @@ class ForceDeleteDirectiveTest extends DBTestCase
     public function testRejectsUsingDirectiveWithNoSoftDeleteModels(): void
     {
         $this->expectExceptionMessage(ForceDeleteDirective::MODEL_NOT_USING_SOFT_DELETES);
-        $this->buildSchema(/* @lang GraphQL */ '
+        $this->buildSchema(/** @lang GraphQL */ '
         type User {
             id: ID!
         }

--- a/tests/Integration/SoftDeletes/RestoreDirectiveTest.php
+++ b/tests/Integration/SoftDeletes/RestoreDirectiveTest.php
@@ -80,7 +80,7 @@ class RestoreDirectiveTest extends DBTestCase
     {
         $this->expectException(DefinitionException::class);
 
-        $this->buildSchema(/* @lang GraphQL */ '
+        $this->buildSchema(/** @lang GraphQL */ '
         type Task {
             id: ID!
         }
@@ -95,7 +95,7 @@ class RestoreDirectiveTest extends DBTestCase
     {
         $this->expectException(DefinitionException::class);
 
-        $this->buildSchema(/* @lang GraphQL */ '
+        $this->buildSchema(/** @lang GraphQL */ '
         type Task {
             id: ID!
         }
@@ -110,7 +110,7 @@ class RestoreDirectiveTest extends DBTestCase
     {
         $this->expectException(DefinitionException::class);
 
-        $this->buildSchema(/* @lang GraphQL */ '
+        $this->buildSchema(/** @lang GraphQL */ '
         type Task {
             id: ID!
         }
@@ -125,7 +125,7 @@ class RestoreDirectiveTest extends DBTestCase
     {
         $this->expectExceptionMessage(RestoreDirective::MODEL_NOT_USING_SOFT_DELETES);
 
-        $this->buildSchema(/* @lang GraphQL */ '
+        $this->buildSchema(/** @lang GraphQL */ '
         type User {
             id: ID!
         }

--- a/tests/Integration/SoftDeletes/SoftDeletesAndTrashedDirectiveTest.php
+++ b/tests/Integration/SoftDeletes/SoftDeletesAndTrashedDirectiveTest.php
@@ -235,7 +235,7 @@ class SoftDeletesAndTrashedDirectiveTest extends DBTestCase
             factory(Task::class, 2)->make()
         );
 
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Task {
             id: ID!
             name: String!
@@ -253,7 +253,7 @@ class SoftDeletesAndTrashedDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             users {
                 tasks(trashed: ONLY) {
@@ -277,7 +277,7 @@ class SoftDeletesAndTrashedDirectiveTest extends DBTestCase
             ],
         ]);
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             usersPaginated(first: 10) {
                 data {
@@ -305,7 +305,7 @@ class SoftDeletesAndTrashedDirectiveTest extends DBTestCase
             ],
         ]);
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             user(id: 1) {
                 tasks(trashed: ONLY) {
@@ -327,7 +327,7 @@ class SoftDeletesAndTrashedDirectiveTest extends DBTestCase
             ],
         ]);
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             users {
                 tasksWith: tasks(trashed: WITH) {
@@ -367,7 +367,7 @@ class SoftDeletesAndTrashedDirectiveTest extends DBTestCase
              ->assertJsonCount(2, 'data.usersPaginated.data.0.tasksWithout')
              ->assertJsonCount(2, 'data.usersPaginated.data.0.tasksSimple');
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             user(id: 1) {
                 tasksWith: tasks(trashed: WITH) {
@@ -389,7 +389,7 @@ class SoftDeletesAndTrashedDirectiveTest extends DBTestCase
 
     public function testThrowsIfModelDoesNotSupportSoftDeletesTrashed(): void
     {
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             trashed(trashed: Trashed @trashed): [User!]! @all
         }
@@ -400,7 +400,7 @@ class SoftDeletesAndTrashedDirectiveTest extends DBTestCase
         ';
 
         $this->expectExceptionMessage(TrashedDirective::MODEL_MUST_USE_SOFT_DELETES);
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             trashed(trashed: WITH) {
                 id
@@ -411,7 +411,7 @@ class SoftDeletesAndTrashedDirectiveTest extends DBTestCase
 
     public function testThrowsIfModelDoesNotSupportSoftDeletes(): void
     {
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             softDeletes: [User!]! @all @softDeletes
         }
@@ -422,7 +422,7 @@ class SoftDeletesAndTrashedDirectiveTest extends DBTestCase
         ';
 
         $this->expectExceptionMessage(TrashedDirective::MODEL_MUST_USE_SOFT_DELETES);
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             softDeletes(trashed: WITH) {
                 id

--- a/tests/Integration/ValidationTest.php
+++ b/tests/Integration/ValidationTest.php
@@ -12,7 +12,7 @@ use Tests\Utils\Queries\Foo;
 
 class ValidationTest extends DBTestCase
 {
-    protected $schema = /* @lang GraphQL */'
+    protected $schema = /** @lang GraphQL */ '
     type Query {
         foo(
             email: String = "hans@peter.rudolf" @rules(apply: ["email"])
@@ -85,7 +85,7 @@ class ValidationTest extends DBTestCase
     public function testRunsValidationBeforeCallingTheResolver(): void
     {
         $shouldNotBeCalled = '@field(resolver: "'.$this->qualifyTestResolver('resolveDoNotCall').'")';
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             ensureThisWorks: String '.$shouldNotBeCalled.'
         }
@@ -100,14 +100,14 @@ class ValidationTest extends DBTestCase
         $this->assertSame(0, self::$callCount);
 
         // Sanity check to ensure the test works
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             ensureThisWorks
         }
         ');
         $this->assertSame(1, self::$callCount);
 
-        $response = $this->graphQL(/* @lang GraphQL */ '
+        $response = $this->graphQL(/** @lang GraphQL */ '
         mutation {
             resolveDoNotCall
         }
@@ -127,7 +127,7 @@ class ValidationTest extends DBTestCase
 
     public function testValidatesDifferentPathsIndividually(): void
     {
-        $result = $this->graphQL(/* @lang GraphQL */ '
+        $result = $this->graphQL(/** @lang GraphQL */ '
         {
             foo(
                 input: [
@@ -160,7 +160,7 @@ class ValidationTest extends DBTestCase
 
     public function testValidatesList(): void
     {
-        $result = $this->graphQL(/* @lang GraphQL */ '
+        $result = $this->graphQL(/** @lang GraphQL */ '
         {
             foo(
                 list: [
@@ -182,7 +182,7 @@ class ValidationTest extends DBTestCase
 
     public function testValidatesInputCount(): void
     {
-        $result = $this->graphQL(/* @lang GraphQL */ '
+        $result = $this->graphQL(/** @lang GraphQL */ '
         {
             foo(
                 stringList: [
@@ -220,7 +220,7 @@ class ValidationTest extends DBTestCase
 
     public function testPassesIfNothingRequiredIsMissing(): void
     {
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             foo(required: "foo")
         }
@@ -233,7 +233,7 @@ class ValidationTest extends DBTestCase
 
     public function testEvaluatesArgDirectivesInDefinitionOrder(): void
     {
-        $validPasswordResult = $this->graphQL(/* @lang GraphQL */ '
+        $validPasswordResult = $this->graphQL(/** @lang GraphQL */ '
         {
             password(password: " 1234567 ")
         }
@@ -243,7 +243,7 @@ class ValidationTest extends DBTestCase
         $this->assertNotSame(' 1234567 ', $password);
         $this->assertTrue(password_verify('1234567', $password));
 
-        $invalidPasswordResult = $this->graphQL(/* @lang GraphQL */ '
+        $invalidPasswordResult = $this->graphQL(/** @lang GraphQL */ '
         {
             password(password: " 1234 ")
         }
@@ -258,7 +258,7 @@ class ValidationTest extends DBTestCase
 
     public function testEvaluatesConditionalValidation(): void
     {
-        $validPasswordResult = $this->graphQL(/* @lang GraphQL */ '
+        $validPasswordResult = $this->graphQL(/** @lang GraphQL */ '
         {
             password
         }
@@ -266,7 +266,7 @@ class ValidationTest extends DBTestCase
 
         $this->assertSame('no-password', $validPasswordResult->jsonGet('data.password'));
 
-        $invalidPasswordResult = $this->graphQL(/* @lang GraphQL */ '
+        $invalidPasswordResult = $this->graphQL(/** @lang GraphQL */ '
         {
             password(id: "foo")
         }
@@ -281,7 +281,7 @@ class ValidationTest extends DBTestCase
 
     public function testEvaluatesInputArgValidation(): void
     {
-        $result = $this->graphQL(/* @lang GraphQL */ '
+        $result = $this->graphQL(/** @lang GraphQL */ '
         {
             password(id: "bar", password: "123456")
         }
@@ -296,7 +296,7 @@ class ValidationTest extends DBTestCase
 
     public function testEvaluatesNonNullInputArgValidation(): void
     {
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             email(
                 userId: 1
@@ -312,7 +312,7 @@ class ValidationTest extends DBTestCase
             ],
         ]);
 
-        $invalidEmailResult = $this->graphQL(/* @lang GraphQL */ '
+        $invalidEmailResult = $this->graphQL(/** @lang GraphQL */ '
         {
             email(
                 userId: 1
@@ -334,7 +334,7 @@ class ValidationTest extends DBTestCase
 
     public function testErrorsIfSomethingRequiredIsMissing(): void
     {
-        $result = $this->graphQL(/* @lang GraphQL */ '
+        $result = $this->graphQL(/** @lang GraphQL */ '
         {
             foo
         }
@@ -351,7 +351,7 @@ class ValidationTest extends DBTestCase
 
     public function testSetsArgumentsOnCustomValidationDirective(): void
     {
-        $this->schema .= /* @lang GraphQL */ '
+        $this->schema .= /** @lang GraphQL */ '
         type Mutation {
             updateUser(
                 input: UpdateUserInput @spread
@@ -379,7 +379,7 @@ class ValidationTest extends DBTestCase
             'name' => 'bar',
         ]);
 
-        $duplicateName = $this->graphQL(/* @lang GraphQL */ '
+        $duplicateName = $this->graphQL(/** @lang GraphQL */ '
         mutation {
             updateUser(
                 input: {
@@ -404,7 +404,7 @@ class ValidationTest extends DBTestCase
 
     public function testIgnoresTheUserWeAreUpdating(): void
     {
-        $this->schema .= /* @lang GraphQL */ '
+        $this->schema .= /** @lang GraphQL */ '
         type Mutation {
             updateUser(
                 input: UpdateUserInput @spread
@@ -426,7 +426,7 @@ class ValidationTest extends DBTestCase
 
         factory(User::class)->create(['name' => 'bar']);
 
-        $updateSelf = $this->graphQL(/* @lang GraphQL */ '
+        $updateSelf = $this->graphQL(/** @lang GraphQL */ '
         mutation {
             updateUser(
                 input: {
@@ -453,7 +453,7 @@ class ValidationTest extends DBTestCase
     {
         $this->markTestSkipped('Not implemented as of now as it would require a larger redo.');
 
-        $this->schema .= /* @lang GraphQL */ '
+        $this->schema .= /** @lang GraphQL */ '
         type Mutation {
             createUser(
                 foo: String @rules(apply: ["max:5"])
@@ -468,7 +468,7 @@ class ValidationTest extends DBTestCase
         }
         ';
 
-        $result = $this->graphQL(/* @lang GraphQL */ '
+        $result = $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createUser(
                 foo: "  ?!?  "
@@ -492,7 +492,7 @@ class ValidationTest extends DBTestCase
         and Lighthouse uses those of the first directive.
         ');
 
-        $this->schema .= /* @lang GraphQL */ '
+        $this->schema .= /** @lang GraphQL */ '
         type Mutation {
             createUser(
                 foo: String @rules(apply: ["max:5"]) @trim @rules(apply: ["min:4"])
@@ -506,7 +506,7 @@ class ValidationTest extends DBTestCase
         }
         ';
 
-        $result = $this->graphQL(/* @lang GraphQL */ '
+        $result = $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createUser(
                 foo: "  ?!?  "
@@ -524,7 +524,7 @@ class ValidationTest extends DBTestCase
 
     public function testCombinesArgumentValidationWhenGrouped(): void
     {
-        $this->schema .= /* @lang GraphQL */ '
+        $this->schema .= /** @lang GraphQL */ '
         type Mutation {
             withMergedRules(
                 bar: String @rules(apply: ["min:40"]) @customRules(apply: ["bool"])

--- a/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
+++ b/tests/Integration/WhereConstraints/WhereConstraintsDirectiveTest.php
@@ -11,7 +11,7 @@ use Tests\Utils\Models\User;
 
 class WhereConstraintsDirectiveTest extends DBTestCase
 {
-    protected $schema = /** @lang GraphQL */'
+    protected $schema = /** @lang GraphQL */ '
     type User {
         id: ID!
         name: String
@@ -453,7 +453,7 @@ class WhereConstraintsDirectiveTest extends DBTestCase
     {
         factory(User::class)->create();
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             whitelistedColumns(
                 where: {

--- a/tests/Unit/Execution/Arguments/ArgumentSetTest.php
+++ b/tests/Unit/Execution/Arguments/ArgumentSetTest.php
@@ -197,9 +197,9 @@ class ArgumentSetTest extends TestCase
     {
         $renameDirective = new RenameDirective();
         $renameDirective->hydrate(
-            PartialParser::directive(/* @lang GraphQL */ "@rename(attribute: \"$attribute\")"),
+            PartialParser::directive(/** @lang GraphQL */ "@rename(attribute: \"$attribute\")"),
             // We require some placeholder for the directive definition to sit on
-            PartialParser::fieldDefinition(/* @lang GraphQL */ 'placeholder: ID')
+            PartialParser::fieldDefinition(/** @lang GraphQL */ 'placeholder: ID')
         );
 
         return $renameDirective;

--- a/tests/Unit/Schema/Directives/BaseDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/BaseDirectiveTest.php
@@ -25,7 +25,7 @@ class BaseDirectiveTest extends TestCase
 {
     public function testGetsModelClassFromDirective(): void
     {
-        $this->schema .= /* @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type User @modelClass(class: "Team") {
             id: ID
         }
@@ -51,7 +51,7 @@ class BaseDirectiveTest extends TestCase
 
     public function testDefaultsToFieldTypeForTheModelClass(): void
     {
-        $this->schema .= /* @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type User {
             id: ID
         }
@@ -75,7 +75,7 @@ class BaseDirectiveTest extends TestCase
 
     public function testThrowsIfTheClassIsNotAModel(): void
     {
-        $this->schema .= /* @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type Exception {
             id: ID
         }
@@ -89,7 +89,7 @@ class BaseDirectiveTest extends TestCase
 
     public function testResolvesAModelThatIsNamedLikeABaseClass(): void
     {
-        $this->schema .= /* @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type Closure {
             id: ID
         }
@@ -105,7 +105,7 @@ class BaseDirectiveTest extends TestCase
 
     public function testPrefersThePrimaryModelNamespace(): void
     {
-        $this->schema .= /* @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type Category {
             id: ID
         }
@@ -121,7 +121,7 @@ class BaseDirectiveTest extends TestCase
 
     public function testAllowsOverwritingTheDefaultModel(): void
     {
-        $this->schema .= /* @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type OnlyHere {
             id: ID
         }
@@ -137,7 +137,7 @@ class BaseDirectiveTest extends TestCase
 
     public function testResolvesFromTheSecondaryModelNamespace(): void
     {
-        $this->schema .= /* @lang GraphQL */'
+        $this->schema .= /** @lang GraphQL */ '
         type OnlyHere {
             id: ID
         }

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -159,7 +159,7 @@ class CanDirectiveTest extends TestCase
     public function testInjectArgsPassesClientArgumentToPolicy(): void
     {
         $this->be(new User);
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             user(foo: String): User!
                 @can(ability:"injectArgs", injectArgs: true)
@@ -171,7 +171,7 @@ class CanDirectiveTest extends TestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             user(foo: "bar"){
                 name
@@ -189,7 +189,7 @@ class CanDirectiveTest extends TestCase
     public function testInjectedArgsAndStaticArgs(): void
     {
         $this->be(new User);
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             user(foo: String): User!
                 @can(
@@ -205,7 +205,7 @@ class CanDirectiveTest extends TestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             user(foo: "dynamic"){
                 name

--- a/tests/Unit/Schema/Directives/FieldDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/FieldDirectiveTest.php
@@ -10,13 +10,13 @@ class FieldDirectiveTest extends TestCase
 {
     public function testAssignsResolverFromCombinedDefinition(): void
     {
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             bar: String! @field(resolver:"Tests\\\Utils\\\Resolvers\\\Foo@bar")
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             bar
         }
@@ -29,13 +29,13 @@ class FieldDirectiveTest extends TestCase
 
     public function testAssignsResolverWithInvokableClass(): void
     {
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             baz: String! @field(resolver:"Tests\\\Utils\\\Resolvers\\\Foo")
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             baz
         }
@@ -48,13 +48,13 @@ class FieldDirectiveTest extends TestCase
 
     public function testCanResolveFieldWithMergedArgs(): void
     {
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             bar: String! @field(resolver: "Tests\\\Utils\\\Resolvers\\\Foo@baz" args:["foo.baz"])
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             bar
         }
@@ -67,13 +67,13 @@ class FieldDirectiveTest extends TestCase
 
     public function testUsesDefaultFieldNamespace(): void
     {
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             bar: String! @field(resolver: "FooBar@customResolve")
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             bar
         }
@@ -86,13 +86,13 @@ class FieldDirectiveTest extends TestCase
 
     public function testUsesDefaultFieldNamespaceForInvokableClass(): void
     {
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             baz: String! @field(resolver: "FooBar")
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             baz
         }
@@ -108,13 +108,13 @@ class FieldDirectiveTest extends TestCase
         $this->expectException(DefinitionException::class);
         $this->expectExceptionMessage("No class 'NonExisting' was found for directive 'field'");
 
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo: String! @field(resolver: "NonExisting")
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             foo
         }
@@ -126,13 +126,13 @@ class FieldDirectiveTest extends TestCase
         $this->expectException(DefinitionException::class);
         $this->expectExceptionMessage("Method '__invoke' does not exist on class 'Tests\Utils\Queries\Foo'");
 
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             bar: String! @field(resolver: "Foo")
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             bar
         }

--- a/tests/Unit/Schema/Directives/GuardDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/GuardDirectiveTest.php
@@ -10,7 +10,7 @@ class GuardDirectiveTest extends TestCase
 {
     public function testGuardsWithDefault(): void
     {
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo: Int @guard
         }
@@ -31,7 +31,7 @@ class GuardDirectiveTest extends TestCase
 
     public function testGuardsWithApi(): void
     {
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo: Int @guard(with: "api")
         }
@@ -58,7 +58,7 @@ class GuardDirectiveTest extends TestCase
     public function testPassesOneFieldButThrowsInAnother(): void
     {
         $this->be(new User());
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo: Int @guard
             bar: String @guard(with: "api")

--- a/tests/Unit/Schema/Directives/MiddlewareDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/MiddlewareDirectiveTest.php
@@ -62,7 +62,7 @@ class MiddlewareDirectiveTest extends TestCase
 
     public function testWrapsExceptionFromMiddlewareInResponse(): void
     {
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             bar: String
             foo: Int @middleware(checks: ["Tests\\\Utils\\\Middleware\\\Authenticate"])
@@ -89,7 +89,7 @@ class MiddlewareDirectiveTest extends TestCase
         $router = $this->app['router'];
         $router->aliasMiddleware('foo', CountRuns::class);
 
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo: Int
                 @middleware(checks: ["foo"])
@@ -114,7 +114,7 @@ class MiddlewareDirectiveTest extends TestCase
         $router = $this->app['router'];
         $router->middlewareGroup('bar', [Authenticate::class]);
 
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo: Int
                 @middleware(checks: ["bar"])
@@ -136,7 +136,7 @@ class MiddlewareDirectiveTest extends TestCase
 
     public function testPassesOneFieldButThrowsInAnother(): void
     {
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo: Int
                 @middleware(checks: ["Tests\\\Utils\\\Middleware\\\Authenticate"])
@@ -177,7 +177,7 @@ class MiddlewareDirectiveTest extends TestCase
 
     public function testAddsMiddlewareDirectiveToFields(): void
     {
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query @middleware(checks: ["auth", "Tests\\\Utils\\\Middleware\\\Authenticate", "api"]) {
             foo: Int
         }
@@ -204,7 +204,7 @@ class MiddlewareDirectiveTest extends TestCase
 
     public function testPrefersFieldMiddlewareOverTypeMiddleware(): void
     {
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query @middleware(checks: ["auth"]) {
             foo: Int @middleware(checks: ["api"])
         }

--- a/tests/Unit/Schema/Directives/RenameDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/RenameDirectiveTest.php
@@ -15,7 +15,7 @@ class RenameDirectiveTest extends TestCase
             ];
         });
 
-        $this->schema = /* @lang GraphQL */ '
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo: Foo @mock
         }
@@ -25,7 +25,7 @@ class RenameDirectiveTest extends TestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             foo {
                 bar
@@ -44,13 +44,13 @@ class RenameDirectiveTest extends TestCase
     {
         $this->expectException(DefinitionException::class);
 
-        $this->schema = /* @lang GraphQL */ '
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo: String! @rename
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             fooBar
         }
@@ -63,7 +63,7 @@ class RenameDirectiveTest extends TestCase
             return $args === ['bar' => 'something'];
         });
 
-        $this->schema = /* @lang GraphQL */ '
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo(
                 baz: String @rename(attribute: "bar")
@@ -71,7 +71,7 @@ class RenameDirectiveTest extends TestCase
         }
         ';
 
-        $this->graphQL(/* @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             foo(baz: "something")
         }

--- a/tests/Unit/Schema/Directives/RulesDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/RulesDirectiveTest.php
@@ -29,7 +29,7 @@ class RulesDirectiveTest extends TestCase
             ];
         });
 
-        $this->schema = /* @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo(bar: String @rules(apply: ["required"])): User @mock
         }
@@ -83,7 +83,7 @@ class RulesDirectiveTest extends TestCase
     public function testCanValidateQueryRootFieldArguments(): void
     {
         $this
-            ->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
+            ->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
 {
     foo {
         first_name
@@ -118,7 +118,7 @@ GRAPHQL
             ])
             ->assertJson(
                 $this
-                    ->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
+                    ->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
 mutation {
     foo {
         first_name
@@ -133,7 +133,7 @@ GRAPHQL
     public function testCanReturnValidFieldsAndErrorMessagesForInvalidFields(): void
     {
         $this
-            ->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
+            ->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
 {
     foo(bar: "foo") {
         first_name
@@ -167,7 +167,7 @@ GRAPHQL
             ])
             ->assertJson(
                 $this
-                    ->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
+                    ->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
 {
     foo(bar: "foo") {
         first_name
@@ -184,7 +184,7 @@ GRAPHQL
     public function testCanValidateRootMutationFieldArgs(): void
     {
         $this
-            ->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
+            ->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
 mutation {
     foo {
         first_name
@@ -202,7 +202,7 @@ GRAPHQL
             ->assertJsonCount(1, 'errors')
             ->assertJson(
                 $this
-                    ->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
+                    ->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
 {
     foo {
         first_name
@@ -219,7 +219,7 @@ GRAPHQL
     public function testCanValidateArrayType(): void
     {
         $this
-            ->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
+            ->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
 {
     foo(bar: "got it") {
         input_object(
@@ -283,7 +283,7 @@ GRAPHQL
     public function testCanReturnCorrectValidationForInputObjects(): void
     {
         $this
-            ->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
+            ->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
 {
     foo(bar: "got it") {
         input_object(
@@ -335,7 +335,7 @@ GRAPHQL
     public function testUsesCustomRuleClass(): void
     {
         $this
-            ->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
+            ->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
 mutation {
     withCustomRuleClass(
         rules: "baz"
@@ -359,7 +359,7 @@ GRAPHQL
     public function testRulesHaveToBeArray(): void
     {
         $this->expectException(DefinitionException::class);
-        $this->buildSchema(/* @lang GraphQL */'
+        $this->buildSchema(/** @lang GraphQL */ '
         type Query {
             foo(bar: ID @rules(apply: 123)): ID
         }

--- a/tests/Unit/Schema/Factories/DirectiveFactoryTest.php
+++ b/tests/Unit/Schema/Factories/DirectiveFactoryTest.php
@@ -37,7 +37,7 @@ class DirectiveFactoryTest extends TestCase
 
     public function testHydratesBaseDirectives(): void
     {
-        $fieldDefinition = PartialParser::fieldDefinition(/* @lang GraphQL */ '
+        $fieldDefinition = PartialParser::fieldDefinition(/** @lang GraphQL */ '
             foo: String @field
         ');
 
@@ -58,7 +58,7 @@ class DirectiveFactoryTest extends TestCase
 
     public function testSkipsHydrationForNonBaseDirectives(): void
     {
-        $fieldDefinition = PartialParser::fieldDefinition(/* @lang GraphQL */ '
+        $fieldDefinition = PartialParser::fieldDefinition(/** @lang GraphQL */ '
             foo: String @foo
         ');
 
@@ -93,7 +93,7 @@ class DirectiveFactoryTest extends TestCase
 
     public function testCanCreateSingleDirective(): void
     {
-        $fieldDefinition = PartialParser::fieldDefinition(/* @lang GraphQL */ '
+        $fieldDefinition = PartialParser::fieldDefinition(/** @lang GraphQL */ '
             foo: [Foo!]! @hasMany
         ');
 
@@ -105,7 +105,7 @@ class DirectiveFactoryTest extends TestCase
     {
         $this->expectException(DirectiveException::class);
 
-        $fieldDefinition = PartialParser::fieldDefinition(/* @lang GraphQL */ '
+        $fieldDefinition = PartialParser::fieldDefinition(/** @lang GraphQL */ '
             bar: [Bar!]! @hasMany @belongsTo
         ');
 
@@ -114,7 +114,7 @@ class DirectiveFactoryTest extends TestCase
 
     public function testCanCreateMultipleDirectives(): void
     {
-        $fieldDefinition = PartialParser::fieldDefinition(/* @lang GraphQL */ '
+        $fieldDefinition = PartialParser::fieldDefinition(/** @lang GraphQL */ '
             bar: String @can(if: ["viewBar"]) @event
         ');
 

--- a/tests/database/factories/ACLFactory.php
+++ b/tests/database/factories/ACLFactory.php
@@ -3,7 +3,7 @@
 use Faker\Generator as Faker;
 use Tests\Utils\Models\ACL;
 
-/* @var \Illuminate\Database\Eloquent\Factory $factory */
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
 $factory->define(ACL::class, function (Faker $faker): array {
     return [
         'create_post' => $faker->boolean,

--- a/tests/database/factories/CategoryFactory.php
+++ b/tests/database/factories/CategoryFactory.php
@@ -3,7 +3,7 @@
 use Faker\Generator as Faker;
 use Tests\Utils\Models\Category;
 
-/* @var \Illuminate\Database\Eloquent\Factory $factory */
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
 $factory->define(Category::class, function (Faker $faker): array {
     return [
         'name' => $faker->name,

--- a/tests/database/factories/Color.php
+++ b/tests/database/factories/Color.php
@@ -3,7 +3,7 @@
 use Faker\Generator as Faker;
 use Tests\Utils\Models\Color;
 
-/* @var \Illuminate\Database\Eloquent\Factory $factory */
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
 $factory->define(Color::class, function (Faker $faker): array {
     return [
         'name' => $faker->name,

--- a/tests/database/factories/CommentFactory.php
+++ b/tests/database/factories/CommentFactory.php
@@ -5,7 +5,7 @@ use Tests\Utils\Models\Comment;
 use Tests\Utils\Models\Post;
 use Tests\Utils\Models\User;
 
-/* @var \Illuminate\Database\Eloquent\Factory $factory */
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
 $factory->define(Comment::class, function (Faker $faker): array {
     return [
         'comment' => $faker->sentence,

--- a/tests/database/factories/CompanyFactory.php
+++ b/tests/database/factories/CompanyFactory.php
@@ -3,7 +3,7 @@
 use Faker\Generator as Faker;
 use Tests\Utils\Models\Company;
 
-/* @var \Illuminate\Database\Eloquent\Factory $factory */
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
 $factory->define(Company::class, function (Faker $faker): array {
     return [
         'name' => $faker->sentence,

--- a/tests/database/factories/HourFactory.php
+++ b/tests/database/factories/HourFactory.php
@@ -4,7 +4,7 @@ use Faker\Generator as Faker;
 use Tests\Utils\Models\Hour;
 use Tests\Utils\Models\Task;
 
-/* @var \Illuminate\Database\Eloquent\Factory $factory */
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
 $factory->define(Hour::class, function (Faker $faker): array {
     return [
         'from' => $faker->time('H:i'),

--- a/tests/database/factories/PostFactory.php
+++ b/tests/database/factories/PostFactory.php
@@ -5,7 +5,7 @@ use Tests\Utils\Models\Post;
 use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
 
-/* @var \Illuminate\Database\Eloquent\Factory $factory */
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
 $factory->define(Post::class, function (Faker $faker): array {
     return [
         'title' => $faker->title,

--- a/tests/database/factories/ProductFactory.php
+++ b/tests/database/factories/ProductFactory.php
@@ -4,7 +4,7 @@ use Faker\Generator as Faker;
 use Tests\Utils\Models\Color;
 use Tests\Utils\Models\Product;
 
-/* @var \Illuminate\Database\Eloquent\Factory $factory */
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
 $factory->define(Product::class, function (Faker $faker): array {
     return [
         'barcode' => $faker->ean13,

--- a/tests/database/factories/RoleFactory.php
+++ b/tests/database/factories/RoleFactory.php
@@ -4,7 +4,7 @@ use Faker\Generator as Faker;
 use Tests\Utils\Models\ACL;
 use Tests\Utils\Models\Role;
 
-/* @var \Illuminate\Database\Eloquent\Factory $factory */
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
 $factory->define(Role::class, function (Faker $faker): array {
     $roles = ['role_1', 'role_2', 'role_3', 'role_4', 'role_5', 'role_6'];
 

--- a/tests/database/factories/TagFactory.php
+++ b/tests/database/factories/TagFactory.php
@@ -3,7 +3,7 @@
 use Faker\Generator as Faker;
 use Tests\Utils\Models\Tag;
 
-/* @var \Illuminate\Database\Eloquent\Factory $factory */
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
 $factory->define(Tag::class, function (Faker $faker): array {
     return [
         'name' => $faker->name,

--- a/tests/database/factories/TaskFactory.php
+++ b/tests/database/factories/TaskFactory.php
@@ -3,7 +3,7 @@
 use Faker\Generator as Faker;
 use Tests\Utils\Models\Task;
 
-/* @var \Illuminate\Database\Eloquent\Factory $factory */
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
 $factory->define(Task::class, function (Faker $faker): array {
     return [
         'name' => $faker->unique()->sentence,

--- a/tests/database/factories/TeamFactory.php
+++ b/tests/database/factories/TeamFactory.php
@@ -3,7 +3,7 @@
 use Faker\Generator as Faker;
 use Tests\Utils\Models\Team;
 
-/* @var \Illuminate\Database\Eloquent\Factory $factory */
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
 $factory->define(Team::class, function (Faker $faker): array {
     return [
         'name' => $faker->name,

--- a/tests/database/factories/UserFactory.php
+++ b/tests/database/factories/UserFactory.php
@@ -5,7 +5,7 @@ use Tests\Utils\Models\Company;
 use Tests\Utils\Models\Team;
 use Tests\Utils\Models\User;
 
-/* @var \Illuminate\Database\Eloquent\Factory $factory */
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
 $factory->define(User::class, function (Faker $faker): array {
     return [
         'company_id' => function () {


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Added Docs for all relevant versions
- [ ] Updated CHANGELOG.md

It just unifies the use of comments to be consistent.

**Changes**

Replace `/* ` by `/** ` and adds a space before the quote, if needed.
For example, there were comments like `/* @lang GraphQL */'...'` and it should be `/** @lang GraphQL */ '...'`.

**Breaking changes**

None.
