### PR TITLE
Use the `@trim` directive on fields to sanitize all input strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Add custom attributes to validations https://github.com/nuwave/lighthouse/pull/1628
 - Add new directive interface `FieldBuilderDirective` https://github.com/nuwave/lighthouse/pull/1636
 - Add `@whereAuth` directive for filtering a field based on authenticated user https://github.com/nuwave/lighthouse/pull/1636
+- Use the `@trim` directive on fields to sanitize all input strings https://github.com/nuwave/lighthouse/pull/1641
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Use `DateTime::ATOM` for DateTimeTZ ISO 8601 compatibility https://github.com/nuwave/lighthouse/pull/1622
 - Split `ProvidesRules` interface into `ArgumentValidation` and `ArgumentSetValidation` https://github.com/nuwave/lighthouse/pull/1628
 - Update to PHP 8 compatible mll-lab/graphql-php-scalars 4 https://github.com/nuwave/lighthouse/pull/1639
+- Add `TrimDirective` to the default `field_middleware` config in `lighthouse.php` https://github.com/nuwave/lighthouse/pull/1641
 
 ### Removed
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2412,9 +2412,13 @@ type Query {
 
 ```graphql
 """
-Run the `trim` function on an input value.
+Remove whitespace from the beginning and end of a given input.
+
+This can be used on:
+- a single argument or input field to sanitize that subtree
+- a field to trim all strings
 """
-directive @trim on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @trim on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 ```
 
 Whitespace around the passed in string will be removed.
@@ -2423,6 +2427,24 @@ Whitespace around the passed in string will be removed.
 type Mutation {
   createUser(name: String @trim): User
 }
+```
+
+Usage on a field applies `trim` recursively to all inputs.
+
+```graphql
+type Mutation {
+  createUser(input: CreateUserInput): User @trim
+}
+```
+
+If you want this for all your fields, consider adding this directive to your
+global field middleware in `lighthouse.php`:
+
+```php
+    'field_middleware' => [
+        \Nuwave\Lighthouse\Schema\Directives\TrimDirective::class,
+        ...
+    ],
 ```
 
 ## @union

--- a/src/Schema/Directives/TrimDirective.php
+++ b/src/Schema/Directives/TrimDirective.php
@@ -2,18 +2,29 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives;
 
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\ArgDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgSanitizerDirective;
+use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+use Nuwave\Lighthouse\Support\Utils;
 
-class TrimDirective extends BaseDirective implements ArgSanitizerDirective, ArgDirective
+class TrimDirective extends BaseDirective implements ArgSanitizerDirective, ArgDirective, FieldMiddleware
 {
     public static function definition(): string
     {
         return /** @lang GraphQL */ <<<'GRAPHQL'
 """
-Run the `trim` function on an input value.
+Run the `trim` function on the input.
+
+This can be used on:
+- a single argument or input field to surgically trim a single string
+- a field to trim all strings within the given input
 """
-directive @trim on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @trim on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 GRAPHQL;
     }
 
@@ -25,5 +36,54 @@ GRAPHQL;
     public function sanitize($argumentValue): string
     {
         return trim($argumentValue);
+    }
+
+    public function handleField(FieldValue $fieldValue, Closure $next): FieldValue
+    {
+        $resolver = $fieldValue->getResolver();
+
+        return $next(
+            $fieldValue->setResolver(
+                function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($resolver) {
+                    $resolveInfo->argumentSet = $this->transformRecursively($resolveInfo->argumentSet);
+
+                    return $resolver(
+                        $root,
+                        $resolveInfo->argumentSet->toArray(),
+                        $context,
+                        $resolveInfo
+                    );
+                }
+            )
+        );
+    }
+
+    public function transformRecursively(ArgumentSet $argumentSet): ArgumentSet
+    {
+        foreach ($argumentSet->arguments as $argument) {
+            $argument->value = Utils::applyEach(
+                function ($value) {
+                    return $value instanceof ArgumentSet
+                        ? $this->transformRecursively($value)
+                        : $this->transform($value);
+                },
+                $argument->value
+            );
+        }
+
+        return $argumentSet;
+    }
+
+    /**
+     * @param  mixed  $value The client given value
+     * @return mixed The transformed value
+     */
+    protected function transform($value)
+    {
+        if (is_string($value)) {
+            return trim($value);
+        }
+
+        return $value;
     }
 }

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -227,6 +227,7 @@ return [
     */
 
     'field_middleware' => [
+        \Nuwave\Lighthouse\Schema\Directives\TrimDirective::class,
         \Nuwave\Lighthouse\Schema\Directives\SanitizeDirective::class,
         \Nuwave\Lighthouse\Validation\ValidateDirective::class,
         \Nuwave\Lighthouse\Schema\Directives\TransformArgsDirective::class,

--- a/tests/Integration/Schema/Directives/TrimDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/TrimDirectiveTest.php
@@ -82,6 +82,7 @@ class TrimDirectiveTest extends DBTestCase
         type Foo {
             foo: String!
             bar: [String!]!
+            baz: Int!
         }
 
         input FooInput {
@@ -99,9 +100,11 @@ class TrimDirectiveTest extends DBTestCase
             foo(input: {
                 foo: " foo "
                 bar: [" bar "]
+                baz: 3
             }) {
                 foo
                 bar
+                baz
             }
         }
         ')->assertJson([
@@ -109,6 +112,7 @@ class TrimDirectiveTest extends DBTestCase
                 'foo' => [
                     'foo' => 'foo',
                     'bar' => ['bar'],
+                    'baz' => 3,
                 ],
             ],
         ]);

--- a/tests/Integration/Schema/Directives/TrimDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/TrimDirectiveTest.php
@@ -6,7 +6,7 @@ use Tests\DBTestCase;
 
 class TrimDirectiveTest extends DBTestCase
 {
-    public function testTrimsArgument(): void
+    public function testTrimsStringArgument(): void
     {
         $this->schema .= /** @lang GraphQL */ '
         type Company {
@@ -22,6 +22,42 @@ class TrimDirectiveTest extends DBTestCase
         $this->graphQL(/** @lang GraphQL */ '
         mutation {
             createCompany(name: "    foo     ") {
+                id
+                name
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'createCompany' => [
+                    'id' => '1',
+                    'name' => 'foo',
+                ],
+            ],
+        ]);
+    }
+
+    public function testTrimsInputArgument(): void
+    {
+        $this->schema .= /** @lang GraphQL */ '
+        input CompanyInput {
+            name: String!
+        }
+
+        type Company {
+            id: ID!
+            name: String!
+        }
+
+        type Mutation {
+            createCompany(input: CompanyInput @trim @spread): Company @create
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            createCompany(input: {
+                name: "    foo     "
+            }) {
                 id
                 name
             }

--- a/tests/Integration/Schema/Directives/TrimDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/TrimDirectiveTest.php
@@ -88,6 +88,7 @@ class TrimDirectiveTest extends DBTestCase
         input FooInput {
             foo: String!
             bar: [String!]!
+            baz: Int!
         }
 
         type Mutation {


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

The `@trim` directive can now also be used upon fields.

**Breaking changes**

No.
