### PR TITLE
FIX php.dockerfile with Composer 2

### DIFF
--- a/php.dockerfile
+++ b/php.dockerfile
@@ -12,8 +12,7 @@ RUN apt-get update && apt-get install -y \
         pdo_mysql \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer \
-    && composer global require hirak/prestissimo --no-progress --no-interaction
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
 RUN pecl install xdebug \
     && docker-php-ext-enable xdebug


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

With the new Composer 2 update, it is no longer necessary to use the [hirak / prestissimo](https://github.com/hirak/prestissimo) package (see its readme.md). When initializing the Lighthouse setup, it throws an error when reaching step 5 of the php.dockerfile. With this small change it is fixed.

**Breaking changes**

No breaking changes. All tests pass without problem.
