### PR TITLE
Check current guard in can directive

### DIFF
--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -9,12 +9,14 @@ use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Auth;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\SoftDeletes\ForceDeleteDirective;
 use Nuwave\Lighthouse\SoftDeletes\RestoreDirective;
 use Nuwave\Lighthouse\SoftDeletes\TrashedDirective;
+use Nuwave\Lighthouse\Support\Authentication;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 use Nuwave\Lighthouse\Support\Utils;
@@ -176,7 +178,7 @@ GRAPHQL;
         // should be [modelClassName, additionalArg, additionalArg...]
         array_unshift($arguments, $model);
 
-        if (! $gate->check($ability, $arguments)) {
+        if (! $gate->forUser(Auth::guard(Authentication::getGuard())->user())->check($ability, $arguments)) {
             throw new AuthorizationException(
                 "You are not authorized to access {$this->nodeName()}"
             );

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Auth;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
@@ -177,8 +176,9 @@ GRAPHQL;
         // The signature of the second argument `$arguments` of `Gate::check`
         // should be [modelClassName, additionalArg, additionalArg...]
         array_unshift($arguments, $model);
+        $authUser = auth()->guard(Authentication::getGuard())->user();
 
-        if (! $gate->forUser(Auth::guard(Authentication::getGuard())->user())->check($ability, $arguments)) {
+        if (! $gate->forUser($authUser)->check($ability, $arguments)) {
             throw new AuthorizationException(
                 "You are not authorized to access {$this->nodeName()}"
             );

--- a/src/Support/Authentication.php
+++ b/src/Support/Authentication.php
@@ -5,7 +5,7 @@ namespace Nuwave\Lighthouse\Support;
 class Authentication
 {
     /**
-     * @return int|string
+     * @return string|null
      */
     public static function getGuard()
     {

--- a/src/Support/Authentication.php
+++ b/src/Support/Authentication.php
@@ -2,21 +2,19 @@
 
 namespace Nuwave\Lighthouse\Support;
 
-use Illuminate\Support\Facades\Auth;
-
 class Authentication
 {
     /**
-     * @return \Illuminate\Config\Repository|\Illuminate\Contracts\Foundation\Application|\Laravel\Lumen\Application|mixed
+     * @return string|null
      */
     public static function getGuard()
     {
-        $customGuards = config('lighthouse.custom_guards');
+        $guards = array_keys(config('auth.guards'));
 
-        if (! empty($customGuards)) {
-            foreach ($customGuards as $customGuard) {
-                if (Auth::guard($customGuard)->check()) {
-                    return $customGuard;
+        if (! empty($guards)) {
+            foreach ($guards as $guard) {
+                if (auth()->guard($guard)->check()) {
+                    return $guard;
                 }
             }
         }

--- a/src/Support/Authentication.php
+++ b/src/Support/Authentication.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Nuwave\Lighthouse\Support;
+
+use Illuminate\Support\Facades\Auth;
+
+class Authentication
+{
+    /**
+     * @return \Illuminate\Config\Repository|\Illuminate\Contracts\Foundation\Application|\Laravel\Lumen\Application|mixed
+     */
+    public static function getGuard()
+    {
+        $customGuards = config('lighthouse.custom_guards');
+
+        if (! empty($customGuards)) {
+            foreach ($customGuards as $customGuard) {
+                if (Auth::guard($customGuard)->check()) {
+                    return $customGuard;
+                }
+            }
+        }
+
+        return config('lighthouse.guard');
+    }
+}

--- a/src/Support/Authentication.php
+++ b/src/Support/Authentication.php
@@ -5,7 +5,7 @@ namespace Nuwave\Lighthouse\Support;
 class Authentication
 {
     /**
-     * @return string|null
+     * @return int|string
      */
     public static function getGuard()
     {

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -61,6 +61,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Custom Guards
+    |--------------------------------------------------------------------------
+    |
+    | Specify here the guards that you have defined in your application and that are different from guard option.
+    | They will be used to check authentication in directives such as @can.
+    |
+    */
+
+    'custom_guards' => [],
+
+    /*
+    |--------------------------------------------------------------------------
     | Schema Location
     |--------------------------------------------------------------------------
     |

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -61,18 +61,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Custom Guards
-    |--------------------------------------------------------------------------
-    |
-    | Specify here the guards that you have defined in your application and that are different from guard option.
-    | They will be used to check authentication in directives such as @can.
-    |
-    */
-
-    'custom_guards' => [],
-
-    /*
-    |--------------------------------------------------------------------------
     | Schema Location
     |--------------------------------------------------------------------------
     |

--- a/tests/Unit/Support/AuthenticationTest.php
+++ b/tests/Unit/Support/AuthenticationTest.php
@@ -8,19 +8,19 @@ use Tests\TestCase;
 
 class AuthenticationTest extends TestCase
 {
-    public function testGetDefaultConfigGuard()
+    public function testGetDefaultConfigGuard(): void
     {
         $this->assertEquals(config('lighthouse.guard'), Authentication::getGuard());
     }
 
-    public function testIfEmptyCustomGuardGetDefault()
+    public function testIfEmptyCustomGuardGetDefault(): void
     {
         config()->set('lighthouse.custom_guards', []);
 
         $this->assertEquals(config('lighthouse.guard'), Authentication::getGuard());
     }
 
-    public function testErrorIfNotExistsCustomGuard()
+    public function testErrorIfNotExistsCustomGuard(): void
     {
         $customGuard = 'some_guard';
 

--- a/tests/Unit/Support/AuthenticationTest.php
+++ b/tests/Unit/Support/AuthenticationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use InvalidArgumentException;
+use Nuwave\Lighthouse\Support\Authentication;
+use Tests\TestCase;
+
+class AuthenticationTest extends TestCase
+{
+    public function testGetDefaultConfigGuard()
+    {
+        $this->assertEquals(config('lighthouse.guard'), Authentication::getGuard());
+    }
+
+    public function testIfEmptyCustomGuardGetDefault()
+    {
+        config()->set('lighthouse.custom_guards', []);
+
+        $this->assertEquals(config('lighthouse.guard'), Authentication::getGuard());
+    }
+
+    public function testErrorIfNotExistsCustomGuard()
+    {
+        $customGuard = 'some_guard';
+
+        config()->set('lighthouse.custom_guards', [$customGuard]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $expectedMessage = 'InvalidArgumentException: Auth guard ['.$customGuard.'] is not defined.';
+        $this->assertEquals($expectedMessage, Authentication::getGuard());
+    }
+}

--- a/tests/Unit/Support/AuthenticationTest.php
+++ b/tests/Unit/Support/AuthenticationTest.php
@@ -4,9 +4,10 @@ namespace Tests\Unit\Support;
 
 use InvalidArgumentException;
 use Nuwave\Lighthouse\Support\Authentication;
-use Tests\TestCase;
+use Tests\DBTestCase;
+use Tests\Utils\Models\User;
 
-class AuthenticationTest extends TestCase
+class AuthenticationTest extends DBTestCase
 {
     public function testGetDefaultConfigGuard(): void
     {
@@ -20,6 +21,18 @@ class AuthenticationTest extends TestCase
         $this->assertEquals(config('lighthouse.guard'), Authentication::getGuard());
     }
 
+    public function testGetCustomConfigGuard(): void
+    {
+        $customGuard = 'web';
+
+        config()->set('lighthouse.custom_guards', [$customGuard]);
+
+        $user = factory(User::class)->make();
+        $this->be($user);
+
+        $this->assertEquals($customGuard, Authentication::getGuard());
+    }
+
     public function testErrorIfNotExistsCustomGuard(): void
     {
         $customGuard = 'some_guard';
@@ -27,7 +40,7 @@ class AuthenticationTest extends TestCase
         config()->set('lighthouse.custom_guards', [$customGuard]);
 
         $this->expectException(InvalidArgumentException::class);
-        $expectedMessage = 'InvalidArgumentException: Auth guard ['.$customGuard.'] is not defined.';
+        $expectedMessage = 'InvalidArgumentException: Auth guard [' . $customGuard . '] is not defined.';
         $this->assertEquals($expectedMessage, Authentication::getGuard());
     }
 }

--- a/tests/Unit/Support/AuthenticationTest.php
+++ b/tests/Unit/Support/AuthenticationTest.php
@@ -9,35 +9,32 @@ use Tests\Utils\Models\User;
 
 class AuthenticationTest extends DBTestCase
 {
-    public function testGetDefaultConfigGuard(): void
+    public function testGetDefaultConfigLighthouseGuard(): void
     {
         $this->assertEquals(config('lighthouse.guard'), Authentication::getGuard());
     }
 
-    public function testIfEmptyCustomGuardGetDefault(): void
+    public function testIfEmptyAuthGuardsGetDefault(): void
     {
-        config()->set('lighthouse.custom_guards', []);
+        config()->set('auth.guards', []);
 
         $this->assertEquals(config('lighthouse.guard'), Authentication::getGuard());
     }
 
-    public function testGetCustomConfigGuard(): void
+    public function testGetAuthUserGuard(): void
     {
-        $customGuard = 'web';
-
-        config()->set('lighthouse.custom_guards', [$customGuard]);
-
         $user = factory(User::class)->make();
         $this->be($user);
 
-        $this->assertEquals($customGuard, Authentication::getGuard());
+        $expectedGuard = 'web';
+        $this->assertEquals($expectedGuard, Authentication::getGuard());
     }
 
     public function testErrorIfNotExistsCustomGuard(): void
     {
         $customGuard = 'some_guard';
 
-        config()->set('lighthouse.custom_guards', [$customGuard]);
+        config()->set('auth.guards', [$customGuard]);
 
         $this->expectException(InvalidArgumentException::class);
         $expectedMessage = 'InvalidArgumentException: Auth guard ['.$customGuard.'] is not defined.';

--- a/tests/Unit/Support/AuthenticationTest.php
+++ b/tests/Unit/Support/AuthenticationTest.php
@@ -40,7 +40,7 @@ class AuthenticationTest extends DBTestCase
         config()->set('lighthouse.custom_guards', [$customGuard]);
 
         $this->expectException(InvalidArgumentException::class);
-        $expectedMessage = 'InvalidArgumentException: Auth guard [' . $customGuard . '] is not defined.';
+        $expectedMessage = 'InvalidArgumentException: Auth guard ['.$customGuard.'] is not defined.';
         $this->assertEquals($expectedMessage, Authentication::getGuard());
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

In directives like can, when evaluating authorization, it is not taken into account if a custom guard is being used (which is not declared in default), so authorization will fail at this point. This is especially the case for queries or mutations where 2 different guards can be used.

This would detect the guard with which we are authenticating in the case that a different one is required than the one declared in default.

<!-- Detail the changes in behaviour this PR introduces. -->

No breaking changes.

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
