### PR TITLE
Fix nesting OR within AND condition when using `@whereConditions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## 4.12.3
 
+### Fixed
+
+- Fix nesting OR within AND condition when using `@whereConditions`
+
+## 4.12.3
+
 ### Changed
 
 - Throw an exception if the return type declaration class for a relation does not exist https://github.com/nuwave/lighthouse/pull/1338

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
-## 4.12.3
+## 4.12.4.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Fix nesting OR within AND condition when using `@whereConditions`
+- Fix nesting OR within AND condition when using `@whereConditions` https://github.com/nuwave/lighthouse/pull/1341
 
 ## 4.12.3
 

--- a/src/WhereConditions/WhereConditionsBaseDirective.php
+++ b/src/WhereConditions/WhereConditionsBaseDirective.php
@@ -41,7 +41,8 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
                     foreach ($andConnectedConditions as $condition) {
                         $this->handleWhereConditions($builder, $condition);
                     }
-                }
+                },
+                $boolean
             );
         }
 
@@ -52,7 +53,7 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
                         $this->handleWhereConditions($builder, $condition, 'or');
                     }
                 },
-                'or'
+                $boolean
             );
         }
 

--- a/tests/Integration/WhereConditions/WhereConditionsDirectiveTest.php
+++ b/tests/Integration/WhereConditions/WhereConditionsDirectiveTest.php
@@ -286,6 +286,53 @@ class WhereConditionsDirectiveTest extends DBTestCase
         ]);
     }
 
+    public function testAddsNestedAndOr(): void
+    {
+        factory(User::class, 5)->create();
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            users(
+                where: {
+                    AND: [
+                        {
+                            column: "id"
+                            operator: GT
+                            value: 1
+                        }
+                        {
+                            OR: [
+                                {
+                                    column: "id"
+                                    value: 2
+                                }
+                                {
+                                    column: "id"
+                                    value: 3
+                                }
+                            ]
+
+                        }
+                    ]
+                }
+            ) {
+                id
+            }
+        }
+        ')->assertExactJson([
+            'data' => [
+                'users' => [
+                    [
+                        'id' => '2',
+                    ],
+                    [
+                        'id' => '3',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
     public function testAddsNot(): void
     {
         $this->markTestSkipped('Kind of works, but breaks down when more nested conditions are added, see https://github.com/nuwave/lighthouse/issues/1124');


### PR DESCRIPTION
- [x] Added or updated tests
~~- [ ] Added Docs for all relevant versions~~
- [x] Updated CHANGELOG.md

Resolves https://github.com/nuwave/lighthouse/issues/1262

**Changes**

Pass the correct boolean operator to `whereNested` call.

**Breaking changes**

No
