### PR TITLE
Fix converting lists of lists into ArgumentSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## 4.12.2
+
+### Fixed
+
+- Fix converting lists of lists into ArgumentSet https://github.com/nuwave/lighthouse/pull/1335
+
 ## 4.12.1
 
 ### Fixed

--- a/src/Execution/Arguments/ArgumentSetFactory.php
+++ b/src/Execution/Arguments/ArgumentSetFactory.php
@@ -135,7 +135,7 @@ class ArgumentSetFactory
     {
         // No need to recurse down further if the value is null
         if ($valueOrValues === null) {
-            return null;
+            return;
         }
 
         // We have to do this conversion as we are resolving a client query

--- a/src/Execution/Arguments/ArgumentSetFactory.php
+++ b/src/Execution/Arguments/ArgumentSetFactory.php
@@ -133,22 +133,22 @@ class ArgumentSetFactory
      */
     protected function wrapWithType($valueOrValues, $type)
     {
+        // No need to recurse down further if the value is null
+        if ($valueOrValues === null) {
+            return null;
+        }
+
         // We have to do this conversion as we are resolving a client query
         // because the incoming arguments put a bound on recursion depth
         if ($type instanceof ListType) {
             $typeInList = $type->type;
 
-            if (is_array($valueOrValues)) {
-                $values = [];
-                foreach ($valueOrValues as $singleValue) {
-                    $values [] = $this->wrapWithNamedType($singleValue, $typeInList);
-                }
-
-                return $values;
+            $values = [];
+            foreach ($valueOrValues as $singleValue) {
+                $values [] = $this->wrapWithType($singleValue, $typeInList);
             }
 
-            // This case happens if `null` is passed
-            return $this->wrapWithNamedType($valueOrValues, $typeInList);
+            return $values;
         }
 
         return $this->wrapWithNamedType($valueOrValues, $type);
@@ -162,11 +162,6 @@ class ArgumentSetFactory
      */
     protected function wrapWithNamedType($value, NamedType $namedType)
     {
-        // As GraphQL does not allow empty input objects, we return null as is
-        if ($value === null) {
-            return;
-        }
-
         // This might be null if the type is
         // - created outside of the schema string
         // - one of the built in types

--- a/src/Execution/Arguments/ListType.php
+++ b/src/Execution/Arguments/ListType.php
@@ -7,7 +7,7 @@ class ListType
     /**
      * The type contained within the list.
      *
-     * @var \Nuwave\Lighthouse\Execution\Arguments\NamedType
+     * @var \Nuwave\Lighthouse\Execution\Arguments\NamedType|\Nuwave\Lighthouse\Execution\Arguments\ListType
      */
     public $type;
 
@@ -18,7 +18,10 @@ class ListType
      */
     public $nonNull = false;
 
-    public function __construct(NamedType $type)
+    /**
+     * @param  \Nuwave\Lighthouse\Execution\Arguments\NamedType|\Nuwave\Lighthouse\Execution\Arguments\ListType  $type
+     */
+    public function __construct($type)
     {
         $this->type = $type;
     }

--- a/tests/Unit/Execution/Arguments/ArgumentSetFactoryTest.php
+++ b/tests/Unit/Execution/Arguments/ArgumentSetFactoryTest.php
@@ -75,21 +75,21 @@ class ArgumentSetFactoryTest extends TestCase
         ';
 
         $barValue =
-            # Level 1
+            // Level 1
             [
-                # Level 2
+                // Level 2
                 [
-                    # Level 3
+                    // Level 3
                     [
-                        # Level 4
+                        // Level 4
                         [
-                            1, 2
+                            1, 2,
                         ],
                         [
-                            3, null
-                        ]
+                            3, null,
+                        ],
                     ],
-                    null
+                    null,
                 ],
             ];
 

--- a/tests/Unit/Execution/Arguments/ArgumentSetFactoryTest.php
+++ b/tests/Unit/Execution/Arguments/ArgumentSetFactoryTest.php
@@ -2,9 +2,12 @@
 
 namespace Tests\Unit\Execution\Arguments;
 
+use GraphQL\Type\Definition\Type;
 use Nuwave\Lighthouse\Execution\Arguments\Argument;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSetFactory;
+use Nuwave\Lighthouse\Execution\Arguments\ListType;
+use Nuwave\Lighthouse\Execution\Arguments\NamedType;
 use Nuwave\Lighthouse\Schema\AST\ASTBuilder;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Tests\TestCase;
@@ -47,6 +50,79 @@ class ArgumentSetFactoryTest extends TestCase
         $bar = $argumentSet->arguments['bar'];
         $this->assertInstanceOf(Argument::class, $bar);
         $this->assertNull($bar->value);
+    }
+
+    public function testItsListsAllTheWayDown(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo(bar:
+                # Level 1
+                [
+                    # Level 2
+                    [
+                        # Level 3
+                        [
+                            # Level 4
+                            [
+                                Int
+                            ]!
+                        ]
+                    ]!
+                ]
+            ): Int
+        }
+        ';
+
+        $barValue =
+            # Level 1
+            [
+                # Level 2
+                [
+                    # Level 3
+                    [
+                        # Level 4
+                        [
+                            1, 2
+                        ],
+                        [
+                            3, null
+                        ]
+                    ],
+                    null
+                ],
+            ];
+
+        $argumentSet = $this->rootQueryArgumentSet([
+            'bar' => $barValue,
+        ]);
+
+        $this->assertCount(1, $argumentSet->arguments);
+
+        $bar = $argumentSet->arguments['bar'];
+        $this->assertInstanceOf(Argument::class, $bar);
+        $this->assertSame($barValue, $bar->value);
+
+        $firstLevel = $bar->type;
+        $this->assertInstanceOf(ListType::class, $firstLevel);
+        $this->assertFalse($firstLevel->nonNull);
+
+        $secondLevel = $firstLevel->type;
+        $this->assertInstanceOf(ListType::class, $secondLevel);
+        $this->assertTrue($secondLevel->nonNull);
+
+        $thirdLevel = $secondLevel->type;
+        $this->assertInstanceOf(ListType::class, $thirdLevel);
+        $this->assertFalse($thirdLevel->nonNull);
+
+        $fourthLevel = $thirdLevel->type;
+        $this->assertInstanceOf(ListType::class, $fourthLevel);
+        $this->assertTrue($fourthLevel->nonNull);
+
+        $finalLevel = $fourthLevel->type;
+        $this->assertInstanceOf(NamedType::class, $finalLevel);
+        $this->assertSame(Type::INT, $finalLevel->name);
+        $this->assertFalse($finalLevel->nonNull);
     }
 
     public function testNullableInputObject(): void


### PR DESCRIPTION
- [x] Added or updated tests
~~- [ ] Added Docs for all relevant versions~~
- [x] Updated CHANGELOG.md

Resolves https://github.com/nuwave/lighthouse/issues/1264

**Changes**

The way arguments were parsed into an `ArgumentSet` wrongly assumed that lists are flat.

**Breaking changes**

None
