### PR TITLE
Introduce the concept of "Public" Subscriptions

### DIFF
--- a/src/Schema/Types/GraphQLSubscription.php
+++ b/src/Schema/Types/GraphQLSubscription.php
@@ -77,14 +77,6 @@ abstract class GraphQLSubscription
     public $IS_PUBLIC = false;
 
     /**
-     * @return ?string
-     */
-    public function getQueryString()
-    {
-        return '';
-    }
-
-    /**
      * @param array<mixed> $args
      *
      * @return ?string

--- a/src/Schema/Types/GraphQLSubscription.php
+++ b/src/Schema/Types/GraphQLSubscription.php
@@ -89,7 +89,7 @@ abstract class GraphQLSubscription
      *
      * @return ?string
      */
-    public function getChannelName(array $args)
+    public function getChannelName(?array $args = [])
     {
         return null;
     }

--- a/src/Schema/Types/GraphQLSubscription.php
+++ b/src/Schema/Types/GraphQLSubscription.php
@@ -70,7 +70,7 @@ abstract class GraphQLSubscription
     abstract public function filter(Subscriber $subscriber, $root);
 
     /**
-     * Boolean flag for public subscriptions
+     * Boolean flag for public subscriptions.
      *
      * @var bool
      */
@@ -81,7 +81,6 @@ abstract class GraphQLSubscription
      */
     public function getQueryString()
     {
-        return null;
     }
 
     /**

--- a/src/Schema/Types/GraphQLSubscription.php
+++ b/src/Schema/Types/GraphQLSubscription.php
@@ -81,6 +81,7 @@ abstract class GraphQLSubscription
      */
     public function getQueryString()
     {
+        return '';
     }
 
     /**
@@ -90,6 +91,6 @@ abstract class GraphQLSubscription
      */
     public function getChannelName(?array $args = [])
     {
-        return null;
+        return '';
     }
 }

--- a/src/Schema/Types/GraphQLSubscription.php
+++ b/src/Schema/Types/GraphQLSubscription.php
@@ -70,9 +70,26 @@ abstract class GraphQLSubscription
     abstract public function filter(Subscriber $subscriber, $root);
 
     /**
+     * Boolean flag for public subscriptions
+     *
+     * @var bool
+     */
+    public $IS_PUBLIC = false;
+
+    /**
      * @return ?string
      */
     public function getQueryString()
+    {
+        return null;
+    }
+
+    /**
+     * @param array<mixed> $args
+     *
+     * @return ?string
+     */
+    public function getChannelName(array $args)
     {
         return null;
     }

--- a/src/Schema/Types/GraphQLSubscription.php
+++ b/src/Schema/Types/GraphQLSubscription.php
@@ -68,4 +68,12 @@ abstract class GraphQLSubscription
      * @return bool
      */
     abstract public function filter(Subscriber $subscriber, $root);
+
+    /**
+     * @return ?string
+     */
+    public function getQueryString()
+    {
+        return null;
+    }
 }

--- a/src/Subscriptions/Contracts/StoresSubscriptions.php
+++ b/src/Subscriptions/Contracts/StoresSubscriptions.php
@@ -42,4 +42,18 @@ interface StoresSubscriptions
      * @return \Nuwave\Lighthouse\Subscriptions\Subscriber|null
      */
     public function deleteSubscriber(string $channel);
+
+    /**
+     * Store main / single subscriber on a public topic
+     *
+     * @return void
+     */
+    public function storeSubscriberPublic(Subscriber $subscriber, string $public_topic_name);
+
+    /**
+     * Get the one and only subscriber for a public topic, if any
+     *
+     * @return \Nuwave\Lighthouse\Subscriptions\Subscriber|null
+     */
+    public function publicSubscriberForTopic(string $channel);
 }

--- a/src/Subscriptions/Contracts/StoresSubscriptions.php
+++ b/src/Subscriptions/Contracts/StoresSubscriptions.php
@@ -44,14 +44,14 @@ interface StoresSubscriptions
     public function deleteSubscriber(string $channel);
 
     /**
-     * Store main / single subscriber on a public topic
+     * Store main / single subscriber on a public topic.
      *
      * @return void
      */
     public function storeSubscriberPublic(Subscriber $subscriber, string $public_topic_name);
 
     /**
-     * Get the one and only subscriber for a public topic, if any
+     * Get the one and only subscriber for a public topic, if any.
      *
      * @return \Nuwave\Lighthouse\Subscriptions\Subscriber|null
      */

--- a/src/Subscriptions/SubscriptionBroadcaster.php
+++ b/src/Subscriptions/SubscriptionBroadcaster.php
@@ -47,6 +47,11 @@ class SubscriptionBroadcaster implements BroadcastsSubscriptions
      */
     protected $eventsDispatcher;
 
+    /**
+     * @var \Nuwave\Lighthouse\Support\Contracts\CreatesContext
+     */
+    protected $createsContext;
+
     public function __construct(
         GraphQL $graphQL,
         AuthorizesSubscriptions $auth,
@@ -119,7 +124,6 @@ class SubscriptionBroadcaster implements BroadcastsSubscriptions
         $subscriber = $this->storage->publicSubscriberForTopic($topic);
         if(!$subscriber){
             throw new \Exception("no subscribers for public channel $topic $fieldName");
-            return;
         }
         $channel_name = $subscription->getChannelName($subscriber->args);
         $data = $this->graphQL->executeQuery(

--- a/src/Subscriptions/SubscriptionBroadcaster.php
+++ b/src/Subscriptions/SubscriptionBroadcaster.php
@@ -4,7 +4,6 @@ namespace Nuwave\Lighthouse\Subscriptions;
 
 use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Http\Request;
-use Nuwave\Lighthouse\Execution\LighthouseRequest;
 use Nuwave\Lighthouse\GraphQL;
 use Nuwave\Lighthouse\Schema\Types\GraphQLSubscription;
 use Nuwave\Lighthouse\Subscriptions\Contracts\AuthorizesSubscriptions;
@@ -88,8 +87,9 @@ class SubscriptionBroadcaster implements BroadcastsSubscriptions
     {
         $topic = $subscription->decodeTopic($fieldName, $root);
 
-        if($subscription->IS_PUBLIC){
+        if ($subscription->IS_PUBLIC) {
             $this->broadcastPublic($subscription, $fieldName, $root);
+
             return;
         }
 
@@ -122,7 +122,7 @@ class SubscriptionBroadcaster implements BroadcastsSubscriptions
     {
         $topic = $subscription->decodeTopic($fieldName, $root);
         $subscriber = $this->storage->publicSubscriberForTopic($topic);
-        if(!$subscriber){
+        if (! $subscriber) {
             throw new \Exception("no subscribers for public channel $topic $fieldName");
         }
         $channel_name = $subscription->getChannelName($subscriber->args);

--- a/src/Subscriptions/SubscriptionRegistry.php
+++ b/src/Subscriptions/SubscriptionRegistry.php
@@ -101,7 +101,8 @@ class SubscriptionRegistry
     /**
      * @return ?string
      */
-    public function getSubscriptionFieldNameFromSubscriberQuery(Subscriber $subscriber){
+    public function getSubscriptionFieldNameFromSubscriberQuery(Subscriber $subscriber)
+    {
         //$subscriber->query->definitions[0]->selectionSet->selections->nodes[0]->name->value;
         return (new Collection($subscriber->query->definitions))
             ->filter(
@@ -130,21 +131,20 @@ class SubscriptionRegistry
         $this->storage->storeSubscriber($subscriber, $topic);
         $this->subscribers[$subscriber->operationName] = $subscriber->channel;
 
-        try{
+        try {
             $field_name = $this->getSubscriptionFieldNameFromSubscriberQuery($subscriber);
-            $subscription =  $this->subscription($field_name);
-            if($subscription->IS_PUBLIC === true){
+            $subscription = $this->subscription($field_name);
+            if ($subscription->IS_PUBLIC === true) {
                 // use "public" channel name, not subscriber->channel's unique channel
                 $channel_name = $subscription->getChannelName($subscriber->args);
-                if($channel_name){
+                if ($channel_name) {
                     $this->subscribers_public[$subscriber->operationName] = $channel_name;
                     $this->storage->storeSubscriberPublic($subscriber, $topic);
                 }
             }
-        }catch(\Exception $e){
+        } catch (\Exception $e) {
             \Log::error($e);
         }
-
 
         return $this;
     }
@@ -198,12 +198,14 @@ class SubscriptionRegistry
     public function handleBuildExtensionsResponse(): ExtensionsResponse
     {
         $channels = $this->subscribers;
-        $channels = collect($channels)->map(function($channel, $operation_name){
-            if(array_key_exists($operation_name,$this->subscribers_public)){
+        $channels = collect($channels)->map(function ($channel, $operation_name) {
+            if (array_key_exists($operation_name, $this->subscribers_public)) {
                 return $this->subscribers_public[$operation_name];
             }
+
             return $channel;
         })->toArray();
+
         return new ExtensionsResponse(
             'lighthouse_subscriptions',
             [

--- a/src/Subscriptions/SubscriptionRegistry.php
+++ b/src/Subscriptions/SubscriptionRegistry.php
@@ -133,7 +133,7 @@ class SubscriptionRegistry
         try{
             $field_name = $this->getSubscriptionFieldNameFromSubscriberQuery($subscriber);
             $subscription =  $this->subscription($field_name);
-            if($subscription && $subscription->IS_PUBLIC){
+            if($subscription->IS_PUBLIC === true){
                 // use "public" channel name, not subscriber->channel's unique channel
                 $channel_name = $subscription->getChannelName($subscriber->args);
                 if($channel_name){

--- a/src/Support/Http/Middleware/AttemptAuthentication.php
+++ b/src/Support/Http/Middleware/AttemptAuthentication.php
@@ -38,7 +38,7 @@ class AttemptAuthentication
     /**
      * Attempt to authenticate the user, but don't do anything if they are not.
      *
-     * @param  array<string>  ...$guards
+     * @param  array<mixed>  ...$guards
      */
     protected function attemptAuthentication(array $guards): void
     {


### PR DESCRIPTION
this feature solves a need we have on a project to not loop through all of our subscribers and broadcast to them individually, but to broadcast to them all using a single pusher event.

Usage:
1. set `public $IS_PUBLIC  = true` on your GraphQLSubscription class definition to flag that it should use a shared public channel for it's subscriptions/broadcasts
2. add a `public function getChannelName(array $args)` method must return a string name for the shared / public channel. It accepts args that are passed to the query at subscription-initialization-time, and can be used to make a semi-dynamic channel name key (in our case we group public channels by a certain model id that is passed in)

What it does:
- when **subscribing** to a "public" channel, the `extensions.lighthouse_subscriptions.channels` array will return the public/shared channel name as returned by `getChannelName` rather than the subscriber's private channel name
- when **broadcasting** on a public subscription, **SubscriptionBroadcaster** will pick up on the fact that it's a public subscription and rather than iterating over all Subscribers subscribed to the topic, it will trigger a single broadcastPublic to the Broadcaster driver using the "public" channel name.

Technical Notes:
- the Subscription Query the client sends during the initial subscription request, will be the query that is used to resolve all future broadcasts on the public channel for all subscribers. (until that subscriber is removed from Redis)
  - this might be a vulnerability, seeing as a ne'er-do-well could technically change the query for all subscribers, breaking the app, if they were able to subscribe first before the "official" primary subscription occurs, so maybe having a mirrored definition on the server's GraphQLSubscription class under "getQueryString" would help thwart that by prescribing what the query should be (which, goes against GraphQL's entire nature, so 🤷 )
  - we could also have something where when the GraphQLSubscription is booted/registered, it injects it's own "primary subscriber" into redis if it's not already there, defining the Query for the public channel, and all subscriber queries would effectively be ignored. Outside of $args which are needed to be passed to getChannelName to enable semi-dynamic channel names
  - or, a user-id or something like that on the GraphQLSubscription that defines that only a particular user is allowed to be saved as the **main** subscriber for a public channel, but then that'd require some extra end-user work to be sure to perform that initial subscription at a specific point in time
- if you try to broadcast on a public channel that hasn't had at least one subscriber, an error will be thrown `"no subscribers for public channel $topic $fieldName"`
- the first time a subscriber subscribes to a public channel, a single redis entry is created mapping the public Topic to that subscriber. Subsequent broadcast request for the public topic refer to that public_topic.subscriber for the Query,Context,Args,etc...
- when users unsubscribe, the public_topic.subscriber persists.
- clearing redis is the only way currently to "close" a public_topic/public_channel
- could add a public_channel_subscribers:<int> field in redis, and increment/decrement it accordingly, closing after last subscriber vacates/unsubscribes.

- [_**Working on getting testing setup on my local**_ ] Added or updated tests
- [Will do if there's interest] Documented user facing changes
- [Will do if there's interest] Updated CHANGELOG.md