### PR TITLE
Add flag `--json` to `print-schema` to output JSON instead of GraphQL SDL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Added
 
-- Add an option `--json` to `lighthouse:print-schema` that allows to output JSON instead of GraphQL SDL https://github.com/nuwave/lighthouse/pull/1268
+- Add flag `--json` to `print-schema` to output JSON instead of GraphQL SDL https://github.com/nuwave/lighthouse/pull/1268
 
 ## 4.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- Add an option `--json` to `lighthouse:print-schema` that allows to output JSON instead of GraphQL SDL https://github.com/nuwave/lighthouse/pull/1268
+
 ## 4.11.0
 
 ### Added

--- a/docs/master/api-reference/commands.md
+++ b/docs/master/api-reference/commands.md
@@ -47,6 +47,8 @@ may influence the final schema.
 Use the `-W` / `--write` option to output the schema to the default file storage
 (usually `storage/app`) as `lighthouse-schema.graphql`.
 
+You can output your schema in JSON format by using the `--json` flag.
+
 ## query
 
 Create a class for a single field on the root Query type.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,6 +18,7 @@ parameters:
   - '#Call to an undefined static method Illuminate\\Support\\Facades\\Event::assertDispatched\(\)\.#'
   - '#Function factory invoked with 2 parameters, 0 required\.#'
   - '#Function factory invoked with 1 parameter, 0 required\.#'
+  - '#Call to protected static method get\(\) of class Illuminate\\Filesystem\\FilesystemManager\.#'
 
   # This is a library, so it should be extendable
   - '#Unsafe usage of new static.*#'

--- a/src/Console/PrintSchemaCommand.php
+++ b/src/Console/PrintSchemaCommand.php
@@ -20,7 +20,7 @@ class PrintSchemaCommand extends Command
     protected $signature = '
         lighthouse:print-schema
         {--W|write : Write the output to a file}
-        {--json: Output JSON instead of GraphQL SDL}
+        {--json : Output JSON instead of GraphQL SDL}
     ';
 
     /**

--- a/src/Console/PrintSchemaCommand.php
+++ b/src/Console/PrintSchemaCommand.php
@@ -12,6 +12,9 @@ use Nuwave\Lighthouse\GraphQL;
 
 class PrintSchemaCommand extends Command
 {
+    const GRAPHQL_FILENAME = 'lighthouse-schema.graphql';
+    const JSON_FILENAME = 'lighthouse-schema.json';
+
     /**
      * The name and signature of the console command.
      *
@@ -45,10 +48,10 @@ class PrintSchemaCommand extends Command
 
         $schema = $graphQL->prepSchema();
         if ($this->option('json')) {
-            $filename = 'lighthouse-schema.json';
+            $filename = self::JSON_FILENAME;
             $schemaString = $this->schemaJson($schema);
         } else {
-            $filename = 'lighthouse-schema.graphql';
+            $filename = self::GRAPHQL_FILENAME;
             $schemaString = SchemaPrinter::doPrint($schema);
         }
 

--- a/src/Console/PrintSchemaCommand.php
+++ b/src/Console/PrintSchemaCommand.php
@@ -40,7 +40,7 @@ class PrintSchemaCommand extends Command
      */
     public function handle(Repository $cache, Filesystem $storage, GraphQL $graphQL): void
     {
-        // Clear the cache so this always gets the current schena
+        // Clear the cache so this always gets the current schema
         $cache->forget(config('lighthouse.cache.key'));
 
         $schema = $graphQL->prepSchema();

--- a/src/Console/PrintSchemaCommand.php
+++ b/src/Console/PrintSchemaCommand.php
@@ -44,7 +44,7 @@ class PrintSchemaCommand extends Command
         $cache->forget(config('lighthouse.cache.key'));
 
         $schema = $graphQL->prepSchema();
-        if($this->option('json')) {
+        if ($this->option('json')) {
             $filename = 'lighthouse-schema.json';
             $schemaString = $this->schemaJson($schema);
         } else {
@@ -54,7 +54,7 @@ class PrintSchemaCommand extends Command
 
         if ($this->option('write')) {
             $storage->put($filename, $schemaString);
-            $this->info('Wrote schema to the default file storage (usually storage/app) as "' . $filename . '".');
+            $this->info('Wrote schema to the default file storage (usually storage/app) as "'.$filename.'".');
         } else {
             $this->info($schemaString);
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use GraphQL\Error\Debug;
 use GraphQL\Type\Schema;
+use Illuminate\Console\Command;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Laravel\Scout\ScoutServiceProvider;
 use Nuwave\Lighthouse\GraphQL;
@@ -16,6 +17,7 @@ use Nuwave\Lighthouse\Testing\MocksResolvers;
 use Nuwave\Lighthouse\Testing\UsesTestSchema;
 use Orchestra\Database\ConsoleServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
 use Tests\Utils\Middleware\CountRuns;
 use Tests\Utils\Policies\AuthServiceProvider;
 
@@ -28,11 +30,12 @@ abstract class TestCase extends BaseTestCase
     /**
      * A dummy query type definition that is added to tests by default.
      */
-    const PLACEHOLDER_QUERY = /** @lang GraphQL */ '
-    type Query {
-        foo: Int
-    }
-    ';
+    const PLACEHOLDER_QUERY = /** @lang GraphQL */ <<<GRAPHQL
+type Query {
+  foo: Int
+}
+
+GRAPHQL;
 
     protected function setUp(): void
     {
@@ -196,5 +199,18 @@ abstract class TestCase extends BaseTestCase
     protected function qualifyTestResolver(string $method = 'resolve'): string
     {
         return addslashes(static::class).'@'.$method;
+    }
+
+    /**
+     * Construct a command tester.
+     *
+     * @param  \Illuminate\Console\Command  $command
+     * @return \Symfony\Component\Console\Tester\CommandTester
+     */
+    protected function commandTester(Command $command): CommandTester
+    {
+        $command->setLaravel($this->app);
+
+        return new CommandTester($command);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -30,7 +30,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * A dummy query type definition that is added to tests by default.
      */
-    const PLACEHOLDER_QUERY = /** @lang GraphQL */ <<<GRAPHQL
+    const PLACEHOLDER_QUERY = /** @lang GraphQL */ <<<'GRAPHQL'
 type Query {
   foo: Int
 }

--- a/tests/Unit/Console/PrintSchemaCommandTest.php
+++ b/tests/Unit/Console/PrintSchemaCommandTest.php
@@ -29,13 +29,13 @@ class PrintSchemaCommandTest extends TestCase
 
     public function testWritesSchema(): void
     {
-        $storage = Storage::fake();
+        Storage::fake();
         $tester = $this->commandTester(new PrintSchemaCommand());
         $tester->execute(['--write' => true]);
 
         $this->assertContains(
             $this->schema,
-            $storage->get(PrintSchemaCommand::GRAPHQL_FILENAME)
+            Storage::get(PrintSchemaCommand::GRAPHQL_FILENAME)
         );
     }
 }

--- a/tests/Unit/Console/PrintSchemaCommandTest.php
+++ b/tests/Unit/Console/PrintSchemaCommandTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\Console;
+
+use Nuwave\Lighthouse\Console\PrintSchemaCommand;
+use Tests\TestCase;
+
+class PrintSchemaCommandTest extends TestCase
+{
+    public function testPrintsSchemaAsGraphQLSDL(): void
+    {
+        $tester = $this->commandTester(new PrintSchemaCommand());
+        $tester->execute([]);
+
+        $this->assertStringContainsString($this->schema, $tester->getDisplay());
+    }
+}

--- a/tests/Unit/Console/PrintSchemaCommandTest.php
+++ b/tests/Unit/Console/PrintSchemaCommandTest.php
@@ -14,4 +14,15 @@ class PrintSchemaCommandTest extends TestCase
 
         $this->assertContains($this->schema, $tester->getDisplay());
     }
+
+    public function testPrintsSchemaAsJSON(): void
+    {
+        $tester = $this->commandTester(new PrintSchemaCommand());
+        $tester->execute(['--json' => true]);
+
+        $json = $tester->getDisplay();
+
+        $this->assertJson($json);
+        $this->assertContains('"name":"foo"', $json, 'Should contain the introspection result for the schema.');
+    }
 }

--- a/tests/Unit/Console/PrintSchemaCommandTest.php
+++ b/tests/Unit/Console/PrintSchemaCommandTest.php
@@ -12,6 +12,6 @@ class PrintSchemaCommandTest extends TestCase
         $tester = $this->commandTester(new PrintSchemaCommand());
         $tester->execute([]);
 
-        $this->assertStringContainsString($this->schema, $tester->getDisplay());
+        $this->assertContains($this->schema, $tester->getDisplay());
     }
 }

--- a/tests/Unit/Console/PrintSchemaCommandTest.php
+++ b/tests/Unit/Console/PrintSchemaCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Console;
 
+use Illuminate\Support\Facades\Storage;
 use Nuwave\Lighthouse\Console\PrintSchemaCommand;
 use Tests\TestCase;
 
@@ -24,5 +25,17 @@ class PrintSchemaCommandTest extends TestCase
 
         $this->assertJson($json);
         $this->assertContains('"name":"foo"', $json, 'Should contain the introspection result for the schema.');
+    }
+
+    public function testWritesSchema(): void
+    {
+        $storage = Storage::fake();
+        $tester = $this->commandTester(new PrintSchemaCommand());
+        $tester->execute(['--write' => true]);
+
+        $this->assertContains(
+            $this->schema,
+            $storage->get(PrintSchemaCommand::GRAPHQL_FILENAME)
+        );
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Add flag `--json` to `print-schema` to output JSON instead of GraphQL SDL

**Breaking changes**

No