### PR TITLE
Add `@hash` directive and deprecate `@bcrypt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find and compare releases at the [GitHub release page](https://github.com/nuwave/lighthouse/releases).
 
 ## Unreleased
+- Add `@hash` directive which uses Laravel's `Hash::make` to create an appropriate hash.
 
 ## 4.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find and compare releases at the [GitHub release page](https://github.com/nuwave/lighthouse/releases).
 
 ## Unreleased
-- Add `@hash` directive which uses Laravel's `Hash::make` to create an appropriate hash.
+
+### Added
+
+- Add `@hash` directive which uses Laravel's hashing configuration https://github.com/nuwave/lighthouse/pull/1200
+
+### Deprecated
+
+- Remove `@bcrypt` in favour of `@hash` https://github.com/nuwave/lighthouse/pull/1200
 
 ## 4.9.0
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -19,8 +19,8 @@ the [`@guard`](docs/master/api-reference/directives.md#guard) on selected fields
 
 ```diff
 type Query {
-- profile: User! @middlware(checks: ["auth"])
-+ profile: User! @guard
+-   profile: User! @middlware(checks: ["auth"])
++   profile: User! @guard
 }
 ```
 
@@ -78,3 +78,18 @@ You can adapt to this change in two refactoring steps that must be done in order
         id: ID!
     }
     ```
+
+### Replace `@bcrypt` with `@hash`
+
+The new `@hash` directive is also used for password hashing, but respects the
+configuration settings of your Laravel project.
+
+```diff
+type Mutation {
+    createUser(
+        name: String!
+-       password: String! @bcrypt
++       password: String! @hash
+    ): User!
+}
+```

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -242,22 +242,16 @@ type CustomRoleEdge implements Edge {
 
 ## @bcrypt
 
-Run the `bcrypt` function on the argument it is defined on.
-
-```graphql
-type Mutation {
-    createUser(name: String, password: String @bcrypt): User
-}
-```
-
-### Definition
-
 ```graphql
 """
 Run the `bcrypt` function on the argument it is defined on.
+
+@deprecated(reason: "Use @hash instead. This directive will be removed in v5.")
 """
 directive @bcrypt on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
+
+Deprecated in favour of [`@hash`](#hash).
 
 ## @broadcast
 
@@ -1084,21 +1078,25 @@ directive @guard(
 
 ## @hash
 
-Runs Laravel's `Hash::make` function on the argument it is defined on.
+```graphql
+"""
+Use Laravel hashing to transform an argument value.
+
+Useful for hashing passwords before inserting them into the database.
+This uses the default hashing driver defined in `config/hashing.php`.
+"""
+directive @hash on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+```
+
+The most common use case for this is when dealing with passwords:
 
 ```graphql
 type Mutation {
-    createUser(name: String, password: String @hash): User
+    createUser(
+        name: String!
+        password: String! @hash
+    ): User!
 }
-```
-
-### Definition
-
-```graphql
-"""
-Laravel's `Hash::make` function on the argument it is defined on.
-"""
-directive @hash on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 ## @hasMany

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -1082,7 +1082,24 @@ directive @guard(
 ) on FIELD_DEFINITION | OBJECT
 ```
 
+## @hash
 
+Runs Laravel's `Hash::make` function on the argument it is defined on.
+
+```graphql
+type Mutation {
+    createUser(name: String, password: String @hash): User
+}
+```
+
+### Definition
+
+```graphql
+"""
+Laravel's `Hash::make` function on the argument it is defined on.
+"""
+directive @hash on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+```
 
 ## @hasMany
 

--- a/docs/master/custom-directives/argument-directives.md
+++ b/docs/master/custom-directives/argument-directives.md
@@ -91,7 +91,7 @@ Argument directives are evaluated in the order that they are defined in the sche
 ```graphql
 type Mutation {
   createUser(
-    password: String @trim @rules(apply: ["min:10,max:20"]) @bcrypt
+    password: String @trim @rules(apply: ["min:10,max:20"]) @hash
   ): User
 }
 ```

--- a/src/Schema/Directives/BcryptDirective.php
+++ b/src/Schema/Directives/BcryptDirective.php
@@ -5,6 +5,9 @@ namespace Nuwave\Lighthouse\Schema\Directives;
 use Nuwave\Lighthouse\Support\Contracts\ArgTransformerDirective;
 use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
 
+/**
+ * @deprecated
+ */
 class BcryptDirective extends BaseDirective implements ArgTransformerDirective, DefinedDirective
 {
     public static function definition(): string
@@ -12,6 +15,8 @@ class BcryptDirective extends BaseDirective implements ArgTransformerDirective, 
         return /** @lang GraphQL */ <<<'SDL'
 """
 Run the `bcrypt` function on the argument it is defined on.
+
+@deprecated(reason: "Use @hash instead. This directive will be removed in v5.")
 """
 directive @bcrypt on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 SDL;

--- a/src/Schema/Directives/HashDirective.php
+++ b/src/Schema/Directives/HashDirective.php
@@ -8,6 +8,9 @@ use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
 
 class HashDirective extends BaseDirective implements ArgTransformerDirective, DefinedDirective
 {
+    /**
+     * @var \Illuminate\Contracts\Hashing\Hasher
+     */
     protected $hasher;
 
     public function __construct(Hasher $hasher)
@@ -19,18 +22,16 @@ class HashDirective extends BaseDirective implements ArgTransformerDirective, De
     {
         return /** @lang GraphQL */ <<<'SDL'
 """
-Run the `Hash::make` function on the argument it is defined on.
+Use Laravel hashing to transform an argument value.
+
+Useful for hashing passwords before inserting them into the database.
+This uses the default hashing driver defined in `config/hashing.php`.
 """
 directive @hash on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 SDL;
     }
 
     /**
-     * Run Laravel's Hash::make on the argument.
-     *
-     * Useful for hashing passwords before inserting them into the database.
-     * Uses the hashing driver defined in config/hashing.php
-     *
      * @param  string  $argumentValue
      * @return string
      */

--- a/src/Schema/Directives/HashDirective.php
+++ b/src/Schema/Directives/HashDirective.php
@@ -2,12 +2,19 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives;
 
-use Illuminate\Support\Facades\Hash;
+use Illuminate\Contracts\Hashing\Hasher;
 use Nuwave\Lighthouse\Support\Contracts\ArgTransformerDirective;
 use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
 
 class HashDirective extends BaseDirective implements ArgTransformerDirective, DefinedDirective
 {
+    protected $hasher;
+
+    public function __construct(Hasher $hasher)
+    {
+        $this->hasher = $hasher;
+    }
+
     public static function definition(): string
     {
         return /** @lang GraphQL */ <<<'SDL'
@@ -29,6 +36,6 @@ SDL;
      */
     public function transform($argumentValue): string
     {
-        return Hash::make($argumentValue);
+        return $this->hasher->make($argumentValue);
     }
 }

--- a/src/Schema/Directives/HashDirective.php
+++ b/src/Schema/Directives/HashDirective.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Directives;
+
+use Illuminate\Support\Facades\Hash;
+use Nuwave\Lighthouse\Support\Contracts\ArgTransformerDirective;
+use Nuwave\Lighthouse\Support\Contracts\DefinedDirective;
+
+class HashDirective extends BaseDirective implements ArgTransformerDirective, DefinedDirective
+{
+    public static function definition(): string
+    {
+        return /** @lang GraphQL */ <<<'SDL'
+"""
+Run the `Hash::make` function on the argument it is defined on.
+"""
+directive @hash on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+SDL;
+    }
+
+    /**
+     * Run Laravel's Hash::make on the argument.
+     *
+     * Useful for hashing passwords before inserting them into the database.
+     * Uses the hashing driver defined in config/hashing.php
+     *
+     * @param  string  $argumentValue
+     * @return string
+     */
+    public function transform($argumentValue): string
+    {
+        return Hash::make($argumentValue);
+    }
+}

--- a/tests/Integration/ValidationTest.php
+++ b/tests/Integration/ValidationTest.php
@@ -29,7 +29,7 @@ class ValidationTest extends DBTestCase
             password: String
                 @trim
                 @rules(apply: ["min:6", "max:20", "required_with:id"])
-                @bcrypt
+                @hash
             bar: Bar
                 @rules(apply: ["required_if:id,bar"])
         ): String @field(resolver: "Tests\\\\Integration\\\\ValidationTest@resolvePassword")

--- a/tests/Unit/Schema/Directives/BcryptDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/BcryptDirectiveTest.php
@@ -4,6 +4,9 @@ namespace Tests\Unit\Schema\Directives;
 
 use Tests\TestCase;
 
+/**
+ * @deprecated
+ */
 class BcryptDirectiveTest extends TestCase
 {
     public function testCanBcryptAnArgument(): void

--- a/tests/Unit/Schema/Directives/HashDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/HashDirectiveTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Unit\Schema\Directives;
+
+use Tests\TestCase;
+
+class HashDirectiveTest extends TestCase
+{
+    public function testCanHashAnArgument(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo(bar: String @hash): Foo @mock
+        }
+
+        type Foo {
+            bar: String
+        }
+        ';
+
+        $this->mockResolver(function ($root, $args) {
+            return $args;
+        });
+
+        $password = $this
+            ->graphQL(/** @lang GraphQL */ '
+            {
+                foo(bar: "password") {
+                    bar
+                }
+            }
+            ')
+            ->jsonGet('data.foo.bar');
+
+        $this->assertNotSame('password', $password);
+        $this->assertTrue(password_verify('password', $password));
+    }
+
+    public function testCanHashAnArgumentInInputObjectAndArray(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            user(input: UserInput): User @mock
+        }
+
+        type User {
+            password: String!
+            alt_passwords: [String]
+            friends: [User]
+        }
+
+        input UserInput {
+            password: String @hash
+            alt_passwords: [String] @hash
+            friends: [UserInput]
+        }
+        ';
+
+        $this->mockResolver(function ($root, array $args) {
+            return $args['input'];
+        });
+
+        $result = $this->graphQL(/** @lang GraphQL */ '
+        {
+            user(input: {
+                password: "password"
+                alt_passwords: ["alt_password_1", "alt_password_2"]
+                friends: [
+                    { password: "friend_password_1" }
+                    { password: "friend_password_2" }
+                    {
+                        password: "friend_password_3"
+                        friends: [
+                            { password: "friend_password_4" }
+                        ]
+                    }
+                ]
+            }) {
+                password
+                alt_passwords
+                friends {
+                    password
+                    friends {
+                        password
+                    }
+                }
+            }
+        }
+        ');
+
+        $password = $result->jsonGet('data.user.password');
+        $this->assertNotSame('password', $password);
+        $this->assertTrue(password_verify('password', $password));
+
+        // apply to array
+        $altPasswordOne = $result->jsonGet('data.user.alt_passwords.0');
+        $this->assertNotSame('alt_password_1', $altPasswordOne);
+        $this->assertTrue(password_verify('alt_password_1', $altPasswordOne));
+
+        $altPasswordTwo = $result->jsonGet('data.user.alt_passwords.1');
+        $this->assertNotSame('alt_password_2', $altPasswordTwo);
+        $this->assertTrue(password_verify('alt_password_2', $altPasswordTwo));
+
+        // apply to (nested) input
+        $friendPasswordOne = $result->jsonGet('data.user.friends.0.password');
+        $this->assertNotSame('friend_password_1', $friendPasswordOne);
+        $this->assertTrue(password_verify('friend_password_1', $friendPasswordOne));
+
+        $friendPasswordTwo = $result->jsonGet('data.user.friends.1.password');
+        $this->assertNotSame('friend_password_2', $friendPasswordTwo);
+        $this->assertTrue(password_verify('friend_password_2', $friendPasswordTwo));
+
+        $friendPasswordThree = $result->jsonGet('data.user.friends.2.password');
+        $this->assertNotSame('friend_password_3', $friendPasswordThree);
+        $this->assertTrue(password_verify('friend_password_3', $friendPasswordThree));
+
+        $friendPasswordFour = $result->jsonGet('data.user.friends.2.friends.0.password');
+        $this->assertNotSame('friend_password_4', $friendPasswordFour);
+        $this->assertTrue(password_verify('friend_password_4', $friendPasswordFour));
+    }
+}

--- a/tests/Unit/Schema/TypeRegistryTest.php
+++ b/tests/Unit/Schema/TypeRegistryTest.php
@@ -156,7 +156,7 @@ class TypeRegistryTest extends TestCase
     {
         $objectTypeNode = PartialParser::objectTypeDefinition('
         type User {
-            foo(bar: String! @bcrypt): String!
+            foo(bar: String! @hash): String!
         }
         ');
         /** @var \GraphQL\Type\Definition\ObjectType $objectType */


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

**Changes**

Adds a directive for Laravel's `Hash::make` facade so Lighthouse uses the defined driver of laravel for password hashing, instead of bcrypt via `@bcrypt` directive.
