### PR TITLE
Prevent silently overwriting types in `TypeRegistry`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Add empty root types automatically when extending them https://github.com/nuwave/lighthouse/pull/1347
 - Configure a default `guard` for all authentication functionality https://github.com/nuwave/lighthouse/pull/1343
 - Configure the default amount of items in paginated lists with `pagination.default_count` https://github.com/nuwave/lighthouse/pull/1352
+- Add new methods `has()`, `overwrite()` and `registerNew()` to `TypeRegistry` to control if types should
+  be overwritten when registering duplicates
 
 ### Changed
 
@@ -26,6 +28,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 ### Deprecated
 
 - The setting `paginate_max_count` will change to `pagination.max_count` https://github.com/nuwave/lighthouse/pull/1352
+- The `registerNew()` method of `TypeRegistry` will be removed in favor of `register()`, which will change
+  its behavior to throw when registering duplicates
 
 ## 4.12.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Configure a default `guard` for all authentication functionality https://github.com/nuwave/lighthouse/pull/1343
 - Configure the default amount of items in paginated lists with `pagination.default_count` https://github.com/nuwave/lighthouse/pull/1352
 - Add new methods `has()`, `overwrite()` and `registerNew()` to `TypeRegistry` to control if types should
-  be overwritten when registering duplicates
+  be overwritten when registering duplicates https://github.com/nuwave/lighthouse/pull/1361
 
 ### Changed
 
@@ -29,7 +29,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 - The setting `paginate_max_count` will change to `pagination.max_count` https://github.com/nuwave/lighthouse/pull/1352
 - The `registerNew()` method of `TypeRegistry` will be removed in favor of `register()`, which will change
-  its behavior to throw when registering duplicates
+  its behavior to throw when registering duplicates https://github.com/nuwave/lighthouse/pull/1361
 
 ## 4.12.4
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -126,3 +126,16 @@ or a call to `Nuwave\Lighthouse\Subscriptions\Contracts\BroadcastsSubscriptions:
 
 In case you depend on an event being fired whenever a subscription is queued, you can bind your
 own implementation of `Nuwave\Lighthouse\Subscriptions\Contracts\BroadcastsSubscriptions`.
+
+### `TypeRegistry` does not register duplicates by default
+
+Calling `register()` on the `\Nuwave\Lighthouse\Schema\TypeRegistry` now throws when passing
+a type that was already registered, as this most likely is an error.
+
+If you want to previous behaviour of overwriting existing types, use `overwrite()` instead.
+
+```diff
+$typeRegistry = app(\Nuwave\Lighthouse\Schema\TypeRegistry::class);
+-$typeRegistry->register($someType);
++$typeRegistry->overwrite($someType);
+```

--- a/src/Console/ValidateSchemaCommand.php
+++ b/src/Console/ValidateSchemaCommand.php
@@ -29,7 +29,8 @@ class ValidateSchemaCommand extends Command
         // Clear the cache so this always validates the current schema
         $cache->forget(config('lighthouse.cache.key'));
 
-        $graphQL->prepSchema()->assertValid();
+        $schema = $graphQL->prepSchema();
+        $schema->assertValid();
 
         $this->info('The defined schema is valid.');
     }

--- a/src/Schema/TypeRegistry.php
+++ b/src/Schema/TypeRegistry.php
@@ -146,7 +146,7 @@ EOL
     public function registerNew(Type $type): self
     {
         $name = $type->name;
-        if($this->has($name)) {
+        if ($this->has($name)) {
             throw new DefinitionException("Tried to register a type that is already present in the schema: {$name}. Use overwrite() to ignore existing types.");
         }
 

--- a/tests/Unit/Schema/TypeRegistryTest.php
+++ b/tests/Unit/Schema/TypeRegistryTest.php
@@ -32,7 +32,7 @@ class TypeRegistryTest extends TestCase
 
     public function testSetsEnumValueThroughDirective(): void
     {
-        $enumNode = PartialParser::enumTypeDefinition('
+        $enumNode = PartialParser::enumTypeDefinition(/** @lang GraphQL */ '
         enum Role {
             ADMIN @enum(value: 123)
         }
@@ -47,7 +47,7 @@ class TypeRegistryTest extends TestCase
 
     public function testDefaultsEnumValueToItsName(): void
     {
-        $enumNode = PartialParser::enumTypeDefinition('
+        $enumNode = PartialParser::enumTypeDefinition(/** @lang GraphQL */ '
         enum Role {
             EMPLOYEE
         }
@@ -62,7 +62,7 @@ class TypeRegistryTest extends TestCase
 
     public function testCanTransformScalars(): void
     {
-        $scalarNode = PartialParser::scalarTypeDefinition('
+        $scalarNode = PartialParser::scalarTypeDefinition(/** @lang GraphQL */ '
         scalar Email
         ');
         /** @var \GraphQL\Type\Definition\ScalarType $scalarType */
@@ -74,7 +74,7 @@ class TypeRegistryTest extends TestCase
 
     public function testCanPointToScalarClassThroughDirective(): void
     {
-        $scalarNode = PartialParser::scalarTypeDefinition('
+        $scalarNode = PartialParser::scalarTypeDefinition(/** @lang GraphQL */ '
         scalar DateTime @scalar(class: "Nuwave\\\Lighthouse\\\Schema\\\Types\\\Scalars\\\DateTime")
         ');
         /** @var \GraphQL\Type\Definition\ScalarType $scalarType */
@@ -86,7 +86,7 @@ class TypeRegistryTest extends TestCase
 
     public function testCanPointToScalarClassThroughDirectiveWithoutNamespace(): void
     {
-        $scalarNode = PartialParser::scalarTypeDefinition('
+        $scalarNode = PartialParser::scalarTypeDefinition(/** @lang GraphQL */ '
         scalar SomeEmail @scalar(class: "Email")
         ');
         /** @var \GraphQL\Type\Definition\ScalarType $scalarType */
@@ -98,7 +98,7 @@ class TypeRegistryTest extends TestCase
 
     public function testCanTransformInterfaces(): void
     {
-        $interfaceNode = PartialParser::interfaceTypeDefinition('
+        $interfaceNode = PartialParser::interfaceTypeDefinition(/** @lang GraphQL */ '
         interface Foo {
             bar: String
         }
@@ -113,7 +113,7 @@ class TypeRegistryTest extends TestCase
 
     public function testResolvesInterfaceThoughNamespace(): void
     {
-        $interfaceNode = PartialParser::interfaceTypeDefinition('
+        $interfaceNode = PartialParser::interfaceTypeDefinition(/** @lang GraphQL */ '
         interface Nameable {
             bar: String
         }
@@ -127,7 +127,7 @@ class TypeRegistryTest extends TestCase
 
     public function testResolvesInterfaceThoughSecondaryNamespace(): void
     {
-        $interfaceNode = PartialParser::interfaceTypeDefinition('
+        $interfaceNode = PartialParser::interfaceTypeDefinition(/** @lang GraphQL */ '
         interface Bar {
             bar: String
         }
@@ -141,7 +141,7 @@ class TypeRegistryTest extends TestCase
 
     public function testCanTransformUnions(): void
     {
-        $unionNode = PartialParser::unionTypeDefinition('
+        $unionNode = PartialParser::unionTypeDefinition(/** @lang GraphQL */ '
         union Foo = Bar
         ');
         /** @var \GraphQL\Type\Definition\UnionType $unionType */
@@ -154,7 +154,7 @@ class TypeRegistryTest extends TestCase
 
     public function testCanTransformObjectTypes(): void
     {
-        $objectTypeNode = PartialParser::objectTypeDefinition('
+        $objectTypeNode = PartialParser::objectTypeDefinition(/** @lang GraphQL */ '
         type User {
             foo(bar: String! @hash): String!
         }
@@ -169,7 +169,7 @@ class TypeRegistryTest extends TestCase
 
     public function testCanTransformInputObjectTypes(): void
     {
-        $inputNode = PartialParser::inputObjectTypeDefinition('
+        $inputNode = PartialParser::inputObjectTypeDefinition(/** @lang GraphQL */ '
         input UserInput {
             foo: String!
         }
@@ -182,9 +182,28 @@ class TypeRegistryTest extends TestCase
         $this->assertArrayHasKey('foo', $inputObjectType->getFields());
     }
 
-    public function testThrowsWhenMissingType(): void
+    public function testGetThrowsWhenMissingType(): void
     {
         $this->expectException(DefinitionException::class);
         $this->typeRegistry->get('ThisTypeDoesNotExist');
+    }
+
+    public function testDeterminesIfHasType(): void
+    {
+        $fooName = 'Foo';
+        $this->assertFalse($this->typeRegistry->has($fooName));
+
+        $foo = new ObjectType(['name' => $fooName]);
+        $this->typeRegistry->register($foo);
+        $this->assertTrue($this->typeRegistry->has($fooName));
+    }
+
+    public function testThrowsWhenRegisteringExistingType(): void
+    {
+        $foo = new ObjectType(['name' => 'Foo']);
+        $this->typeRegistry->registerNew($foo);
+
+        $this->expectException(DefinitionException::class);
+        $this->typeRegistry->registerNew($foo);
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Adds granular control to prevent accidental overwrites.

**Breaking changes**

Not yet, but the default behaviour will change in v5.