### PR TITLE
Add Sanctum cookie endpoint to default CORS paths

### DIFF
--- a/docs/master/getting-started/configuration.md
+++ b/docs/master/getting-started/configuration.md
@@ -17,8 +17,8 @@ for your GraphQL endpoint in `config/cors.php`:
 
 ```diff
 return [
--   'paths' => ['api/*'],
-+   'paths' => ['api/*', 'graphql'],
+-   'paths' => ['api/*', 'sanctum/csrf-cookie'],
++   'paths' => ['api/*', 'graphql', 'sanctum/csrf-cookie'],
     ...
 ];
 ```


### PR DESCRIPTION
Minor documentation update to match the default config value that you would see when opening the CORS config file.