### PR TITLE
Properly test pagination error messages

### DIFF
--- a/src/Pagination/PaginationArgs.php
+++ b/src/Pagination/PaginationArgs.php
@@ -45,7 +45,7 @@ class PaginationArgs
 
         if ($instance->first <= 0) {
             throw new Error(
-                "Requested pagination amount must be more than 0, got $instance->first"
+                self::requestedZeroOrLessItems($instance->first)
             );
         }
 
@@ -55,11 +55,21 @@ class PaginationArgs
             && $instance->first > $paginateMaxCount
         ) {
             throw new Error(
-                "Maximum number of {$paginateMaxCount} requested items exceeded. Fetch smaller chunks."
+                self::requestedTooManyItems($paginateMaxCount, $instance->first)
             );
         }
 
         return $instance;
+    }
+
+    public static function requestedZeroOrLessItems(int $amount): string
+    {
+        return "Requested pagination amount must be more than 0, got {$amount}.";
+    }
+
+    public static function requestedTooManyItems(int $maxCount, int $actualCount): string
+    {
+        return "Maximum number of {$maxCount} requested items exceeded, got {$actualCount}. Fetch smaller chunks.";
     }
 
     /**

--- a/tests/Integration/Schema/Directives/HasManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/HasManyDirectiveTest.php
@@ -4,6 +4,7 @@ namespace Tests\Integration\Schema\Directives;
 
 use GraphQL\Error\Error;
 use Illuminate\Support\Arr;
+use Nuwave\Lighthouse\Pagination\PaginationArgs;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Post;
 use Tests\Utils\Models\Task;
@@ -235,7 +236,7 @@ class HasManyDirectiveTest extends DBTestCase
         ');
 
         $this->assertSame(
-            'Maximum number of 3 requested items exceeded. Fetch smaller chunks.',
+            PaginationArgs::requestedTooManyItems(3, 5),
             $result->jsonGet('errors.0.message')
         );
     }
@@ -311,7 +312,7 @@ class HasManyDirectiveTest extends DBTestCase
         ');
 
         $this->assertSame(
-            'Maximum number of 3 requested items exceeded. Fetch smaller chunks.',
+            PaginationArgs::requestedTooManyItems(3, 5),
             $result->jsonGet('errors.0.message')
         );
     }
@@ -347,7 +348,7 @@ class HasManyDirectiveTest extends DBTestCase
         ');
 
         $this->assertSame(
-            'Maximum number of 2 requested items exceeded. Fetch smaller chunks.',
+            PaginationArgs::requestedTooManyItems(2, 3),
             $result->jsonGet('errors.0.message')
         );
     }
@@ -385,7 +386,7 @@ class HasManyDirectiveTest extends DBTestCase
         ');
 
         $this->assertSame(
-            'Maximum number of 2 requested items exceeded. Fetch smaller chunks.',
+            PaginationArgs::requestedTooManyItems(2, 3),
             $result->jsonGet('errors.0.message')
         );
     }

--- a/tests/Integration/Schema/Directives/MorphManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/MorphManyDirectiveTest.php
@@ -5,6 +5,7 @@ namespace Tests\Integration\Schema\Directives;
 use GraphQL\Error\Error;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Collection;
+use Nuwave\Lighthouse\Pagination\PaginationArgs;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Image;
 use Tests\Utils\Models\Post;
@@ -260,7 +261,7 @@ class MorphManyDirectiveTest extends DBTestCase
         ");
 
         $this->assertSame(
-            'Maximum number of 3 requested items exceeded. Fetch smaller chunks.',
+            PaginationArgs::requestedTooManyItems(3, 10),
             $result->jsonGet('errors.0.message')
         );
     }
@@ -304,7 +305,7 @@ class MorphManyDirectiveTest extends DBTestCase
         ");
 
         $this->assertSame(
-            'Maximum number of 2 requested items exceeded. Fetch smaller chunks.',
+            PaginationArgs::requestedTooManyItems(2, 10),
             $result->jsonGet('errors.0.message')
         );
     }
@@ -507,7 +508,7 @@ class MorphManyDirectiveTest extends DBTestCase
         ");
 
         $this->assertSame(
-            'Maximum number of 3 requested items exceeded. Fetch smaller chunks.',
+            PaginationArgs::requestedTooManyItems(3, 10),
             $result->jsonGet('errors.0.message')
         );
     }
@@ -553,7 +554,7 @@ class MorphManyDirectiveTest extends DBTestCase
         ");
 
         $this->assertSame(
-            'Maximum number of 2 requested items exceeded. Fetch smaller chunks.',
+            PaginationArgs::requestedTooManyItems(2, 10),
             $result->jsonGet('errors.0.message')
         );
     }

--- a/tests/Integration/Schema/Directives/PaginateDirectiveDBTest.php
+++ b/tests/Integration/Schema/Directives/PaginateDirectiveDBTest.php
@@ -14,7 +14,7 @@ class PaginateDirectiveDBTest extends DBTestCase
     {
         factory(User::class, 3)->create();
 
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */ '
         type User {
             id: ID!
             name: String!
@@ -25,7 +25,7 @@ class PaginateDirectiveDBTest extends DBTestCase
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             users(first: 2) {
                 paginatorInfo {
@@ -105,7 +105,7 @@ class PaginateDirectiveDBTest extends DBTestCase
             'post_id' => $posts->first()->id,
         ]);
 
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */ '
         type User {
             id: ID!
             name: String!
@@ -126,7 +126,7 @@ class PaginateDirectiveDBTest extends DBTestCase
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             users(first: 2, page: 1) {
                 paginatorInfo {
@@ -187,7 +187,7 @@ class PaginateDirectiveDBTest extends DBTestCase
     {
         factory(User::class, 3)->create();
 
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */ '
         type User {
             id: ID!
             name: String!
@@ -198,7 +198,7 @@ class PaginateDirectiveDBTest extends DBTestCase
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             users(first: 2) {
                 pageInfo {
@@ -225,7 +225,7 @@ class PaginateDirectiveDBTest extends DBTestCase
 
     public function testQueriesConnectionWithNoData(): void
     {
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */ '
         type User {
             id: ID!
             name: String!
@@ -236,7 +236,7 @@ class PaginateDirectiveDBTest extends DBTestCase
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             users(first: 5) {
                 pageInfo {
@@ -277,7 +277,7 @@ class PaginateDirectiveDBTest extends DBTestCase
 
     public function testQueriesPaginationWithNoData(): void
     {
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */ '
         type User {
             id: ID!
         }
@@ -287,7 +287,7 @@ class PaginateDirectiveDBTest extends DBTestCase
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             users(first: 5) {
                 paginatorInfo {
@@ -327,7 +327,7 @@ class PaginateDirectiveDBTest extends DBTestCase
     {
         factory(User::class, 2)->create();
 
-        $this->schema .= '
+        $this->schema .= /** @lang GraphQL */ '
         type User {
             id: ID!
             name: String!
@@ -338,7 +338,7 @@ class PaginateDirectiveDBTest extends DBTestCase
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             users(first: 1) {
                 data {
@@ -354,7 +354,7 @@ class PaginateDirectiveDBTest extends DBTestCase
     {
         factory(User::class, 3)->create();
 
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */ '
         type User {
             id: ID!
             name: String!
@@ -365,7 +365,7 @@ class PaginateDirectiveDBTest extends DBTestCase
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             users {
                 paginatorInfo {

--- a/tests/Unit/Schema/Directives/PaginateDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/PaginateDirectiveTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Unit\Schema\Directives;
 
-use GraphQL\Error\Error;
 use GraphQL\Type\Definition\FieldArgument;
 use GraphQL\Type\Definition\FieldDefinition;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Pagination\PaginationArgs;
 use Tests\TestCase;
 
 class PaginateDirectiveTest extends TestCase
@@ -21,11 +21,11 @@ class PaginateDirectiveTest extends TestCase
     protected function getConnectionQueryField(string $type): FieldDefinition
     {
         return $this
-            ->buildSchema("
+            ->buildSchema(/** @lang GraphQL */ "
             type User {
                 name: String
             }
-            
+
             type Query {
                 users: [User!]! @paginate(type: \"$type\")
             }
@@ -36,14 +36,14 @@ class PaginateDirectiveTest extends TestCase
 
     public function testOnlyRegistersOneTypeForMultiplePaginators(): void
     {
-        $schema = $this->buildSchema('
+        $schema = $this->buildSchema(/** @lang GraphQL */ '
         type User {
             name: String
             users: [User!]! @paginate
             users2: [User!]! @paginate(type: "relay")
             users3: [User!]! @paginate(type: "connection")
         }
-        
+
         type Query {
             users: [User!]! @paginate
             users2: [User!]! @paginate(type: "relay")
@@ -65,7 +65,7 @@ class PaginateDirectiveTest extends TestCase
 
     public function testRegistersPaginatorFromTypeExtensionField(): void
     {
-        $schema = $this->buildSchemaWithPlaceholderQuery('
+        $schema = $this->buildSchemaWithPlaceholderQuery(/** @lang GraphQL */ '
         type User {
             id: ID!
             name: String!
@@ -94,7 +94,7 @@ class PaginateDirectiveTest extends TestCase
         config(['lighthouse.paginate_max_count' => 5]);
 
         $queryType = $this
-            ->buildSchema('
+            ->buildSchema(/** @lang GraphQL */ '
             type Query {
                 defaultPaginated: [User!]! @paginate
                 defaultRelay: [User!]! @paginate(type: "relay")
@@ -134,7 +134,7 @@ class PaginateDirectiveTest extends TestCase
         config(['lighthouse.pagination_amount_argument' => 'first']);
 
         $queryType = $this
-            ->buildSchema('
+            ->buildSchema(/** @lang GraphQL */ '
             type Query {
                 defaultPaginated: [User!]! @paginate
             }
@@ -155,19 +155,20 @@ class PaginateDirectiveTest extends TestCase
     {
         config(['lighthouse.paginate_max_count' => 5]);
 
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */
+            '
         type User {
             id: ID!
             name: String!
         }
-        
+
         type Query {
             users1: [User!]! @paginate(maxCount: 6)
             users2: [User!]! @paginate(maxCount: 10)
         }
         ';
 
-        $result = $this->graphQL('
+        $result = $this->graphQL(/** @lang GraphQL */ '
         {
             users1(first: 10) {
                 data {
@@ -179,7 +180,7 @@ class PaginateDirectiveTest extends TestCase
         ');
 
         $this->assertSame(
-            'Maximum number of 6 requested items exceeded. Fetch smaller chunks.',
+            PaginationArgs::requestedTooManyItems(6, 10),
             $result->jsonGet('errors.0.message')
         );
     }
@@ -188,19 +189,19 @@ class PaginateDirectiveTest extends TestCase
     {
         config(['lighthouse.paginate_max_count' => 5]);
 
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */ '
         type User {
             id: ID!
             name: String!
         }
-        
+
         type Query {
             users1: [User!]! @paginate
             users2: [User!]! @paginate(type: "relay")
         }
         ';
 
-        $resultFromDefaultPagination = $this->graphQL('
+        $resultFromDefaultPagination = $this->graphQL(/** @lang GraphQL */ '
         {
             users1(first: 10) {
                 data {
@@ -212,11 +213,11 @@ class PaginateDirectiveTest extends TestCase
         ');
 
         $this->assertSame(
-            'Maximum number of 5 requested items exceeded. Fetch smaller chunks.',
+            PaginationArgs::requestedTooManyItems(5, 10),
             $resultFromDefaultPagination->jsonGet('errors.0.message')
         );
 
-        $resultFromRelayPagination = $this->graphQL('
+        $resultFromRelayPagination = $this->graphQL(/** @lang GraphQL */ '
         {
             users2(first: 10) {
                 edges {
@@ -230,25 +231,25 @@ class PaginateDirectiveTest extends TestCase
         ');
 
         $this->assertSame(
-            'Maximum number of 5 requested items exceeded. Fetch smaller chunks.',
+            PaginationArgs::requestedTooManyItems(5, 10),
             $resultFromRelayPagination->jsonGet('errors.0.message')
         );
     }
 
     public function testThrowsWhenPaginationWithCountZeroIsRequested(): void
     {
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */ '
         type User {
             id: ID!
             name: String!
         }
-        
+
         type Query {
             users: [User!] @paginate
         }
         ';
 
-        $this->graphQL('
+        $result = $this->graphQL(/** @lang GraphQL */ '
         {
             users(first: 0) {
                 data {
@@ -261,18 +262,22 @@ class PaginateDirectiveTest extends TestCase
             'data' => [
                 'users' => null,
             ],
-        ])
-        ->assertErrorCategory(Error::CATEGORY_GRAPHQL);
+        ]);
+
+        $this->assertSame(
+            PaginationArgs::requestedZeroOrLessItems(0),
+            $result->jsonGet('errors.0.message')
+        );
     }
 
     public function testDoesNotRequireModelWhenUsingBuilder(): void
     {
         $validationErrors = $this
-            ->buildSchema('
+            ->buildSchema(/** @lang GraphQL */ '
             type Query {
                 users: [NotAnActualModelName!] @paginate(builder: "'.$this->qualifyTestResolver('testDoesNotRequireModelWhenUsingBuilder').'")
             }
-            
+
             type NotAnActualModelName {
                 id: ID!
             }
@@ -286,7 +291,7 @@ class PaginateDirectiveTest extends TestCase
     {
         $this->expectException(DefinitionException::class);
         $this->expectExceptionMessageRegExp('/NonexistingClass/');
-        $this->buildSchema('
+        $this->buildSchema(/** @lang GraphQL */ '
         type Query {
             users: [Query!] @paginate(builder: "NonexistingClass@notFound")
         }


### PR DESCRIPTION
Refactor tests around error messages in `@paginate` and improve information content.
