### PR TITLE
Avoid infinite loop with empty namespace in generator commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 ### Fixed
 
 - Eager load nested relations using the `@with` directive https://github.com/nuwave/lighthouse/pull/1068 
+- Avoid infinite loop with empty namespace in generator commands https://github.com/nuwave/lighthouse/pull/1245
 
 ## 4.10.2
 

--- a/src/Console/LighthouseGeneratorCommand.php
+++ b/src/Console/LighthouseGeneratorCommand.php
@@ -61,16 +61,16 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
             return reset($namespaces);
         }
 
+        // Save the first namespac
+        $preferredNamespaceFallback = reset($namespaces);
+
         // If the strings are sorted, any prefix common to all strings
         // will be common to the sorted first and last strings.
         // All the strings in the middle can be ignored.
         sort($namespaces);
 
-        $firstNamespace = reset($namespaces);
-        $firstParts = explode('\\', $firstNamespace);
-
-        $lastNamespace = end($namespaces);
-        $lastParts = explode('\\', $lastNamespace);
+        $firstParts = explode('\\', reset($namespaces));
+        $lastParts = explode('\\', end($namespaces));
 
         $matching = [];
         foreach ($firstParts as $i => $part) {
@@ -90,7 +90,7 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
         // We could not determine a common part of the configured namespaces,
         // so we just assume the user will prefer the first one in the list.
         if ($matching === []) {
-            return $firstNamespace;
+            return $preferredNamespaceFallback;
         }
 
         return implode('\\', $matching);

--- a/src/Console/LighthouseGeneratorCommand.php
+++ b/src/Console/LighthouseGeneratorCommand.php
@@ -66,18 +66,21 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
         // All the strings in the middle can be ignored.
         sort($namespaces);
 
-        $first = explode('\\', reset($namespaces));
-        $last = explode('\\', end($namespaces));
+        $firstNamespace = reset($namespaces);
+        $firstParts = explode('\\', $firstNamespace);
+
+        $lastNamespace = end($namespaces);
+        $lastParts = explode('\\', $lastNamespace);
 
         $matching = [];
-        foreach ($first as $i => $part) {
+        foreach ($firstParts as $i => $part) {
             // We ran out of elements to compare, so we reached the maximum common length
-            if (! isset($last[$i])) {
+            if (! isset($lastParts[$i])) {
                 break;
             }
 
             // We found an element that differs
-            if ($last[$i] !== $part) {
+            if ($lastParts[$i] !== $part) {
                 break;
             }
 
@@ -87,7 +90,7 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
         // We could not determine a common part of the configured namespaces,
         // so we just assume the user will prefer the first one in the list.
         if ($matching === []) {
-            return reset($namespaces);
+            return $firstNamespace;
         }
 
         return implode('\\', $matching);

--- a/src/Console/LighthouseGeneratorCommand.php
+++ b/src/Console/LighthouseGeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace Nuwave\Lighthouse\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use InvalidArgumentException;
 
 abstract class LighthouseGeneratorCommand extends GeneratorCommand
 {
@@ -51,7 +52,9 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
     public static function commonNamespace(array $namespaces): string
     {
         if ($namespaces === []) {
-            return '';
+            throw new InvalidArgumentException(
+                "A default namespace is required for code generation."
+            );
         }
 
         if (count($namespaces) === 1) {
@@ -79,6 +82,12 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
             }
 
             $matching [] = $part;
+        }
+
+        // We could not determine a common part of the configured namespaces,
+        // so we just assume the user will prefer the first one in the list.
+        if ($matching === []) {
+            return reset($namespaces);
         }
 
         return implode('\\', $matching);

--- a/src/Console/LighthouseGeneratorCommand.php
+++ b/src/Console/LighthouseGeneratorCommand.php
@@ -53,7 +53,7 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
     {
         if ($namespaces === []) {
             throw new InvalidArgumentException(
-                "A default namespace is required for code generation."
+                'A default namespace is required for code generation.'
             );
         }
 

--- a/tests/Unit/Console/LighthouseGeneratorCommandTest.php
+++ b/tests/Unit/Console/LighthouseGeneratorCommandTest.php
@@ -24,7 +24,7 @@ class LighthouseGeneratorCommandTest extends TestCase
             LighthouseGeneratorCommand::commonNamespace(['App\\Foo', 'App\\Bar', 'App\\Foo\\Bar'])
         );
         $this->assertSame(
-            '',
+            'Foo',
             LighthouseGeneratorCommand::commonNamespace(['Foo', 'Bar'])
         );
     }

--- a/tests/Unit/Console/LighthouseGeneratorCommandTest.php
+++ b/tests/Unit/Console/LighthouseGeneratorCommandTest.php
@@ -17,7 +17,7 @@ class LighthouseGeneratorCommandTest extends TestCase
         );
     }
 
-    public function testCommonNamespaceMultiple(): void
+    public function testCommonNamespaceSharedBase(): void
     {
         $this->assertSame(
             'App',
@@ -29,11 +29,19 @@ class LighthouseGeneratorCommandTest extends TestCase
         );
     }
 
+    public function testCommonNamespaceNothingShared(): void
+    {
+        $first = 'App\\Foo';
+
+        $this->assertSame(
+            $first,
+            LighthouseGeneratorCommand::commonNamespace([$first, 'Foo\\Bar'])
+        );
+    }
+
     public function testCommonNamespaceNone(): void
     {
-        $this->assertSame(
-            '',
-            LighthouseGeneratorCommand::commonNamespace([])
-        );
+        $this->expectException(\InvalidArgumentException::class);
+        LighthouseGeneratorCommand::commonNamespace([]);
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

Resolves #1236 

**Changes**

Without a default namespace, code generation does not work. Fail explicitely when no namespace is set and default to the first one when no shared base can be established.

**Breaking changes**

Previously broken behaviour now fails explicitely.
