### PR TITLE
Prefix complex conditions with table name to avoid ambiguous SQL

### DIFF
--- a/src/WhereConditions/WhereConditionsBaseDirective.php
+++ b/src/WhereConditions/WhereConditionsBaseDirective.php
@@ -115,10 +115,15 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
                     $relation,
                     function ($builder) use ($relation, $model, $condition): void {
                         if ($condition) {
+                            $relatedModel = $this->nestedRelatedModel($model, $relation);
+
                             $this->handleWhereConditions(
                                 $builder,
-                                $condition,
-                                $this->nestedRelatedModel($model, $relation)
+                                $this->prefixConditionWithTableName(
+                                    $condition,
+                                    $relatedModel
+                                ),
+                                $relatedModel
                             );
                         }
                     },
@@ -174,7 +179,7 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
      */
     protected static function assertValidColumnName(string $column): void
     {
-        $match = \Safe\preg_match('/^(?![0-9])[A-Za-z0-9_-]*$/', $column);
+        $match = \Safe\preg_match('/^(?![0-9])[.A-Za-z0-9_-]*$/', $column);
         if ($match === 0) {
             throw new Error(
                 self::invalidColumnName($column)
@@ -192,6 +197,15 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
         });
 
         return $relatedModel;
+    }
+
+    protected function prefixConditionWithTableName(array $conditions, Model $model): array
+    {
+        if ($conditions['column'] ?? null) {
+            $conditions['column'] = $model->getTable() . '.' .$conditions['column'];
+        }
+
+        return $conditions;
     }
 
     /**

--- a/src/WhereConditions/WhereConditionsBaseDirective.php
+++ b/src/WhereConditions/WhereConditionsBaseDirective.php
@@ -115,10 +115,15 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
                     $relation,
                     function ($builder) use ($relation, $model, $condition): void {
                         if ($condition) {
+                            $relatedModel = $this->nestedRelatedModel($model, $relation);
+
                             $this->handleWhereConditions(
                                 $builder,
-                                $condition,
-                                $this->nestedRelatedModel($model, $relation)
+                                $this->prefixConditionWithTableName(
+                                    $condition,
+                                    $relatedModel
+                                ),
+                                $relatedModel
                             );
                         }
                     },
@@ -192,6 +197,19 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
         });
 
         return $relatedModel;
+    }
+
+    /**
+     * @param array<string, mixed> $condition
+     * @return array<string, mixed>
+     */
+    protected function prefixConditionWithTableName(array $condition, Model $model): array
+    {
+        if ($condition['column'] ?? null) {
+            $condition['column'] = $model->getTable().'.'.$condition['column'];
+        }
+
+        return $condition;
     }
 
     /**

--- a/src/WhereConditions/WhereConditionsBaseDirective.php
+++ b/src/WhereConditions/WhereConditionsBaseDirective.php
@@ -201,13 +201,12 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
 
     /**
      * @param array<string, mixed> $condition
-     * @param Model $model
      * @return array<string, mixed>
      */
     protected function prefixConditionWithTableName(array $condition, Model $model): array
     {
         if ($condition['column'] ?? null) {
-            $condition['column'] = $model->getTable() . '.' .$condition['column'];
+            $condition['column'] = $model->getTable() .'.'.$condition['column'];
         }
 
         return $condition;

--- a/src/WhereConditions/WhereConditionsBaseDirective.php
+++ b/src/WhereConditions/WhereConditionsBaseDirective.php
@@ -115,15 +115,10 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
                     $relation,
                     function ($builder) use ($relation, $model, $condition): void {
                         if ($condition) {
-                            $relatedModel = $this->nestedRelatedModel($model, $relation);
-
                             $this->handleWhereConditions(
                                 $builder,
-                                $this->prefixConditionWithTableName(
-                                    $condition,
-                                    $relatedModel
-                                ),
-                                $relatedModel
+                                $condition,
+                                $this->nestedRelatedModel($model, $relation)
                             );
                         }
                     },
@@ -197,19 +192,6 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
         });
 
         return $relatedModel;
-    }
-
-    /**
-     * @param array<string, mixed> $condition
-     * @return array<string, mixed>
-     */
-    protected function prefixConditionWithTableName(array $condition, Model $model): array
-    {
-        if ($condition['column'] ?? null) {
-            $condition['column'] = $model->getTable().'.'.$condition['column'];
-        }
-
-        return $condition;
     }
 
     /**

--- a/src/WhereConditions/WhereConditionsBaseDirective.php
+++ b/src/WhereConditions/WhereConditionsBaseDirective.php
@@ -206,7 +206,7 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
     protected function prefixConditionWithTableName(array $condition, Model $model): array
     {
         if ($condition['column'] ?? null) {
-            $condition['column'] = $model->getTable() .'.'.$condition['column'];
+            $condition['column'] = $model->getTable().'.'.$condition['column'];
         }
 
         return $condition;

--- a/src/WhereConditions/WhereConditionsBaseDirective.php
+++ b/src/WhereConditions/WhereConditionsBaseDirective.php
@@ -199,13 +199,18 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
         return $relatedModel;
     }
 
-    protected function prefixConditionWithTableName(array $conditions, Model $model): array
+    /**
+     * @param array<string, mixed>|null $condition
+     * @param Model $model
+     * @return array<string, mixed>|null
+     */
+    protected function prefixConditionWithTableName(array $condition, Model $model): array
     {
-        if ($conditions['column'] ?? null) {
-            $conditions['column'] = $model->getTable() . '.' .$conditions['column'];
+        if ($condition['column'] ?? null) {
+            $condition['column'] = $model->getTable() . '.' .$condition['column'];
         }
 
-        return $conditions;
+        return $condition;
     }
 
     /**

--- a/src/WhereConditions/WhereConditionsBaseDirective.php
+++ b/src/WhereConditions/WhereConditionsBaseDirective.php
@@ -200,9 +200,9 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
     }
 
     /**
-     * @param array<string, mixed>|null $condition
+     * @param array<string, mixed> $condition
      * @param Model $model
-     * @return array<string, mixed>|null
+     * @return array<string, mixed>
      */
     protected function prefixConditionWithTableName(array $condition, Model $model): array
     {

--- a/src/WhereConditions/WhereHasConditionsDirective.php
+++ b/src/WhereConditions/WhereHasConditionsDirective.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\WhereConditions;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
 class WhereHasConditionsDirective extends WhereConditionsBaseDirective
@@ -56,7 +57,13 @@ SDL;
             $builder,
             $builder->getModel(),
             $this->getRelationName(),
-            $whereConditions
+            $this->prefixConditionWithTableName(
+                $whereConditions,
+                $this->nestedRelatedModel(
+                    $builder->getModel(),
+                    $this->getRelationName()
+                )
+            ),
         );
 
         return $builder;
@@ -83,5 +90,18 @@ SDL;
     protected function generatedInputSuffix(): string
     {
         return 'WhereHasConditions';
+    }
+
+    /**
+     * @param array<string, mixed> $condition
+     * @return array<string, mixed>
+     */
+    protected function prefixConditionWithTableName(array $condition, Model $model): array
+    {
+        if ($condition['column'] ?? null) {
+            $condition['column'] = $model->getTable().'.'.$condition['column'];
+        }
+
+        return $condition;
     }
 }

--- a/src/WhereConditions/WhereHasConditionsDirective.php
+++ b/src/WhereConditions/WhereHasConditionsDirective.php
@@ -63,7 +63,7 @@ SDL;
                     $builder->getModel(),
                     $this->getRelationName()
                 )
-            ),
+            )
         );
 
         return $builder;

--- a/src/WhereConditions/WhereHasConditionsDirective.php
+++ b/src/WhereConditions/WhereHasConditionsDirective.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\WhereConditions;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
 class WhereHasConditionsDirective extends WhereConditionsBaseDirective
@@ -57,13 +56,7 @@ SDL;
             $builder,
             $builder->getModel(),
             $this->getRelationName(),
-            $this->prefixConditionWithTableName(
-                $whereConditions,
-                $this->nestedRelatedModel(
-                    $builder->getModel(),
-                    $this->getRelationName()
-                )
-            )
+            $whereConditions
         );
 
         return $builder;
@@ -90,18 +83,5 @@ SDL;
     protected function generatedInputSuffix(): string
     {
         return 'WhereHasConditions';
-    }
-
-    /**
-     * @param array<string, mixed> $condition
-     * @return array<string, mixed>
-     */
-    protected function prefixConditionWithTableName(array $condition, Model $model): array
-    {
-        if ($condition['column'] ?? null) {
-            $condition['column'] = $model->getTable().'.'.$condition['column'];
-        }
-
-        return $condition;
     }
 }

--- a/tests/Integration/WhereConditions/WhereHasConditionsDirectiveTest.php
+++ b/tests/Integration/WhereConditions/WhereHasConditionsDirectiveTest.php
@@ -4,6 +4,7 @@ namespace Tests\Integration\WhereConditions;
 
 use Nuwave\Lighthouse\WhereConditions\WhereConditionsServiceProvider;
 use Tests\DBTestCase;
+use Tests\Utils\Models\Role;
 use Tests\Utils\Models\User;
 
 class WhereHasConditionsDirectiveTest extends DBTestCase
@@ -13,6 +14,7 @@ class WhereHasConditionsDirectiveTest extends DBTestCase
         id: ID!
         name: String
         email: String
+        roles: [Role!]! @belongsToMany
     }
 
     type Post {
@@ -26,6 +28,11 @@ class WhereHasConditionsDirectiveTest extends DBTestCase
         name: String
     }
 
+    type Role {
+        id: Int!
+        name: String!
+    }
+
     type Query {
         posts(
             hasUser: _ @whereHasConditions(relation: "user")
@@ -34,6 +41,7 @@ class WhereHasConditionsDirectiveTest extends DBTestCase
         users(
             hasCompany: _ @whereHasConditions(relation: "company")
             hasPost: _ @whereHasConditions(relation: "posts")
+            hasRoles: _ @whereHasConditions(relation: "roles")
         ): [User!]! @all
 
         companies(
@@ -165,6 +173,42 @@ class WhereHasConditionsDirectiveTest extends DBTestCase
                     ],
                     [
                         'id' => '3',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testWhereHasBelongsToMany(): void
+    {
+        factory(Role::class)->create();
+        factory(User::class)->create();
+
+        /** @var User $user */
+        $user = factory(User::class)->create();
+
+        $user
+            ->roles()
+            ->attach(
+                factory(Role::class, 4)->create()
+            );
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            users(
+                hasRoles: {
+                    column: "id",
+                    value: 1
+                }
+            ) {
+                id
+            }
+        }
+        ')->assertExactJson([
+            'data' => [
+                'users' => [
+                    [
+                        'id' => '2',
                     ],
                 ],
             ],

--- a/tests/Integration/WhereConditions/WhereHasConditionsDirectiveTest.php
+++ b/tests/Integration/WhereConditions/WhereHasConditionsDirectiveTest.php
@@ -181,24 +181,22 @@ class WhereHasConditionsDirectiveTest extends DBTestCase
 
     public function testWhereHasBelongsToMany(): void
     {
-        factory(Role::class)->create();
         factory(User::class)->create();
+
+        /** @var Role $role */
+        $role = factory(Role::class)->create();
 
         /** @var User $user */
         $user = factory(User::class)->create();
 
-        $user
-            ->roles()
-            ->attach(
-                factory(Role::class, 4)->create()
-            );
+        $user->roles()->attach($role);
 
         $this->graphQL(/** @lang GraphQL */ '
         {
             users(
                 hasRoles: {
                     column: "id",
-                    value: 1
+                    value: ' . $role->getKey() . '
                 }
             ) {
                 id
@@ -208,7 +206,7 @@ class WhereHasConditionsDirectiveTest extends DBTestCase
             'data' => [
                 'users' => [
                     [
-                        'id' => '2',
+                        'id' => (string) $user->getKey(),
                     ],
                 ],
             ],

--- a/tests/Integration/WhereConditions/WhereHasConditionsDirectiveTest.php
+++ b/tests/Integration/WhereConditions/WhereHasConditionsDirectiveTest.php
@@ -196,7 +196,7 @@ class WhereHasConditionsDirectiveTest extends DBTestCase
             users(
                 hasRoles: {
                     column: "id",
-                    value: ' . $role->getKey() . '
+                    value: '.$role->getKey().'
                 }
             ) {
                 id


### PR DESCRIPTION
Relates to: #1470

Test whereHas on belongsToMany relationship results in QueryException.

```
SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous (SQL: select * from `users` where (exists (select * from `roles` inner join `role_user` on `roles`.`id` = `role_user`.`role_id` where `users`.`id` = `role_user`.`user_id` and `id` = 1)))
```

- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
