### PR TITLE
Update PusherLink example to handle unsubscribes

### DIFF
--- a/docs/master/subscriptions/client-implementations.md
+++ b/docs/master/subscriptions/client-implementations.md
@@ -11,58 +11,113 @@ client library you will need to create an `apollo-link`
 ```js
 import { ApolloLink, Observable } from "apollo-link";
 
+// Inspired by https://github.com/rmosolgo/graphql-ruby/blob/master/javascript_client/src/subscriptions/PusherLink.ts
 class PusherLink extends ApolloLink {
   constructor(options) {
     super();
-    // Retain a handle to the Pusher client
+
     this.pusher = options.pusher;
   }
 
   request(operation, forward) {
-    return new Observable((observer) => {
-      // Check the result of the operation
+    const subscribeObservable = new Observable((_observer) => {
+      //
+    });
+
+    // Capture the super method
+    const prevSubscribe = subscribeObservable.subscribe.bind(
+      subscribeObservable
+    );
+
+    // Override subscribe to return an `unsubscribe` object, see
+    // https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/client.ts#L182-L212
+    subscribeObservable.subscribe = (observerOrNext, onError, onComplete) => {
+      prevSubscribe(observerOrNext, onError, onComplete);
+
+      const observer = getObserver(observerOrNext, onError, onComplete);
+
+      let subscriptionChannel;
+
       forward(operation).subscribe({
         next: (data) => {
-          // If the operation has the subscription extension, it's a subscription
-          const subscriptionChannel = this._getChannel(data, operation);
+          // If the operation has the subscription channel, it's a subscription
+          subscriptionChannel = this.getChannelFromResponse(data, operation);
 
-          if (subscriptionChannel) {
-            this._createSubscription(subscriptionChannel, observer);
-          } else {
-            // No subscription found in the response, pipe data through
+          // No subscription found in the response, pipe data through
+          if (!subscriptionChannel) {
             observer.next(data);
             observer.complete();
+
+            return;
           }
+
+          this.subscribeToChannel(subscriptionChannel, observer);
         },
       });
-    });
+
+      // Return an object that will unsubscribe_if the query was a subscription
+      return {
+        closed: false,
+        unsubscribe: () => {
+          subscriptionChannel &&
+            this.unsubscribeFromChannel(subscriptionChannel);
+        },
+      };
+    };
+
+    return subscribeObservable;
   }
 
-  _getChannel(data, operation) {
-    return !!data.extensions &&
-      !!data.extensions.lighthouse_subscriptions &&
-      !!data.extensions.lighthouse_subscriptions.channels
-      ? data.extensions.lighthouse_subscriptions.channels[
+  subscribeToChannel(subscriptionChannel, observer) {
+    this.pusher
+      .subscribe(subscriptionChannel)
+      .bind("lighthouse-subscription", (payload) => {
+        if (!payload.more) {
+          this.unsubscribeFromChannel(subscriptionChannel);
+
+          observer.complete();
+        }
+
+        const result = payload.result;
+
+        if (result) {
+          observer.next(result);
+        }
+      });
+  }
+
+  unsubscribeFromChannel(subscriptionChannel) {
+    this.pusher.unsubscribe(subscriptionChannel);
+  }
+
+  getChannelFromResponse(response, operation) {
+    return !!response.extensions &&
+      !!response.extensions.lighthouse_subscriptions &&
+      !!response.extensions.lighthouse_subscriptions.channels
+      ? response.extensions.lighthouse_subscriptions.channels[
           operation.operationName
         ]
       : null;
   }
+}
 
-  _createSubscription(subscriptionChannel, observer) {
-    const pusherChannel = this.pusher.subscribe(subscriptionChannel);
-    // Subscribe for more update
-    pusherChannel.bind("lighthouse-subscription", (payload) => {
-      if (!payload.more) {
-        // This is the end, the server says to unsubscribe
-        this.pusher.unsubscribe(subscriptionChannel);
-        observer.complete();
-      }
-      const result = payload.result;
-      if (result) {
-        // Send the new response to listeners
-        observer.next(result);
-      }
-    });
+// Turn `subscribe` arguments into an observer-like thing, see getObserver
+// https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/client.ts#L329-L343
+function getObserver(observerOrNext, onError, onComplete) {
+  if (typeof observerOrNext === "function") {
+    // Duck-type an observer
+    return {
+      next: (v) => observerOrNext(v),
+      error: (e) => onError && onError(e),
+      complete: () => onComplete && onComplete(),
+    };
+  } else {
+    // Make an object that calls to the given object, with safety checks
+    return {
+      next: (v) => observerOrNext.next && observerOrNext.next(v),
+      error: (e) => observerOrNext.error && observerOrNext.error(e),
+      complete: () => observerOrNext.complete && observerOrNext.complete(),
+    };
   }
 }
 


### PR DESCRIPTION
- [ ] ~Added or updated tests~
- [ ] ~Documented user facing changes~
- [ ] ~Updated CHANGELOG.md~

I don't think this requires any of the above unless we want to mention it in the changelog, although it is not really a change... more a doc update :)

**Changes**

I noticed the PusherLink for Apollo example does not unsubscribe correctly, this PR aims to resolve that and have a "proper" PusherLink that unsubscribes when Apollo closes the subscription.

**Breaking changes**

None. User paste this code in their project.
