### PR TITLE
Add graphql init to docs about graphql-cli

### DIFF
--- a/docs/4.12/getting-started/migrating-to-lighthouse.md
+++ b/docs/4.12/getting-started/migrating-to-lighthouse.md
@@ -14,6 +14,7 @@ can use introspection to retrieve this schema and save it to a file.
 A simple tool that is also generally useful is [graphql-cli](https://github.com/graphql-cli/graphql-cli).
 
     npm install -g graphql-cli
+    graphql init
     graphql get-schema --endpoint=example.com/graphql --output=schema.graphql
 
 Type definitions that previously done through code can mostly be deduced from


### PR DESCRIPTION
without the graphql init 
✖ ".graphqlconfig" file is not available in the provided config directory: /datos/webs/sid/sidapi/sidapi
Please check the config directory.

- [ ] Added or updated tests
- [ ] Added Docs for all relevant versions
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- If there are any breaking changes, list them here.
Make sure to mention them in UPGRADE.md. -->
