### PR TITLE
Allow passing additional headers to `multipartGraphQL` Lumen test helper too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 ### Fixed
 
 - Fix the error message when using multiple exclusive directives on a single node https://github.com/nuwave/lighthouse/pull/1387
-- Allow passing additional headers to `multipartGraphQL` Lumen test helper too
+- Allow passing additional headers to `multipartGraphQL` Lumen test helper too https://github.com/nuwave/lighthouse/pull/1395
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 ### Fixed
 
 - Fix the error message when using multiple exclusive directives on a single node https://github.com/nuwave/lighthouse/pull/1387
+- Allow passing additional headers to `multipartGraphQL` Lumen test helper too
 
 ### Deprecated
 

--- a/src/Testing/MakesGraphQLRequestsLumen.php
+++ b/src/Testing/MakesGraphQLRequestsLumen.php
@@ -84,9 +84,10 @@ trait MakesGraphQLRequestsLumen
      *
      * @param  array<string, mixed>  $parameters
      * @param  array<int, \Illuminate\Http\Testing\File>  $files
+     * @param  array<string, string>  $headers  Will be merged with Content-Type: multipart/form-data
      * @return $this
      */
-    protected function multipartGraphQL(array $parameters, array $files): self
+    protected function multipartGraphQL(array $parameters, array $files, array $headers = []): self
     {
         $this->call(
             'POST',
@@ -94,9 +95,12 @@ trait MakesGraphQLRequestsLumen
             $parameters,
             [],
             $files,
-            $this->transformHeadersToServerVars([
-                'Content-Type' => 'multipart/form-data',
-            ])
+            $this->transformHeadersToServerVars(array_merge(
+                [
+                    'Content-Type' => 'multipart/form-data',
+                ],
+                $headers
+            ))
         );
 
         return $this;


### PR DESCRIPTION
This was forgotten in https://github.com/nuwave/lighthouse/pull/1342