### PR TITLE
Multiple belongs to in the same level with existing records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## 4.12.1
+
+### Fixed
+
+- Fix creating multiple nested BelongsTo relationships on the same level when previous records
+  with matching attributes exist https://github.com/nuwave/lighthouse/pull/1321
+
 ## 4.12.0
 
 ### Added

--- a/src/Execution/Arguments/SaveModel.php
+++ b/src/Execution/Arguments/SaveModel.php
@@ -75,7 +75,7 @@ class SaveModel implements ArgResolver
             // If the parent Model does not exist (still to be saved),
             // a save could break any pending belongsTo relations that still
             // needs to be created and associated with the parent model
-            if ($parentModel->exists()) {
+            if ($parentModel->exists) {
                 $parentModel->save();
             }
         }

--- a/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
@@ -1084,8 +1084,6 @@ GRAPHQL
             }
         }';
 
-
-
         // first create a user, role_user, and a role, all associated, to allow role_user_creation
         $this->graphQL($query)->assertJson([
             'data' => [

--- a/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
@@ -1059,15 +1059,15 @@ GRAPHQL
         $query = /** @lang GraphQL */ '
         mutation {
             createRoleUser(input: {
-                meta: "1"
+                meta: "asdf"
                 user: {
                     create: {
-                        name: "user 1"
+                        name: "some username"
                     }
                 }
                 role: {
                     create: {
-                        name: "role 1"
+                        name: "some rolename"
                     }
                 }
             }) {
@@ -1084,39 +1084,37 @@ GRAPHQL
             }
         }';
 
-        // first create a user, role_user, and a role, all associated, to allow role_user_creation
+        // This must first create a user, then a role, then attach them to the pivot
         $this->graphQL($query)->assertJson([
             'data' => [
                 'createRoleUser' => [
                     'id' => '1',
-                    'meta' => '1',
+                    'meta' => 'asdf',
                     'user' => [
                         'id' => '1',
-                        'name' => 'user 1',
+                        'name' => 'some username',
                     ],
                     'role' => [
                         'id' => '1',
-                        'name' => 'role 1',
+                        'name' => 'some rolename',
                     ],
                 ],
             ],
         ]);
 
-        // now create a second role_user, the exact same way as previously created.
-        // This should test than an existing rule_user match with the attribute meta,
-        // should not interfere with consequent mutations.
+        // We should be able to repeat this query and create new entries the same way
         $this->graphQL($query)->assertJson([
             'data' => [
                 'createRoleUser' => [
                     'id' => '2',
-                    'meta' => '1',
+                    'meta' => 'asdf',
                     'user' => [
                         'id' => '2',
-                        'name' => 'user 1',
+                        'name' => 'some username',
                     ],
                     'role' => [
                         'id' => '2',
-                        'name' => 'role 1',
+                        'name' => 'some rolename',
                     ],
                 ],
             ],

--- a/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
@@ -804,6 +804,7 @@ GRAPHQL
         }
 
         input UpsertRoleUserPivotInput {
+            id: ID
             role: UpsertRoleBelongsTo
         }
 
@@ -874,6 +875,7 @@ GRAPHQL
                 name: "fooz"
                 rolesPivot: {
                     upsert: [{
+                        id: "1"
                         role: {
                             upsert: {
                                 id: "1"

--- a/tests/Integration/Execution/MutationExecutor/HasManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasManyTest.php
@@ -3,9 +3,9 @@
 namespace Tests\Integration\Execution\MutationExecutor;
 
 use Tests\DBTestCase;
+use Tests\Utils\Models\Role;
 use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
-use Tests\Utils\Models\Role;
 
 class HasManyTest extends DBTestCase
 {

--- a/tests/Integration/Execution/MutationExecutor/HasManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasManyTest.php
@@ -5,6 +5,7 @@ namespace Tests\Integration\Execution\MutationExecutor;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
+use Tests\Utils\Models\Role;
 
 class HasManyTest extends DBTestCase
 {
@@ -443,5 +444,121 @@ GRAPHQL
                 ],
             ],
         ]);
+    }
+
+    public function testUpsertAcrossPivotTableOverrideExistingModel(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type User {
+            id: ID!
+            name: String!
+            roles: [Role!] @belongsToMany
+        }
+
+        type Role {
+            id: ID!
+            name: String!
+        }
+
+        type Mutation {
+            upsertUser(input: UpsertUserInput! @spread): User @upsert
+        }
+
+        input UpsertUserInput {
+            id: ID
+            name: String!
+            roles: UpsertRolesHasMany
+        }
+
+        input UpsertRolesHasMany {
+            upsert: [UpsertRoleInput!]
+        }
+
+        input UpsertRoleInput {
+            id: ID
+            name: String!
+            users: UpsertRoleUsersRelation
+        }
+
+        input UpsertRoleUsersRelation {
+            sync: [ID!]
+        }
+        '.self::PLACEHOLDER_QUERY;
+
+        // Create the first User with a Role.
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            upsertUser(input: {
+                name: "foo"
+                roles: {
+                    upsert: [{
+                        name: "bar"
+                    }]
+                }
+            }) {
+                id
+                name
+                roles {
+                    id
+                    name
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'upsertUser' => [
+                    'id' => '1',
+                    'name' => 'foo',
+                    'roles' => [
+                        [
+                            'id' => '1',
+                            'name' => 'bar',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        // The first User has the first Role.
+        $role = Role::first();
+        $this->assertEquals([1], $role->users()->pluck('users.id')->toArray());
+
+        // Create another User.
+        factory(User::class)->create();
+
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            upsertUser(input: {
+                id: "1"
+                name: "fooz"
+                roles: {
+                    upsert: [{
+                        id: "1"
+                        name: "baz"
+                        users: {
+                            sync: ["2"] # Here the first User is switching the relationship of the first Role to another User.
+                        }
+                    }]
+                }
+            }) {
+                id
+                name
+                roles {
+                    id
+                    name
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'upsertUser' => [
+                    'id' => '1',
+                    'name' => 'fooz',
+                    'roles' => [],
+                ],
+            ],
+        ]);
+
+        $this->assertEquals([2], $role->users()->pluck('users.id')->toArray());
     }
 }


### PR DESCRIPTION
- [ x ] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

Related with #1285 

**Changes**

This solves a problem that I detected related with multiple belongsTo at the same level.

The method used to solve this problem, was the exists method of the class Model. This method makes a query with the current attributes of the model instance and check if such exists. This could lead to a true result even if such instance don't exist on the database. 

To solve this, the use of the exists property of the model should be used instead of the method. This property tells if the instance is associated to a record of the database. 

I added tests to test this specific case.

**Breaking changes**

This breaks the test *testUpsertAcrossTwoNestedBelongsToRelationsAndOverrideExistingModel*. 

I believe this test will create a duplication for the role_user, before the sync is being made. In the way the test is written, it will create a second relationship between user and role, even if we are referencing the same user and role of the first creation. 

I think there are other ways of achieving what this test is achieving, by two ways:

- specify the id of the relation role_user
- use the belongsToMany relationship to access the related role

I modified this test, specifying the role_user id, as also i created a new test for the belongsToMany case. 

I added this in the breaking changes because i don't know if this was the intended behaviour of lighthouse or not.
