### PR TITLE
Autoregister `TestingServiceProvider` for `@mock` in unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 ### Fixed
 
 - Eager load nested relations using the `@with` directive https://github.com/nuwave/lighthouse/pull/1068 
+- Automatically register `TestingServiceProvider` for `@mock` when running unit tests https://github.com/nuwave/lighthouse/pull/1244
 
 ## 4.10.2
 

--- a/docs/master/testing/extensions.md
+++ b/docs/master/testing/extensions.md
@@ -51,7 +51,9 @@ class MyCustomDirectiveTest extends TestCase
 ## Mock resolvers
 
 When testing custom functionality through a dummy schema, you still need to have
-a way to resolve fields. Add the `MocksResolvers` trait to your test class:
+a way to resolve fields. Lighthouse provides a simple way to mock resolvers in a dummy schema.
+
+Add the `MocksResolvers` trait to your test class:
 
 ```php
 <?php

--- a/src/LighthouseServiceProvider.php
+++ b/src/LighthouseServiceProvider.php
@@ -50,6 +50,7 @@ use Nuwave\Lighthouse\Support\Contracts\GlobalId as GlobalIdContract;
 use Nuwave\Lighthouse\Support\Contracts\ProvidesResolver;
 use Nuwave\Lighthouse\Support\Contracts\ProvidesSubscriptionResolver;
 use Nuwave\Lighthouse\Support\Http\Responses\ResponseStream;
+use Nuwave\Lighthouse\Testing\TestingServiceProvider;
 
 class LighthouseServiceProvider extends ServiceProvider
 {
@@ -180,6 +181,10 @@ class LighthouseServiceProvider extends ServiceProvider
                 UnionCommand::class,
                 ValidateSchemaCommand::class,
             ]);
+        }
+
+        if ($this->app->runningUnitTests()) {
+            $this->app->register(TestingServiceProvider::class);
         }
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,7 +13,6 @@ use Nuwave\Lighthouse\SoftDeletes\SoftDeletesServiceProvider;
 use Nuwave\Lighthouse\Support\AppVersion;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\MocksResolvers;
-use Nuwave\Lighthouse\Testing\TestingServiceProvider;
 use Nuwave\Lighthouse\Testing\UsesTestSchema;
 use Orchestra\Database\ConsoleServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
@@ -61,7 +60,6 @@ abstract class TestCase extends BaseTestCase
             LighthouseServiceProvider::class,
             SoftDeletesServiceProvider::class,
             OrderByServiceProvider::class,
-            TestingServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

Resolves https://github.com/nuwave/lighthouse/issues/1241

**Changes**

Now it just works™.

**Breaking changes**

No.
