### PR TITLE
Set `lighthouse.debug` config through env `LIGHTHOUSE_DEBUG'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Change `ErrorHandler` method `handle()` to non-static `__invoke()` and allow discarding
   errors by returning `null`
 - Allow subscriptions without named operations, base channels on the field name
+- Hardcoded `debug` option in `lighthouse.php` config has been replaced to `env('LIGHTHOUSE_DEBUG')` 
 
 ### Removed
 

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -177,6 +177,26 @@ return [
     | Control the debug level as described in http://webonyx.github.io/graphql-php/error-handling/
     | Debugging is only applied if the global Laravel debug config is set to true.
     |
+    | Instead of using the bitwise "OR" operator https://www.php.net/manual/en/language.operators.bitwise.php
+    | you can specify an integer inside LIGHTHOUSE_DEBUG environment variable.
+    |
+    |    0 => INCLUDE_NONE
+    |    1 => INCLUDE_DEBUG_MESSAGE
+    |    2 => INCLUDE_TRACE
+    |    3 => INCLUDE_TRACE | INCLUDE_DEBUG_MESSAGE
+    |    4 => RETHROW_INTERNAL_EXCEPTIONS
+    |    5 => RETHROW_INTERNAL_EXCEPTIONS | INCLUDE_DEBUG_MESSAGE
+    |    6 => RETHROW_INTERNAL_EXCEPTIONS | INCLUDE_TRACE
+    |    7 => RETHROW_INTERNAL_EXCEPTIONS | INCLUDE_TRACE | INCLUDE_DEBUG_MESSAGE
+    |    8 => RETHROW_UNSAFE_EXCEPTIONS
+    |    9 => RETHROW_UNSAFE_EXCEPTIONS | INCLUDE_DEBUG_MESSAGE
+    |   10 => RETHROW_UNSAFE_EXCEPTIONS | INCLUDE_TRACE
+    |   11 => RETHROW_UNSAFE_EXCEPTIONS | INCLUDE_TRACE | INCLUDE_DEBUG_MESSAGE
+    |   12 => RETHROW_UNSAFE_EXCEPTIONS | RETHROW_INTERNAL_EXCEPTIONS
+    |   13 => RETHROW_UNSAFE_EXCEPTIONS | RETHROW_INTERNAL_EXCEPTIONS | INCLUDE_DEBUG_MESSAGE
+    |   14 => RETHROW_UNSAFE_EXCEPTIONS | RETHROW_INTERNAL_EXCEPTIONS | INCLUDE_TRACE
+    |   15 => RETHROW_UNSAFE_EXCEPTIONS | RETHROW_INTERNAL_EXCEPTIONS | INCLUDE_TRACE | INCLUDE_DEBUG_MESSAGE
+    |
     */
 
     'debug' => env('LIGHTHOUSE_DEBUG', \GraphQL\Error\DebugFlag::INCLUDE_DEBUG_MESSAGE | \GraphQL\Error\DebugFlag::INCLUDE_TRACE),

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -179,7 +179,7 @@ return [
     |
     */
 
-    'debug' => \GraphQL\Error\DebugFlag::INCLUDE_DEBUG_MESSAGE | \GraphQL\Error\DebugFlag::INCLUDE_TRACE,
+    'debug' => env('LIGHTHOUSE_DEBUG', \GraphQL\Error\DebugFlag::INCLUDE_DEBUG_MESSAGE | \GraphQL\Error\DebugFlag::INCLUDE_TRACE),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
- [ ] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Hello Lighthouse team! This PR is not related to any issues.

**Changes**

Hardcoded `debug` option in `lighthouse.php` config has been replaced to `env('LIGHTHOUSE_DEBUG')` with default value: `\GraphQL\Error\DebugFlag::INCLUDE_DEBUG_MESSAGE | \GraphQL\Error\DebugFlag::INCLUDE_TRACE`

This will allow changing the logging mode through environment variables without changing the parameters of the configuration file.

**Breaking changes**

There is no breaking changes, just a small tune for usability in k8s.
