### PR TITLE
Access nested inputs with dot notation in `find` option of `@can` #1216

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Added
 
-- Updated option `find` to `@can` to allow dot notation https://github.com/nuwave/lighthouse/pull/1216
+- Access nested inputs with dot notation using the `find` option of `@can` https://github.com/nuwave/lighthouse/pull/1216
 - Add `@hash` directive which uses Laravel's hashing configuration https://github.com/nuwave/lighthouse/pull/1200
 - Add option `passOrdered` to `@method` to pass just the arguments as ordered parameters https://github.com/nuwave/lighthouse/pull/1208
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Added
 
+- Updated option `find` to `@can` to allow dot notation https://github.com/nuwave/lighthouse/pull/1216
 - Add `@hash` directive which uses Laravel's hashing configuration https://github.com/nuwave/lighthouse/pull/1200
 - Add option `passOrdered` to `@method` to pass just the arguments as ordered parameters https://github.com/nuwave/lighthouse/pull/1208
 

--- a/docs/4.9/api-reference/directives.md
+++ b/docs/4.9/api-reference/directives.md
@@ -452,6 +452,8 @@ directive @can(
   """
   The name of the argument that is used to find a specific model
   instance against which the permissions should be checked.
+
+  You may pass the string as a dot notation to search in a array.
   """
   find: String
 

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\SoftDeletes\ForceDeleteDirective;
@@ -118,6 +119,10 @@ SDL;
     protected function modelsToCheck(ArgumentSet $argumentSet, array $args): iterable
     {
         if ($find = $this->directiveArgValue('find')) {
+            if (($findValue = Arr::get($args, $find)) === null) {
+                throw new DefinitionException("Could not find key: \"${find}\". The key must be a non-null field");
+            }
+
             $queryBuilder = $this->getModelClass()::query();
 
             $directivesContainsForceDelete = $argumentSet->directives->contains(
@@ -146,7 +151,7 @@ SDL;
                         return $directive instanceof TrashedDirective;
                     }
                 )
-                ->findOrFail(Arr::get($args, $find));
+                ->findOrFail($findValue);
 
             if ($modelOrModels instanceof Model) {
                 $modelOrModels = [$modelOrModels];

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -6,6 +6,7 @@ use Closure;
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
@@ -143,7 +144,7 @@ SDL;
                         return $directive instanceof TrashedDirective;
                     }
                 )
-                ->findOrFail($args[$find]);
+                ->findOrFail(Arr::get($args, $find));
 
             if ($modelOrModels instanceof Model) {
                 $modelOrModels = [$modelOrModels];

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -53,6 +53,8 @@ directive @can(
   """
   The name of the argument that is used to find a specific model
   instance against which the permissions should be checked.
+
+  You may pass the string as a dot notation to search in a array.
   """
   find: String
 

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -2,13 +2,12 @@
 
 namespace Tests\Unit\Schema\Directives;
 
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
-use Tests\DBTestCase;
+use Tests\TestCase;
 use Tests\Utils\Models\User;
 use Tests\Utils\Policies\UserPolicy;
 
-class CanDirectiveTest extends DBTestCase
+class CanDirectiveTest extends TestCase
 {
     public function testThrowsIfNotAuthorized(): void
     {
@@ -216,87 +215,6 @@ class CanDirectiveTest extends DBTestCase
         $this->graphQL(/** @lang GraphQL */ '
         {
             user(foo: "dynamic"){
-                name
-            }
-        }
-        ')->assertJson([
-            'data' => [
-                'user' => [
-                    'name' => 'foo',
-                ],
-            ],
-        ]);
-    }
-
-    public function testFindArgument(): void
-    {
-        $user = factory(User::class)->create(['name' => 'foo']);
-        $this->be($user);
-
-        $this->mockResolver([$this, 'resolveUser']);
-        $this->schema = /** @lang GraphQL */ '
-        type Query {
-            user(foo: ID): User!
-                @can(ability: "alwaysTrue", find: "foo")
-                @mock
-        }
-
-        type User {
-            name: String
-        }
-        ';
-
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            user(foo: 1) {
-                name
-            }
-        }
-        ')->assertJson([
-            'data' => [
-                'user' => [
-                    'name' => 'foo',
-                ],
-            ],
-        ]);
-
-        $this->expectException(ModelNotFoundException::class);
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            user {
-                name
-            }
-        }
-        ');
-    }
-
-    public function testFindArgumentNested(): void
-    {
-        $user = factory(User::class)->create(['name' => 'foo']);
-        $this->be($user);
-
-        $this->mockResolver([$this, 'resolveUser']);
-        $this->schema = /** @lang GraphQL */ '
-        type Query {
-            user(input: FindUserInput): User!
-                @can(ability: "alwaysTrue", find: "input.foo")
-                @mock
-        }
-
-        type User {
-            name: String
-        }
-        
-        input FindUserInput {
-            foo: ID
-        }
-        ';
-
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            user(input: {
-                foo: 1
-            }) {
                 name
             }
         }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

Resolves #1162

**Changes**
The `find` method of the can directive now uses [Arr::get](https://laravel.com/docs/6.x/helpers#method-array-get), to search the model. This allows to pass a string in a dot notation like `data.foo.bar`.

**Breaking changes**
Previously it would throw an `Undefined Index Error` if the string did not map to a value. Now it will throw a `DefinitionException`.
