### PR TITLE
Add a failing test case for custom relationship method names (#1594)

### DIFF
--- a/tests/Integration/Schema/Directives/MorphToDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/MorphToDirectiveTest.php
@@ -135,6 +135,57 @@ class MorphToDirectiveTest extends DBTestCase
         ]);
     }
 
+    public function testCanResolveMorphToWithAlternateMethodName(): void
+    {
+        $this->schema =
+            /** @lang GraphQL */
+            '
+        type Image {
+            id: ID!
+            imageableAlias: Task! @morphTo
+        }
+
+        type Task {
+            id: ID!
+            name: String!
+        }
+
+        type Query {
+            image (
+                id: ID! @eq
+            ): Image @find
+        }
+        ';
+
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+        query ($id: ID!) {
+            image(id: $id) {
+                id
+                imageableAlias {
+                    id
+                    name
+                }
+            }
+        }
+        ',
+            [
+                'id' => $this->image->id,
+            ]
+        )->assertJson([
+            'data' => [
+                'image' => [
+                    'id' => $this->image->id,
+                    'imageableAlias' => [
+                        'id' => $this->task->id,
+                        'name' => $this->task->name,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
     public function testCanResolveMorphToUsingInterfaces(): void
     {
         /** @var \Tests\Utils\Models\Post $post */

--- a/tests/Utils/Models/Image.php
+++ b/tests/Utils/Models/Image.php
@@ -21,4 +21,9 @@ class Image extends Model
     {
         return $this->morphTo();
     }
+
+    public function imageableAlias(): MorphTo
+    {
+        return $this->morphTo('imageable');
+    }
 }


### PR DESCRIPTION
- [x]  Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Failing test case as per request in  #1594

**Changes**

Adds a failing test case to prove `@morphTo` directive breaks returned values for "MorphTo"-relationships which use an different method and morph/relationship name in the model.

**Breaking changes**

None