### PR TITLE
Fix typo in upgrade guide from @middlware to @middleware

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -52,7 +52,7 @@ the [@guard](docs/master/api-reference/directives.md#guard) directive on selecte
 
 ```diff
 type Query {
--   profile: User! @middlware(checks: ["auth"])
+-   profile: User! @middleware(checks: ["auth"])
 +   profile: User! @guard
 }
 ```


### PR DESCRIPTION
**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

fixed typo in `@middlware` to `@middleware`
