### PR TITLE
Exclude or include trashed models in `@can` when `@forceDelete` or `@restore` are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add optional `columnsEnum` argument to the `@whereConditions`, `@whereHasConditions`
   and `@orderBy` directives https://github.com/nuwave/lighthouse/pull/1150
+- Exclude or include trashed models in `@can` when `@forceDelete` or `@restore` are used
+  so the client does not have to filter explicitly https://github.com/nuwave/lighthouse/pull/1157
 
 ### Fixed
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -476,51 +476,6 @@ directive @can(
 ) on FIELD_DEFINITION
 ```
 
-This directive is most commonly used for mutations:
-
-```graphql
-type Mutation {
-    createPost(input: PostInput): Post @can(ability: "create")
-}
-```
-
-```php
-class PostPolicy
-{
-    public function create(User $user): bool
-    {
-        return $user->is_admin;
-    }
-}
-```
-
-In `find` parameter you may specify an input argument which is used to find a specific model
-instance by primary key against which the permissions should be checked:
-
-```graphql
-type Query {
-    post(id: ID @eq): Post @can(ability: "view", find: "id")
-}
-```
-
-```php
-class PostPolicy
-{
-    public function update(User $user, Post $post): bool
-    {
-        return $user->id === $post->author_id;
-    }
-}
-```
-
-It also works with soft deleted models in combination with `@softDeletes` directive:
-
-```graphql
-type Query {
-    post(id: ID @eq): Post @softDeletes @can(ability: "view", find: "id")
-}
-```
-
 The name of the returned Type `Post` is used as the Model class, however you may overwrite this by
 passing the `model` argument.
 
@@ -531,29 +486,7 @@ type Mutation {
 }
 ```
 
-You can pass additional arguments to the policy checks by specifying them as `args`:
-
-```graphql
-type Mutation {
-    createPost(input: PostInput): Post
-        @can(ability: "create", args: ["FROM_GRAPHQL"])
-}
-```
-
-You can pass along the client given input data as arguments to the policy checks
-with the `injectArgs` argument:
-
-```graphql
-type Mutation {
-    createPost(input: PostInput): Post
-        @can(ability: "create", injectArgs: "true")
-}
-```
-
-Now you will have access to `PostInput` values in the policy. 
-
-Starting from Laravel 5.7, [authorization of guest users](https://laravel.com/docs/authorization#guest-users) is supported.
-Because of this, Lighthouse does **not** validate that the user is authenticated before passing it along to the policy.
+You can find usage examples of this directive in [the authorization docs](../security/authorization.md#restrict-fields-through-policies).
 
 ## @complexity
 

--- a/docs/master/eloquent/soft-deleting.md
+++ b/docs/master/eloquent/soft-deleting.md
@@ -68,7 +68,7 @@ This mutation will return the restored object.
 
 ## Permanently Deleting Models
 
-To truly remove model from database,
+To truly remove a model from the database,
 use the [@forceDelete](../api-reference/directives.md#forcedelete) directive.
 Your model must use the `Illuminate\Database\Eloquent\SoftDeletes` trait. 
 
@@ -78,7 +78,7 @@ type Mutation {
 }
 ```
 
-Simply call it with the ID of the Flight you want to permanently remove.
+Simply call it with the ID of the `Flight` you want to permanently remove.
 
 ```graphql
 mutation {

--- a/docs/master/security/authorization.md
+++ b/docs/master/security/authorization.md
@@ -54,4 +54,109 @@ limited to seeing just those.
 ## Restrict fields through policies
 
 Lighthouse allows you to restrict field operations to a certain group of users.
-Use the [@can](../api-reference/directives.md#can) directive to leverage [Laravel Policies](https://laravel.com/docs/authorization) for authorization.
+Use the [@can](../api-reference/directives.md#can) directive
+to leverage [Laravel Policies](https://laravel.com/docs/authorization) for authorization.
+
+Starting from Laravel 5.7, [authorization of guest users](https://laravel.com/docs/authorization#guest-users) is supported.
+Because of this, Lighthouse does **not** validate that the user is authenticated before passing it along to the policy.
+
+### Protect mutations
+
+As an example, you might want to allow only admin users of your application to create posts.
+Start out by defining `@can` upon a mutation you want to protect:
+
+```graphql
+type Mutation {
+    createPost(input: PostInput): Post @can(ability: "create")
+}
+```
+
+The `create` ability that is referenced in the example above is backed by a Laravel policy:
+
+```php
+class PostPolicy
+{
+    public function create(User $user): bool
+    {
+        return $user->is_admin;
+    }
+}
+```
+
+### Protect specific model instances
+
+For some models, you may want to restrict access for specific instances of a model.
+Use the `find` parameter to specify the name of an input argument that is the primary
+key of the model. Lighthouse will use that to find a specific model
+instance against which the permissions should be checked:
+
+```graphql
+type Query {
+    post(id: ID @eq): Post @can(ability: "view", find: "id")
+}
+```
+
+```php
+class PostPolicy
+{
+    public function view(User $user, Post $post): bool
+    {
+        return $user->id === $post->author_id;
+    }
+}
+```
+
+Finding models combines nicely with [soft deleting](../eloquent/soft-deleting.md).
+Lighthouse will detect if the query will require a filter for trashed models and
+apply that as needed.
+
+### Passing additional arguments 
+
+You can pass additional arguments to the policy checks by specifying them as `args`:
+
+```graphql
+type Mutation {
+    createPost(input: PostInput): Post
+        @can(ability: "create", args: ["FROM_GRAPHQL"])
+}
+```
+
+```php
+class PostPolicy
+{
+    public function create(User $user, array $args): bool
+    {
+        // $args will be the PHP representation of what is in the schema: [0 => 'FROM_GRAPHQL']
+    }
+}
+```
+
+You can pass along the client given input data as arguments to the policy checks
+with the `injectArgs` argument:
+
+```graphql
+type Mutation {
+    createPost(title: String!): Post
+        @can(ability: "create", injectArgs: "true")
+}
+```
+
+```php
+class PostPolicy
+{
+    public function create(User $user, array $injected): bool
+    {
+        // $injected will hold the args given by the client: ['title' => string(?)]
+    }
+}
+```
+
+When you combine both ways of passing arguments, the policy will be passed the `injectArgs` as
+the second parameter and the static `args` as the third parameter:
+
+```php
+class PostPolicy
+{
+    public function create($user, array $injectedArgs, array $staticArgs): bool { ... }
+}
+```

--- a/docs/master/security/authorization.md
+++ b/docs/master/security/authorization.md
@@ -1,5 +1,8 @@
 # Authorization
 
+Not every user in your application may be allowed to see all data or do any action.
+You can control what they can do by enforcing authorization rules.
+
 ## Utilize the Viewer pattern
 
 A common pattern is to allow users to only access entries that belong to them.

--- a/src/Schema/Directives/RelationDirective.php
+++ b/src/Schema/Directives/RelationDirective.php
@@ -79,7 +79,10 @@ abstract class RelationDirective extends BaseDirective
         return function ($builder) use ($resolveInfo) {
             $resolveInfo
                 ->argumentSet
-                ->enhanceBuilder($builder, $this->directiveArgValue('scopes', []));
+                ->enhanceBuilder(
+                    $builder,
+                    $this->directiveArgValue('scopes', [])
+                );
         };
     }
 

--- a/src/Schema/Directives/WithDirective.php
+++ b/src/Schema/Directives/WithDirective.php
@@ -58,7 +58,10 @@ SDL;
                             'decorateBuilder' => function ($query) use ($resolveInfo) {
                                 $resolveInfo
                                     ->argumentSet
-                                    ->enhanceBuilder($query, $this->directiveArgValue('scopes', []));
+                                    ->enhanceBuilder(
+                                        $query,
+                                        $this->directiveArgValue('scopes', [])
+                                    );
                             },
                         ]
                     );

--- a/tests/Integration/SoftDeletes/ForceDeleteDirectiveTest.php
+++ b/tests/Integration/SoftDeletes/ForceDeleteDirectiveTest.php
@@ -152,9 +152,10 @@ class ForceDeleteDirectiveTest extends DBTestCase
 
         type Mutation {
             forceDeleteTasks(id: ID!): Task!
-                @softDeletes
                 @can(ability: "delete", find: "id")
                 @forceDelete
+                # The order has to be like this, otherwise @forceDelete will throw
+                @softDeletes
         }
         ';
 

--- a/tests/Integration/SoftDeletes/ForceDeleteDirectiveTest.php
+++ b/tests/Integration/SoftDeletes/ForceDeleteDirectiveTest.php
@@ -100,7 +100,7 @@ class ForceDeleteDirectiveTest extends DBTestCase
         $this->assertCount(0, Task::withTrashed()->get());
     }
 
-    public function testForceDeleteWorksWithCan(): void
+    public function testCanDirectiveIncludesTrashedModelsWhenUsingForceDelete(): void
     {
         $user = User::create([
             'name' => UserPolicy::ADMIN,
@@ -117,7 +117,9 @@ class ForceDeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            forceDeleteTasks(id: ID!): Task! @forceDelete @can(ability: "delete", find: "id")
+            forceDeleteTasks(id: ID!): Task!
+                @can(ability: "delete", find: "id")
+                @forceDelete
         }
         ';
 
@@ -132,7 +134,7 @@ class ForceDeleteDirectiveTest extends DBTestCase
         $this->assertCount(0, Task::withTrashed()->get());
     }
 
-    public function testForceDeleteWorksWithCanOldWay(): void
+    public function testCanDirectiveUsesExplicitTrashedArgument(): void
     {
         $user = User::create([
             'name' => UserPolicy::ADMIN,
@@ -149,7 +151,10 @@ class ForceDeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            forceDeleteTasks(id: ID!): Task! @forceDelete @softDeletes @can(ability: "delete", find: "id")
+            forceDeleteTasks(id: ID!): Task!
+                @softDeletes
+                @can(ability: "delete", find: "id")
+                @forceDelete
         }
         ';
 

--- a/tests/Integration/SoftDeletes/RestoreDirectiveTest.php
+++ b/tests/Integration/SoftDeletes/RestoreDirectiveTest.php
@@ -6,6 +6,8 @@ use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\SoftDeletes\RestoreDirective;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Task;
+use Tests\Utils\Models\User;
+use Tests\Utils\Policies\UserPolicy;
 
 class RestoreDirectiveTest extends DBTestCase
 {
@@ -17,17 +19,17 @@ class RestoreDirectiveTest extends DBTestCase
         $this->assertCount(1, Task::withTrashed()->get());
         $this->assertCount(0, Task::withoutTrashed()->get());
 
-        $this->schema .= '
+        $this->schema .= /** @lang GraphQL */ '
         type Task {
             id: ID!
         }
-        
+
         type Mutation {
             restoreTask(id: ID!): Task @restore
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             restoreTask(id: 1) {
                 id
@@ -54,18 +56,18 @@ class RestoreDirectiveTest extends DBTestCase
         $this->assertCount(2, Task::withTrashed()->get());
         $this->assertCount(0, Task::withoutTrashed()->get());
 
-        $this->schema .= '
+        $this->schema .= /** @lang GraphQL */ '
         type Task {
             id: ID!
             name: String
         }
-        
+
         type Mutation {
             restoreTasks(id: [ID!]!): [Task!]! @restore
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             restoreTasks(id: [1, 2]) {
                 name
@@ -76,6 +78,46 @@ class RestoreDirectiveTest extends DBTestCase
         $this->assertCount(2, Task::withoutTrashed()->get());
     }
 
+    public function testRestoreWorksWithCan(): void
+    {
+        $user = User::create([
+            'name' => UserPolicy::ADMIN,
+        ]);
+        $task = factory(Task::class)->make();
+        $user->tasks()->save($task);
+        $task->delete();
+        $this->be($user);
+
+        $this->assertCount(0, Task::withoutTrashed()->get());
+
+        $this->schema .= /** @lang GraphQL */ '
+        type Task {
+            id: ID!
+            name: String
+        }
+
+        type Mutation {
+            restoreTasks(id: ID!): Task! @restore @can(ability: "delete", find: "id")
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            restoreTasks(id: 1) {
+                name
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'restoreTasks' => [
+                    'name' => $task->name,
+                ],
+            ],
+        ]);
+
+        $this->assertCount(1, Task::withoutTrashed()->get());
+    }
+
     public function testRejectsDefinitionWithNullableArgument(): void
     {
         $this->expectException(DefinitionException::class);
@@ -84,7 +126,7 @@ class RestoreDirectiveTest extends DBTestCase
         type Task {
             id: ID!
         }
-        
+
         type Query {
             restoreTask(id: ID): Task @restore
         }
@@ -99,7 +141,7 @@ class RestoreDirectiveTest extends DBTestCase
         type Task {
             id: ID!
         }
-        
+
         type Query {
             restoreTask: Task @restore
         }
@@ -114,7 +156,7 @@ class RestoreDirectiveTest extends DBTestCase
         type Task {
             id: ID!
         }
-        
+
         type Query {
             restoreTask(foo: String, bar: Int): Task @restore
         }
@@ -129,7 +171,7 @@ class RestoreDirectiveTest extends DBTestCase
         type User {
             id: ID!
         }
-        
+
         type Query {
             restoreUser(id: ID!): User @restore
         }

--- a/tests/Integration/SoftDeletes/RestoreDirectiveTest.php
+++ b/tests/Integration/SoftDeletes/RestoreDirectiveTest.php
@@ -78,7 +78,7 @@ class RestoreDirectiveTest extends DBTestCase
         $this->assertCount(2, Task::withoutTrashed()->get());
     }
 
-    public function testRestoreWorksWithCan(): void
+    public function testCanDirectiveExcludesTrashedModelsWhenUsingRestore(): void
     {
         $user = User::create([
             'name' => UserPolicy::ADMIN,
@@ -97,7 +97,9 @@ class RestoreDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            restoreTasks(id: ID!): Task! @restore @can(ability: "delete", find: "id")
+            restoreTasks(id: ID!): Task!
+                @can(ability: "delete", find: "id")
+                @restore
         }
         ';
 

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -13,19 +13,19 @@ class CanDirectiveTest extends TestCase
     {
         $this->be(new User);
 
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             user: User!
                 @can(ability: "adminOnly")
-                @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
+                @mock
         }
-        
+
         type User {
             name: String
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             user {
                 name
@@ -40,19 +40,20 @@ class CanDirectiveTest extends TestCase
         $user->name = UserPolicy::ADMIN;
         $this->be($user);
 
-        $this->schema = '
+        $this->mockResolver([$this, 'resolveUser']);
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             user: User!
                 @can(ability: "adminOnly")
-                @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
+                @mock
         }
-        
+
         type User {
             name: String
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             user {
                 name
@@ -73,19 +74,20 @@ class CanDirectiveTest extends TestCase
             $this->markTestSkipped('Version less than 5.7 do not support guest user.');
         }
 
-        $this->schema = '
+        $this->mockResolver([$this, 'resolveUser']);
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             user: User!
                 @can(ability: "guestOnly")
-                @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
+                @mock
         }
-        
+
         type User {
             name: String
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             user {
                 name
@@ -106,19 +108,20 @@ class CanDirectiveTest extends TestCase
         $user->name = UserPolicy::ADMIN;
         $this->be($user);
 
-        $this->schema = '
+        $this->mockResolver([$this, 'resolveUser']);
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             user: User!
                 @can(ability: ["adminOnly", "alwaysTrue"])
-                @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
+                @mock
         }
-        
+
         type User {
             name: String
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             user {
                 name
@@ -135,19 +138,19 @@ class CanDirectiveTest extends TestCase
 
     public function testProcessesTheArgsArgument(): void
     {
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             user: User!
                 @can(ability: "dependingOnArg", args: [false])
-                @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
+                @mock
         }
-        
+
         type User {
             name: String
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             user {
                 name
@@ -159,13 +162,15 @@ class CanDirectiveTest extends TestCase
     public function testInjectArgsPassesClientArgumentToPolicy(): void
     {
         $this->be(new User);
+
+        $this->mockResolver([$this, 'resolveUser']);
         $this->schema = /** @lang GraphQL */ '
         type Query {
             user(foo: String): User!
                 @can(ability:"injectArgs", injectArgs: true)
-                @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
+                @mock
         }
-        
+
         type User {
             name: String
         }
@@ -189,6 +194,8 @@ class CanDirectiveTest extends TestCase
     public function testInjectedArgsAndStaticArgs(): void
     {
         $this->be(new User);
+
+        $this->mockResolver([$this, 'resolveUser']);
         $this->schema = /** @lang GraphQL */ '
         type Query {
             user(foo: String): User!
@@ -197,9 +204,9 @@ class CanDirectiveTest extends TestCase
                     args: { foo: "static" }
                     injectArgs: true
                 )
-                @field(resolver: "'.$this->qualifyTestResolver('resolveUser').'")
+                @mock
         }
-        
+
         type User {
             name: String
         }

--- a/tests/Utils/Policies/TaskPolicy.php
+++ b/tests/Utils/Policies/TaskPolicy.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Utils\Policies;
 
+use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
 
 class TaskPolicy
@@ -11,5 +12,10 @@ class TaskPolicy
     public function adminOnly(User $user): bool
     {
         return $user->name === self::ADMIN;
+    }
+
+    public function delete(User $user, Task $task): bool
+    {
+        return $user->id === $task->user->id;
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

Resolves #1116 

**Changes**

Fetching model inside `@can` directive was reworked, so query builder gets extended if `@forceDelete` or `@restore` is used;  

**Breaking changes**

No, old behavior still works (using `@softDeletes` with passing `trashed` argument from client). The usage of `@softDeletes` is even more granular and overrides these new implementation, as query still gets enhanced.

Should we write something to changelog? and docs?