### PR TITLE
Add `UsesTestSchema` helper trait for usage in unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so the client does not have to filter explicitly https://github.com/nuwave/lighthouse/pull/1157
 - Add test trait `\Nuwave\Lighthouse\Testing\MakesGraphQLRequestsLumen` for usage
   with Lumen https://github.com/nuwave/lighthouse/pull/1100
+- Add test trait `\Nuwave\Lighthouse\Testing\UsesTestSchema` to enable using
+  a dummy schema for testing custom Lighthouse extensions https://github.com/nuwave/lighthouse/pull/1171
 
 ### Fixed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build: .
     volumes:
     - ./:/var/www
+    depends_on:
+      - mysql
     environment:
       XDEBUG_CONFIG: "remote_enable=1 remote_mode=req remote_port=9000 remote_host=$XDEBUG_REMOTE_HOST remote_connect_back=0"
       PHP_IDE_CONFIG: "serverName=lighthouse"

--- a/docs/master/sidebar.js
+++ b/docs/master/sidebar.js
@@ -31,6 +31,7 @@ module.exports = [
         title: "Testing",
         children: [
             'testing/phpunit',
+            'testing/extensions',
         ],
     },
     {

--- a/docs/master/testing/extensions.md
+++ b/docs/master/testing/extensions.md
@@ -7,7 +7,7 @@ your extensions in isolation from the rest of your application.
 
 When you enhance functionality related to the schema definition, such as adding
 a [custom directive](../custom-directives), you need a test schema where you can use it.
-Add the `UsesTestSchema` trait to your test class and define your test schema:
+Add the `UsesTestSchema` trait to your test class, call `setUpTestSchema()` and define your test schema:
 
 ```php
 <?php
@@ -20,16 +20,23 @@ class MyCustomDirectiveTest extends TestCase
 {
     use UsesTestSchema;
 
-    // You may set the schema once for your class
+    // You may set the schema once and use it in many test methods
     protected $schema = /** @lang GraphQL */ '
     type Query {
         foo: Int @myCustom
     }
     ';
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpTestSchema();;
+    }
+
     public function testSpecificScenario(): void
     {
-        // Or overwrite it for testing specific cases
+        // You can overwrite the schema for testing specific cases
         $this->schema = /** @lang GraphQL */ '
         type Query {
             foo(bar: String @myCustom): Int

--- a/docs/master/testing/extensions.md
+++ b/docs/master/testing/extensions.md
@@ -1,0 +1,146 @@
+# Testing Lighthouse extensions
+
+When you extend Lighthouse with custom functionality, it is a great idea to test
+your extensions in isolation from the rest of your application.
+
+## Use a test schema
+
+When you enhance functionality related to the schema definition, such as adding
+a [custom directive](../custom-directives), you need a test schema where you can use it.
+Add the `UsesTestSchema` trait to your test class and define your test schema:
+
+```php
+<?php
+
+namespace Tests;
+
+use Nuwave\Lighthouse\Testing\UsesTestSchema;
+
+class MyCustomDirectiveTest extends TestCase
+{
+    use UsesTestSchema;
+
+    // You may set the schema once for your class
+    protected $schema = /** @lang GraphQL */ '
+    type Query {
+        foo: Int @myCustom
+    }
+    ';
+
+    public function testSpecificScenario(): void
+    {
+        // Or overwrite it for testing specific cases
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo(bar: String @myCustom): Int
+        }
+        ';
+
+        // ...
+    }
+}
+```
+
+## Mock resolvers
+
+When testing custom functionality through a dummy schema, you still need to have
+a way to resolve fields. Add the `MocksResolvers` trait to your test class:
+
+```php
+<?php
+
+namespace Tests;
+
+use Nuwave\Lighthouse\Testing\MocksResolvers;
+
+class ReverseDirectiveTest extends TestCase
+{
+    use MocksResolvers;
+}
+```
+
+In this example, we will be testing this fictional custom directive:
+
+```graphql
+"""
+Reverts a string, e.g. 'foo' => 'oof'.
+"""
+directive @revert on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+```
+
+We just pass a resolver function into `mockResolver()` and place
+the `@mock` directive on the field:
+
+```php
+    public function testReverseField(): void
+    {
+        $this->mockResolver(function(): string {
+            return 'foo';
+        });
+
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo: String @reverse @mock
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            foo
+        }
+        ')->assertExactJson([
+            'data' => [
+                'foo' => 'oof',
+            ],
+        ]);
+    }
+}
+```
+
+Since we get back an instance of PHPUnit's `InvocationMocker`, we can also assert
+that our resolver is called with certain values. Note that we are not passing an
+explicit resolver function here. The default resolver will simply return `null`.
+
+```php
+    public function testReverseInput(): void
+    {
+        $this->mockResolver()
+            ->with(null, ['bar' => 'rab']);
+
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo(bar: String @reverse): String @mock
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            foo(bar: "bar")
+        }
+        ')->assertExactJson([
+            'data' => [
+                'foo' => null,
+            ],
+        ]);
+    }
+}
+```
+
+We might have a need to add multiple resolvers to a single schema. For that case,
+we can specify unique `key` for the mock resolver (it defaults to `default`):
+
+```php
+    public function testMultipleResolvers(): void
+    {
+        $this->mockResolver(function () { ... }, 'first');
+        $this->mockResolver(function () { ... }, 'second');
+
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo: Int @mock(key: "first")
+            bar: ID @mock(key: "second")
+        }
+        ';
+    }
+}
+```

--- a/src/Testing/TestSchemaProvider.php
+++ b/src/Testing/TestSchemaProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Nuwave\Lighthouse\Testing;
 
 use Nuwave\Lighthouse\Schema\Source\SchemaSourceProvider;
 

--- a/src/Testing/UsesTestSchema.php
+++ b/src/Testing/UsesTestSchema.php
@@ -18,6 +18,10 @@ trait UsesTestSchema
         app()->bind(
             SchemaSourceProvider::class,
             function (): TestSchemaProvider {
+                if(! is_string($this->schema)) {
+                    throw new \Exception('Missing test schema, provide one by setting $this->schema.');
+                }
+
                 return new TestSchemaProvider($this->schema);
             }
         );

--- a/src/Testing/UsesTestSchema.php
+++ b/src/Testing/UsesTestSchema.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Nuwave\Lighthouse\Testing;
+
+use Nuwave\Lighthouse\Schema\Source\SchemaSourceProvider;
+
+trait UsesTestSchema
+{
+    /**
+     * The schema that Lighthouse will use.
+     *
+     * @var string
+     */
+    protected $schema;
+
+    protected function setUpTestSchema(): void
+    {
+        app()->bind(
+            SchemaSourceProvider::class,
+            function (): TestSchemaProvider {
+                return new TestSchemaProvider($this->schema);
+            }
+        );
+    }
+}

--- a/src/Testing/UsesTestSchema.php
+++ b/src/Testing/UsesTestSchema.php
@@ -18,7 +18,7 @@ trait UsesTestSchema
         app()->bind(
             SchemaSourceProvider::class,
             function (): TestSchemaProvider {
-                if(! is_string($this->schema)) {
+                if (! is_string($this->schema)) {
                     throw new \Exception('Missing test schema, provide one by setting $this->schema.');
                 }
 

--- a/tests/Integration/Execution/MutationExecutor/MorphOneTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphOneTest.php
@@ -8,8 +8,7 @@ use Tests\Utils\Models\Task;
 
 class MorphOneTest extends DBTestCase
 {
-    protected $schema = /** @lang GraphQL */
-        '
+    protected $schema = /** @lang GraphQL */ '
     type Task {
         id: ID!
         name: String!

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,7 +28,10 @@ abstract class TestCase extends BaseTestCase
     use MocksResolvers;
     use UsesTestSchema;
 
-    const PLACEHOLDER_QUERY = '
+    /**
+     * A dummy query type definition that is added to tests by default.
+     */
+    const PLACEHOLDER_QUERY = /** @lang GraphQL */ '
     type Query {
         foo: Int
     }
@@ -38,7 +41,10 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
-        $this->schema = self::PLACEHOLDER_QUERY;
+        if(!$this->schema) {
+            $this->schema = self::PLACEHOLDER_QUERY;
+        }
+
         $this->setUpTestSchema();
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,7 +11,6 @@ use Laravel\Scout\ScoutServiceProvider;
 use Nuwave\Lighthouse\GraphQL;
 use Nuwave\Lighthouse\LighthouseServiceProvider;
 use Nuwave\Lighthouse\OrderBy\OrderByServiceProvider;
-use Nuwave\Lighthouse\Schema\Source\SchemaSourceProvider;
 use Nuwave\Lighthouse\SoftDeletes\SoftDeletesServiceProvider;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\MocksResolvers;
@@ -41,7 +40,7 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
-        if(!$this->schema) {
+        if (! $this->schema) {
             $this->schema = self::PLACEHOLDER_QUERY;
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,6 +16,7 @@ use Nuwave\Lighthouse\SoftDeletes\SoftDeletesServiceProvider;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\MocksResolvers;
 use Nuwave\Lighthouse\Testing\TestingServiceProvider;
+use Nuwave\Lighthouse\Testing\UsesTestSchema;
 use Orchestra\Database\ConsoleServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use Tests\Utils\Middleware\CountRuns;
@@ -25,6 +26,7 @@ abstract class TestCase extends BaseTestCase
 {
     use MakesGraphQLRequests;
     use MocksResolvers;
+    use UsesTestSchema;
 
     const PLACEHOLDER_QUERY = '
     type Query {
@@ -32,14 +34,13 @@ abstract class TestCase extends BaseTestCase
     }
     ';
 
-    /**
-     * This variable is injected the main GraphQL class
-     * during execution of each test. It may be set either
-     * for an entire test class or for a single test.
-     *
-     * @var string
-     */
-    protected $schema = self::PLACEHOLDER_QUERY;
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->schema = self::PLACEHOLDER_QUERY;
+        $this->setUpTestSchema();
+    }
 
     /**
      * Get package providers.
@@ -68,13 +69,6 @@ abstract class TestCase extends BaseTestCase
      */
     protected function getEnvironmentSetUp($app)
     {
-        $app->bind(
-            SchemaSourceProvider::class,
-            function (): TestSchemaProvider {
-                return new TestSchemaProvider($this->schema);
-            }
-        );
-
         /** @var \Illuminate\Contracts\Config\Repository $config */
         $config = $app['config'];
 

--- a/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
@@ -29,7 +29,7 @@ class SpreadDirectiveTest extends TestCase
         }
         ';
 
-        $r = $this->graphQL(/** @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             foo(input: {
                 foo: 1

--- a/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
@@ -14,22 +14,22 @@ class SpreadDirectiveTest extends TestCase
                 'baz' => 2,
             ]);
 
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo(input: Foo @spread): Int @mock
         }
-        
+
         input Foo {
             foo: Int
             bar: Bar @spread
         }
-        
+
         input Bar {
             baz: Int
         }
         ';
 
-        $this->graphQL('
+        $r = $this->graphQL(/** @lang GraphQL */ '
         {
             foo(input: {
                 foo: 1

--- a/tests/Unit/Schema/Source/SchemaSourceProviderTest.php
+++ b/tests/Unit/Schema/Source/SchemaSourceProviderTest.php
@@ -24,6 +24,10 @@ class SchemaSourceProviderTest extends TestCase
     {
         parent::setUp();
 
+        app()->singleton(SchemaSourceProvider::class, function () {
+            return new SchemaStitcher(config('lighthouse.schema.register', ''));
+        });
+
         $currentDir = new Filesystem(new Local(__DIR__));
 
         $currentDir->deleteDir('schema');
@@ -39,13 +43,6 @@ class SchemaSourceProviderTest extends TestCase
         $currentDir = new Filesystem(new Local(__DIR__));
 
         $currentDir->deleteDir('schema');
-    }
-
-    protected function getEnvironmentSetUp($app)
-    {
-        $app->singleton(SchemaSourceProvider::class, function () {
-            return new SchemaStitcher(config('lighthouse.schema.register', ''));
-        });
     }
 
     public function testCanSetRootPath(): void

--- a/tests/Utils/Middleware/CountRuns.php
+++ b/tests/Utils/Middleware/CountRuns.php
@@ -5,6 +5,9 @@ namespace Tests\Utils\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 
+/**
+ * @deprecated will be removed with @middleware
+ */
 class CountRuns
 {
     /**


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

Resolves https://github.com/nuwave/lighthouse/issues/1170

**Changes**

Expose Lighthouse's internal mechanism to use test schemas as a reusable trait. This can be useful for testing Lighthouse extensions, such as custom directives.

I also documented the usage of the `MocksResolvers` trait, which is complimentary to the `UsesTestSchema` trait.

**Breaking changes**

No
