### PR TITLE
Add TTL option for subscriptions storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@ You can find and compare releases at the [GitHub release page](https://github.co
 ### Added
 
 - Add flag `--json` to `print-schema` to output JSON instead of GraphQL SDL https://github.com/nuwave/lighthouse/pull/1268
-
-### Changed
-
 - Add TTL option for subscriptions storage https://github.com/nuwave/lighthouse/pull/1284
 
 ## 4.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 - Add flag `--json` to `print-schema` to output JSON instead of GraphQL SDL https://github.com/nuwave/lighthouse/pull/1268
 
+### Changed
+
+- Add TTL option for subscriptions storage https://github.com/nuwave/lighthouse/pull/1284
+
 ## 4.11.0
 
 ### Added

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -254,9 +254,11 @@ return [
         'storage' => env('LIGHTHOUSE_SUBSCRIPTION_STORAGE', 'redis'),
 
         /*
-         * Default subscription storage TTL.
+         * Default subscription storage time to live.
          *
          * Indicates how long a subscription can be active before it's automatically removed from storage.
+         * Setting this to `null` means the subscriptions are stored forever. This may cause
+         * stale subscriptions to linger indefinitely in case cleanup fails for any reason.
          */
         'storage_ttl' => env('LIGHTHOUSE_SUBSCRIPTION_STORAGE_TTL', null),
 

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -254,6 +254,13 @@ return [
         'storage' => env('LIGHTHOUSE_SUBSCRIPTION_STORAGE', 'redis'),
 
         /*
+         * Default subscription storage TTL.
+         *
+         * Indicates how long a subscription can be active before it's automatically removed from storage.
+         */
+        'storage_ttl' => env('LIGHTHOUSE_SUBSCRIPTION_STORAGE_TTL', null),
+
+        /*
          * Default subscription broadcaster.
          */
         'broadcaster' => env('LIGHTHOUSE_BROADCASTER', 'pusher'),


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Adds an optional TTL to the subscription storage manager that allows auto-cleanup of subscriptions.

If for some reason a webhook is missed it is nice to have a way to cleanup stale subscription to prevent broadcasting unneeded. Currently topics and subscribers are stored forever (and topics are never cleanup up, but that's for another day), this allows setting a TTL that will let the cache driver know when an item can be removed from storage.

**Breaking changes**

None.