### PR TITLE
Fix docs: Laravel's function is `syncWithoutDetaching`

### DIFF
--- a/docs/4.16/eloquent/nested-mutations.md
+++ b/docs/4.16/eloquent/nested-mutations.md
@@ -690,7 +690,7 @@ type UserMoviePivot {
 }
 ```
 
-Laravel's `sync()`, `syncWithoutDetach()` or `connect()` methods allow you to pass
+Laravel's `sync()`, `syncWithoutDetaching()` or `connect()` methods allow you to pass
 an array where the keys are IDs of related models and the values are pivot data.
 
 Lighthouse exposes this capability through the nested operations on many-to-many relations.
@@ -765,7 +765,7 @@ You will get the following response:
 }
 ```
 
-It is also possible to use the `sync` and `syncWithoutDetach` operations.
+It is also possible to use the `sync` and `syncWithoutDetaching` operations.
 
 ## MorphToMany
 


### PR DESCRIPTION
Laravel's function is syncWithoutDetaching but it is written syncWithoutDetach in current documentations for nested mutations.

Changed syncWithoutDetach function mentioned in docs to syncWithoutDetaching.