### PR TITLE
Defer apollo link update

### DIFF
--- a/docs/3.0/extensions/deferred.md
+++ b/docs/3.0/extensions/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/3.1/extensions/deferred.md
+++ b/docs/3.1/extensions/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/resources/graphql-glossary/#deferred-query).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/3.1/extensions/deferred.md
+++ b/docs/3.1/extensions/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/resources/graphql-glossary/#deferred-query).
 
 ## Setup
 

--- a/docs/3.2/extensions/deferred.md
+++ b/docs/3.2/extensions/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/3.3/extensions/deferred.md
+++ b/docs/3.3/extensions/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/3.4/extensions/deferred.md
+++ b/docs/3.4/extensions/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/3.5/extensions/deferred.md
+++ b/docs/3.5/extensions/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/3.6/extensions/deferred.md
+++ b/docs/3.6/extensions/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/3.7/performance/deferred.md
+++ b/docs/3.7/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/4.0/performance/deferred.md
+++ b/docs/4.0/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/4.1/performance/deferred.md
+++ b/docs/4.1/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/4.10/performance/deferred.md
+++ b/docs/4.10/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/4.11/performance/deferred.md
+++ b/docs/4.11/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/4.12/performance/deferred.md
+++ b/docs/4.12/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/4.13/performance/deferred.md
+++ b/docs/4.13/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse adds support for the experimental `@defer` directive through an extension.
-Read more about it [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+Read more about it [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/4.14/performance/deferred.md
+++ b/docs/4.14/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse adds support for the experimental `@defer` directive through an extension.
-Read more about it [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+Read more about it [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/4.2/performance/deferred.md
+++ b/docs/4.2/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/4.3/performance/deferred.md
+++ b/docs/4.3/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/4.4/performance/deferred.md
+++ b/docs/4.4/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/4.5/performance/deferred.md
+++ b/docs/4.5/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/4.6/performance/deferred.md
+++ b/docs/4.6/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/4.7/performance/deferred.md
+++ b/docs/4.7/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/4.8/performance/deferred.md
+++ b/docs/4.8/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/4.9/performance/deferred.md
+++ b/docs/4.9/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse's `DeferExtension` adds support for the experimental `@defer` directive
-provided by Apollo which you can read more about [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+provided by Apollo which you can read more about [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 

--- a/docs/master/performance/deferred.md
+++ b/docs/master/performance/deferred.md
@@ -9,7 +9,7 @@ Deferring fields allows you to prioritize fetching data needed to render the mos
 as fast as possible, and then loading the rest of the page in the background.
 
 Lighthouse adds support for the experimental `@defer` directive through an extension.
-Read more about it [here](https://www.apollographql.com/docs/react/features/defer-support.html).
+Read more about it [here](https://www.apollographql.com/blog/introducing-defer-in-apollo-server-f6797c4e9d6e).
 
 ## Setup
 


### PR DESCRIPTION
**Description** 
Updated the documentation of `defer` extension to link correctly in the apollo documentation page to defer queries

**Issue link**
"Resolves #1441"

**The change was made in: ** 
-`3.1/extensions/deferred.md`

**Change made manually the vue press site. The vue press command I didn't run because it wasn't specified. If any changes are needed let me know.**

Thank you

