### PR TITLE
Add `FieldBuilderDirective` interface and `@whereAuth` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Mark directives that can be used more than once per location as `repeatable` https://github.com/nuwave/lighthouse/pull/1529
 - Allow configuring global field middleware directives in `config/lighthouse.php` https://github.com/nuwave/lighthouse/pull/1533
 - Add custom attributes to validations https://github.com/nuwave/lighthouse/pull/1628
-- Interface for directives `FieldBuilderDirective` https://github.com/nuwave/lighthouse/pull/1636
-- Directive for filtering a field based on authenticated user `@whereAuth` https://github.com/nuwave/lighthouse/pull/1636
+- Add new directive interface `FieldBuilderDirective` https://github.com/nuwave/lighthouse/pull/1636
+- Add `@whereAuth` directive for filtering a field based on authenticated user https://github.com/nuwave/lighthouse/pull/1636
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Mark directives that can be used more than once per location as `repeatable` https://github.com/nuwave/lighthouse/pull/1529
 - Allow configuring global field middleware directives in `config/lighthouse.php` https://github.com/nuwave/lighthouse/pull/1533
 - Add custom attributes to validations https://github.com/nuwave/lighthouse/pull/1628
+- Interface for directives `FieldBuilderDirective` https://github.com/nuwave/lighthouse/pull/1636
+- Directive for filtering a field based on authenticated user `@whereAuth` https://github.com/nuwave/lighthouse/pull/1636
 
 ### Changed
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2658,6 +2658,35 @@ type Query {
 }
 ```
 
+## @whereAuth
+
+```graphql
+"""
+Filter a type to only return instances owned by the current user.
+"""
+directive @whereAuth(
+    """
+    Name of the relationship that links to the user model.
+    """
+    relation: String!
+
+    """
+    Specify which guard to use, e.g. "api".
+    When not defined, the default from `lighthouse.php` is used.
+    """
+    guard: String
+) on FIELD_DEFINITION
+```
+
+This example defines a query and filter away any posts where the user relationship is not the authenticated user.  
+Behind the scenes it is using a `whereHas` query.
+
+```graphql
+type Query {
+    posts: [Post!]! @all @whereAuth(relation: "user")
+}
+```
+
 ## @whereBetween
 
 ```graphql

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2678,7 +2678,7 @@ directive @whereAuth(
 ) on FIELD_DEFINITION
 ```
 
-This example defines a query and filter away any posts where the user relationship is not the authenticated user.  
+The following query returns all posts that belong to the currently authenticated user.  
 Behind the scenes it is using a `whereHas` query.
 
 ```graphql

--- a/docs/master/custom-directives/field-directives.md
+++ b/docs/master/custom-directives/field-directives.md
@@ -67,7 +67,7 @@ GRAPHQL;
 An [`\Nuwave\Lighthouse\Support\Contracts\FieldBuilderDirective`](https://github.com/nuwave/lighthouse/blob/master/src/Support/Contracts/FieldBuilderDirective.php)
 directive allows modifying the query that Lighthouse creates for a field.
 
-Currently, the following directives use the defined filters for resolving the query:
+Currently, the following directives use the defined filter for resolving the query:
 
 - [@whereAuth](../api-reference/directives.md#whereauth)
 

--- a/docs/master/custom-directives/field-directives.md
+++ b/docs/master/custom-directives/field-directives.md
@@ -64,16 +64,16 @@ GRAPHQL;
 
 ## FieldBuilderDirective
 
-An [`\Nuwave\Lighthouse\Support\Contracts\FieldBuilderDirective`](https://github.com/nuwave/lighthouse/blob/master/src/Support/Contracts/FieldBuilderDirective.php)
-directive allows modifying the query that Lighthouse creates for a field.
+A [`\Nuwave\Lighthouse\Support\Contracts\FieldBuilderDirective`](https://github.com/nuwave/lighthouse/blob/master/src/Support/Contracts/FieldBuilderDirective.php)
+directive allows modifying the database query that Lighthouse creates for a field.
 
-Currently, the following directives use the defined filter for resolving the query:
+The following directives use the defined filter for resolving the query:
 
 - [@whereAuth](../api-reference/directives.md#whereauth)
 
 ## FieldManipulator
 
-An [`\Nuwave\Lighthouse\Support\Contracts\FieldManipulator`](https://github.com/nuwave/lighthouse/tree/master/src/Support/Contracts/FieldManipulator.php)
+A [`\Nuwave\Lighthouse\Support\Contracts\FieldManipulator`](https://github.com/nuwave/lighthouse/tree/master/src/Support/Contracts/FieldManipulator.php)
 directive can be used to manipulate the schema AST.
 
 ## ValidationDirective

--- a/docs/master/custom-directives/field-directives.md
+++ b/docs/master/custom-directives/field-directives.md
@@ -62,6 +62,16 @@ GRAPHQL;
 }
 ```
 
+## FieldBuilderDirective
+
+An [`\Nuwave\Lighthouse\Support\Contracts\FieldBuilderDirective`](https://github.com/nuwave/lighthouse/blob/master/src/Support/Contracts/FieldBuilderDirective.php)
+directive allows modifying the query that Lighthouse creates for a field.
+
+Currently, the following directives use the defined filters for resolving the query:
+
+- [@whereAuth](../api-reference/directives.md#whereauth)
+
+
 ## FieldManipulator
 
 An [`\Nuwave\Lighthouse\Support\Contracts\FieldManipulator`](https://github.com/nuwave/lighthouse/tree/master/src/Support/Contracts/FieldManipulator.php)

--- a/src/Execution/Arguments/ArgumentSet.php
+++ b/src/Execution/Arguments/ArgumentSet.php
@@ -6,6 +6,7 @@ use Closure;
 use Nuwave\Lighthouse\Schema\Directives\RenameDirective;
 use Nuwave\Lighthouse\Schema\Directives\SpreadDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective;
+use Nuwave\Lighthouse\Support\Contracts\FieldBuilderDirective;
 use Nuwave\Lighthouse\Support\Utils;
 
 class ArgumentSet
@@ -149,6 +150,7 @@ class ArgumentSet
     public function enhanceBuilder(object $builder, array $scopes, Closure $directiveFilter = null): object
     {
         self::applyArgBuilderDirectives($this, $builder, $directiveFilter);
+        self::applyFieldBuilderDirectives($this, $builder);
 
         foreach ($scopes as $scope) {
             $builder->{$scope}($this->toArray());
@@ -198,6 +200,24 @@ class ArgumentSet
                 $argument->value
             );
         }
+    }
+
+    /**
+     * Apply the FieldBuilderDirectives onto the builder.
+     *
+     * TODO get rid of the reference passing in here. The issue is that @search makes a new builder instance,
+     * but we must special case that in some way anyhow, as only eq filters can be added on top of search.
+     *
+     * @param  \Nuwave\Lighthouse\Execution\Arguments\ArgumentSet  $argumentSet
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation  $builder
+     */
+    protected static function applyFieldBuilderDirectives(self $argumentSet, object &$builder): void
+    {
+        $argumentSet->directives
+            ->filter(Utils::instanceofMatcher(FieldBuilderDirective::class))
+            ->each(function (FieldBuilderDirective $fieldBuilderDirective) use (&$builder) {
+                $builder = $fieldBuilderDirective->handleFieldBuilder($builder);
+            });
     }
 
     /**

--- a/src/Execution/Arguments/ArgumentSet.php
+++ b/src/Execution/Arguments/ArgumentSet.php
@@ -215,7 +215,7 @@ class ArgumentSet
     {
         $argumentSet->directives
             ->filter(Utils::instanceofMatcher(FieldBuilderDirective::class))
-            ->each(function (FieldBuilderDirective $fieldBuilderDirective) use (&$builder) {
+            ->each(static function (FieldBuilderDirective $fieldBuilderDirective) use (&$builder): void {
                 $builder = $fieldBuilderDirective->handleFieldBuilder($builder);
             });
     }

--- a/src/Schema/Directives/AuthDirective.php
+++ b/src/Schema/Directives/AuthDirective.php
@@ -37,11 +37,11 @@ GRAPHQL;
 
     public function resolveField(FieldValue $fieldValue): FieldValue
     {
-        /** @var string|null $guard */
-        $guard = $this->directiveArgValue('guard', config('lighthouse.guard'));
-
         return $fieldValue->setResolver(
-            function () use ($guard): ?Authenticatable {
+            function (): ?Authenticatable {
+                /** @var string|null $guard */
+                $guard = $this->directiveArgValue('guard', config('lighthouse.guard'));
+
                 // @phpstan-ignore-next-line phpstan does not know about App\User, which implements Authenticatable
                 return $this
                     ->authFactory

--- a/src/Schema/Directives/WhereAuthDirective.php
+++ b/src/Schema/Directives/WhereAuthDirective.php
@@ -40,17 +40,16 @@ GRAPHQL;
 
     public function handleFieldBuilder(object $builder): object
     {
-        $guard = $this->directiveArgValue('guard', config('lighthouse.guard'));
-        $relation = $this->directiveArgValue('relation');
-        $userId = $this
-            ->authFactory
-            ->guard($guard)
-            ->id();
-
-        // @phpstan-ignore-next-line phpstan cannot find this method.
+        // @phpstan-ignore-next-line Mixins are magic
         return $builder->whereHas(
-            $relation,
-            static function ($query) use ($userId): void {
+            $this->directiveArgValue('relation'),
+            static function ($query): void {
+                $guard = $this->directiveArgValue('guard', config('lighthouse.guard'));
+                $userId = $this
+                    ->authFactory
+                    ->guard($guard)
+                    ->id();
+
                 $query->whereKey($userId);
             }
         );

--- a/src/Schema/Directives/WhereAuthDirective.php
+++ b/src/Schema/Directives/WhereAuthDirective.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Directives;
+
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
+use Nuwave\Lighthouse\Support\Contracts\FieldBuilderDirective;
+
+class WhereAuthDirective extends BaseDirective implements FieldBuilderDirective
+{
+    /**
+     * @var \Illuminate\Contracts\Auth\Factory
+     */
+    protected $authFactory;
+
+    public function __construct(AuthFactory $authFactory)
+    {
+        $this->authFactory = $authFactory;
+    }
+
+    public static function definition(): string
+    {
+        return /** @lang GraphQL */ <<<'GRAPHQL'
+"""
+Filter a type to only return instances owned by the current user.
+"""
+directive @whereAuth(
+  """
+  Name of the relationship that links to the user model.
+  """
+  relation: String!
+  """
+  Specify which guard to use, e.g. "api".
+  When not defined, the default from `lighthouse.php` is used.
+  """
+  guard: String
+) on FIELD_DEFINITION
+GRAPHQL;
+    }
+
+    public function handleFieldBuilder(object $builder): object
+    {
+        $guard = $this->directiveArgValue('guard', config('lighthouse.guard'));
+        $relation = $this->directiveArgValue('relation');
+        $userId = $this
+            ->authFactory
+            ->guard($guard)
+            ->id();
+
+        // @phpstan-ignore-next-line phpstan cannot find this method.
+        return $builder->whereHas(
+            $relation,
+            function ($query) use ($userId) {
+                $query->whereKey($userId);
+            }
+        );
+    }
+}

--- a/src/Schema/Directives/WhereAuthDirective.php
+++ b/src/Schema/Directives/WhereAuthDirective.php
@@ -28,6 +28,7 @@ directive @whereAuth(
   Name of the relationship that links to the user model.
   """
   relation: String!
+
   """
   Specify which guard to use, e.g. "api".
   When not defined, the default from `lighthouse.php` is used.
@@ -49,7 +50,7 @@ GRAPHQL;
         // @phpstan-ignore-next-line phpstan cannot find this method.
         return $builder->whereHas(
             $relation,
-            function ($query) use ($userId) {
+            static function ($query) use ($userId): void {
                 $query->whereKey($userId);
             }
         );

--- a/src/Schema/Directives/WhereAuthDirective.php
+++ b/src/Schema/Directives/WhereAuthDirective.php
@@ -43,7 +43,7 @@ GRAPHQL;
         // @phpstan-ignore-next-line Mixins are magic
         return $builder->whereHas(
             $this->directiveArgValue('relation'),
-            static function ($query): void {
+            function ($query): void {
                 $guard = $this->directiveArgValue('guard', config('lighthouse.guard'));
                 $userId = $this
                     ->authFactory

--- a/src/Support/Contracts/FieldBuilderDirective.php
+++ b/src/Support/Contracts/FieldBuilderDirective.php
@@ -7,7 +7,7 @@ interface FieldBuilderDirective extends Directive
     /**
      * Add additional constraints to the builder.
      *
-     * @param \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation $builder The builder used to resolve the field.
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation $builder The builder used to resolve the field.
      * @return \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation The modified builder.
      */
     public function handleFieldBuilder(object $builder): object;

--- a/src/Support/Contracts/FieldBuilderDirective.php
+++ b/src/Support/Contracts/FieldBuilderDirective.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Nuwave\Lighthouse\Support\Contracts;
+
+interface FieldBuilderDirective extends Directive
+{
+    /**
+     * Add additional constraints to the builder.
+     *
+     * @param \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation $builder The builder used to resolve the field.
+     * @return \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation The modified builder.
+     */
+    public function handleFieldBuilder(object $builder): object;
+}

--- a/src/Support/Http/Middleware/AttemptAuthentication.php
+++ b/src/Support/Http/Middleware/AttemptAuthentication.php
@@ -3,7 +3,7 @@
 namespace Nuwave\Lighthouse\Support\Http\Middleware;
 
 use Closure;
-use Illuminate\Contracts\Auth\Factory as Auth;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Http\Request;
 
 /**
@@ -14,11 +14,11 @@ class AttemptAuthentication
     /**
      * @var \Illuminate\Contracts\Auth\Factory
      */
-    protected $auth;
+    protected $authFactory;
 
-    public function __construct(Auth $auth)
+    public function __construct(AuthFactory $authFactory)
     {
-        $this->auth = $auth;
+        $this->authFactory = $authFactory;
     }
 
     /**
@@ -42,8 +42,8 @@ class AttemptAuthentication
         }
 
         foreach ($guards as $guard) {
-            if ($this->auth->guard($guard)->check()) {
-                $this->auth->shouldUse($guard);
+            if ($this->authFactory->guard($guard)->check()) {
+                $this->authFactory->shouldUse($guard);
 
                 return;
             }

--- a/tests/Integration/Execution/FieldBuilderDirectiveTest.php
+++ b/tests/Integration/Execution/FieldBuilderDirectiveTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Integration\Execution;
+
+use Tests\DBTestCase;
+use Tests\Utils\Models\Post;
+use Tests\Utils\Models\User;
+
+class FieldBuilderDirectiveTest extends DBTestCase
+{
+    protected $schema = /** @lang GraphQL */ '
+    type Post {
+        id: ID!
+        title: String
+    }
+    ';
+
+    public function testCanLimitPostByAuthenticatedUser(): void
+    {
+        $this->schema .= /** @lang GraphQL */ '
+        type Query {
+            posts: [Post!]! @all @whereAuth(relation: "user")
+        }
+        ';
+        $user = factory(User::class)->create();
+        $ownedPosts = factory(Post::class, 3)->create([
+            'user_id' => $user->getKey(),
+        ]);
+        $nonOwnedPosts = factory(Post::class, 3)->create();
+
+        $response = $this
+            ->actingAs($user)
+            ->graphQL(/** @lang GraphQL */ '
+            query {
+                posts {
+                    id
+                }
+            }
+            ');
+
+        $this->assertCount(
+            0,
+            $ownedPosts
+                ->map(function (Post $post) {
+                    return $post->getKey();
+                })
+                ->diff($response->json('data.posts.*.id'))
+        );
+    }
+
+    public function testCanChangeGuard(): void
+    {
+        $this->schema .= /** @lang GraphQL */ '
+        type Query {
+            posts: [Post!]! @all @whereAuth(
+                relation: "user"
+                guard: "api"
+            )
+        }
+        ';
+        $user = factory(User::class)->create();
+        $ownedPosts = factory(Post::class, 3)->create([
+            'user_id' => $user->getKey(),
+        ]);
+        $nonOwnedPosts = factory(Post::class, 3)->create();
+
+        $this->app['auth']->guard('api')->setUser($user);
+
+        $response = $this
+            ->graphQL(/** @lang GraphQL */ '
+            query {
+                posts {
+                    id
+                }
+            }
+            ');
+
+        $this->assertCount(
+            0,
+            $ownedPosts
+                ->map(function (Post $post) {
+                    return $post->getKey();
+                })
+                ->diff($response->json('data.posts.*.id'))
+        );
+    }
+}

--- a/tests/Integration/Execution/FieldBuilderDirectiveTest.php
+++ b/tests/Integration/Execution/FieldBuilderDirectiveTest.php
@@ -71,13 +71,9 @@ class FieldBuilderDirectiveTest extends DBTestCase
             }
             ');
 
-        $this->assertCount(
-            0,
-            $ownedPosts
-                ->map(function (Post $post) {
-                    return $post->getKey();
-                })
-                ->diff($response->json('data.posts.*.id'))
+        $this->assertSame(
+            $ownedPosts->pluck('id')->all(),
+            $response->json('data.posts.*.id')
         );
     }
 }

--- a/tests/Integration/Execution/FieldBuilderDirectiveTest.php
+++ b/tests/Integration/Execution/FieldBuilderDirectiveTest.php
@@ -10,7 +10,7 @@ class FieldBuilderDirectiveTest extends DBTestCase
 {
     protected $schema = /** @lang GraphQL */ '
     type Post {
-        id: ID!
+        id: Int!
         title: String
     }
     ';
@@ -39,8 +39,8 @@ class FieldBuilderDirectiveTest extends DBTestCase
             ');
 
         $this->assertSame(
-            $ownedPosts->pluck('id'),
-            $response->json('data.posts.*.id'),
+            $ownedPosts->pluck('id')->all(),
+            $response->json('data.posts.*.id')
         );
     }
 

--- a/tests/Integration/Execution/FieldBuilderDirectiveTest.php
+++ b/tests/Integration/Execution/FieldBuilderDirectiveTest.php
@@ -38,13 +38,9 @@ class FieldBuilderDirectiveTest extends DBTestCase
             }
             ');
 
-        $this->assertCount(
-            0,
-            $ownedPosts
-                ->map(function (Post $post) {
-                    return $post->getKey();
-                })
-                ->diff($response->json('data.posts.*.id'))
+        $this->assertSame(
+            $ownedPosts->pluck('id'),
+            $response->json('data.posts.*.id'),
         );
     }
 

--- a/tests/Unit/Schema/Directives/AuthDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/AuthDirectiveTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Schema\Directives;
 
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Tests\TestCase;
 use Tests\Utils\Models\User;
 
@@ -43,7 +44,8 @@ class AuthDirectiveTest extends TestCase
         $user = new User();
         $user->name = 'foo';
 
-        $this->app['auth']->guard('api')->setUser($user);
+        $authFactory = $this->app->make(AuthFactory::class);
+        $authFactory->guard('api')->setUser($user);
 
         $this->schema = /** @lang GraphQL */ '
         type User {


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves #1632 

This PR is not completely done, I think I would add more test cases to it first and possibly also allow changing the guard on the `whereAuth`.  
The purpose of this PR was mostly to get support for manipulating the builder on fields, not the new directive. However I feel that this directive shows the power of the new interface.

Was hoping to get some feedback about the idea here before I finished the pr completely.


**Changes**
- Adds a new interface for manipulating the builder on fields
- Adds a new directive for filtering a relationship on the currently authenticated user.