### PR TITLE
WIP: Where conditions and order by relation

### DIFF
--- a/src/Pagination/PaginationArgs.php
+++ b/src/Pagination/PaginationArgs.php
@@ -99,6 +99,8 @@ class PaginationArgs
             return $builder->paginate($this->first, 'page', $this->page);
         }
 
-        return $builder->paginate($this->first, ['*'], 'page', $this->page);
+        $table = $builder instanceof \Illuminate\Database\Eloquent\Builder ? $builder->toBase()->from : $builder->from;
+
+        return $builder->paginate($this->first, [$table . '.*'], 'page', $this->page);
     }
 }

--- a/src/Schema/Directives/AllDirective.php
+++ b/src/Schema/Directives/AllDirective.php
@@ -45,6 +45,7 @@ SDL;
                         $this->getModelClass()::query(),
                         $this->directiveArgValue('scopes', [])
                     )
+                    ->select(app()->make($this->getModelClass())->qualifyColumn('*'))
                     ->get();
             }
         );

--- a/src/WhereConditions/Operator.php
+++ b/src/WhereConditions/Operator.php
@@ -30,7 +30,8 @@ interface Operator
      * @param  \Illuminate\Database\Query\Builder  $builder
      * @param  array  $whereConditions
      * @param  string  $boolean
+     * @param  \Illuminate\Database\Eloquent\Model $model
      * @return \Illuminate\Database\Query\Builder
      */
-    public function applyConditions($builder, array $whereConditions, string $boolean);
+    public function applyConditions($builder, array $whereConditions, string $boolean, $model);
 }

--- a/src/WhereConditions/SQLOperator.php
+++ b/src/WhereConditions/SQLOperator.php
@@ -139,7 +139,7 @@ GRAPHQL;
         $query = $boolean === 'or' ? 'orWhereHas' : 'whereHas';
 
         $builder->$query($relation, function ($builder) use ($whereConditions, $relationColumn, $relation) {
-            $builder->where($relationColumn, '=', $whereConditions['value']);
+            $builder->where($relationColumn, $whereConditions['operator'], $whereConditions['value']);
         });
 
         return $builder;


### PR DESCRIPTION
**Disclosure**

This is a proposal that might or might not be in the scope or on the roadmap for this package. The reason of this PR is to determine if there is any point of pursuing this further.

**Proposal**
What this PR attempts to accomplish is:

- allow the `whereConditions` directive to filter based on relation attributes using whereHas()
- allow the `orderBy` directive to work with relation attributes

Considering the following schema:

```
type County {
    id: ID!
    name: String!
    cities: [City] @hasMany
}

type City {
    id: ID!
    county: County! @belongsTo
    name: String!
}

type Query {
    counties(
        filter: _ @whereConditions, 
        orderBy: [OrderByClause!] @orderBy
    ): [County!]!
}
```
This PR aims to make queries similar to the following possible:

```
{
    counties(
        filter:{
            column: "cities.name", operator: LIKE, value: "%Test%"
        }
    ) {
        id
    }
}
```

The same would also be possible for the orderBy directive: ordering by a property of a related model.

As I said, this is just a proposal and nowhere near ready to be merged as documentation and tests are missing. Also I'm more than certain not every scenario has been covered by this PR, especially since I'm fairly new to GraphQL and Lighthouse.

Any feedback is greatly appreciated. Thank you