### PR TITLE
Add `model` argument to `@can` directive definition

### DIFF
--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -19,7 +19,7 @@ in the default model namespace `App`. [You can change this configuration](../get
 directive @all(
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 
@@ -436,7 +436,46 @@ directive @cacheKey on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
 ## @can
 
+```graphql
+"""
 Check a Laravel Policy to ensure the current user is authorized to access a field.
+
+When `injectArgs` and `args` are used together, the client given
+arguments will be passed before the static args.
+"""
+directive @can(
+  """
+  The ability to check permissions for.
+  """
+  ability: String!
+
+  """
+  The name of the argument that is used to find a specific model
+  instance against which the permissions should be checked.
+  """
+  find: String
+
+  """
+  Specify the class name of the model to use.
+  This is only needed when the default model detection does not work.
+  """
+  model: String
+
+  """
+  Pass along the client given input data as arguments to `Gate::check`.
+  """
+  injectArgs: Boolean = false
+  """
+  Statically defined arguments that are passed to `Gate::check`.
+
+  You may pass pass arbitrary GraphQL literals,
+  e.g.: [1, 2, 3] or { foo: "bar" }
+  """
+  args: Mixed
+) on FIELD_DEFINITION
+```
+
+This directive is most commonly used for mutations:
 
 ```graphql
 type Mutation {
@@ -453,44 +492,6 @@ class PostPolicy
     }
 }
 ```
-
-### Definition
-
-```graphql
-"""
-Check a Laravel Policy to ensure the current user is authorized to access a field.
-
-When `injectArgs` and `args` are used together, the client given
-arguments will be passed before the static args.
-"""
-directive @can(
-  """
-  The ability to check permissions for.
-  """
-  ability: String!
-  
-  """
-  The name of the argument that is used to find a specific model
-  instance against which the permissions should be checked.
-  """
-  find: String
-
-  """
-  Pass along the client given input data as arguments to `Gate::check`. 
-  """
-  injectArgs: Boolean = false
-
-  """
-  Statically defined arguments that are passed to `Gate::check`.
-  
-  You may pass pass arbitrary GraphQL literals,
-  e.g.: [1, 2, 3] or { foo: "bar" }
-  """
-  args: Mixed
-) on FIELD_DEFINITION
-```
-
-### Examples
 
 In `find` parameter you may specify an input argument which is used to find a specific model
 instance by primary key against which the permissions should be checked:
@@ -655,7 +656,7 @@ Create a new Eloquent model with the given arguments.
 directive @create(
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 
@@ -716,7 +717,7 @@ directive @delete(
 
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 
@@ -896,7 +897,7 @@ Find a model based on the arguments provided.
 directive @find(  
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 
@@ -939,7 +940,7 @@ Get the first query result from a collection of Eloquent models.
 directive @first(  
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 
@@ -979,7 +980,7 @@ directive @forceDelete(
 
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 ) on FIELD_DEFINITION
@@ -1842,7 +1843,7 @@ directive @node(
 
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 ) on FIELD_DEFINITION
@@ -2101,7 +2102,7 @@ directive @paginate(
 
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 
@@ -2257,7 +2258,7 @@ directive @restore(
 
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 ) on FIELD_DEFINITION
@@ -2734,7 +2735,7 @@ Update an Eloquent model with the input values of the field.
 directive @update(
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 
@@ -2796,7 +2797,7 @@ Create or update an Eloquent model with the input values of the field.
 directive @upsert(
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -465,6 +465,7 @@ directive @can(
   Pass along the client given input data as arguments to `Gate::check`.
   """
   injectArgs: Boolean = false
+
   """
   Statically defined arguments that are passed to `Gate::check`.
 

--- a/src/Schema/Directives/AllDirective.php
+++ b/src/Schema/Directives/AllDirective.php
@@ -17,7 +17,7 @@ class AllDirective extends BaseDirective implements DefinedDirective, FieldResol
 directive @all(
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -52,10 +52,10 @@ directive @can(
   instance against which the permissions should be checked.
   """
   find: String
-  
+
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -52,6 +52,12 @@ directive @can(
   instance against which the permissions should be checked.
   """
   find: String
+  
+  """
+  Specify the class name of the model to use.
+  This is only needed when the default model resolution does not work.
+  """
+  model: String
 
   """
   Pass along the client given input data as arguments to `Gate::check`.

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -63,6 +63,7 @@ directive @can(
   Pass along the client given input data as arguments to `Gate::check`.
   """
   injectArgs: Boolean = false
+
   """
   Statically defined arguments that are passed to `Gate::check`.
 

--- a/src/Schema/Directives/CreateDirective.php
+++ b/src/Schema/Directives/CreateDirective.php
@@ -16,7 +16,7 @@ Create a new Eloquent model with the given arguments.
 directive @create(
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 

--- a/src/Schema/Directives/DeleteDirective.php
+++ b/src/Schema/Directives/DeleteDirective.php
@@ -34,7 +34,7 @@ directive @delete(
 
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 

--- a/src/Schema/Directives/FindDirective.php
+++ b/src/Schema/Directives/FindDirective.php
@@ -21,7 +21,7 @@ Find a model based on the arguments provided.
 directive @find(
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 

--- a/src/Schema/Directives/FirstDirective.php
+++ b/src/Schema/Directives/FirstDirective.php
@@ -20,7 +20,7 @@ Get the first query result from a collection of Eloquent models.
 directive @first(
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 

--- a/src/Schema/Directives/NodeDirective.php
+++ b/src/Schema/Directives/NodeDirective.php
@@ -48,7 +48,7 @@ directive @node(
 
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 ) on FIELD_DEFINITION

--- a/src/Schema/Directives/PaginateDirective.php
+++ b/src/Schema/Directives/PaginateDirective.php
@@ -33,7 +33,7 @@ directive @paginate(
 
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 

--- a/src/Schema/Directives/UpdateDirective.php
+++ b/src/Schema/Directives/UpdateDirective.php
@@ -17,7 +17,7 @@ Update an Eloquent model with the input values of the field.
 directive @update(
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 

--- a/src/Schema/Directives/UpsertDirective.php
+++ b/src/Schema/Directives/UpsertDirective.php
@@ -17,7 +17,7 @@ Create or update an Eloquent model with the input values of the field.
 directive @upsert(
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 

--- a/src/SoftDeletes/ForceDeleteDirective.php
+++ b/src/SoftDeletes/ForceDeleteDirective.php
@@ -28,7 +28,7 @@ directive @forceDelete(
 
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 ) on FIELD_DEFINITION

--- a/src/SoftDeletes/RestoreDirective.php
+++ b/src/SoftDeletes/RestoreDirective.php
@@ -30,7 +30,7 @@ directive @restore(
 
   """
   Specify the class name of the model to use.
-  This is only needed when the default model resolution does not work.
+  This is only needed when the default model detection does not work.
   """
   model: String
 ) on FIELD_DEFINITION


### PR DESCRIPTION
model field is not generated in the definition causing the IDE to raise alerts

- [x ] Added or updated tests
- [x ] Added Docs for all relevant versions
- [x ] Updated CHANGELOG.md

Resolves non

**Changes**
Added model directive to definition area

**Breaking changes**
None