### PR TITLE
Update installation.md

### DIFF
--- a/docs/4.12/getting-started/installation.md
+++ b/docs/4.12/getting-started/installation.md
@@ -44,3 +44,5 @@ composer require mll-lab/laravel-graphql-playground
 
 You can use any GraphQL client with Lighthouse, make sure to point it to the URL defined in
 the config. By default, the endpoint lives at `/graphql`.
+
+To view the graphql client after installing the package navigate to `/graphql-playground` in your installation.


### PR DESCRIPTION
The endpoint for the Laravel GraphQL Playground visual query editor is at `/graphql-playground` according to their docs.

- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

no issues logged for this that I know of.

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

Updated the documentation to the correct URL for Laravel GraphQL Playground client  query editor.

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
