### PR TITLE
Fix nested mutations with multiple belongsTo relations at the same level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
-- `Fixed` Fix query error when using @create/@upsert directives with multiple belongsTo at the same level https://github.com/nuwave/lighthouse/pull/1285
+### Fixed
+
+- Fix nested mutations with multiple `belongsTo` relations at the same level https://github.com/nuwave/lighthouse/pull/1285
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+- `Fixed` Fix query error when using @create/@upsert directives with multiple belongsTo at the same level https://github.com/nuwave/lighthouse/pull/1285
+
 ### Added
 
 - Add flag `--json` to `print-schema` to output JSON instead of GraphQL SDL https://github.com/nuwave/lighthouse/pull/1268
@@ -27,7 +29,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Eager load nested relations using the `@with` directive https://github.com/nuwave/lighthouse/pull/1068 
+- Eager load nested relations using the `@with` directive https://github.com/nuwave/lighthouse/pull/1068
 - Avoid infinite loop with empty namespace in generator commands https://github.com/nuwave/lighthouse/pull/1245
 - Automatically register `TestingServiceProvider` for `@mock` when running unit tests https://github.com/nuwave/lighthouse/pull/1244
 
@@ -235,7 +237,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Fix broken behaviour when using union types with schema caching https://github.com/nuwave/lighthouse/pull/1015 
+- Fix broken behaviour when using union types with schema caching https://github.com/nuwave/lighthouse/pull/1015
 
 ## 4.4.2
 
@@ -380,7 +382,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Change the signature of the AST manipulating directive interfaces:
   `TypeManipulator`, `FieldManipulator` and `ArgManipulator` https://github.com/nuwave/lighthouse/pull/768
 - Change the API of the `DocumentAST` class to enable a more performant implementation https://github.com/nuwave/lighthouse/pull/768
-- Enable the schema caching option `lighthouse.cache.enable` by default https://github.com/nuwave/lighthouse/pull/768 
+- Enable the schema caching option `lighthouse.cache.enable` by default https://github.com/nuwave/lighthouse/pull/768
 - Lazily load types from the schema. Directives defined on parts of the schema that are not used within the current
   query are no longer run on every request https://github.com/nuwave/lighthouse/pull/768
 - Simplify the default route configuration.
@@ -429,7 +431,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Deprecated
 
-- The `GraphQL` facade and the container alias `graphql` will be removed in v4 
+- The `GraphQL` facade and the container alias `graphql` will be removed in v4
 
 ## 3.6.1
 
@@ -550,8 +552,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
   that sets a default value for the generated field argument `count` https://github.com/nuwave/lighthouse/pull/428
 - Allow user to be guest when using the `@can` directive https://github.com/nuwave/lighthouse/pull/431
 - Add shortcut to get NodeValue type definition fields https://github.com/nuwave/lighthouse/pull/432
-- Use `@inject` with dot notation to set nested value https://github.com/nuwave/lighthouse/pull/511 
-- Populate more relationship types through nested mutations https://github.com/nuwave/lighthouse/pull/514 https://github.com/nuwave/lighthouse/pull/549 
+- Use `@inject` with dot notation to set nested value https://github.com/nuwave/lighthouse/pull/511
+- Populate more relationship types through nested mutations https://github.com/nuwave/lighthouse/pull/514 https://github.com/nuwave/lighthouse/pull/549
 - Support the `@deprecated` directive https://github.com/nuwave/lighthouse/pull/522
 - Allow defining default namespaces as an array https://github.com/nuwave/lighthouse/pull/525
 - Add config & directive argument for `@paginate` to limit the maximum requested count https://github.com/nuwave/lighthouse/pull/569

--- a/src/Execution/Arguments/NestedBelongsTo.php
+++ b/src/Execution/Arguments/NestedBelongsTo.php
@@ -8,7 +8,7 @@ use Nuwave\Lighthouse\Support\Contracts\ArgResolver;
 class NestedBelongsTo implements ArgResolver
 {
     /**
-     * @var BelongsTo
+     * @var \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     protected $relation;
 

--- a/src/Execution/Arguments/NestedBelongsTo.php
+++ b/src/Execution/Arguments/NestedBelongsTo.php
@@ -8,13 +8,13 @@ use Nuwave\Lighthouse\Support\Contracts\ArgResolver;
 class NestedBelongsTo implements ArgResolver
 {
     /**
-     * @var string
+     * @var BelongsTo
      */
-    private $relationName;
+    protected $relation;
 
-    public function __construct(string $relationName)
+    public function __construct(BelongsTo $relation)
     {
-        $this->relationName = $relationName;
+        $this->relation = $relation;
     }
 
     /**
@@ -23,44 +23,41 @@ class NestedBelongsTo implements ArgResolver
      */
     public function __invoke($parent, $args): void
     {
-        /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo $relation */
-        $relation = $parent->{$this->relationName}();
-
         if ($args->has('create')) {
-            $saveModel = new ResolveNested(new SaveModel($relation));
+            $saveModel = new ResolveNested(new SaveModel($this->relation));
 
             $related = $saveModel(
-                $relation->make(),
+                $this->relation->make(),
                 $args->arguments['create']->value
             );
-            $relation->associate($related);
+            $this->relation->associate($related);
         }
 
         if ($args->has('connect')) {
-            $relation->associate($args->arguments['connect']->value);
+            $this->relation->associate($args->arguments['connect']->value);
         }
 
         if ($args->has('update')) {
-            $updateModel = new ResolveNested(new UpdateModel(new SaveModel($relation)));
+            $updateModel = new ResolveNested(new UpdateModel(new SaveModel($this->relation)));
 
             $related = $updateModel(
-                $relation->make(),
+                $this->relation->make(),
                 $args->arguments['update']->value
             );
-            $relation->associate($related);
+            $this->relation->associate($related);
         }
 
         if ($args->has('upsert')) {
-            $upsertModel = new ResolveNested(new UpsertModel(new SaveModel($relation)));
+            $upsertModel = new ResolveNested(new UpsertModel(new SaveModel($this->relation)));
 
             $related = $upsertModel(
-                $relation->make(),
+                $this->relation->make(),
                 $args->arguments['upsert']->value
             );
-            $relation->associate($related);
+            $this->relation->associate($related);
         }
 
-        self::disconnectOrDelete($relation, $args);
+        self::disconnectOrDelete($this->relation, $args);
     }
 
     public static function disconnectOrDelete(BelongsTo $relation, ArgumentSet $args): void

--- a/src/Execution/Arguments/NestedMorphTo.php
+++ b/src/Execution/Arguments/NestedMorphTo.php
@@ -2,18 +2,19 @@
 
 namespace Nuwave\Lighthouse\Execution\Arguments;
 
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Nuwave\Lighthouse\Support\Contracts\ArgResolver;
 
 class NestedMorphTo implements ArgResolver
 {
     /**
-     * @var string
+     * @var \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    private $relationName;
+    private $relation;
 
-    public function __construct(string $relationName)
+    public function __construct(MorphTo $relation)
     {
-        $this->relationName = $relationName;
+        $this->relation = $relation;
     }
 
     /**
@@ -23,15 +24,12 @@ class NestedMorphTo implements ArgResolver
      */
     public function __invoke($parent, $args)
     {
-        /** @var \Illuminate\Database\Eloquent\Relations\MorphTo $relation */
-        $relation = $parent->{$this->relationName}();
-
         // TODO implement create and update once we figure out how to do polymorphic input types https://github.com/nuwave/lighthouse/issues/900
 
         if ($args->has('connect')) {
             $connectArgs = $args->arguments['connect']->value;
 
-            $morphToModel = $relation->createModelByType(
+            $morphToModel = $this->relation->createModelByType(
                 (string) $connectArgs->arguments['type']->value
             );
             $morphToModel->setAttribute(
@@ -39,9 +37,9 @@ class NestedMorphTo implements ArgResolver
                 $connectArgs->arguments['id']->value
             );
 
-            $relation->associate($morphToModel);
+            $this->relation->associate($morphToModel);
         }
 
-        NestedBelongsTo::disconnectOrDelete($relation, $args);
+        NestedBelongsTo::disconnectOrDelete($this->relation, $args);
     }
 }

--- a/src/Execution/Arguments/SaveModel.php
+++ b/src/Execution/Arguments/SaveModel.php
@@ -45,12 +45,16 @@ class SaveModel implements ArgResolver
         $model->fill($remaining->toArray());
 
         foreach ($belongsTo->arguments as $relationName => $nestedOperations) {
-            $belongsToResolver = new ResolveNested(new NestedBelongsTo($relationName));
+            /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo $belongsTo */
+            $belongsTo = $model->{$relationName}();
+            $belongsToResolver = new ResolveNested(new NestedBelongsTo($belongsTo));
             $belongsToResolver($model, $nestedOperations->value);
         }
 
         foreach ($morphTo->arguments as $relationName => $nestedOperations) {
-            $morphToResolver = new ResolveNested(new NestedMorphTo($relationName));
+            /** @var \Illuminate\Database\Eloquent\Relations\MorphTo $morphTo */
+            $morphTo = $model->{$relationName}();
+            $morphToResolver = new ResolveNested(new NestedMorphTo($morphTo));
             $morphToResolver($model, $nestedOperations->value);
         }
 
@@ -66,8 +70,7 @@ class SaveModel implements ArgResolver
         $model->save();
 
         if ($this->parentRelation instanceof BelongsTo) {
-            $parentModel = $this->parentRelation
-                                ->associate($model);
+            $parentModel = $this->parentRelation->associate($model);
 
             // If the parent Model does not exist (still to be saved),
             // a save could break any pending belongsTo relations that still

--- a/src/Execution/Arguments/SaveModel.php
+++ b/src/Execution/Arguments/SaveModel.php
@@ -66,9 +66,15 @@ class SaveModel implements ArgResolver
         $model->save();
 
         if ($this->parentRelation instanceof BelongsTo) {
-            $this->parentRelation
-                ->associate($model)
-                ->save();
+            $parentModel = $this->parentRelation
+                                ->associate($model);
+
+            // If the parent Model does not exist (still to be saved),
+            // a save could break any pending belongsTo relations that still
+            // needs to be created and associated with the parent model
+            if ($parentModel->exists()) {
+                $parentModel->save();
+            }
         }
 
         if ($this->parentRelation instanceof BelongsToMany) {

--- a/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
@@ -907,7 +907,7 @@ GRAPHQL
         $this->assertEquals([2], $role->users()->pluck('users.id')->toArray());
     }
 
-    public function testCreateMultipleBelongsTothatDontExist()
+    public function testCreateMultipleBelongsToThatDontExistYet(): void
     {
         $this->schema = /** @lang GraphQL */ '
         type RoleUserPivot {
@@ -927,7 +927,9 @@ GRAPHQL
         }
 
         type Mutation {
-            createRoleUser(input: RoleUserInput! @spread): RoleUserPivot @create
+            createRoleUser(
+                input: RoleUserInput! @spread
+            ): RoleUserPivot @create
         }
 
         input RoleUserInput {
@@ -956,34 +958,34 @@ GRAPHQL
         '.self::PLACEHOLDER_QUERY;
 
         $this->graphQL(/** @lang GraphQL */ '
-            mutation {
-                createRoleUser(input: {
-                    id: "1"
-                    user: {
-                        create: {
-                            id: "2"
-                            name: "user 1"
-                        }
-                    }
-                    role: {
-                        create: {
-                            id: "3",
-                            name: "role 1"
-                        }
-                    }
-                }) {
-                    id
-                    user {
-                        id
-                        name
-                    }
-                    role {
-                        id
-                        name
+        mutation {
+            createRoleUser(input: {
+                id: "1"
+                user: {
+                    create: {
+                        id: "2"
+                        name: "user 1"
                     }
                 }
+                role: {
+                    create: {
+                        id: "3",
+                        name: "role 1"
+                    }
+                }
+            }) {
+                id
+                user {
+                    id
+                    name
+                }
+                role {
+                    id
+                    name
+                }
             }
-            ')->assertJson([
+        }
+        ')->assertJson([
             'data' => [
                 'createRoleUser' => [
                     'id' => '1',

--- a/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
@@ -910,7 +910,6 @@ GRAPHQL
     public function testCreateMultipleBelongsTothatDontExist()
     {
         $this->schema = /** @lang GraphQL */ '
-
         type RoleUserPivot {
             id: ID!
             user: User!

--- a/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
@@ -985,19 +985,19 @@ GRAPHQL
                 }
             }
             ')->assertJson([
-                'data' => [
-                    'createRoleUser' => [
-                        'id' => '1',
-                        'user' => [
-                            'id' => '2',
-                            'name' => 'user 1',
-                        ],
-                        'role' => [
-                            'id' => '3',
-                            'name' => 'role 1',
-                        ],
+            'data' => [
+                'createRoleUser' => [
+                    'id' => '1',
+                    'user' => [
+                        'id' => '2',
+                        'name' => 'user 1',
+                    ],
+                    'role' => [
+                        'id' => '3',
+                        'name' => 'role 1',
                     ],
                 ],
-            ]);
+            ],
+        ]);
     }
 }

--- a/tests/Integration/Schema/Directives/CreateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/CreateDirectiveTest.php
@@ -359,7 +359,7 @@ class CreateDirectiveTest extends DBTestCase
         ]);
     }
 
-    public function testNestedArgResolverBelongsTo(): void
+    public function testNestedArgResolverForOptionalBelongsTo(): void
     {
         $this->schema .= /** @lang GraphQL */ '
         type Mutation {


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

Resolves #1213.

**Changes**

This resolves a bug when inserting a model that relates to multiple belongs to relations that also are being created (using create or upsert wihtout id).

When SaveModel detects a BelongsTo relation, he associates with the relation, and also persist the relation. Since belongsTo means the relation is related with a model that contains the foreign key,
the code will try to persist. What happens is that the model have multiple belongsTo relations, all required and without default value. When this happens, and the code tries to save the model, it's still missing the remaining belongsTo relations id, generating a query error. 

This PR adds a check so when the parent model, related by a BelongsTo relation, doesn't exist, it will not call the save method in that level. The save will then be called after the for each applied for the parent model level. 

**Breaking changes**

No breaking changes are introduced in this PR.
