### PR TITLE
Pull primary key from arguments in `@update` before force filling them into the Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Pull primary key from arguments in `@update` before force filling them into the Model
+
 ## 4.13.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Pull primary key from arguments in `@update` before force filling them into the Model
+- Pull primary key from arguments in `@update` before force filling them into the Model https://github.com/nuwave/lighthouse/pull/1377
 
 ## 4.13.0
 

--- a/docs/4.13/api-reference/directives.md
+++ b/docs/4.13/api-reference/directives.md
@@ -2748,18 +2748,13 @@ type Mutation {
 }
 ```
 
-Lighthouse uses the argument `id` to fetch the model by its primary key.
-This will work even if your model has a differently named primary key,
-so you can keep your schema simple and independent of your database structure.
-
-If you want your schema to directly reflect your database schema,
-you can also use the name of the underlying primary key.
-This is not recommended as it makes client-side caching more difficult
-and couples your schema to the underlying implementation.
+If the primary key of your model is not called `id`, it is recommended to rename it.
+Client libraries such as Apollo base their caching mechanism on that assumption.
 
 ```graphql
 type Mutation {
-  updatePost(post_id: ID!, content: String): Post @update
+  updatePost(id: ID! @rename(attribute: "post_id"), content: String): Post
+    @update
 }
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2748,18 +2748,12 @@ type Mutation {
 }
 ```
 
-Lighthouse uses the argument `id` to fetch the model by its primary key.
-This will work even if your model has a differently named primary key,
-so you can keep your schema simple and independent of your database structure.
-
-If you want your schema to directly reflect your database schema,
-you can also use the name of the underlying primary key.
-This is not recommended as it makes client-side caching more difficult
-and couples your schema to the underlying implementation.
+If the primary key of your model is not called `id`, it is recommended to rename it.
+Client libraries such as Apollo base their caching mechanism on that assumption.
 
 ```graphql
 type Mutation {
-  updatePost(post_id: ID!, content: String): Post @update
+  updatePost(id: ID! @rename(attribute: "post_id"), content: String): Post @update
 }
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2753,7 +2753,8 @@ Client libraries such as Apollo base their caching mechanism on that assumption.
 
 ```graphql
 type Mutation {
-  updatePost(id: ID! @rename(attribute: "post_id"), content: String): Post @update
+  updatePost(id: ID! @rename(attribute: "post_id"), content: String): Post
+    @update
 }
 ```
 

--- a/src/Execution/Arguments/UpdateModel.php
+++ b/src/Execution/Arguments/UpdateModel.php
@@ -2,10 +2,13 @@
 
 namespace Nuwave\Lighthouse\Execution\Arguments;
 
+use GraphQL\Error\Error;
+use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Support\Contracts\ArgResolver;
 
 class UpdateModel implements ArgResolver
 {
+    const MISSING_PRIMARY_KEY_FOR_UPDATE = 'Missing primary key for update.';
     /**
      * @var callable|\Nuwave\Lighthouse\Support\Contracts\ArgResolver
      */
@@ -25,8 +28,14 @@ class UpdateModel implements ArgResolver
      */
     public function __invoke($model, $args)
     {
-        $id = $args->arguments['id']
-            ?? $args->arguments[$model->getKeyName()];
+        /** @var \Nuwave\Lighthouse\Execution\Arguments\Argument|null $id */
+        $id = Arr::pull($args->arguments, 'id')
+            ?? Arr::pull($args->arguments, $model->getKeyName())
+            ?? null;
+
+        if($id === null) {
+            throw new Error(self::MISSING_PRIMARY_KEY_FOR_UPDATE);
+        }
 
         $model = $model->newQuery()->findOrFail($id->value);
 

--- a/src/Execution/Arguments/UpdateModel.php
+++ b/src/Execution/Arguments/UpdateModel.php
@@ -33,7 +33,7 @@ class UpdateModel implements ArgResolver
             ?? Arr::pull($args->arguments, $model->getKeyName())
             ?? null;
 
-        if($id === null) {
+        if ($id === null) {
             throw new Error(self::MISSING_PRIMARY_KEY_FOR_UPDATE);
         }
 

--- a/tests/Integration/Schema/Directives/UpdateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/UpdateDirectiveTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Integration\Schema\Directives;
 
 use Illuminate\Database\QueryException;
+use Nuwave\Lighthouse\Execution\Arguments\UpdateModel;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Category;
 use Tests\Utils\Models\Company;
@@ -73,7 +74,7 @@ class UpdateDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             updateCompany(input: {
                 id: 1
@@ -95,6 +96,33 @@ class UpdateDirectiveTest extends DBTestCase
         $this->assertSame('bar', Company::first()->name);
     }
 
+    public function testThrowsWhenMissingPrimaryKey(): void
+    {
+        $this->schema .= /** @lang GraphQL */ '
+        type Company {
+            id: ID!
+        }
+
+        type Mutation {
+            updateCompany: Company @update
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            updateCompany {
+                id
+            }
+        }
+        ')->assertJson([
+            'errors' => [
+                [
+                    'message' => UpdateModel::MISSING_PRIMARY_KEY_FOR_UPDATE,
+                ]
+            ]
+        ]);
+    }
+
     public function testCanUpdateWithCustomPrimaryKey(): void
     {
         factory(Category::class)->create(['name' => 'foo']);
@@ -113,7 +141,7 @@ class UpdateDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL('
+        $this->graphQL(/** @lang GraphQL */ '
         mutation {
             updateCategory(
                 category_id: 1
@@ -127,6 +155,46 @@ class UpdateDirectiveTest extends DBTestCase
             'data' => [
                 'updateCategory' => [
                     'category_id' => '1',
+                    'name' => 'bar',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('bar', Category::first()->name);
+    }
+
+    public function testCanUpdateWithCustomPrimaryKeyAsId(): void
+    {
+        factory(Category::class)->create(['name' => 'foo']);
+
+        $this->schema .= /** @lang GraphQL */ '
+        type Category {
+            id: ID! @rename(attribute: "category_id")
+            name: String!
+        }
+
+        type Mutation {
+            updateCategory(
+                id: ID!
+                name: String
+            ): Category @update
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            updateCategory(
+                id: 1
+                name: "bar"
+            ) {
+                id
+                name
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'updateCategory' => [
+                    'id' => '1',
                     'name' => 'bar',
                 ],
             ],

--- a/tests/Integration/Schema/Directives/UpdateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/UpdateDirectiveTest.php
@@ -118,8 +118,8 @@ class UpdateDirectiveTest extends DBTestCase
             'errors' => [
                 [
                     'message' => UpdateModel::MISSING_PRIMARY_KEY_FOR_UPDATE,
-                ]
-            ]
+                ],
+            ],
         ]);
     }
 


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves https://github.com/nuwave/lighthouse/issues/1372

**Changes**

Compatibility fix for when users relied on the fact that a wrongly named `id` argument is not force filled into models with different primary keys.

**Breaking changes**

I hope not.
