### PR TITLE
Avoid race condition that may occur when using Cache::has()

### DIFF
--- a/src/Schema/Directives/CacheDirective.php
+++ b/src/Schema/Directives/CacheDirective.php
@@ -88,12 +88,10 @@ SDL;
                 ? $this->cacheManager->tags($cacheValue->getTags())
                 : $this->cacheManager;
 
-            $cacheHasKey = $cache->has($cacheKey);
-
             // We found a matching value in the cache, so we can just return early
             // without actually running the query
-            if ($cacheHasKey) {
-                return $cache->get($cacheKey);
+            if ($value = $cache->get($cacheKey)) {
+                return $value;
             }
 
             $resolvedValue = $resolver($root, $args, $context, $resolveInfo);

--- a/src/Subscriptions/StorageManager.php
+++ b/src/Subscriptions/StorageManager.php
@@ -112,14 +112,6 @@ class StorageManager implements StoresSubscriptions
 
     public function deleteSubscriber(string $channel): ?Subscriber
     {
-        $key = self::SUBSCRIBER_KEY.".{$channel}";
-
-        $subscriber = $this->cache->get($key);
-
-        if ($subscriber) {
-            $this->cache->forget($key);
-        }
-
-        return $subscriber;
+        return $this->cache->pull(self::SUBSCRIBER_KEY.".{$channel}");
     }
 }

--- a/src/Subscriptions/StorageManager.php
+++ b/src/Subscriptions/StorageManager.php
@@ -74,13 +74,12 @@ class StorageManager implements StoresSubscriptions
      */
     public function subscribersByTopic(string $topic): Collection
     {
-        $key = self::TOPIC_KEY.".{$topic}";
-
-        if (! $this->cache->has($key)) {
+        $channelsJson = $this->cache->get(self::TOPIC_KEY.".{$topic}");
+        if (! $channelsJson) {
             return new Collection;
         }
 
-        $channels = json_decode($this->cache->get($key), true);
+        $channels = json_decode($channelsJson, true);
 
         return (new Collection($channels))
             ->map(function (string $channel): ?Subscriber {
@@ -90,18 +89,14 @@ class StorageManager implements StoresSubscriptions
             ->values();
     }
 
-    /**
-     * Store subscription.
-     *
-     * @param  \Nuwave\Lighthouse\Subscriptions\Subscriber  $subscriber
-     */
     public function storeSubscriber(Subscriber $subscriber, string $topic): void
     {
         $topicKey = self::TOPIC_KEY.".{$topic}";
         $subscriberKey = self::SUBSCRIBER_KEY.".{$subscriber->channel}";
 
-        $topic = $this->cache->has($topicKey)
-            ? json_decode($this->cache->get($topicKey), true)
+        $topicJson = $this->cache->get($topicKey);
+        $topic = $topicJson
+            ? json_decode($topicJson, true)
             : [];
 
         $topic[] = $subscriber->channel;
@@ -115,19 +110,13 @@ class StorageManager implements StoresSubscriptions
         }
     }
 
-    /**
-     * Delete subscriber.
-     *
-     * @return \Nuwave\Lighthouse\Subscriptions\Subscriber|null
-     */
     public function deleteSubscriber(string $channel): ?Subscriber
     {
         $key = self::SUBSCRIBER_KEY.".{$channel}";
-        $hasSubscriber = $this->cache->has($key);
 
         $subscriber = $this->cache->get($key);
 
-        if ($hasSubscriber) {
+        if ($subscriber) {
             $this->cache->forget($key);
         }
 


### PR DESCRIPTION
As documented in `CacheInterface`:

> NOTE: It is recommended that has() is only to be used for cache warming type purposes
and not to be used within your live applications operations for get/set, as this method
is subject to a race condition where your has() will return true and immediately after,
another script can remove it making the state of your app out of date.