### PR TITLE
Remove excessive composer script from docs

### DIFF
--- a/docs/4.12/api-reference/commands.md
+++ b/docs/4.12/api-reference/commands.md
@@ -30,7 +30,6 @@ is to add it to your `composer.json`:
 "scripts": {
     ...
     "post-update-cmd": [
-        "Illuminate\\Foundation\\ComposerScripts::postUpdate",
         "php artisan lighthouse:ide-helper"
     ],
 ```

--- a/docs/4.13/api-reference/commands.md
+++ b/docs/4.13/api-reference/commands.md
@@ -30,7 +30,6 @@ is to add it to your `composer.json`:
 "scripts": {
     ...
     "post-update-cmd": [
-        "Illuminate\\Foundation\\ComposerScripts::postUpdate",
         "php artisan lighthouse:ide-helper"
     ],
 ```

--- a/docs/4.14/api-reference/commands.md
+++ b/docs/4.14/api-reference/commands.md
@@ -34,7 +34,6 @@ is to add this script to your `composer.json`:
 "scripts": {
     ...
     "post-update-cmd": [
-        "Illuminate\\Foundation\\ComposerScripts::postUpdate",
         "php artisan lighthouse:ide-helper"
     ],
 ```

--- a/docs/4.15/api-reference/commands.md
+++ b/docs/4.15/api-reference/commands.md
@@ -39,7 +39,6 @@ is to add this script to your `composer.json`:
 "scripts": {
     ...
     "post-update-cmd": [
-        "Illuminate\\Foundation\\ComposerScripts::postUpdate",
         "php artisan lighthouse:ide-helper"
     ],
 ```

--- a/docs/4.16/api-reference/commands.md
+++ b/docs/4.16/api-reference/commands.md
@@ -45,7 +45,6 @@ is to add this script to your `composer.json`:
 "scripts": {
     ...
     "post-update-cmd": [
-        "Illuminate\\Foundation\\ComposerScripts::postUpdate",
         "php artisan lighthouse:ide-helper"
     ],
 ```

--- a/docs/master/api-reference/commands.md
+++ b/docs/master/api-reference/commands.md
@@ -45,7 +45,6 @@ is to add this script to your `composer.json`:
 "scripts": {
     ...
     "post-update-cmd": [
-        "Illuminate\\Foundation\\ComposerScripts::postUpdate",
         "php artisan lighthouse:ide-helper"
     ],
 ```


### PR DESCRIPTION
*Disclaimer:* This is my first PR here.

[ComposerScripts::postUpdate](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/ComposerScripts.php#L28) is doing exact same thing [ComposerScripts::postAutoloadDump](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/ComposerScripts.php#L41) doing after running
`$ composer update`. By this reason `ComposerScripts::postUpdate` is no longer being used in default `composer.json` in `Laravel v5.5` (sorry can't find exact commit). This is what I'd call "documentation legacy".

- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->
Docs improvement.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
No breaking changes.
