### PR TITLE
fix the key name for column for orderBy queries

### DIFF
--- a/docs/4.14/api-reference/directives.md
+++ b/docs/4.14/api-reference/directives.md
@@ -1975,7 +1975,7 @@ Querying a field that has an `orderBy` argument looks like this:
 
 ```graphql
 {
-  posts(orderBy: [{ column: POSTED_AT, order: ASC }]) {
+  posts(orderBy: [{ field: POSTED_AT, order: ASC }]) {
     title
   }
 }


### PR DESCRIPTION
posts(orderBy: [{ column: POSTED_AT, order: ASC }]) changed to posts(orderBy: [{ field: POSTED_AT, order: ASC }])

- [ ] Added or updated tests
- [x] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**
No
<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
