### PR TITLE
update(docs) Link to English PHP manual

### DIFF
--- a/docs/4.12/performance/server-configuration.md
+++ b/docs/4.12/performance/server-configuration.md
@@ -4,7 +4,7 @@ You can tune the configuration of your PHP server for Lighthouse.
 
 ## OPcache
 
-The nature of the schema operations in Lighthouse plays nicely with [PHP's OPcache](https://php.net/manual/de/book.opcache.php).
+The nature of the schema operations in Lighthouse plays nicely with [PHP's OPcache](https://php.net/manual/en/book.opcache.php).
 If you have the freedom to install it on your server, it's an easy way to get a nice performance boost.
 
 ## Xdebug

--- a/docs/master/performance/server-configuration.md
+++ b/docs/master/performance/server-configuration.md
@@ -4,7 +4,7 @@ You can tune the configuration of your PHP server for Lighthouse.
 
 ## OPcache
 
-The nature of the schema operations in Lighthouse plays nicely with [PHP's OPcache](https://php.net/manual/de/book.opcache.php).
+The nature of the schema operations in Lighthouse plays nicely with [PHP's OPcache](https://php.net/manual/en/book.opcache.php).
 If you have the freedom to install it on your server, it's an easy way to get a nice performance boost.
 
 ## Xdebug


### PR DESCRIPTION
**Changes**

Changed a link in `server-configuration.md` to link to the English PHP docs instead of German.