### PR TITLE
Improve Xdebug in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
     depends_on:
       - mysql
     environment:
-      XDEBUG_CONFIG: "remote_enable=1 remote_mode=req remote_port=9000 remote_connect_back=0"
+      XDEBUG_CONFIG: "remote_enable=1 remote_mode=req remote_port=9000 remote_connect_back=0 remote_host=host.docker.internal"
+      PHP_IDE_CONFIG: "serverName=lighthouse"
     tty: true
 
   mysql:


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

I improve the default options a bit so that from IDE like PHPStorm you can work with XDebug by default. You just have to configure the server in the IDE.

<!-- Detail the changes in behaviour this PR introduces. -->

No breaking changes.

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
