### PR TITLE
Additional information to run the IDE helper

### DIFF
--- a/docs/master/getting-started/installation.md
+++ b/docs/master/getting-started/installation.md
@@ -27,6 +27,12 @@ To improve your editing experience, you can generate a definition file
 php artisan lighthouse:ide-helper
 ```
 
+This command requires `haydenpierce/class-finder`. Install it by running:
+
+```bash
+composer require --dev haydenpierce/class-finder
+```
+
 We recommend the following plugins:
 
 | IDE      | Plugin                                               |


### PR DESCRIPTION
When I start a new project and publish the IDE Helpers I always get this error message:

```bash
This command requires haydenpierce/class-finder. Install it by running:

    composer require --dev haydenpierce/class-finder
```

It's obvious what needs to be done but some users might still be confused. It would be nice to give them a little heads up ;)