### PR TITLE
Allow setting test database connection data from env vars

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,6 +10,8 @@ on:
 
 env:
   REQUIRED_PHP_EXTENSIONS: "mbstring, mysqli, pdo_mysql"
+  LIGHTHOUSE_TEST_DB_HOST: "127.0.0.1"
+  LIGHTHOUSE_TEST_DB_PASSWORD: "root"
 
 jobs:
   coding-standards:

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -38,10 +38,10 @@ abstract class DBTestCase extends TestCase
         $app['config']->set('database.default', 'mysql');
         $app['config']->set('database.connections.mysql', [
             'driver' => 'mysql',
-            'database' => env('LIGHTHOUSE_TEST_DB', 'test'),
-            'host' => env('GITHUB_ACTIONS') ? '127.0.0.1' : env('LIGHTHOUSE_TEST_DB_HOST', 'mysql'),
+            'database' => env('LIGHTHOUSE_TEST_DB_DATABASE', 'test'),
+            'host' => env('LIGHTHOUSE_TEST_DB_HOST', 'mysql'),
             'username' => env('LIGHTHOUSE_TEST_DB_USERNAME', 'root'),
-            'password' => env('GITHUB_ACTIONS') ? 'root' : env('LIGHTHOUSE_TEST_DB_PASSWORD', ''),
+            'password' => env('LIGHTHOUSE_TEST_DB_PASSWORD', ''),
         ]);
     }
 }

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -38,10 +38,10 @@ abstract class DBTestCase extends TestCase
         $app['config']->set('database.default', 'mysql');
         $app['config']->set('database.connections.mysql', [
             'driver' => 'mysql',
-            'database' => 'test',
-            'host' => env('GITHUB_ACTIONS') ? '127.0.0.1' : 'mysql',
-            'username' => 'root',
-            'password' => env('GITHUB_ACTIONS') ? 'root' : '',
+            'database' => env('LIGHTHOUSE_TEST_DB', 'test'),
+            'host' => env('GITHUB_ACTIONS') ? '127.0.0.1' : env('LIGHTHOUSE_TEST_DB_HOST', 'mysql'),
+            'username' => env('LIGHTHOUSE_TEST_DB_USERNAME', 'root'),
+            'password' => env('GITHUB_ACTIONS') ? 'root' : env('LIGHTHOUSE_TEST_DB_PASSWORD', ''),
         ]);
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Read test database connection data from env variables. This makes it easier to run tests locally without docker.

**Breaking changes**

None.
