### PR TITLE
Make mass assignment behavior configurable through `force_fill` option in `lighthouse.php`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Fix the error message when using multiple exclusive directives on a single node https://github.com/nuwave/lighthouse/pull/1387
 - Allow passing additional headers to `multipartGraphQL` Lumen test helper too https://github.com/nuwave/lighthouse/pull/1395
 - Rectify that `@orderBy`, `@whereConditions` and `@whereHasConditions` only work on field arguments https://github.com/nuwave/lighthouse/pull/1402
-- Make `forceFill()` behavior configurable through `force_fill` option in `lighthouse.php`
+- Make mass assignment behavior configurable through `force_fill` option in `lighthouse.php` https://github.com/nuwave/lighthouse/pull/1405
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Fix the error message when using multiple exclusive directives on a single node https://github.com/nuwave/lighthouse/pull/1387
 - Allow passing additional headers to `multipartGraphQL` Lumen test helper too https://github.com/nuwave/lighthouse/pull/1395
 - Rectify that `@orderBy`, `@whereConditions` and `@whereHasConditions` only work on field arguments https://github.com/nuwave/lighthouse/pull/1402
+- Make `forceFill()` behavior configurable through `force_fill` option in `lighthouse.php`
 
 ### Deprecated
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -182,3 +182,16 @@ $typeRegistry = app(\Nuwave\Lighthouse\Schema\TypeRegistry::class);
 -$typeRegistry->register($someType);
 +$typeRegistry->overwrite($someType);
 ```
+
+### Mass assignment protection is disabled by default
+
+Since GraphQL constrains allowed inputs by design, mass assignment protection is not needed.
+By default, Lighthouse will use `forceFill()` when populating a model with arguments in mutation directives.
+This allows you to use mass assignment protection for other cases where it is actually useful.
+
+If you need to revert to the old behavior of using `fill()`, you can change your `lighthouse.php`:
+
+```diff
+-   'force_fill' => true,
++   'force_fill' => false,
+```

--- a/src/Execution/Arguments/SaveModel.php
+++ b/src/Execution/Arguments/SaveModel.php
@@ -41,8 +41,14 @@ class SaveModel implements ArgResolver
             BelongsTo::class
         );
 
+        $argsToFill = $remaining->toArray();
+
         // Use all the remaining attributes and fill the model
-        $model->forceFill($remaining->toArray());
+        if(config('lighthouse.force_fill')) {
+            $model->forceFill($argsToFill);
+        } else {
+            $model->fill($argsToFill);
+        }
 
         foreach ($belongsTo->arguments as $relationName => $nestedOperations) {
             /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo $belongsTo */

--- a/src/Execution/Arguments/SaveModel.php
+++ b/src/Execution/Arguments/SaveModel.php
@@ -44,7 +44,7 @@ class SaveModel implements ArgResolver
         $argsToFill = $remaining->toArray();
 
         // Use all the remaining attributes and fill the model
-        if(config('lighthouse.force_fill')) {
+        if (config('lighthouse.force_fill')) {
             $model->forceFill($argsToFill);
         } else {
             $model->fill($argsToFill);

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -248,8 +248,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | If set to true, mutations will use forceFill() over fill() when populating
-    | a model with arguments in mutation directives. Since GraphQL limits args
-    | clients can pass in by design, mass assignment protection is not needed.
+    | a model with arguments in mutation directives. Since GraphQL constrains
+    | allowed inputs by design, mass assignment protection is not needed.
     |
     | Will default to true in v5.
     |

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -244,7 +244,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | ForceFill Models
+    | Mass Assignment Protection
     |--------------------------------------------------------------------------
     |
     | If set to true, mutations will use forceFill() over fill() when populating

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -244,6 +244,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | ForceFill Models
+    |--------------------------------------------------------------------------
+    |
+    | If set to true, mutations will use forceFill() over fill() when populating
+    | a model with arguments in mutation directives. Since GraphQL limits args
+    | clients can pass in by design, mass assignment protection is not needed.
+    |
+    | Will default to true in v5.
+    |
+    */
+
+    'force_fill' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Batchload Relations
     |--------------------------------------------------------------------------
     |

--- a/tests/Integration/Schema/Directives/CreateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/CreateDirectiveTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Integration\Schema\Directives;
 
+use Illuminate\Database\Eloquent\MassAssignmentException;
 use Tests\Constants;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Task;
@@ -548,5 +549,30 @@ class CreateDirectiveTest extends DBTestCase
                 ],
             ],
         ]);
+    }
+
+    public function testTurnOnMassAssignment(): void
+    {
+        config(['lighthouse.force_fill' => false]);
+
+        $this->schema .= /** @lang GraphQL */ '
+        type Company {
+            name: String!
+        }
+
+        type Mutation {
+            createCompany(name: String): Company @create
+        }
+        ';
+
+        $this->expectException(MassAssignmentException::class);
+
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            createCompany(name: "foo") {
+                name
+            }
+        }
+        ');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -126,6 +126,9 @@ GRAPHQL;
             ]
         );
 
+        // TODO remove when the default changes
+        $config->set('lighthouse.force_fill', true);
+
         $config->set('app.debug', true);
     }
 


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

- https://github.com/nuwave/lighthouse/issues/1403
- https://github.com/nuwave/lighthouse/issues/1384

**Changes**

This adds a new config option to allow for a gradual opt-in to circumvent mass assignment protection.

**Breaking changes**

This actually fixes a breaking change, but some users that already relied on the new behaviour must change their configuration.
