### PR TITLE
Throw GraphQL error when ModelNotFoundException is thrown in CanDirective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find and compare releases at the [GitHub release page](https://github.com/nuwave/lighthouse/releases).
 
 ## Unreleased
-### Changes
+
+### Changed
 
 - Throw user readable `Error` instead of `ModelNotFoundException` when model is not found in `@can` https://github.com/nuwave/lighthouse/pull/1225
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find and compare releases at the [GitHub release page](https://github.com/nuwave/lighthouse/releases).
 
 ## Unreleased
+- Using `@can` no longer throws `ModelNotFoundException` when model is not found. Instead the object returns as null, and a GraphQL error is sent. Status code is also changed to 200.
 
 ## 4.10.1
 

--- a/tests/Integration/Schema/Directives/CanDirectiveDBTest.php
+++ b/tests/Integration/Schema/Directives/CanDirectiveDBTest.php
@@ -124,7 +124,6 @@ class CanDirectiveDBTest extends DBTestCase
         ')->assertJson([
             'errors' => [
                 [
-
                     'message' => CanDirective::missingKeyToFindModel('some.path'),
                 ],
             ],

--- a/tests/Integration/Schema/Directives/CanDirectiveDBTest.php
+++ b/tests/Integration/Schema/Directives/CanDirectiveDBTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Integration\Schema\Directives;
 
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Nuwave\Lighthouse\Schema\Directives\CanDirective;
 use Tests\DBTestCase;
@@ -77,14 +76,22 @@ class CanDirectiveDBTest extends DBTestCase
         }
         ';
 
-        $this->expectException(ModelNotFoundException::class);
         $this->graphQL(/** @lang GraphQL */ '
         {
             user(id: "not-present") {
                 name
             }
         }
-        ');
+        ')->assertJson([
+            'errors' => [
+                [
+                    'message' => 'No query results for model [Tests\Utils\Models\User] not-present',
+                ],
+            ],
+            'data' => [
+                'user' => null,
+            ],
+        ])->assertStatus(200);
     }
 
     public function testThrowsIfFindValueIsNotGiven(): void

--- a/tests/Integration/Schema/Directives/CanDirectiveDBTest.php
+++ b/tests/Integration/Schema/Directives/CanDirectiveDBTest.php
@@ -91,8 +91,7 @@ class CanDirectiveDBTest extends DBTestCase
             'data' => [
                 'user' => null,
             ],
-        ])->assertErrorCategory('graphql')
-            ->assertStatus(200);
+        ]);
     }
 
     public function testThrowsIfFindValueIsNotGiven(): void
@@ -128,8 +127,7 @@ class CanDirectiveDBTest extends DBTestCase
                     'message' => CanDirective::missingKeyToFindModel('some.path'),
                 ],
             ],
-        ])->assertErrorCategory('graphql')
-            ->assertStatus(200);
+        ]);
     }
 
     public function testFindUsingNestedInputWithDotNotation(): void
@@ -215,8 +213,7 @@ class CanDirectiveDBTest extends DBTestCase
                 title
             }
         }
-        ")->assertErrorCategory(AuthorizationException::CATEGORY)
-            ->assertStatus(200);
+        ")->assertErrorCategory(AuthorizationException::CATEGORY);
     }
 
     public function testCanHandleMultipleModels(): void

--- a/tests/Integration/Schema/Directives/CanDirectiveDBTest.php
+++ b/tests/Integration/Schema/Directives/CanDirectiveDBTest.php
@@ -91,7 +91,8 @@ class CanDirectiveDBTest extends DBTestCase
             'data' => [
                 'user' => null,
             ],
-        ])->assertStatus(200);
+        ])->assertErrorCategory('graphql')
+            ->assertStatus(200);
     }
 
     public function testThrowsIfFindValueIsNotGiven(): void
@@ -127,7 +128,8 @@ class CanDirectiveDBTest extends DBTestCase
                     'message' => CanDirective::missingKeyToFindModel('some.path'),
                 ],
             ],
-        ]);
+        ])->assertErrorCategory('graphql')
+            ->assertStatus(200);
     }
 
     public function testFindUsingNestedInputWithDotNotation(): void
@@ -213,7 +215,8 @@ class CanDirectiveDBTest extends DBTestCase
                 title
             }
         }
-        ")->assertErrorCategory(AuthorizationException::CATEGORY);
+        ")->assertErrorCategory(AuthorizationException::CATEGORY)
+            ->assertStatus(200);
     }
 
     public function testCanHandleMultipleModels(): void


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions N/A
- [x] Updated CHANGELOG.md

**Changes**
Catch `ModelNotFoundException` in `CanDirective` and instead throw `GraphQL\Error\Error`.

Also improved a few tests with GraphQL errors.

**Breaking changes**
Using `@can` no longer throws `ModelNotFoundException` when model is not found. Instead the object returns as null, and a GraphQL error is sent. Status code is also changed to 200.