### PR TITLE
Fix handling of nested mutation operations that receive `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix eager-loading relations where the parent type is an `interface` or `union` and
   may correspond to multiple different models https://github.com/nuwave/lighthouse/pull/1035
 - Fix renaming input fields that are nested within lists using @rename https://github.com/nuwave/lighthouse/pull/1166
+- Fix handling of nested mutation operations that receive `null` https://github.com/nuwave/lighthouse/pull/1174
 
 ## [4.8.1](https://github.com/nuwave/lighthouse/compare/v4.8.1...4.8.0)
 

--- a/src/Execution/Arguments/ArgumentSet.php
+++ b/src/Execution/Arguments/ArgumentSet.php
@@ -45,6 +45,24 @@ class ArgumentSet
     }
 
     /**
+     * Check if the ArgumentSet has a non-null value with the given key.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function has(string $key): bool
+    {
+        /** @var \Nuwave\Lighthouse\Execution\Arguments\Argument|null $argument */
+        $argument = $this->arguments[$key] ?? null;
+
+        if($argument === null) {
+            return false;
+        }
+
+        return $argument->value !== null;
+    }
+
+    /**
      * Apply the @spread directive and return a new, modified instance.
      *
      * @return self

--- a/src/Execution/Arguments/ArgumentSet.php
+++ b/src/Execution/Arguments/ArgumentSet.php
@@ -55,7 +55,7 @@ class ArgumentSet
         /** @var \Nuwave\Lighthouse\Execution\Arguments\Argument|null $argument */
         $argument = $this->arguments[$key] ?? null;
 
-        if($argument === null) {
+        if ($argument === null) {
             return false;
         }
 

--- a/src/Execution/Arguments/NestedBelongsTo.php
+++ b/src/Execution/Arguments/NestedBelongsTo.php
@@ -27,7 +27,7 @@ class NestedBelongsTo implements ArgResolver
         /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo $relation */
         $relation = $parent->{$this->relationName}();
 
-        if (isset($args->arguments['create'])) {
+        if ($args->has('create')) {
             $saveModel = new ResolveNested(new SaveModel($relation));
 
             $related = $saveModel(
@@ -37,11 +37,11 @@ class NestedBelongsTo implements ArgResolver
             $relation->associate($related);
         }
 
-        if (isset($args->arguments['connect'])) {
+        if ($args->has('connect')) {
             $relation->associate($args->arguments['connect']->value);
         }
 
-        if (isset($args->arguments['update'])) {
+        if ($args->has('update')) {
             $updateModel = new ResolveNested(new UpdateModel(new SaveModel($relation)));
 
             $related = $updateModel(
@@ -51,7 +51,7 @@ class NestedBelongsTo implements ArgResolver
             $relation->associate($related);
         }
 
-        if (isset($args->arguments['upsert'])) {
+        if ($args->has('upsert')) {
             $upsertModel = new ResolveNested(new UpsertModel(new SaveModel($relation)));
 
             $related = $upsertModel(
@@ -71,14 +71,14 @@ class NestedBelongsTo implements ArgResolver
         // but GraphQL forces us to pass some value. It would be unintuitive for
         // the end user if the given value had no effect on the execution.
         if (
-            isset($args->arguments['disconnect'])
+            $args->has('disconnect')
             && $args->arguments['disconnect']->value
         ) {
             $relation->dissociate();
         }
 
         if (
-            isset($args->arguments['delete'])
+            $args->has('delete')
             && $args->arguments['delete']->value
         ) {
             $relation->dissociate();

--- a/src/Execution/Arguments/NestedManyToMany.php
+++ b/src/Execution/Arguments/NestedManyToMany.php
@@ -27,13 +27,13 @@ class NestedManyToMany implements ArgResolver
         /** @var \Illuminate\Database\Eloquent\Relations\BelongsToMany|\Illuminate\Database\Eloquent\Relations\MorphToMany $relation */
         $relation = $parent->{$this->relationName}();
 
-        if (isset($args->arguments['sync'])) {
+        if ($args->has('sync')) {
             $relation->sync(
                 $this->generateRelationArray($args->arguments['sync'])
             );
         }
 
-        if (isset($args->arguments['syncWithoutDetaching'])) {
+        if ($args->has('syncWithoutDetaching')) {
             $relation->syncWithoutDetaching(
                 $this->generateRelationArray($args->arguments['syncWithoutDetaching'])
             );
@@ -41,20 +41,20 @@ class NestedManyToMany implements ArgResolver
 
         NestedOneToMany::createUpdateUpsert($args, $relation);
 
-        if (isset($args->arguments['delete'])) {
+        if ($args->has('delete')) {
             $ids = $args->arguments['delete']->toPlain();
 
             $relation->detach($ids);
             $relation->getRelated()::destroy($ids);
         }
 
-        if (isset($args->arguments['connect'])) {
+        if ($args->has('connect')) {
             $relation->attach(
                 $this->generateRelationArray($args->arguments['connect'])
             );
         }
 
-        if (isset($args->arguments['disconnect'])) {
+        if ($args->has('disconnect')) {
             $relation->detach(
                 $args->arguments['disconnect']->toPlain()
             );

--- a/src/Execution/Arguments/NestedMorphTo.php
+++ b/src/Execution/Arguments/NestedMorphTo.php
@@ -28,7 +28,7 @@ class NestedMorphTo implements ArgResolver
 
         // TODO implement create and update once we figure out how to do polymorphic input types https://github.com/nuwave/lighthouse/issues/900
 
-        if (isset($args->arguments['connect'])) {
+        if ($args->has('connect')) {
             $connectArgs = $args->arguments['connect']->value;
 
             $morphToModel = $relation->createModelByType(

--- a/src/Execution/Arguments/NestedOneToMany.php
+++ b/src/Execution/Arguments/NestedOneToMany.php
@@ -29,7 +29,7 @@ class NestedOneToMany implements ArgResolver
 
         static::createUpdateUpsert($args, $relation);
 
-        if (isset($args->arguments['delete'])) {
+        if ($args->has('delete')) {
             $relation->getRelated()::destroy(
                 $args->arguments['delete']->toPlain()
             );
@@ -42,7 +42,7 @@ class NestedOneToMany implements ArgResolver
      */
     public static function createUpdateUpsert(ArgumentSet $args, Relation $relation): void
     {
-        if (isset($args->arguments['create'])) {
+        if ($args->has('create')) {
             $saveModel = new ResolveNested(new SaveModel($relation));
 
             foreach ($args->arguments['create']->value as $childArgs) {
@@ -50,7 +50,7 @@ class NestedOneToMany implements ArgResolver
             }
         }
 
-        if (isset($args->arguments['update'])) {
+        if ($args->has('update')) {
             $updateModel = new ResolveNested(new UpdateModel(new SaveModel($relation)));
 
             foreach ($args->arguments['update']->value as $childArgs) {
@@ -58,7 +58,7 @@ class NestedOneToMany implements ArgResolver
             }
         }
 
-        if (isset($args->arguments['upsert'])) {
+        if ($args->has('upsert')) {
             $upsertModel = new ResolveNested(new UpsertModel(new SaveModel($relation)));
 
             foreach ($args->arguments['upsert']->value as $childArgs) {

--- a/src/Execution/Arguments/NestedOneToOne.php
+++ b/src/Execution/Arguments/NestedOneToOne.php
@@ -27,25 +27,25 @@ class NestedOneToOne implements ArgResolver
         $relation = $parent->{$this->relationName}();
 
         /** @var \Nuwave\Lighthouse\Execution\Arguments\Argument|null $create */
-        if (isset($args->arguments['create'])) {
+        if ($args->has('create')) {
             $saveModel = new ResolveNested(new SaveModel($relation));
 
             $saveModel($relation->make(), $args->arguments['create']->value);
         }
 
-        if (isset($args->arguments['update'])) {
+        if ($args->has('update')) {
             $updateModel = new ResolveNested(new UpdateModel(new SaveModel($relation)));
 
             $updateModel($relation->make(), $args->arguments['update']->value);
         }
 
-        if (isset($args->arguments['upsert'])) {
+        if ($args->has('upsert')) {
             $upsertModel = new ResolveNested(new UpsertModel(new SaveModel($relation)));
 
             $upsertModel($relation->make(), $args->arguments['upsert']->value);
         }
 
-        if (isset($args->arguments['delete'])) {
+        if ($args->has('delete')) {
             $relation->getRelated()::destroy(
                 $args->arguments['delete']->toPlain()
             );

--- a/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
@@ -450,6 +450,45 @@ GRAPHQL
         $this->assertSame('is_user', $role->name);
     }
 
+    public function testAllowsNullOperations(): void
+    {
+        factory(Role::class)->create();
+
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            updateRole(input: {
+                id: 1
+                name: "is_user"
+                users: {
+                    create: null
+                    update: null
+                    upsert: null
+                    delete: null
+                    connect: null
+                    sync: null
+                    syncWithoutDetaching: null
+                    disconnect: null
+                }
+            }) {
+                id
+                name
+                users {
+                    id
+                    name
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'updateRole' => [
+                    'id' => '1',
+                    'name' => 'is_user',
+                    'users' => [],
+                ],
+            ],
+        ]);
+    }
+
     public function testCanUpsertUsingCreationWithBelongsToMany(): void
     {
         factory(Role::class)->create([

--- a/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
@@ -144,6 +144,42 @@ class BelongsToTest extends DBTestCase
         ]);
     }
 
+    public function testAllowsNullOperations(): void
+    {
+        factory(User::class)->create();
+
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            upsertTask(input: {
+                id: 1
+                name: "foo"
+                user: {
+                    connect: null
+                    create: null
+                    update: null
+                    upsert: null
+                    disconnect: null
+                    delete: null
+                }
+            }) {
+                id
+                name
+                user {
+                    id
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'upsertTask' => [
+                    'id' => '1',
+                    'name' => 'foo',
+                    'user' => null,
+                ],
+            ],
+        ]);
+    }
+
     public function testCanCreateWithNewBelongsTo(): void
     {
         $this->graphQL(/** @lang GraphQL */ '

--- a/tests/Integration/Execution/MutationExecutor/HasManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasManyTest.php
@@ -8,51 +8,51 @@ use Tests\Utils\Models\User;
 
 class HasManyTest extends DBTestCase
 {
-    protected $schema = '
+    protected $schema = /** @lang GraphQL */ '
     type Task {
         id: ID!
         name: String!
     }
-    
+
     type User {
         id: ID!
         name: String
         tasks: [Task!]! @hasMany
     }
-    
+
     type Mutation {
         createUser(input: CreateUserInput! @spread): User @create
         updateUser(input: UpdateUserInput! @spread): User @update
         upsertUser(input: UpsertUserInput! @spread): User @upsert
     }
-    
+
     input CreateUserInput {
         name: String
         tasks: CreateTaskRelation
     }
-    
+
     input CreateTaskRelation {
         create: [CreateTaskInput!]
         upsert: [UpsertTaskInput!]
     }
-    
+
     input CreateTaskInput {
         name: String
     }
-        
+
     input UpdateUserInput {
         id: ID!
         name: String
         tasks: UpdateTaskRelation
     }
-    
+
     input UpdateTaskRelation {
         create: [CreateTaskInput!]
         update: [UpdateTaskInput!]
         upsert: [UpsertTaskInput!]
         delete: [ID!]
     }
-    
+
     input UpdateTaskInput {
         id: ID!
         name: String
@@ -79,14 +79,16 @@ class HasManyTest extends DBTestCase
 
     public function testCanCreateWithNewHasMany(): void
     {
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createUser(input: {
                 name: "foo"
                 tasks: {
-                    create: [{
-                        name: "bar"
-                    }]
+                    create: [
+                        {
+                            name: "bar"
+                        }
+                    ]
                 }
             }) {
                 id
@@ -108,6 +110,38 @@ class HasManyTest extends DBTestCase
                             'name' => 'bar',
                         ],
                     ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testAllowsNullOperations(): void
+    {
+        factory(User::class)->create();
+
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            updateUser(input: {
+                id: 1
+                name: "foo"
+                tasks: {
+                    create: null
+                    update: null
+                    upsert: null
+                    delete: null
+                }
+            }) {
+                name
+                tasks {
+                    id
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'updateUser' => [
+                    'name' => 'foo',
+                    'tasks' => [],
                 ],
             ],
         ]);

--- a/tests/Integration/Execution/MutationExecutor/HasOneTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasOneTest.php
@@ -217,6 +217,39 @@ class HasOneTest extends DBTestCase
         ]);
     }
 
+    public function testAllowsNullOperations(): void
+    {
+        factory(Task::class)->create();
+
+        $this->graphQL(/** @lang GraphQL */ <<<GRAPHQL
+        mutation {
+            updateTask(input: {
+                id: 1
+                name: "foo"
+                post: {
+                    create: null
+                    update: null
+                    upsert: null
+                    delete: null
+                }
+            }) {
+                name
+                post {
+                    id
+                }
+            }
+        }
+GRAPHQL
+        )->assertJson([
+            'data' => [
+                "updateTask" => [
+                    'name' => 'foo',
+                    'post' => null,
+                ],
+            ],
+        ]);
+    }
+
     public function existingModelMutations(): array
     {
         return [

--- a/tests/Integration/Execution/MutationExecutor/HasOneTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasOneTest.php
@@ -221,7 +221,7 @@ class HasOneTest extends DBTestCase
     {
         factory(Task::class)->create();
 
-        $this->graphQL(/** @lang GraphQL */ <<<GRAPHQL
+        $this->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
         mutation {
             updateTask(input: {
                 id: 1
@@ -242,7 +242,7 @@ class HasOneTest extends DBTestCase
 GRAPHQL
         )->assertJson([
             'data' => [
-                "updateTask" => [
+                'updateTask' => [
                     'name' => 'foo',
                     'post' => null,
                 ],

--- a/tests/Integration/Execution/MutationExecutor/MorphManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphManyTest.php
@@ -182,7 +182,37 @@ GRAPHQL
             ],
         ]);
     }
+    public function testAllowsNullOperations(): void
+    {
+        factory(Task::class)->create();
 
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            updateTask(input: {
+                id: 1
+                name: "foo"
+                images: {
+                    create: null
+                    update: null
+                    upsert: null
+                    delete: null
+                }
+            }) {
+                name
+                images {
+                    url
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                "updateTask" => [
+                    'name' => 'foo',
+                    'images' => [],
+                ],
+            ],
+        ]);
+    }
     public function existingModelMutations()
     {
         return [

--- a/tests/Integration/Execution/MutationExecutor/MorphManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphManyTest.php
@@ -182,6 +182,7 @@ GRAPHQL
             ],
         ]);
     }
+
     public function testAllowsNullOperations(): void
     {
         factory(Task::class)->create();
@@ -206,13 +207,14 @@ GRAPHQL
         }
         ')->assertJson([
             'data' => [
-                "updateTask" => [
+                'updateTask' => [
                     'name' => 'foo',
                     'images' => [],
                 ],
             ],
         ]);
     }
+
     public function existingModelMutations()
     {
         return [

--- a/tests/Integration/Execution/MutationExecutor/MorphOneTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphOneTest.php
@@ -177,6 +177,38 @@ GRAPHQL
         ]);
     }
 
+    public function testAllowsNullOperations(): void
+    {
+        factory(Task::class)->create();
+
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            updateTask(input: {
+                id: 1
+                name: "foo"
+                image: {
+                    create: null
+                    update: null
+                    upsert: null
+                    delete: null
+                }
+            }) {
+                name
+                image {
+                    url
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'updateTask' => [
+                    'name' => 'foo',
+                    'image' => null,
+                ],
+            ],
+        ]);
+    }
+
     public function existingModelMutations()
     {
         return [

--- a/tests/Integration/Execution/MutationExecutor/MorphToManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToManyTest.php
@@ -7,7 +7,7 @@ use Tests\Utils\Models\Tag;
 
 class MorphToManyTest extends DBTestCase
 {
-    protected $schema = '
+    protected $schema = /** @lang GraphQL */ '
     type Mutation {
         createTask(input: CreateTaskInput! @spread): Task @create
         upsertTask(input: UpsertTaskInput! @spread): Task @upsert
@@ -63,7 +63,7 @@ class MorphToManyTest extends DBTestCase
     {
         $id = factory(Tag::class)->create(['name' => 'php'])->id;
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createTask(input: {
                 name: "Finish tests"
@@ -71,7 +71,7 @@ class MorphToManyTest extends DBTestCase
                     connect: [1]
                 }
             }) {
-                tags{
+                tags {
                     id
                 }
             }
@@ -84,6 +84,35 @@ class MorphToManyTest extends DBTestCase
                             'id' => $id,
                         ],
                     ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testAllowsNullOperations(): void
+    {
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            createTask(input: {
+                name: "Finish tests"
+                tags: {
+                    create: null
+                    upsert: null
+                    sync: null
+                    connect: null
+                }
+            }) {
+                name
+                tags {
+                    id
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'createTask' => [
+                    'name' => 'Finish tests',
+                    'tags' => [],
                 ],
             ],
         ]);

--- a/tests/Integration/Execution/MutationExecutor/MorphToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToTest.php
@@ -169,7 +169,7 @@ class MorphToTest extends DBTestCase
         }
         ')->assertJson([
             'data' => [
-                "updateImage" => [
+                'updateImage' => [
                     'url' => 'foo',
                     'imageable' => null,
                 ],

--- a/tests/Integration/Execution/MutationExecutor/MorphToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToTest.php
@@ -3,11 +3,12 @@
 namespace Tests\Integration\Execution\MutationExecutor;
 
 use Tests\DBTestCase;
+use Tests\Utils\Models\Image;
 use Tests\Utils\Models\Task;
 
 class MorphToTest extends DBTestCase
 {
-    protected $schema = '
+    protected $schema = /** @lang GraphQL */ '
     type Task {
         id: ID
         name: String
@@ -140,6 +141,37 @@ class MorphToTest extends DBTestCase
                         'id' => '1',
                         'name' => 'first_task',
                     ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testAllowsNullOperations(): void
+    {
+        factory(Image::class)->create();
+
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            updateImage(input: {
+                id: 1
+                url: "foo"
+                imageable: {
+                    connect: null
+                    disconnect: null
+                    delete: null
+                }
+            }) {
+                url
+                imageable {
+                    id
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                "updateImage" => [
+                    'url' => 'foo',
+                    'imageable' => null,
                 ],
             ],
         ]);

--- a/tests/Unit/Execution/Arguments/ArgumentSetTest.php
+++ b/tests/Unit/Execution/Arguments/ArgumentSetTest.php
@@ -25,9 +25,10 @@ class ArgumentSetTest extends TestCase
         $set->arguments['foo'] = $arg;
         $this->assertFalse($set->has('foo'));
 
-        $arg = new Argument();
-        $arg->value = 0;
-        $set->arguments['foo'] = $arg;
+        $arg->value = false;
+        $this->assertTrue($set->has('foo'));
+
+        $arg->value = 'foobar';
         $this->assertTrue($set->has('foo'));
     }
 

--- a/tests/Unit/Execution/Arguments/ArgumentSetTest.php
+++ b/tests/Unit/Execution/Arguments/ArgumentSetTest.php
@@ -11,6 +11,26 @@ use Tests\TestCase;
 
 class ArgumentSetTest extends TestCase
 {
+    public function testHasArgument(): void
+    {
+        $set = new ArgumentSet();
+
+        $this->assertFalse($set->has('foo'));
+
+        $set->arguments['foo'] = new Argument();
+        $this->assertFalse($set->has('foo'));
+
+        $arg = new Argument();
+        $arg->value = null;
+        $set->arguments['foo'] = $arg;
+        $this->assertFalse($set->has('foo'));
+
+        $arg = new Argument();
+        $arg->value = 0;
+        $set->arguments['foo'] = $arg;
+        $this->assertTrue($set->has('foo'));
+    }
+
     public function testSpreadsNestedInput(): void
     {
         $spreadDirective = new SpreadDirective();


### PR DESCRIPTION
(cherry picked from commit 03a6d6bf8bf52217a05d9308a899c437275cadb6)

- [x] Added or updated tests
~~- [ ] Added Docs for all relevant versions~~
- [x] Updated CHANGELOG.md

**Changes**

When passing `null` into a nested mutation operation, such as `create` or `sync`, Lighthouse throws an error.

Since `null` is an acceptable value, it should be handled gracefully and simply do nothing.

**Breaking changes**

None.