### PR TITLE
Force load type when GlobalId\Node is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Make `@node` force load the type if it has not been loaded
+
 ## 5.0.1
 
 ### Fixed

--- a/src/GlobalId/NodeRegistry.php
+++ b/src/GlobalId/NodeRegistry.php
@@ -76,7 +76,10 @@ class NodeRegistry
     {
         [$decodedType, $decodedId] = $args['id'];
 
-        // Load the type and register it if it hasn't been loaded yet
+        // This check forces Lighthouse to eagerly load the type, which might not have
+        // happened if the client only references it indirectly through an interface.
+        // Loading the type in turn causes the TypeMiddleware to run and thus register
+        // the type in the NodeRegistry.
         if (! $this->typeRegistry->has($decodedType)) {
             throw new Error("[{$decodedType}] is not a type and cannot be resolved.");
         }

--- a/src/GlobalId/NodeRegistry.php
+++ b/src/GlobalId/NodeRegistry.php
@@ -76,6 +76,11 @@ class NodeRegistry
     {
         [$decodedType, $decodedId] = $args['id'];
 
+        // Load the type and register it if it hasn't been loaded yet
+        if (!$this->typeRegistry->has($decodedType)) {
+            throw new Error("[{$decodedType}] is not a type and cannot be resolved.");
+        }
+
         // Check if we have a resolver registered for the given type
         if (! $resolver = Arr::get($this->nodeResolver, $decodedType)) {
             throw new Error("[{$decodedType}] is not a registered node and cannot be resolved.");

--- a/src/GlobalId/NodeRegistry.php
+++ b/src/GlobalId/NodeRegistry.php
@@ -77,7 +77,7 @@ class NodeRegistry
         [$decodedType, $decodedId] = $args['id'];
 
         // Load the type and register it if it hasn't been loaded yet
-        if (!$this->typeRegistry->has($decodedType)) {
+        if (! $this->typeRegistry->has($decodedType)) {
             throw new Error("[{$decodedType}] is not a type and cannot be resolved.");
         }
 

--- a/tests/Integration/Schema/NodeInterfaceTest.php
+++ b/tests/Integration/Schema/NodeInterfaceTest.php
@@ -74,6 +74,38 @@ class NodeInterfaceTest extends DBTestCase
         ]);
     }
 
+    public function testCanResolveNodesViaInterface(): void
+    {
+        $this->schema .= /** @lang GraphQL */ '
+        interface IUser {
+            name: String!        
+        }
+        type User implements IUser @node(resolver: "Tests\\\Integration\\\Schema\\\NodeInterfaceTest@resolveNode") {
+            name: String!
+        }
+        ';
+
+        $firstGlobalId = $this->globalIdResolver->encode('User', $this->testTuples[1]['id']);
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            node: node(id: "'.$firstGlobalId.'") {
+                id
+                ...on IUser {
+                    name
+                }
+            }
+        }
+        ')->assertExactJson([
+            'data' => [
+                'node' => [
+                    'id' => $firstGlobalId,
+                    'name' => $this->testTuples[1]['name'],
+                ],
+            ],
+        ]);
+    }
+
     /**
      * @return array<mixed>
      */

--- a/tests/Integration/Schema/NodeInterfaceTest.php
+++ b/tests/Integration/Schema/NodeInterfaceTest.php
@@ -48,13 +48,13 @@ class NodeInterfaceTest extends DBTestCase
 
         $this->graphQL(/** @lang GraphQL */ '
         {
-            first: node(id: "' . $firstGlobalId . '") {
+            first: node(id: "'.$firstGlobalId.'") {
                 id
                 ...on User {
                     name
                 }
             }
-            second: node(id: "' . $secondGlobalId . '") {
+            second: node(id: "'.$secondGlobalId.'") {
                 id
                 ...on User {
                     name
@@ -91,7 +91,7 @@ class NodeInterfaceTest extends DBTestCase
 
         $this->graphQL(/** @lang GraphQL */ '
         {
-            node: node(id: "' . $globalId . '") {
+            node: node(id: "'.$globalId.'") {
                 id
                 ...on IUser {
                     name
@@ -120,19 +120,19 @@ class NodeInterfaceTest extends DBTestCase
         $globalId = $this->globalIdResolver->encode('WrongClass', $this->testTuples[1]['id']);
         $this->graphQL(/** @lang GraphQL */ '
         {
-            node: node(id: "' . $globalId . '") {
+            node: node(id: "'.$globalId.'") {
                 id
             }
         }
         ')->assertJson([
             'data' => [
-                'node' => null
+                'node' => null,
             ],
             'errors' => [
                 [
                     'message' => '[WrongClass] is not a type and cannot be resolved.',
-                ]
-            ]
+                ],
+            ],
         ]);
     }
 
@@ -152,19 +152,19 @@ class NodeInterfaceTest extends DBTestCase
         $globalId = $this->globalIdResolver->encode('User2', $this->testTuples[1]['id']);
         $this->graphQL(/** @lang GraphQL */ '
         {
-            node: node(id: "' . $globalId . '") {
+            node: node(id: "'.$globalId.'") {
                 id
             }
         }
         ')->assertJson([
             'data' => [
-                'node' => null
+                'node' => null,
             ],
             'errors' => [
                 [
                     'message' => '[User2] is not a registered node and cannot be resolved.',
-                ]
-            ]
+                ],
+            ],
         ]);
     }
 
@@ -195,7 +195,7 @@ class NodeInterfaceTest extends DBTestCase
 
         $this->graphQL(/** @lang GraphQL */ '
         {
-            node(id: "' . $globalId . '") {
+            node(id: "'.$globalId.'") {
                 id
                 ...on User {
                     name


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**The problem**
1) Query node() for some object but don't mention its type in the query.
2) This type won't be loaded as it isn't needed to resolve the query.
3) `TypeMiddleware` won't be executed.
4) It won't register itself in the `NodeRegistry`.
5) The query will fail with the `[Class] is not a registered node and cannot be resolved.` error.

**Changes**

This PR forces the type to load during node resolving, so that it can register itself.
