### PR TITLE
Change column to field.

### DIFF
--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -1777,7 +1777,7 @@ Querying a field that has an `orderBy` argument looks like this:
 
 ```graphql
 {
-  posts(orderBy: [{ column: POSTED_AT, order: ASC }]) {
+  posts(orderBy: [{ field: POSTED_AT, order: ASC }]) {
     title
   }
 }
@@ -1802,7 +1802,7 @@ This can be queried like this:
 
 ```graphql
 {
-  posts(filter: { orderBy: [{ column: "posted_at", order: ASC }] }) {
+  posts(filter: { orderBy: [{ field: "posted_at", order: ASC }] }) {
     title
   }
 }


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**


When querying an order by directive the documentation specifies you to use `column:`, however `field:` should be used instead.

Using `column:` results in the following error. 

```
Field "column" is not defined by type FooOrderByOrderByClause.
```


**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
