### PR TITLE
Update code samples in the tutorial to the latest Laravel version

### DIFF
--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -162,7 +162,7 @@ Replace the newly generated `app/Post.php` and the `create_posts_table.php` with
 ```php
 <?php
 
-namespace App;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -216,7 +216,7 @@ Let's do the same for the Comment model:
 ```php
 <?php
 
-namespace App;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -265,7 +265,7 @@ Finally, add the `posts` relation to `app/User.php`
 ```php
 <?php
 
-namespace App;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

This PR updates the tutorial code samples to use the `App\Models` namespace for sample models, instead of `App`. I'm no Laravel expert, but I believe that `App` was used in a previous version of Laravel, but now it's deprecated.

I've tested that `App` does not work whereas `App\Models` does. The `make:model` generates the model file with `App\Models`.

Notice that the documentation says:

> Replace the newly generated `app/Post.php` and the `create_posts_table.php` with this:

An expert Laravel user being introduced to Lighthouse should be able to identify that the tutorial is simply outdated, but to a developer being introduced to Laravel and Lighthouse simultaneously this can cause some confusion.

Thanks for your time!

**Breaking changes**

None
