### PR TITLE
Ignore nested relation mutation when null is given

### DIFF
--- a/src/Execution/Arguments/ArgPartitioner.php
+++ b/src/Execution/Arguments/ArgPartitioner.php
@@ -84,7 +84,7 @@ class ArgPartitioner
         $nonNullRelations = new ArgumentSet();
         $nonNullRelations->arguments = array_filter(
             $relations->arguments,
-            static function (?Argument $argument): bool {
+            static function (Argument $argument): bool {
                 return null !== $argument->value;
             }
         );

--- a/src/Execution/Arguments/ArgPartitioner.php
+++ b/src/Execution/Arguments/ArgPartitioner.php
@@ -74,12 +74,22 @@ class ArgPartitioner
     ): array {
         $modelReflection = new ReflectionClass($model);
 
-        return static::partition(
+        [$relations, $remaining] = static::partition(
             $argumentSet,
             static function (string $name) use ($modelReflection, $relationClass): bool {
                 return static::methodReturnsRelation($modelReflection, $name, $relationClass);
             }
         );
+
+        $nonNullRelations = new ArgumentSet();
+        $nonNullRelations->arguments = array_filter(
+            $relations->arguments,
+            static function (?Argument $argument): bool {
+                return null !== $argument->value;
+            }
+        );
+
+        return [$nonNullRelations, $remaining];
     }
 
     /**

--- a/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
@@ -112,6 +112,32 @@ class BelongsToTest extends DBTestCase
         ]);
     }
 
+    public function testBelongsToExplicitNullHasNoEffect(): void
+    {
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            createTask(input: {
+                name: "foo"
+                user: null
+            }) {
+                id
+                name
+                user {
+                    id
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'createTask' => [
+                    'id' => '1',
+                    'name' => 'foo',
+                    'user' => null,
+                ],
+            ],
+        ]);
+    }
+
     public function testCanUpsertUsingCreateAndConnectWithBelongsTo(): void
     {
         factory(User::class)->create();

--- a/tests/Unit/Execution/Arguments/ArgPartitionerTest.php
+++ b/tests/Unit/Execution/Arguments/ArgPartitionerTest.php
@@ -14,7 +14,7 @@ use Tests\Utils\Models\WithoutRelationClassImport;
 
 class ArgPartitionerTest extends TestCase
 {
-    public function testPartitionArgsWithArResolvers(): void
+    public function testPartitionArgsWithArgResolvers(): void
     {
         $argumentSet = new ArgumentSet();
 
@@ -46,7 +46,12 @@ class ArgPartitionerTest extends TestCase
         $argumentSet->arguments['regular'] = $regular;
 
         $tasksRelation = new Argument();
+        $tasksRelation->value = new ArgumentSet();
         $argumentSet->arguments['tasks'] = $tasksRelation;
+
+        $postsRelation = new Argument();
+        $postsRelation->value = null;
+        $argumentSet->arguments['posts'] = $postsRelation;
 
         [$hasManyArgs, $regularArgs] = ArgPartitioner::relationMethods(
             $argumentSet,


### PR DESCRIPTION
- [x] Added or updated tests
- ~[ ] Documented user facing changes~
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Gracefully handle when `null` is passed as the argument of a nested mutation relation.

**Breaking changes**

No.