### PR TITLE
Fix typo in @can docs

### DIFF
--- a/docs/4.16/security/authorization.md
+++ b/docs/4.16/security/authorization.md
@@ -139,7 +139,7 @@ with the `injectArgs` argument:
 
 ```graphql
 type Mutation {
-  createPost(title: String!): Post @can(ability: "create", injectArgs: "true")
+  createPost(title: String!): Post @can(ability: "create", injectArgs: true)
 }
 ```
 


### PR DESCRIPTION
Otherwise PhpStorm complains `Argument value is not a valid value of scalar "Boolean".`