### PR TITLE
Use `forceFill()` when mutating models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 ### Changed
 
 - Improve validation error when extending a type that is not defined https://github.com/nuwave/lighthouse/pull/1347
+- Use `forceFill()` when mutating models
 
 ## 4.12.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 ### Changed
 
 - Improve validation error when extending a type that is not defined https://github.com/nuwave/lighthouse/pull/1347
-- Use `forceFill()` when mutating models
+- Use `forceFill()` when mutating models https://github.com/nuwave/lighthouse/pull/1348
 
 ## 4.12.4
 

--- a/docs/master/eloquent/getting-started.md
+++ b/docs/master/eloquent/getting-started.md
@@ -163,18 +163,6 @@ The newly created user is returned as a result:
 }
 ```
 
-**Note**: Due to Laravel's protections against mass assignment, any arguments used in `@create` or `@update` must be added to the `$fillable` property in your Model. For the above example, we would need the following in `\App\Models\User`:
-
-```php
-class User extends Model
-{
-  // ...
-  protected $fillable = ["name"];
-}
-```
-
-For more information, see the [laravel docs](https://laravel.com/docs/eloquent#mass-assignment).
-
 ## Update
 
 You can update a model with the [@update](../api-reference/directives.md#update) directive.
@@ -228,8 +216,8 @@ type Mutation {
 }
 ```
 
-Since upsert can create or update your data you must have all the minimum fields for a creation as required.
-The `id` is always required and must be marked as fillable in the model.
+Since upsert can create or update your data, your input should mark the minimum required fields as non-nullable.
+The `id` must always be required.
 
 ```graphql
 mutation {

--- a/src/Execution/Arguments/SaveModel.php
+++ b/src/Execution/Arguments/SaveModel.php
@@ -42,7 +42,7 @@ class SaveModel implements ArgResolver
         );
 
         // Use all the remaining attributes and fill the model
-        $model->fill($remaining->toArray());
+        $model->forceFill($remaining->toArray());
 
         foreach ($belongsTo->arguments as $relationName => $nestedOperations) {
             /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo $belongsTo */

--- a/tests/Integration/Execution/MutationExecutor/MorphToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToTest.php
@@ -192,15 +192,18 @@ class MorphToTest extends DBTestCase
     {
         /** @var \Tests\Utils\Models\Task $task */
         $task = factory(Task::class)->create(['name' => 'first_task']);
-        $task->image()->create([
-            'url' => 'bar',
-        ]);
 
-        $this->graphQL("
+        /** @var \Tests\Utils\Models\Image $image */
+        $image = $task->image()->make();
+        $image->url = 'bar';
+        $image->save();
+
+        $field = "${action}Image";
+        $this->graphQL(/** @lang GraphQL */ <<<GRAPHQL
         mutation {
-            ${action}Image(input: {
+            {$field}(input: {
                 id: 1
-                url: \"foo\"
+                url: "foo"
                 imageable: {
                     disconnect: true
                 }
@@ -212,9 +215,10 @@ class MorphToTest extends DBTestCase
                 }
             }
         }
-        ")->assertJson([
+GRAPHQL
+        )->assertJson([
             'data' => [
-                "${action}Image" => [
+                $field => [
                     'url' => 'foo',
                     'imageable' => null,
                 ],
@@ -229,15 +233,18 @@ class MorphToTest extends DBTestCase
     {
         /** @var \Tests\Utils\Models\Task $task */
         $task = factory(Task::class)->create(['name' => 'first_task']);
-        $task->image()->create([
-            'url' => 'bar',
-        ]);
 
-        $this->graphQL(/** @lang GraphQL */ "
+        /** @var \Tests\Utils\Models\Image $image */
+        $image = $task->image()->make();
+        $image->url = 'bar';
+        $image->save();
+
+        $field = "${action}Image";
+        $this->graphQL(/** @lang GraphQL */ <<<GRAPHQL
         mutation {
-            ${action}Image(input: {
+            {$field}(input: {
                 id: 1
-                url: \"foo\"
+                url: "foo"
                 imageable: {
                     delete: true
                 }
@@ -249,18 +256,17 @@ class MorphToTest extends DBTestCase
                 }
             }
         }
-        ")->assertJson([
+
+GRAPHQL
+        )->assertJson([
             'data' => [
-                "${action}Image" => [
+                $field => [
                     'url' => 'foo',
                     'imageable' => null,
                 ],
             ],
         ]);
 
-        $this->assertSame(
-            0,
-            Task::count()
-        );
+        $this->assertSame(0, Task::count());
     }
 }

--- a/tests/Integration/Schema/Directives/CanDirectiveDBTest.php
+++ b/tests/Integration/Schema/Directives/CanDirectiveDBTest.php
@@ -14,11 +14,9 @@ class CanDirectiveDBTest extends DBTestCase
 {
     public function testQueriesForSpecificModel(): void
     {
-        $this->be(
-            new User([
-                'name' => UserPolicy::ADMIN,
-            ])
-        );
+        $user = new User();
+        $user->name = UserPolicy::ADMIN;
+        $this->be($user);
 
         $user = factory(User::class)->create([
             'name' => 'foo',
@@ -54,11 +52,10 @@ class CanDirectiveDBTest extends DBTestCase
 
     public function testFailsToFindSpecificModel(): void
     {
-        $this->be(
-            new User([
-                'name' => UserPolicy::ADMIN,
-            ])
-        );
+        $user = new User();
+        $user->name = UserPolicy::ADMIN;
+        $this->be($user);
+
         $this->mockResolverExpects(
             $this->never()
         );
@@ -96,11 +93,9 @@ class CanDirectiveDBTest extends DBTestCase
 
     public function testThrowsIfFindValueIsNotGiven(): void
     {
-        $this->be(
-            new User([
-                'name' => UserPolicy::ADMIN,
-            ])
-        );
+        $user = new User();
+        $user->name = UserPolicy::ADMIN;
+        $this->be($user);
 
         $this->schema = /** @lang GraphQL */ '
         type Query {
@@ -175,15 +170,13 @@ class CanDirectiveDBTest extends DBTestCase
 
     public function testThrowsIfNotAuthorized(): void
     {
-        $this->be(
-            new User([
-                'name' => UserPolicy::ADMIN,
-            ])
-        );
+        $user = new User();
+        $user->name = UserPolicy::ADMIN;
+        $this->be($user);
 
-        $userB = User::create([
-            'name' => 'foo',
-        ]);
+        $userB = new User();
+        $userB->name = 'foo';
+        $userB->save();
 
         $postB = factory(Post::class)->create([
             'user_id' => $userB->getKey(),
@@ -218,9 +211,8 @@ class CanDirectiveDBTest extends DBTestCase
 
     public function testCanHandleMultipleModels(): void
     {
-        $user = User::create([
-            'name' => UserPolicy::ADMIN,
-        ]);
+        $user = new User();
+        $user->name = UserPolicy::ADMIN;
         $this->be($user);
 
         $postA = factory(Post::class)->create([
@@ -267,11 +259,9 @@ class CanDirectiveDBTest extends DBTestCase
 
     public function testWorksWithSoftDeletes(): void
     {
-        $this->be(
-            new User([
-                'name' => UserPolicy::ADMIN,
-            ])
-        );
+        $user = new User();
+        $user->name = UserPolicy::ADMIN;
+        $this->be($user);
 
         $task = factory(Task::class)->create();
         $task->delete();

--- a/tests/Integration/SchemaCachingTest.php
+++ b/tests/Integration/SchemaCachingTest.php
@@ -32,7 +32,7 @@ class SchemaCachingTest extends TestCase
         union Foo = Comment | Color
 
         type Comment {
-            bar: ID
+            comment: ID
         }
 
         type Color {
@@ -41,22 +41,22 @@ class SchemaCachingTest extends TestCase
         ';
         $this->cacheSchema();
 
-        $this->mockResolver(new Comment([
-            'bar' => 'bar',
-        ]));
+        $comment = new Comment();
+        $comment->comment = 'foo';
+        $this->mockResolver($comment);
 
         $this->graphQL(/** @lang GraphQL */ '
         {
             foo {
                 ... on Comment {
-                    bar
+                    comment
                 }
             }
         }
         ')->assertExactJson([
             'data' => [
                 'foo' => [
-                    'bar' => 'bar',
+                    'comment' => $comment->comment,
                 ],
             ],
         ]);

--- a/tests/Integration/SoftDeletes/ForceDeleteDirectiveTest.php
+++ b/tests/Integration/SoftDeletes/ForceDeleteDirectiveTest.php
@@ -102,13 +102,14 @@ class ForceDeleteDirectiveTest extends DBTestCase
 
     public function testCanDirectiveIncludesTrashedModelsWhenUsingForceDelete(): void
     {
-        $user = User::create([
-            'name' => UserPolicy::ADMIN,
-        ]);
+        $user = new User();
+        $user->name = UserPolicy::ADMIN;
+        $user->save();
+        $this->be($user);
+
         $task = factory(Task::class)->make();
         $user->tasks()->save($task);
         $task->delete();
-        $this->be($user);
 
         $this->schema .= /** @lang GraphQL */ '
         type Task {
@@ -136,13 +137,14 @@ class ForceDeleteDirectiveTest extends DBTestCase
 
     public function testCanDirectiveUsesExplicitTrashedArgument(): void
     {
-        $user = User::create([
-            'name' => UserPolicy::ADMIN,
-        ]);
+        $user = new User();
+        $user->name = UserPolicy::ADMIN;
+        $user->save();
+        $this->be($user);
+
         $task = factory(Task::class)->make();
         $user->tasks()->save($task);
         $task->delete();
-        $this->be($user);
 
         $this->schema .= /** @lang GraphQL */ '
         type Task {

--- a/tests/Integration/SoftDeletes/RestoreDirectiveTest.php
+++ b/tests/Integration/SoftDeletes/RestoreDirectiveTest.php
@@ -80,13 +80,14 @@ class RestoreDirectiveTest extends DBTestCase
 
     public function testCanDirectiveExcludesTrashedModelsWhenUsingRestore(): void
     {
-        $user = User::create([
-            'name' => UserPolicy::ADMIN,
-        ]);
+        $user = new User();
+        $user->name = UserPolicy::ADMIN;
+        $user->save();
+        $this->be($user);
+
         $task = factory(Task::class)->make();
         $user->tasks()->save($task);
         $task->delete();
-        $this->be($user);
 
         $this->assertCount(0, Task::withoutTrashed()->get());
 

--- a/tests/Unit/Schema/Directives/AuthDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/AuthDirectiveTest.php
@@ -9,29 +9,30 @@ class AuthDirectiveTest extends TestCase
 {
     public function testCanResolveAuthenticatedUser(): void
     {
-        $user = new User(['foo' => 'bar']);
+        $user = new User();
+        $user->name = 'foo';
         $this->be($user);
 
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */ '
         type User {
-            foo: String!
+            name: String!
         }
-        
+
         type Query {
             user: User! @auth
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             user {
-                foo
+                name
             }
-        }           
+        }
         ')->assertJson([
             'data' => [
                 'user' => [
-                    'foo' => 'bar',
+                    'name' => $user->name,
                 ],
             ],
         ]);
@@ -39,30 +40,31 @@ class AuthDirectiveTest extends TestCase
 
     public function testCanResolveAuthenticatedUserWithGuardArgument(): void
     {
-        $user = new User(['foo' => 'bar']);
+        $user = new User();
+        $user->name = 'foo';
 
         $this->app['auth']->guard('api')->setUser($user);
 
-        $this->schema = '
+        $this->schema = /** @lang GraphQL */ '
         type User {
-            foo: String!
+            name: String!
         }
-        
+
         type Query {
             user: User! @auth(guard: "api")
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         {
             user {
-                foo
+                name
             }
-        }           
+        }
         ')->assertJson([
             'data' => [
                 'user' => [
-                    'foo' => 'bar',
+                    'name' => $user->name,
                 ],
             ],
         ]);

--- a/tests/Utils/Models/Category.php
+++ b/tests/Utils/Models/Category.php
@@ -12,6 +12,5 @@ use Illuminate\Database\Eloquent\Model;
  */
 class Category extends Model
 {
-    protected $guarded = [];
     protected $primaryKey = 'category_id';
 }

--- a/tests/Utils/Models/Comment.php
+++ b/tests/Utils/Models/Comment.php
@@ -15,8 +15,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class Comment extends Model
 {
-    protected $guarded = [];
-
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/tests/Utils/Models/Company.php
+++ b/tests/Utils/Models/Company.php
@@ -13,8 +13,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 class Company extends Model
 {
-    protected $guarded = [];
-
     public function users(): HasMany
     {
         return $this->hasMany(User::class);

--- a/tests/Utils/Models/Contractor.php
+++ b/tests/Utils/Models/Contractor.php
@@ -14,8 +14,6 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
  */
 class Contractor extends Model
 {
-    protected $guarded = [];
-
     public function user(): MorphOne
     {
         return $this->morphOne(User::class, 'person');

--- a/tests/Utils/Models/Employee.php
+++ b/tests/Utils/Models/Employee.php
@@ -14,8 +14,6 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
  */
 class Employee extends Model
 {
-    protected $guarded = [];
-
     public function user(): MorphOne
     {
         return $this->morphOne(User::class, 'person');

--- a/tests/Utils/Models/Image.php
+++ b/tests/Utils/Models/Image.php
@@ -17,8 +17,6 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  */
 class Image extends Model
 {
-    protected $guarded = [];
-
     public function imageable(): MorphTo
     {
         return $this->morphTo();

--- a/tests/Utils/Models/Post.php
+++ b/tests/Utils/Models/Post.php
@@ -23,8 +23,6 @@ class Post extends Model
 {
     use Searchable;
 
-    protected $guarded = [];
-
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/tests/Utils/Models/Role.php
+++ b/tests/Utils/Models/Role.php
@@ -15,8 +15,6 @@ class Role extends Model
 {
     public $timestamps = false;
 
-    protected $guarded = [];
-
     public function users(): BelongsToMany
     {
         return $this

--- a/tests/Utils/Models/RoleUserPivot.php
+++ b/tests/Utils/Models/RoleUserPivot.php
@@ -17,8 +17,6 @@ class RoleUserPivot extends Model
 
     public $timestamps = false;
 
-    protected $guarded = [];
-
     public function role(): BelongsTo
     {
         return $this->belongsTo(Role::class);

--- a/tests/Utils/Models/Tag.php
+++ b/tests/Utils/Models/Tag.php
@@ -14,8 +14,6 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
  */
 class Tag extends Model
 {
-    protected $guarded = [];
-
     public function posts(): MorphToMany
     {
         return $this->morphedByMany(Post::class, 'taggable');

--- a/tests/Utils/Models/Task.php
+++ b/tests/Utils/Models/Task.php
@@ -26,8 +26,6 @@ class Task extends Model
 {
     use SoftDeletes;
 
-    protected $guarded = [];
-
     protected static function boot()
     {
         parent::boot();

--- a/tests/Utils/Models/Team.php
+++ b/tests/Utils/Models/Team.php
@@ -13,8 +13,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 class Team extends Model
 {
-    protected $guarded = [];
-
     public function users(): HasMany
     {
         return $this->hasMany(User::class);

--- a/tests/Utils/Models/User.php
+++ b/tests/Utils/Models/User.php
@@ -25,11 +25,6 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
  */
 class User extends Authenticatable
 {
-    /**
-     * @var mixed[]
-     */
-    protected $guarded = [];
-
     public function company(): BelongsTo
     {
         return $this->belongsTo(Company::class);

--- a/tests/Utils/Models/WithEnum.php
+++ b/tests/Utils/Models/WithEnum.php
@@ -15,7 +15,6 @@ class WithEnum extends Model
 {
     use CastsEnums;
 
-    protected $guarded = [];
     public $timestamps = false;
 
     protected $enumCasts = [


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added Docs for all relevant versions
- [x] Updated CHANGELOG.md

**Changes**

The schema already prevents clients from passing attributes they are not allowed to set.
This avoids forcing the user to mark all their attributes as fillable, allowing
mass-assignment protection to be used for other cases, where it makes sense.

**Breaking changes**

No
