### PR TITLE
Decode @globalId before validation

### DIFF
--- a/src/Schema/Directives/GlobalIdDirective.php
+++ b/src/Schema/Directives/GlobalIdDirective.php
@@ -6,11 +6,11 @@ use Closure;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\ArgDirective;
-use Nuwave\Lighthouse\Support\Contracts\ArgTransformerDirective;
+use Nuwave\Lighthouse\Support\Contracts\ArgSanitizerDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
 use Nuwave\Lighthouse\Support\Contracts\GlobalId;
 
-class GlobalIdDirective extends BaseDirective implements FieldMiddleware, ArgTransformerDirective, ArgDirective
+class GlobalIdDirective extends BaseDirective implements FieldMiddleware, ArgSanitizerDirective, ArgDirective
 {
     /**
      * @var \Nuwave\Lighthouse\Support\Contracts\GlobalId
@@ -66,7 +66,7 @@ SDL;
      * @param  string  $argumentValue
      * @return string|string[]
      */
-    public function transform($argumentValue)
+    public function sanitize($argumentValue)
     {
         if ($decode = $this->directiveArgValue('decode')) {
             switch ($decode) {

--- a/tests/Utils/Validators/WithGlobalIdValidator.php
+++ b/tests/Utils/Validators/WithGlobalIdValidator.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Utils\Validators;
+
+use Nuwave\Lighthouse\Validation\Validator;
+
+class WithGlobalIdValidator extends Validator
+{
+    public function rules(): array
+    {
+        return [
+            'id' => ['array'],
+        ];
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- ~[ ] Documented user facing changes~
- ~[ ] Updated CHANGELOG.md~

Resolves https://github.com/nuwave/lighthouse/issues/1495

**Changes**

Make sure that `@globalId` runs before validation.

**Breaking changes**

No
