### PR TITLE
Fix documentation of @orderBy

### DIFF
--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -1722,14 +1722,22 @@ type Query {
 }
 ```
 
+You can easily set the default value:
+
+```graphql
+type Query {
+  posts(orderBy: _  = [{ field: TITLE, order: ASC }] @orderBy(columns: ["posted_at", "title"])): [Post!]! @all
+}
+```
+
 Lighthouse will automatically generate an input that takes enumerated column names,
 together with the `SortOrder` enum, and add that to your schema. Here is how it looks:
 
 ```graphql
 "Allows ordering a list of records."
 input QueryPostsOrderByOrderByClause {
-  "The column that is used for ordering."
-  column: QueryPostsOrderByColumn!
+  "The field that is used for ordering."
+  field: QueryPostsOrderByColumn!
 
   "The direction that is used for ordering."
   order: SortOrder!
@@ -1777,7 +1785,7 @@ Querying a field that has an `orderBy` argument looks like this:
 
 ```graphql
 {
-  posts(orderBy: [{ column: POSTED_AT, order: ASC }]) {
+  posts(orderBy: [{ field: POSTED_AT, order: ASC }]) {
     title
   }
 }
@@ -1802,7 +1810,7 @@ This can be queried like this:
 
 ```graphql
 {
-  posts(filter: { orderBy: [{ column: "posted_at", order: ASC }] }) {
+  posts(filter: { orderBy: [{ field: "posted_at", order: ASC }] }) {
     title
   }
 }


### PR DESCRIPTION
Documentation says that `@orderBy` parameter in the query is `column`, when it's actually `field`. It's here: https://lighthouse-php.com/4.18/api-reference/directives.html#orderby. The last example in the documentation is correct, but the earlier ones are not. I'm guessing the parameter name changed in time. This PR corrects the documentation. I also added an example of how to set the default value for sorting.

- [X] Documented user facing changes

No issue was created.

**Changes**

Only updates docs.

**Breaking changes**

No breaking changes.