### PR TITLE
Nested arg builder directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix handling of nested mutation operations that receive `null` https://github.com/nuwave/lighthouse/pull/1174
 - Fix nested mutation `upsert` across two levels of BelongsTo relations https://github.com/nuwave/lighthouse/pull/1169
 - Apply query filters using an `ArgBuilderDirective` such as `@eq` when the argument
-  is nested deeply within the input
+  is nested deeply within the input https://github.com/nuwave/lighthouse/pull/1176
 
 ## [4.8.1](https://github.com/nuwave/lighthouse/compare/v4.8.0...4.8.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix renaming input fields that are nested within lists using `@rename` https://github.com/nuwave/lighthouse/pull/1166
 - Fix handling of nested mutation operations that receive `null` https://github.com/nuwave/lighthouse/pull/1174
 - Fix nested mutation `upsert` across two levels of BelongsTo relations https://github.com/nuwave/lighthouse/pull/1169
+- Apply query filters using an `ArgBuilderDirective` such as `@eq` when the argument
+  is nested deeply within the input
 
 ## [4.8.1](https://github.com/nuwave/lighthouse/compare/v4.8.0...4.8.1)
 

--- a/src/Execution/Arguments/ArgumentSet.php
+++ b/src/Execution/Arguments/ArgumentSet.php
@@ -160,11 +160,14 @@ class ArgumentSet
     /**
      * Recursively apply the ArgBuilderDirectives onto the builder.
      *
+     * TODO get rid of the reference passing in here. The issue is that @search makes a new builder instance,
+     * but we must special case that in some way anyhow, as only eq filters can be added on top of search.
+     *
      * @param  \Nuwave\Lighthouse\Execution\Arguments\ArgumentSet  $argumentSet
      * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation  $builder
      * @param  \Closure|null  $directiveFilter
      */
-    protected static function applyArgBuilderDirectives(self $argumentSet, $builder, Closure $directiveFilter = null)
+    protected static function applyArgBuilderDirectives(self $argumentSet, &$builder, Closure $directiveFilter = null)
     {
         foreach ($argumentSet->arguments as $argument) {
             $value = $argument->toPlain();
@@ -190,7 +193,7 @@ class ArgumentSet
             });
 
             Utils::applyEach(
-                function ($value) use ($builder, $directiveFilter) {
+                function ($value) use (&$builder, $directiveFilter) {
                     if ($value instanceof self) {
                         self::applyArgBuilderDirectives($value, $builder, $directiveFilter);
                     }

--- a/src/Execution/Arguments/ArgumentSet.php
+++ b/src/Execution/Arguments/ArgumentSet.php
@@ -190,8 +190,8 @@ class ArgumentSet
             });
 
             Utils::applyEach(
-                function ($value)  use ($builder, $directiveFilter){
-                    if($value instanceof self){
+                function ($value) use ($builder, $directiveFilter) {
+                    if ($value instanceof self) {
                         self::applyArgBuilderDirectives($value, $builder, $directiveFilter);
                     }
                 },

--- a/tests/Integration/Execution/ArgBuilderDirectiveTest.php
+++ b/tests/Integration/Execution/ArgBuilderDirectiveTest.php
@@ -5,25 +5,26 @@ namespace Tests\Integration\Execution;
 use Tests\DBTestCase;
 use Tests\Utils\Models\User;
 
-class BuilderTest extends DBTestCase
+class ArgBuilderDirectiveTest extends DBTestCase
 {
     /**
      * @var \Illuminate\Database\Eloquent\Collection<\Tests\Utils\Models\User>
      */
     protected $users;
 
+    protected $schema = /** @lang GraphQL */ '
+    type User {
+        id: ID!
+        name: String
+        email: String
+    }
+    ';
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->users = factory(User::class, 5)->create();
-        $this->schema = '
-        type User {
-            id: ID!
-            name: String
-            email: String
-        }
-        ';
     }
 
     public function testCanAttachEqFilterToQuery(): void
@@ -51,7 +52,7 @@ class BuilderTest extends DBTestCase
     {
         $this->schema .= /** @lang GraphQL */ '
         type Query {
-            users(input: UserInput! @spread): [User!]! @all
+            users(input: UserInput!): [User!]! @all
         }
 
         input UserInput {
@@ -66,6 +67,37 @@ class BuilderTest extends DBTestCase
                     input: {
                         id: $id
                     }
+                ) {
+                    id
+                }
+            }
+            ', [
+                'id' => $this->users->first()->getKey(),
+            ])
+            ->assertJsonCount(1, 'data.users');
+    }
+
+    public function testCanAttachEqFilterFromInputObjectWithinList(): void
+    {
+        $this->schema .= /** @lang GraphQL */ '
+        type Query {
+            users(input: [UserInput!]!): [User!]! @all
+        }
+
+        input UserInput {
+            id: ID @eq
+        }
+        ';
+
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            query ($id: ID) {
+                users(
+                    input: [
+                        {
+                            id: $id
+                        }
+                    ]
                 ) {
                     id
                 }
@@ -132,7 +164,7 @@ class BuilderTest extends DBTestCase
         $user1 = $this->users->first()->getKey();
         $user2 = $this->users->last()->getKey();
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             users(exclude: ['.$user1.', '.$user2.']) {
                 id
@@ -143,7 +175,7 @@ class BuilderTest extends DBTestCase
 
     public function testCanAttachWhereFilterToQuery(): void
     {
-        $this->schema .= '
+        $this->schema .= /** @lang GraphQL */ '
         type Query {
             users(id: Int @where(operator: ">")): [User!]! @all
         }
@@ -151,18 +183,22 @@ class BuilderTest extends DBTestCase
 
         $user1 = $this->users->first()->getKey();
 
-        $this->graphQL('
-        {
-            users(id: '.$user1.') {
-                id
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            query ($userId: Int) {
+                users(id: $userId) {
+                    id
+                }
             }
-        }
-        ')->assertJsonCount(4, 'data.users');
+            ', [
+                'userId' => $user1->id,
+            ])
+            ->assertJsonCount(4, 'data.users');
     }
 
     public function testCanAttachTwoWhereFilterWithTheSameKeyToQuery(): void
     {
-        $this->schema .= '
+        $this->schema .= /** @lang GraphQL */ '
         type Query {
             users(
                 start: Int @where(key: "id", operator: ">")
@@ -174,9 +210,12 @@ class BuilderTest extends DBTestCase
         $user1 = $this->users->first()->getKey();
         $user2 = $this->users->last()->getKey();
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
-            users(start: '.$user1.' end: '.$user2.') {
+            users(
+                start: '.$user1.'
+                end: '.$user2.'
+            ) {
                 id
             }
         }
@@ -185,7 +224,7 @@ class BuilderTest extends DBTestCase
 
     public function testCanAttachWhereBetweenFilterToQuery(): void
     {
-        $this->schema .= '
+        $this->schema .= /** @lang GraphQL */ '
         type Query {
             users(
                 createdBetween: [String!]! @whereBetween(key: "created_at")
@@ -204,7 +243,7 @@ class BuilderTest extends DBTestCase
         $start = now()->subDay()->startOfDay()->format('Y-m-d H:i:s');
         $end = now()->subDay()->endOfDay()->format('Y-m-d H:i:s');
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             users(
                 createdBetween: ["'.$start.'", "'.$end.'"]
@@ -241,7 +280,7 @@ class BuilderTest extends DBTestCase
         $start = now()->subDay()->startOfDay()->format('Y-m-d H:i:s');
         $end = now()->subDay()->endOfDay()->format('Y-m-d H:i:s');
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             users(
                 created: {
@@ -257,7 +296,7 @@ class BuilderTest extends DBTestCase
 
     public function testCanAttachWhereNotBetweenFilterToQuery(): void
     {
-        $this->schema .= '
+        $this->schema .= /** @lang GraphQL */ '
         type Query {
             users(
                 notCreatedBetween: [String!]! @whereNotBetween(key: "created_at")
@@ -276,7 +315,7 @@ class BuilderTest extends DBTestCase
         $start = now()->subDay()->startOfDay()->format('Y-m-d H:i:s');
         $end = now()->subDay()->endOfDay()->format('Y-m-d H:i:s');
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             users(
                 notCreatedBetween: ["'.$start.'", "'.$end.'"]
@@ -289,7 +328,7 @@ class BuilderTest extends DBTestCase
 
     public function testCanAttachWhereClauseFilterToQuery(): void
     {
-        $this->schema .= '
+        $this->schema .= /** @lang GraphQL */ '
         type Query {
             users(
                 created_at: String! @where(clause: "whereYear")
@@ -307,7 +346,7 @@ class BuilderTest extends DBTestCase
 
         $year = now()->subYear()->format('Y');
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             users(created_at: "'.$year.'") {
                 id
@@ -318,7 +357,7 @@ class BuilderTest extends DBTestCase
 
     public function testOnlyProcessesFilledArguments(): void
     {
-        $this->schema .= '
+        $this->schema .= /** @lang GraphQL */ '
         type Query {
             users(
                 id: ID @eq
@@ -327,7 +366,7 @@ class BuilderTest extends DBTestCase
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             users(name: "'.$this->users->first()->name.'") {
                 id

--- a/tests/Integration/Execution/ArgBuilderDirectiveTest.php
+++ b/tests/Integration/Execution/ArgBuilderDirectiveTest.php
@@ -181,7 +181,8 @@ class ArgBuilderDirectiveTest extends DBTestCase
         }
         ';
 
-        $user1 = $this->users->first()->getKey();
+        /** @var \Tests\Utils\Models\User $user1 */
+        $user1 = $this->users->first();
 
         $this
             ->graphQL(/** @lang GraphQL */ '

--- a/tests/Integration/Schema/Directives/SearchDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/SearchDirectiveTest.php
@@ -52,20 +52,26 @@ class SearchDirectiveTest extends DBTestCase
             'title' => 'another great title',
         ]);
 
-        $this->engine->shouldReceive('map')->andReturn(new Collection([$postA, $postC]));
+        $this->engine
+            ->shouldReceive('map')
+            ->andReturn(
+                new Collection([$postA, $postC])
+            );
 
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */ '
         type Post {
             id: ID!
             title: String!
         }
 
         type Query {
-            posts(search: String @search): [Post!]! @paginate(type: "paginator" model: "Post")
+            posts(
+                search: String @search
+            ): [Post!]! @paginate(type: "paginator")
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             posts(first: 10 search: "great") {
                 data {
@@ -123,18 +129,20 @@ class SearchDirectiveTest extends DBTestCase
             ->andReturn(new Collection([$postA, $postB]))
             ->once();
 
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */ '
         type Post {
             id: ID!
             title: String!
         }
 
         type Query {
-            posts(search: String @search(within: "my.index")): [Post!]! @paginate(type: "paginator" model: "Post")
+            posts(
+                search: String @search(within: "my.index")
+            ): [Post!]! @paginate
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             posts(first: 10 search: "great") {
                 data {
@@ -186,18 +194,20 @@ class SearchDirectiveTest extends DBTestCase
             ->andReturn(new Collection([$postA, $postB]))
             ->once();
 
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */ '
         type Post {
             id: ID!
             title: String!
         }
 
         type Query {
-            posts(search: String @search): [Post!]! @paginate(type: "paginator" model: "Post")
+            posts(
+                search: String @search
+            ): [Post!]! @paginate(type: "paginator")
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             posts(first: 10 search: "great") {
                 data {


### PR DESCRIPTION
- [x] Added or updated tests
~~- [ ] Added Docs for all relevant versions~~
- [x] Updated CHANGELOG.md

**Changes**

Apply query filters using an `ArgBuilderDirective` such as `@eq` when the argument
is nested deeply within the input

**Breaking changes**

<!-- If there are any breaking changes, list them here.
Make sure to mention them in UPGRADE.md. -->

No