### PR TITLE
Add artisan command `lighthouse:directive` to add directive class #1240

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Add `AttemptAuthentication` middleware to optionally log in users and delegate access guards
   to the field level https://github.com/nuwave/lighthouse/pull/1197
 
+- Add `lighthouse:directive` Artisan command to create an empty directive class
+
 ### Fixed
 
 - Eager load nested relations using the `@with` directive https://github.com/nuwave/lighthouse/pull/1068 

--- a/docs/master/api-reference/commands.md
+++ b/docs/master/api-reference/commands.md
@@ -8,6 +8,12 @@ are namespaced under `lighthouse`.
 Clear the cache for the GraphQL AST.
 
     php artisan lighthouse:clear-cache
+
+## directive
+
+Create a class for a GraphQL directive.
+
+    php artisan lighthouse:directive
    
 ## ide-helper
 

--- a/src/Console/DirectiveCommand.php
+++ b/src/Console/DirectiveCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Nuwave\Lighthouse\Console;
+
+class DirectiveCommand extends LighthouseGeneratorCommand
+{
+    /**
+     * The name of the console command.
+     *
+     * @var string
+     */
+    protected $name = 'lighthouse:directive';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a class for a directive.';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Directive';
+
+    protected function namespaceConfigKey(): string
+    {
+        return 'directives';
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub(): string
+    {
+        return __DIR__.'/stubs/directive.stub';
+    }
+}

--- a/src/Console/DirectiveCommand.php
+++ b/src/Console/DirectiveCommand.php
@@ -25,6 +25,11 @@ class DirectiveCommand extends LighthouseGeneratorCommand
      */
     protected $type = 'Directive';
 
+    protected function getNameInput(): string
+    {
+        return ucfirst(trim($this->argument('name'))) . 'Directive';
+    }
+
     protected function namespaceConfigKey(): string
     {
         return 'directives';

--- a/src/Console/stubs/directive.stub
+++ b/src/Console/stubs/directive.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace DummyNamespace;
+
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+
+class DummyClass
+{
+    // TODO implement the directive
+}

--- a/src/Console/stubs/directive.stub
+++ b/src/Console/stubs/directive.stub
@@ -4,7 +4,7 @@ namespace DummyNamespace;
 
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 
-class DummyClass
+class DummyClass extends BaseDirective
 {
     // TODO implement the directive
 }


### PR DESCRIPTION
- [ ] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

Note: I could not find any tests for the other generator command and don't really know what to test or how, so if that's required / wanted I'd definitely like some help on that.

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->
Adds a `lighthouse:directive` command which creates an empty directive class in the appropriate namespace according to the `lighthouse.php` config file.

**Breaking changes**

None.

**Final remarks**

I initially wanted to let the command also implement / include the various directive interfaces, but could not find a way to make that developer-friendly without creating a lot of options for the command. Thus I stuck with an empty class.

<!-- If there are any breaking changes, list them here.
Make sure to mention them in UPGRADE.md. -->
