### PR TITLE
Failing test case for trait UsesTestSchema

### DIFF
--- a/tests/Integration/Testing/UsesTestSchemaTest.php
+++ b/tests/Integration/Testing/UsesTestSchemaTest.php
@@ -64,8 +64,7 @@ class UsesTestSchemaTest extends DBTestCase
         // It fails, because schema cannot be overridden 
         $this->graphQL('
             {
-                categories{
-                    id
+                categories{                    
                     name
                 }
             }

--- a/tests/Integration/Testing/UsesTestSchemaTest.php
+++ b/tests/Integration/Testing/UsesTestSchemaTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Integration\Schema\Directives;
+
+use Tests\DBTestCase;
+use Tests\Utils\Models\Category;
+use Tests\Utils\Models\Color;
+
+class UsesTestSchemaTest extends DBTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testCanSwitchSchemaOnSucessiveRequests(): void
+    {
+        factory(Color::class, 3)->create();
+        factory(Category::class, 4)->create();
+
+        $this->schema = '          
+            type Color {                
+                id: ID!
+                name: String!
+            }
+
+            type Query {
+                colors: [Color] @all
+            }
+            ';
+
+        $this->graphQL('
+            {
+                colors{
+                    id
+                    name
+                }
+            }
+            ')
+            ->assertJsonStructure([
+                'data' => ['colors']
+            ])
+            ->assertJsonCount(3, 'data.colors');
+
+
+        $this->schema = '          
+            type Color {                
+                id: ID!
+                name: String!
+            }
+
+            type Category {                
+                id: ID!
+                name: String!
+            }
+
+            type Query {
+                colors: [Color] @all
+                categories: [Category] @all
+            }
+            ';
+
+        $this->graphQL('
+            {
+                categories{
+                    id
+                    name
+                }
+            }
+            ')
+            ->assertJsonStructure([
+                'data' => ['categories']
+            ])
+            ->assertJsonCount(4, 'data.categories');
+    }
+}

--- a/tests/Integration/Testing/UsesTestSchemaTest.php
+++ b/tests/Integration/Testing/UsesTestSchemaTest.php
@@ -18,6 +18,7 @@ class UsesTestSchemaTest extends DBTestCase
         factory(Color::class, 3)->create();
         factory(Category::class, 4)->create();
 
+        // It passes
         $this->schema = '          
             type Color {                
                 id: ID!
@@ -60,6 +61,7 @@ class UsesTestSchemaTest extends DBTestCase
             }
             ';
 
+        // It fails, because schema cannot be overridden 
         $this->graphQL('
             {
                 categories{


### PR DESCRIPTION
https://lighthouse-php.com/4.16/testing/extensions.htm

Cant override schema as described on docs, when using sucessive graphql requests.


Resolves #1569 
