### PR TITLE
Add failing test for @update with a custom primary key

### DIFF
--- a/tests/Integration/Schema/Directives/UpdateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/UpdateDirectiveTest.php
@@ -75,7 +75,7 @@ class UpdateDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             updateCompany(input: {
                 id: 1
@@ -115,7 +115,7 @@ class UpdateDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             updateCategory(
                 category_id: 1
@@ -341,7 +341,7 @@ class UpdateDirectiveTest extends DBTestCase
         ]);
     }
 
-    public function testCanUpdateWhenPrimaryKeyIsRenamed()
+    public function testCanUpdateWhenPrimaryKeyIsRenamed(): void
     {
         $user = factory(UserCustomPrimaryKey::class)->create([
             'name' => 'foo',
@@ -350,7 +350,7 @@ class UpdateDirectiveTest extends DBTestCase
         $this->schema .= /** @lang GraphQL */ '
         type Mutation {
             updateUser(
-                id: ID!
+                id: ID! @rename(attribute: "uuid")
                 name: String!
             ): UserCustomPrimaryKey @update
         }
@@ -361,7 +361,7 @@ class UpdateDirectiveTest extends DBTestCase
         }
         ';
 
-        $response = $this->graphQL(/** @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         mutation (
             $id: ID!
             $name: String!
@@ -376,16 +376,13 @@ class UpdateDirectiveTest extends DBTestCase
         ', [
             'id' => $user->uuid,
             'name' => 'bar',
+        ])
+        ->assertExactJson([
+            'data' => [
+                'updateUser' => [
+                    'name' => 'bar',
+                ],
+            ],
         ]);
-
-//        ->assertExactJson([
-//            'data' => [
-//                'updateUser' => [
-//                    'name' => 'bar',
-//                ],
-//            ],
-//        ]);
-
-        dd($response->json());
     }
 }

--- a/tests/Utils/Models/UserCustomPrimaryKey.php
+++ b/tests/Utils/Models/UserCustomPrimaryKey.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Utils\Models;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Support\Str;
+
+/**
+ * @property int $id
+ * @property string|null $name
+ */
+class UserCustomPrimaryKey extends Authenticatable
+{
+    protected $primaryKey = 'uuid';
+
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+
+    protected $table = 'users_custom_primary_key';
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function($model) {
+            $model->attributes['uuid'] = Str::uuid();
+        });
+    }
+}

--- a/tests/database/factories/UserCustomPrimaryKeyFactory.php
+++ b/tests/database/factories/UserCustomPrimaryKeyFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+use Faker\Generator as Faker;
+use Tests\Utils\Models\UserCustomPrimaryKey;
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+$factory->define(UserCustomPrimaryKey::class, function (Faker $faker): array {
+    return [
+        'name' => $faker->name,
+    ];
+});

--- a/tests/database/migrations/2020_05_21_000001_create_testbench_users_custom_primary_key_table.php
+++ b/tests/database/migrations/2020_05_21_000001_create_testbench_users_custom_primary_key_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTestbenchUsersCustomPrimaryKeyTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users_custom_primary_key', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->uuid('uuid');
+            $table->string('name')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::drop('users');
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Adds a failing test for #1372.

This error is caused by `forceFill` in https://github.com/nuwave/lighthouse/pull/1348. By using `forcefill` all attributes gets updated, including `id`, even when the `id` shouldn't get updated.