### PR TITLE
Allow auxiliary types in directive definitions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,7 +40,7 @@ jobs:
         uses: "shivammathur/setup-php@2.7.0"
         with:
           coverage: "none"
-          tools: pecl
+          tools: "pecl"
           extensions: "${{ env.REQUIRED_PHP_EXTENSIONS }}"
           php-version: "${{ matrix.php-version }}"
 
@@ -99,7 +99,7 @@ jobs:
         uses: "shivammathur/setup-php@2.7.0"
         with:
           coverage: "none"
-          tools: pecl
+          tools: "pecl"
           extensions: "${{ env.REQUIRED_PHP_EXTENSIONS }}"
           php-version: "${{ matrix.php-version }}"
 
@@ -147,13 +147,13 @@ jobs:
       - name: "Start Redis"
         uses: "supercharge/redis-github-action@1.1.0"
         with:
-          redis-version: 6
+          redis-version: "6"
 
       - name: "Install PHP with extensions"
         uses: "shivammathur/setup-php@2.7.0"
         with:
           coverage: "pcov"
-          tools: pecl
+          tools: "pecl"
           extensions: "${{ env.REQUIRED_PHP_EXTENSIONS }}"
           php-version: "${{ matrix.php-version }}"
 
@@ -207,7 +207,7 @@ jobs:
         uses: "shivammathur/setup-php@2.7.0"
         with:
           coverage: "none"
-          tools: pecl
+          tools: "pecl"
           extensions: "${{ env.REQUIRED_PHP_EXTENSIONS }}"
           php-version: "${{ matrix.php-version }}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Add new directive interface `FieldBuilderDirective` https://github.com/nuwave/lighthouse/pull/1636
 - Add `@whereAuth` directive for filtering a field based on authenticated user https://github.com/nuwave/lighthouse/pull/1636
 - Use the `@trim` directive on fields to sanitize all input strings https://github.com/nuwave/lighthouse/pull/1641
+- Allow auxiliary types in directive definitions https://github.com/nuwave/lighthouse/pull/1649
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Prefix complex conditions with table name to avoid ambiguous SQL https://github.com/nuwave/lighthouse/pull/1530
 - Merge type interfaces when extending type https://github.com/nuwave/lighthouse/pull/1635
 
+### Deprecated
+
+- Deprecate values for the `type` argument of `@paginate` that are not `PAGINATOR` or `CONNECTION`
+
 ## 4.18.0
 
 ### Added

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -200,7 +200,7 @@ type User {
 }
 ```
 
-When using the connection `type` argument, you may create your own
+When using the `type` argument with pagination style `CONNECTION`, you may create your own
 [Edge type](https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types) which
 may have fields that resolve from the model [pivot](https://laravel.com/docs/eloquent-relationships#many-to-many)
 data. You may also add a custom field resolver for fields you want to resolve yourself.
@@ -210,7 +210,7 @@ look for a {type}Edge type to be defined. In this case it would be `RoleEdge`.
 
 ```graphql
 type User {
-  roles: [Role!]! @belongsToMany(type: "connection", edgeType: "CustomRoleEdge")
+  roles: [Role!]! @belongsToMany(type: CONNECTION, edgeType: "CustomRoleEdge")
 }
 
 type CustomRoleEdge implements Edge {
@@ -228,7 +228,7 @@ Broadcast the results of a mutation to subscribed clients.
 """
 directive @broadcast(
   """
-  Name of the subscription that should be retriggered as a result of this operation..
+  Name of the subscription that should be retriggered as a result of this operation.
   """
   subscription: String!
 
@@ -1085,8 +1085,8 @@ You can return the related models paginated by setting the `type`.
 
 ```graphql
 type User {
-  postsPaginated: [Post!]! @hasMany(type: "paginator")
-  postsRelayConnection: [Post!]! @hasMany(type: "connection")
+  postsPaginated: [Post!]! @hasMany(type: PAGINATOR)
+  postsRelayConnection: [Post!]! @hasMany(type: CONNECTION)
 }
 ```
 
@@ -1901,15 +1901,15 @@ And can be queried like this:
 
 ### Pagination type
 
-The `type` of pagination defaults to `paginator`, but may also be set to a Relay
-compliant `connection`.
+The `type` of pagination defaults to `PAGINATOR`, but may also be set to a Relay
+compliant `CONNECTION`.
 
 > Lighthouse does not support actual cursor-based pagination as of now, see https://github.com/nuwave/lighthouse/issues/311 for details.
 > Under the hood, the "cursor" is decoded into a page offset.
 
 ```graphql
 type Query {
-  posts: [Post!]! @paginate(type: "connection")
+  posts: [Post!]! @paginate(type: CONNECTION)
 }
 ```
 
@@ -1941,15 +1941,15 @@ type PostEdge {
 
 ### Default count
 
-You can supply a `defaultCount` to set a default count for any kind of paginator.
+You can supply a `defaultCount` to set a default count for any type of pagination.
 
 ```graphql
 type Query {
-  posts: [Post!]! @paginate(type: "connection", defaultCount: 25)
+  posts: [Post!]! @paginate(type: CONNECTION, defaultCount: 25)
 }
 ```
 
-This let's you omit the `count` argument when querying:
+This lets you omit the `count` argument when querying:
 
 ```graphql
 query {

--- a/docs/master/digging-deeper/relay.md
+++ b/docs/master/digging-deeper/relay.md
@@ -4,14 +4,14 @@
 
 Relay requires a particular kind of pagination which is the [Cursor Connection](https://facebook.github.io/relay/graphql/connections.htm)
 To get a relay-compatible connection on a root query field, use the [@paginate](../api-reference/directives.md#paginate)
-directive with the pagination type `connection`.
+directive with the pagination type `CONNECTION`.
 
 > Lighthouse does not support actual cursor-based pagination as of now, see https://github.com/nuwave/lighthouse/issues/311 for details.
 > Under the hood, the "cursor" is decoded into a page offset.
 
 ```graphql
 type Query {
-  users: [User!]! @paginate(type: "connection")
+  users: [User!]! @paginate(type: CONNECTION)
 }
 ```
 
@@ -24,7 +24,7 @@ in Eloquent. Use the [@hasMany](../api-reference/directives.md#hasmany) directiv
 ```graphql
 type User {
   name: String
-  posts: [Post!]! @hasMany(type: "connection")
+  posts: [Post!]! @hasMany(type: CONNECTION)
 }
 ```
 

--- a/src/Console/IdeHelperCommand.php
+++ b/src/Console/IdeHelperCommand.php
@@ -2,15 +2,11 @@
 
 namespace Nuwave\Lighthouse\Console;
 
-use GraphQL\Error\SyntaxError;
-use GraphQL\Language\AST\DirectiveDefinitionNode;
-use GraphQL\Language\Parser;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Utils\SchemaPrinter;
 use HaydenPierce\ClassFinder\ClassFinder;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Schema\DirectiveLocator;
 use Nuwave\Lighthouse\Schema\TypeRegistry;

--- a/src/Console/IdeHelperCommand.php
+++ b/src/Console/IdeHelperCommand.php
@@ -115,11 +115,11 @@ GRAPHQL;
     }
 
     /**
+     * @param  class-string<\Nuwave\Lighthouse\Support\Contracts\Directive> $directiveClass
      * @throws \Nuwave\Lighthouse\Exceptions\DefinitionException
      */
     protected function define(string $directiveClass): string
     {
-        /** @var \Nuwave\Lighthouse\Support\Contracts\Directive $directiveClass */
         $definitionString = $directiveClass::definition();
 
         try {

--- a/src/GlobalId/GlobalIdDirective.php
+++ b/src/GlobalId/GlobalIdDirective.php
@@ -28,17 +28,37 @@ class GlobalIdDirective extends BaseDirective implements FieldMiddleware, ArgSan
         return /** @lang GraphQL */ <<<'GRAPHQL'
 """
 Converts between IDs/types and global IDs.
-When used upon a field, it encodes,
+
+When used upon a field, it encodes;
 when used upon an argument, it decodes.
 """
 directive @globalId(
   """
-  By default, an array of `[$type, $id]` is returned when decoding.
-  You may limit this to returning just one of both.
-  Allowed values: ARRAY, TYPE, ID
+  Decoding a global id produces a tuple of `$type` and `$id`.
+  This setting controls which of those is passed along.
   """
-  decode: String = ARRAY
+  decode: GlobalIdDecode = ARRAY
 ) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION
+
+"""
+Options for the `decode` argument of `@globalId`.
+"""
+enum GlobalIdDecode {
+    """
+    Return an array of `[$type, $id]`.
+    """
+    ARRAY
+
+    """
+    Return just `$type`.
+    """
+    TYPE
+
+    """
+    Return just `$id`.
+    """
+    ID
+}
 GRAPHQL;
     }
 

--- a/src/Pagination/PaginateDirective.php
+++ b/src/Pagination/PaginateDirective.php
@@ -23,10 +23,9 @@ Query multiple model entries as a paginated list.
 """
 directive @paginate(
   """
-  Which pagination style to use.
-  Allowed values: `paginator`, `connection`.
+  Which pagination style should be used.
   """
-  type: String = "paginator"
+  type: PaginateType = PAGINATOR
 
   """
   Specify the class name of the model to use.
@@ -57,6 +56,21 @@ directive @paginate(
   """
   maxCount: Int
 ) on FIELD_DEFINITION
+
+"""
+Options for the `type` argument of `@paginate`.
+"""
+enum PaginateType {
+    """
+    Offset-based pagination, similar to the Laravel default.
+    """
+    PAGINATOR
+
+    """
+    Cursor-based pagination, compatible with the Relay specification.
+    """
+    CONNECTION
+}
 GRAPHQL;
     }
 
@@ -78,8 +92,7 @@ GRAPHQL;
                 $this->paginationType(),
                 $fieldDefinition,
                 $parentType,
-                $this->directiveArgValue('defaultCount')
-                    ?? config('lighthouse.pagination.default_count'),
+                $this->defaultCount(),
                 $this->paginateMaxCount()
             );
     }
@@ -113,13 +126,16 @@ GRAPHQL;
     protected function paginationType(): PaginationType
     {
         return new PaginationType(
-            $this->directiveArgValue('type', PaginationType::TYPE_PAGINATOR)
+            $this->directiveArgValue('type', PaginationType::PAGINATOR)
         );
     }
 
-    /**
-     * Get either the specific max or the global setting.
-     */
+    protected function defaultCount(): ?int
+    {
+        return $this->directiveArgValue('defaultCount')
+            ?? config('lighthouse.pagination.default_count');
+    }
+
     protected function paginateMaxCount(): ?int
     {
         return $this->directiveArgValue('maxCount')

--- a/src/Pagination/PaginationType.php
+++ b/src/Pagination/PaginationType.php
@@ -9,11 +9,11 @@ use Nuwave\Lighthouse\Exceptions\DefinitionException;
  */
 class PaginationType
 {
-    public const TYPE_PAGINATOR = 'paginator';
-    public const PAGINATION_TYPE_CONNECTION = 'connection';
+    public const PAGINATOR = 'PAGINATOR';
+    public const CONNECTION = 'CONNECTION';
 
     /**
-     * @var string PAGINATION_TYPE_PAGINATOR|PAGINATION_TYPE_CONNECTION
+     * @var string One of the constant values in this class
      */
     protected $type;
 
@@ -22,14 +22,15 @@ class PaginationType
      */
     public function __construct(string $paginationType)
     {
-        switch ($paginationType) {
+        // TODO remove lowercase and alternate options in v6
+        switch (strtolower($paginationType)) {
             case 'default':
             case 'paginator':
-                $this->type = self::TYPE_PAGINATOR;
+                $this->type = self::PAGINATOR;
                 break;
             case 'connection':
             case 'relay':
-                $this->type = self::PAGINATION_TYPE_CONNECTION;
+                $this->type = self::CONNECTION;
                 break;
             default:
                 throw new DefinitionException(
@@ -40,11 +41,11 @@ class PaginationType
 
     public function isPaginator(): bool
     {
-        return $this->type === self::TYPE_PAGINATOR;
+        return $this->type === self::PAGINATOR;
     }
 
     public function isConnection(): bool
     {
-        return $this->type === self::PAGINATION_TYPE_CONNECTION;
+        return $this->type === self::CONNECTION;
     }
 }

--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -297,7 +297,7 @@ class ASTHelper
         /** @var \Nuwave\Lighthouse\Schema\DirectiveLocator $directiveLocator */
         $directiveLocator = app(DirectiveLocator::class);
         $directive = $directiveLocator->resolve($name);
-        $directiveDefinition = Parser::directiveDefinition($directive::definition());
+        $directiveDefinition = self::extractDirectiveDefinition($directive::definition());
 
         /** @var iterable<\GraphQL\Language\AST\FieldDefinitionNode> $fieldDefinitions */
         $fieldDefinitions = $objectType->fields;

--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -352,8 +352,6 @@ class ASTHelper
     }
 
     /**
-     * @param class-string<\Nuwave\Lighthouse\Support\Contracts\Directive> $definitionString
-     *
      * @throws \Nuwave\Lighthouse\Exceptions\DefinitionException
      */
     public static function extractDirectiveDefinition(string $definitionString): DirectiveDefinitionNode
@@ -362,7 +360,7 @@ class ASTHelper
             $document = Parser::parse($definitionString);
         } catch (SyntaxError $error) {
             throw new DefinitionException(
-                "Encountered syntax error while parsing the definition of {$definitionString}.",
+                "Encountered syntax error while parsing this directive definition::\n\n{$definitionString}",
                 $error->getCode(),
                 $error
             );
@@ -374,7 +372,7 @@ class ASTHelper
             if ($definitionNode instanceof DirectiveDefinitionNode) {
                 if ($directive !== null) {
                     throw new DefinitionException(
-                        "Found more than one directives while parsing the definition of {$definitionString}."
+                        "Found multiple directives while trying to extract a single directive from this definition:\n\n{$definitionString}"
                     );
                 }
 

--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -380,6 +380,12 @@ class ASTHelper
             }
         }
 
+        if ($directive === null) {
+            throw new DefinitionException(
+                "Found no directive while trying to extract a single directive from this definition:\n\n{$definitionString}"
+            );
+        }
+
         return $directive;
     }
 }

--- a/src/Schema/DirectiveLocator.php
+++ b/src/Schema/DirectiveLocator.php
@@ -128,7 +128,7 @@ class DirectiveLocator
         $definitions = [];
 
         foreach ($this->classes() as $directiveClass) {
-            $definitions [] = Parser::directiveDefinition($directiveClass::definition());
+            $definitions [] = ASTHelper::extractDirectiveDefinition($directiveClass::definition());
         }
 
         return $definitions;

--- a/src/Schema/DirectiveLocator.php
+++ b/src/Schema/DirectiveLocator.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;
+use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\Directive;
 use Nuwave\Lighthouse\Support\Utils;
@@ -126,7 +127,6 @@ class DirectiveLocator
     {
         $definitions = [];
 
-        /** @var \Nuwave\Lighthouse\Support\Contracts\Directive $directiveClass */
         foreach ($this->classes() as $directiveClass) {
             $definitions [] = Parser::directiveDefinition($directiveClass::definition());
         }
@@ -245,6 +245,8 @@ class DirectiveLocator
      * Use this for directives types that can only occur once, such as field resolvers.
      * This throws if more than one such directive is found.
      *
+     * @param  class-string<\Nuwave\Lighthouse\Support\Contracts\Directive> $directiveClass
+     *
      * @throws \Nuwave\Lighthouse\Exceptions\DirectiveException
      */
     public function exclusiveOfType(Node $node, string $directiveClass): ?Directive
@@ -254,7 +256,7 @@ class DirectiveLocator
         if ($directives->count() > 1) {
             $directiveNames = $directives
                 ->map(function (Directive $directive): string {
-                    $definition = Parser::directiveDefinition(
+                    $definition = ASTHelper::extractDirectiveDefinition(
                         $directive::definition()
                     );
 

--- a/src/Schema/DirectiveLocator.php
+++ b/src/Schema/DirectiveLocator.php
@@ -4,7 +4,6 @@ namespace Nuwave\Lighthouse\Schema;
 
 use GraphQL\Language\AST\DirectiveNode;
 use GraphQL\Language\AST\Node;
-use GraphQL\Language\Parser;
 use HaydenPierce\ClassFinder\ClassFinder;
 use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\Collection;

--- a/src/Schema/Directives/BelongsToManyDirective.php
+++ b/src/Schema/Directives/BelongsToManyDirective.php
@@ -26,9 +26,8 @@ directive @belongsToMany(
 
   """
   Allows to resolve the relation as a paginated list.
-  Allowed values: `paginator`, `connection`.
   """
-  type: String
+  type: BelongsToManyType
 
   """
   Allow clients to query paginated lists without specifying the amount of items.
@@ -49,6 +48,21 @@ directive @belongsToMany(
   """
   edgeType: String
 ) on FIELD_DEFINITION
+
+"""
+Options for the `type` argument of `@belongsToMany`.
+"""
+enum PaginateType {
+    """
+    Offset-based pagination, similar to the Laravel default.
+    """
+    PAGINATOR
+
+    """
+    Cursor-based pagination, compatible with the Relay specification.
+    """
+    CONNECTION
+}
 GRAPHQL;
     }
 }

--- a/src/Schema/Directives/BroadcastDirective.php
+++ b/src/Schema/Directives/BroadcastDirective.php
@@ -18,7 +18,7 @@ Broadcast the results of a mutation to subscribed clients.
 """
 directive @broadcast(
   """
-  Name of the subscription that should be retriggered as a result of this operation..
+  Name of the subscription that should be retriggered as a result of this operation.
   """
   subscription: String!
 

--- a/src/Schema/Directives/HasManyDirective.php
+++ b/src/Schema/Directives/HasManyDirective.php
@@ -28,7 +28,7 @@ directive @hasMany(
   Allows to resolve the relation as a paginated list.
   Allowed values: `paginator`, `connection`.
   """
-  type: String
+  type: HasManyType
 
   """
   Allow clients to query paginated lists without specifying the amount of items.
@@ -49,6 +49,21 @@ directive @hasMany(
   """
   edgeType: String
 ) on FIELD_DEFINITION
+
+"""
+Options for the `type` argument of `@hasMany`.
+"""
+enum HasManyType {
+    """
+    Offset-based pagination, similar to the Laravel default.
+    """
+    PAGINATOR
+
+    """
+    Cursor-based pagination, compatible with the Relay specification.
+    """
+    CONNECTION
+}
 GRAPHQL;
     }
 }

--- a/src/Schema/Directives/MorphManyDirective.php
+++ b/src/Schema/Directives/MorphManyDirective.php
@@ -26,9 +26,8 @@ directive @morphMany(
 
   """
   Allows to resolve the relation as a paginated list.
-  Allowed values: `paginator`, `connection`.
   """
-  type: String
+  type: MorphManyType
 
   """
   Allow clients to query paginated lists without specifying the amount of items.
@@ -49,6 +48,21 @@ directive @morphMany(
   """
   edgeType: String
 ) on FIELD_DEFINITION
+
+"""
+Options for the `type` argument of `@morphMany`.
+"""
+enum MorphManyType {
+    """
+    Offset-based pagination, similar to the Laravel default.
+    """
+    PAGINATOR
+
+    """
+    Cursor-based pagination, compatible with the Relay specification.
+    """
+    CONNECTION
+}
 GRAPHQL;
     }
 }

--- a/src/Schema/Directives/ScopeDirective.php
+++ b/src/Schema/Directives/ScopeDirective.php
@@ -20,7 +20,7 @@ directive @scope(
   """
   The name of the scope.
   """
-  name: String
+  name: String!
 ) repeatable on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 GRAPHQL;
     }

--- a/src/Support/Contracts/Directive.php
+++ b/src/Support/Contracts/Directive.php
@@ -6,6 +6,11 @@ interface Directive
 {
     /**
      * Formal directive specification in schema definition language (SDL).
+     *
+     * @see http://spec.graphql.org/draft/#sec-Type-System.Directives
+     *
+     * This must contain a single directive definition, but can also contain
+     * auxiliary types, such as enum definitions for directive arguments.
      */
     public static function definition(): string;
 }

--- a/tests/Integration/Events/FieldDirective.php
+++ b/tests/Integration/Events/FieldDirective.php
@@ -9,10 +9,10 @@ class FieldDirective extends BaseDirective
     public static function definition(): string
     {
         return /** @lang GraphQL */ <<<'GRAPHQL'
-    """
-    An alternate @field.
-    """
-    directive @field on FIELD_DEFINITION
+"""
+An alternate @field.
+"""
+directive @field on FIELD_DEFINITION
 GRAPHQL;
     }
 }

--- a/tests/Integration/Pagination/PaginateDirectiveDBTest.php
+++ b/tests/Integration/Pagination/PaginateDirectiveDBTest.php
@@ -246,7 +246,7 @@ class PaginateDirectiveDBTest extends DBTestCase
         }
 
         type Query {
-            users: [User!]! @paginate(type: "relay")
+            users: [User!]! @paginate(type: CONNECTION)
         }
         ';
 
@@ -284,7 +284,7 @@ class PaginateDirectiveDBTest extends DBTestCase
         }
 
         type Query {
-            users: [User!]! @paginate(type: "relay")
+            users: [User!]! @paginate(type: CONNECTION)
         }
         ';
 

--- a/tests/Integration/Schema/Directives/BelongsToManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/BelongsToManyDirectiveTest.php
@@ -107,7 +107,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
     {
         $this->schema = /** @lang GraphQL */ '
         type User {
-            roles: [Role!]! @belongsToMany(type: PAGINATION)
+            roles: [Role!]! @belongsToMany(type: PAGINATOR)
         }
 
         type Role {

--- a/tests/Integration/Schema/Directives/BelongsToManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/BelongsToManyDirectiveTest.php
@@ -107,7 +107,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
     {
         $this->schema = /** @lang GraphQL */ '
         type User {
-            roles: [Role!]! @belongsToMany(type: "paginator")
+            roles: [Role!]! @belongsToMany(type: PAGINATION)
         }
 
         type Role {
@@ -154,7 +154,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
     {
         $this->schema = /** @lang GraphQL */ '
         type User {
-            roles: [Role!]! @belongsToMany(type: "relay")
+            roles: [Role!]! @belongsToMany(type: CONNECTION)
         }
 
         type Role {
@@ -199,7 +199,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
     {
         $this->schema = /** @lang GraphQL */ '
         type User {
-            roles: [Role!]! @belongsToMany(type: "relay", edgeType: "CustomRoleEdge")
+            roles: [Role!]! @belongsToMany(type: CONNECTION, edgeType: "CustomRoleEdge")
         }
 
         type Role {
@@ -250,7 +250,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
     {
         $this->schema = /** @lang GraphQL */ '
         type User {
-            roles: [Role!]! @belongsToMany(type: "relay", edgeType: "CustomRoleEdge")
+            roles: [Role!]! @belongsToMany(type: CONNECTION, edgeType: "CustomRoleEdge")
         }
 
         type Role {
@@ -285,7 +285,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
     {
         $this->schema = /** @lang GraphQL */ '
         type User {
-            roles: [Role!]! @belongsToMany(type: "relay")
+            roles: [Role!]! @belongsToMany(type: CONNECTION)
         }
 
         type Role {
@@ -340,7 +340,7 @@ class BelongsToManyDirectiveTest extends DBTestCase
         $this->schema = /** @lang GraphQL */ '
         type User {
             id: Int!
-            roles: [Role!]! @belongsToMany(type: "relay")
+            roles: [Role!]! @belongsToMany(type: CONNECTION)
         }
 
         type ACL {

--- a/tests/Integration/Schema/Directives/CacheDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/CacheDirectiveTest.php
@@ -220,7 +220,7 @@ class CacheDirectiveTest extends DBTestCase
         }
 
         type Query {
-            users: [User] @paginate(type: "paginator", model: "User") @cache
+            users: [User] @paginate(type: PAGINATOR, model: "User") @cache
         }
         ';
 
@@ -258,7 +258,7 @@ class CacheDirectiveTest extends DBTestCase
         type User {
             id: ID!
             name: String!
-            posts: [Post] @hasMany(type: "paginator") @cache
+            posts: [Post] @hasMany(type: PAGINATOR) @cache
         }
 
         type Query {
@@ -322,7 +322,7 @@ class CacheDirectiveTest extends DBTestCase
         type User {
             id: ID!
             name: String!
-            posts: [Post] @hasMany(type: "paginator") @cache
+            posts: [Post] @hasMany(type: PAGINATOR) @cache
         }
 
         type Query {

--- a/tests/Integration/Schema/Directives/HasManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/HasManyDirectiveTest.php
@@ -151,8 +151,8 @@ class HasManyDirectiveTest extends DBTestCase
     {
         $this->schema = /** @lang GraphQL */ '
         type User {
-            tasks: [Task!]! @hasMany(type: "paginator")
-            posts: [Post!]! @hasMany(type: "paginator")
+            tasks: [Task!]! @hasMany(type: PAGINATOR)
+            posts: [Post!]! @hasMany(type: PAGINATOR)
         }
 
         type Task {
@@ -202,7 +202,7 @@ class HasManyDirectiveTest extends DBTestCase
     {
         $this->schema = /** @lang GraphQL */ '
         type User {
-            tasks: [NotTheModelNameTask!]! @hasMany(type: "paginator")
+            tasks: [NotTheModelNameTask!]! @hasMany(type: PAGINATOR)
         }
 
         type NotTheModelNameTask {
@@ -250,7 +250,7 @@ class HasManyDirectiveTest extends DBTestCase
 
         $this->schema = /** @lang GraphQL */ '
         type User {
-            tasks: [Task!]! @hasMany(type: "paginator", maxCount: 3)
+            tasks: [Task!]! @hasMany(type: PAGINATOR, maxCount: 3)
         }
 
         type Task {
@@ -285,7 +285,7 @@ class HasManyDirectiveTest extends DBTestCase
         $this->schema = /** @lang GraphQL */ '
         type User {
             id: ID
-            tasks: [Task!] @hasMany(type: "paginator")
+            tasks: [Task!] @hasMany(type: PAGINATOR)
         }
 
         type Task {
@@ -324,7 +324,7 @@ class HasManyDirectiveTest extends DBTestCase
 
         $this->schema = /** @lang GraphQL */ '
         type User {
-            tasks: [Task!]! @hasMany(type: "relay", maxCount: 3)
+            tasks: [Task!]! @hasMany(type: PAGINATOR, maxCount: 3)
         }
 
         type Task {
@@ -362,7 +362,7 @@ class HasManyDirectiveTest extends DBTestCase
 
         $this->schema = /** @lang GraphQL */ '
         type User {
-            tasks: [Task!]! @hasMany(type: "paginator")
+            tasks: [Task!]! @hasMany(type: PAGINATOR)
         }
 
         type Task {
@@ -398,7 +398,7 @@ class HasManyDirectiveTest extends DBTestCase
 
         $this->schema = /** @lang GraphQL */ '
         type User {
-            tasks: [Task!]! @hasMany(type: "relay")
+            tasks: [Task!]! @hasMany(type: CONNECTION)
         }
 
         type Task {
@@ -435,7 +435,7 @@ class HasManyDirectiveTest extends DBTestCase
         $this->schema = /** @lang GraphQL */ '
         type User {
             tasks: [Task!]! @hasMany (
-                type: "relay"
+                type: CONNECTION
                 edgeType: "TaskEdge"
             )
         }
@@ -481,7 +481,7 @@ class HasManyDirectiveTest extends DBTestCase
     {
         $this->schema = /** @lang GraphQL */ '
         type User {
-            tasks: [Task!]! @hasMany(type: "paginator", defaultCount: 2)
+            tasks: [Task!]! @hasMany(type: PAGINATOR, defaultCount: 2)
         }
 
         type Task {
@@ -527,7 +527,7 @@ class HasManyDirectiveTest extends DBTestCase
     {
         $this->schema = /** @lang GraphQL */ '
         type User {
-            tasks: [Task!]! @hasMany(type: "relay")
+            tasks: [Task!]! @hasMany(type: CONNECTION)
         }
 
         type Task {
@@ -571,7 +571,7 @@ class HasManyDirectiveTest extends DBTestCase
     {
         $this->schema = /** @lang GraphQL */ '
         type User {
-            tasks: [Task!]! @hasMany(type: "relay", defaultCount: 2)
+            tasks: [Task!]! @hasMany(type: CONNECTION, defaultCount: 2)
         }
 
         type Task {
@@ -615,7 +615,7 @@ class HasManyDirectiveTest extends DBTestCase
     {
         $this->schema = /** @lang GraphQL */ '
         type User {
-            tasks: [Task!]! @hasMany(type: "relay")
+            tasks: [Task!]! @hasMany(type: CONNECTION)
         }
 
         type Task {
@@ -760,7 +760,7 @@ class HasManyDirectiveTest extends DBTestCase
         $this->schema = /** @lang GraphQL */ '
         type User {
             id: Int!
-            tasks: [Task!]! @hasMany(type: "paginator")
+            tasks: [Task!]! @hasMany(type: PAGINATOR)
         }
 
         type Task {
@@ -795,7 +795,7 @@ class HasManyDirectiveTest extends DBTestCase
 
         type User {
             id: Int!
-            tasks: [Task!]! @hasMany(type: "paginator")
+            tasks: [Task!]! @hasMany(type: PAGINATOR)
         }
 
         type Task {

--- a/tests/Integration/Schema/Directives/HasManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/HasManyDirectiveTest.php
@@ -324,7 +324,7 @@ class HasManyDirectiveTest extends DBTestCase
 
         $this->schema = /** @lang GraphQL */ '
         type User {
-            tasks: [Task!]! @hasMany(type: PAGINATOR, maxCount: 3)
+            tasks: [Task!]! @hasMany(type: CONNECTION, maxCount: 3)
         }
 
         type Task {

--- a/tests/Integration/Schema/Directives/MorphManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/MorphManyDirectiveTest.php
@@ -161,7 +161,7 @@ class MorphManyDirectiveTest extends DBTestCase
         type Post {
             id: ID!
             title: String!
-            images: [Image!] @morphMany(type: "paginator")
+            images: [Image!] @morphMany(type: PAGINATOR)
         }
 
         type Image {
@@ -214,7 +214,7 @@ class MorphManyDirectiveTest extends DBTestCase
         type Post {
             id: ID!
             title: String!
-            images: [Image!] @morphMany(type: "paginator", maxCount: 3)
+            images: [Image!] @morphMany(type: PAGINATOR, maxCount: 3)
         }
 
         type Image {
@@ -256,7 +256,7 @@ class MorphManyDirectiveTest extends DBTestCase
         type Post {
             id: ID!
             title: String!
-            images: [Image!] @morphMany(type: "paginator")
+            images: [Image!] @morphMany(type: PAGINATOR)
         }
 
         type Image {
@@ -296,7 +296,7 @@ class MorphManyDirectiveTest extends DBTestCase
         type Post {
             id: ID!
             title: String!
-            images: [Image!] @morphMany(type: "paginator")
+            images: [Image!] @morphMany(type: PAGINATOR)
         }
 
         type Image {
@@ -339,7 +339,7 @@ class MorphManyDirectiveTest extends DBTestCase
         type Task {
             id: ID!
             name: String!
-            images: [Image!] @morphMany(type: "paginator", defaultCount: 3)
+            images: [Image!] @morphMany(type: PAGINATOR, defaultCount: 3)
         }
 
         type Image {
@@ -393,7 +393,7 @@ class MorphManyDirectiveTest extends DBTestCase
         type Task {
             id: ID!
             name: String!
-            images: [Image!] @morphMany(type: "relay")
+            images: [Image!] @morphMany(type: CONNECTION)
         }
 
         type Image {
@@ -447,7 +447,7 @@ class MorphManyDirectiveTest extends DBTestCase
         type Task {
             id: ID!
             name: String!
-            images: [Image!] @morphMany(type: "relay", maxCount: 3)
+            images: [Image!] @morphMany(type: CONNECTION, maxCount: 3)
         }
 
         type Image {
@@ -491,7 +491,7 @@ class MorphManyDirectiveTest extends DBTestCase
         type Task {
             id: ID!
             name: String!
-            images: [Image!] @morphMany(type: "relay")
+            images: [Image!] @morphMany(type: CONNECTION)
         }
 
         type Image {
@@ -533,7 +533,7 @@ class MorphManyDirectiveTest extends DBTestCase
         type Task {
             id: ID!
             name: String!
-            images: [Image!] @morphMany(type: "relay", defaultCount: 3)
+            images: [Image!] @morphMany(type: CONNECTION, defaultCount: 3)
         }
 
         type Image {

--- a/tests/Integration/Schema/Directives/SearchDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/SearchDirectiveTest.php
@@ -67,7 +67,7 @@ class SearchDirectiveTest extends DBTestCase
         type Query {
             posts(
                 search: String @search
-            ): [Post!]! @paginate(type: "paginator")
+            ): [Post!]! @paginate
         }
         ';
 
@@ -203,7 +203,7 @@ class SearchDirectiveTest extends DBTestCase
         type Query {
             posts(
                 search: String @search
-            ): [Post!]! @paginate(type: "paginator")
+            ): [Post!]! @paginate
         }
         ';
 

--- a/tests/Integration/Schema/Types/UnionTest.php
+++ b/tests/Integration/Schema/Types/UnionTest.php
@@ -70,11 +70,11 @@ class UnionTest extends DBTestCase
             : '';
 
         $customResolver = $withCustomTypeResolver
-            ? '@union(resolveType: "Tests\\\\Utils\\\\Unions\\\\CustomStuff@resolveType")'
+            ? /** @lang GraphQL */ '@union(resolveType: "Tests\\\\Utils\\\\Unions\\\\CustomStuff@resolveType")'
             : '';
 
         return [
-            "
+            /** @lang GraphQL */ "
             union Stuff {$customResolver} = {$prefix}User | {$prefix}Post
 
             type {$prefix}User {
@@ -89,7 +89,7 @@ class UnionTest extends DBTestCase
                 stuff: [Stuff!]! @field(resolver: \"{$this->qualifyTestResolver()}\")
             }
             ",
-            "
+            /** @lang GraphQL */ "
             {
                 stuff {
                     ... on {$prefix}User {

--- a/tests/Unit/Pagination/PaginateDirectiveTest.php
+++ b/tests/Unit/Pagination/PaginateDirectiveTest.php
@@ -6,13 +6,14 @@ use GraphQL\Type\Definition\FieldArgument;
 use GraphQL\Type\Definition\FieldDefinition;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Pagination\PaginationArgs;
+use Nuwave\Lighthouse\Pagination\PaginationType;
 use Tests\TestCase;
 
 class PaginateDirectiveTest extends TestCase
 {
     public function testCanAliasRelayToConnection(): void
     {
-        $connection = $this->getConnectionQueryField('connection');
+        $connection = $this->getConnectionQueryField(PaginationType::CONNECTION);
         $relay = $this->getConnectionQueryField('relay');
 
         $this->assertSame($connection, $relay);
@@ -26,7 +27,7 @@ class PaginateDirectiveTest extends TestCase
         }
 
         type Query {
-            users: [User!]! @paginate(type: \"$type\")
+            users: [User!]! @paginate(type: {$type})
         }
         ");
 
@@ -42,14 +43,14 @@ class PaginateDirectiveTest extends TestCase
         type User {
             name: String
             users: [User!]! @paginate
-            users2: [User!]! @paginate(type: "relay")
-            users3: [User!]! @paginate(type: "connection")
+            users2: [User!]! @paginate(type: CONNECTION)
+            users3: [User!]! @paginate(type: "relay")
         }
 
         type Query {
             users: [User!]! @paginate
-            users2: [User!]! @paginate(type: "relay")
-            users3: [User!]! @paginate(type: "connection")
+            users2: [User!]! @paginate(type: CONNECTION)
+            users3: [User!]! @paginate(type: "relay")
         }
         ');
         $typeMap = $schema->getTypeMap();
@@ -100,9 +101,9 @@ class PaginateDirectiveTest extends TestCase
             ->buildSchema(/** @lang GraphQL */ '
             type Query {
                 defaultPaginated: [User!]! @paginate
-                defaultRelay: [User!]! @paginate(type: "relay")
+                defaultRelay: [User!]! @paginate(type: CONNECTION)
                 customPaginated:  [User!]! @paginate(maxCount: 10)
-                customRelay:  [User!]! @paginate(maxCount: 10, type: "relay")
+                customRelay:  [User!]! @paginate(maxCount: 10, type: CONNECTION)
             }
 
             type User {
@@ -202,7 +203,7 @@ class PaginateDirectiveTest extends TestCase
 
         type Query {
             users1: [User!]! @paginate
-            users2: [User!]! @paginate(type: "relay")
+            users2: [User!]! @paginate(type: CONNECTION)
         }
         ';
 

--- a/tests/Unit/Schema/AST/ASTHelperTest.php
+++ b/tests/Unit/Schema/AST/ASTHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Schema\AST;
 
+use GraphQL\Language\AST\DirectiveDefinitionNode;
 use GraphQL\Language\Parser;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
@@ -170,6 +171,57 @@ class ASTHelperTest extends TestCase
         $this->assertSame(
             'guard',
             $object->fields[1]->directives[0]->name->value
+        );
+    }
+
+    public function testExtractDirectiveDefinition(): void
+    {
+        $this->assertInstanceOf(
+            DirectiveDefinitionNode::class,
+            ASTHelper::extractDirectiveDefinition(/** @lang GraphQL */ 'directive @foo on OBJECT')
+        );
+    }
+
+    public function testExtractDirectiveDefinitionAllowsAuxiliaryTypes(): void
+    {
+        $this->assertInstanceOf(
+            DirectiveDefinitionNode::class,
+            ASTHelper::extractDirectiveDefinition(/** @lang GraphQL */ <<<'GRAPHQL'
+directive @foo on OBJECT
+scalar Bar
+GRAPHQL
+)
+        );
+    }
+
+    public function testThrowsOnSyntaxError(): void
+    {
+        $this->expectException(DefinitionException::class);
+
+        ASTHelper::extractDirectiveDefinition(/** @lang GraphQL */ <<<'GRAPHQL'
+invalid GraphQL
+GRAPHQL
+        );
+    }
+
+    public function testThrowsIfMissingDirectiveDefinitions(): void
+    {
+        $this->expectException(DefinitionException::class);
+
+        ASTHelper::extractDirectiveDefinition(/** @lang GraphQL */ <<<'GRAPHQL'
+scalar Foo
+GRAPHQL
+        );
+    }
+
+    public function testThrowsOnMultipleDirectiveDefinitions(): void
+    {
+        $this->expectException(DefinitionException::class);
+
+        ASTHelper::extractDirectiveDefinition(/** @lang GraphQL */ <<<'GRAPHQL'
+directive @foo on OBJECT
+directive @bar on OBJECT
+GRAPHQL
         );
     }
 }

--- a/tests/Unit/Schema/Factories/DirectiveFactoryTest.php
+++ b/tests/Unit/Schema/Factories/DirectiveFactoryTest.php
@@ -65,7 +65,7 @@ class DirectiveFactoryTest extends TestCase
         $directive = new class implements FieldMiddleware {
             public static function definition(): string
             {
-                return 'foo';
+                return /** @lang GraphQL */ 'foo';
             }
 
             public function handleField(FieldValue $fieldValue, Closure $next): FieldValue


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

https://github.com/nuwave/lighthouse/issues/1644#issuecomment-750307571

**Changes**

It is now possible to include auxiliary types, such as `enum` definitions, to directive definitions return from `Directive::definition()`.

**Breaking changes**

No
