### PR TITLE
Deprecate the `globalId` argument on the `@delete`, `@forceDelete` and `@restore` directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Deprecated
+
+- Deprecate the `globalId` argument on the `@delete`, `@forceDelete` and `@restore` directives
+
+### Fixed
+
+- Remove non-functional `globalId` argument definition from `@update`
+
 ## 5.0.2
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Deprecated
 
-- Deprecate the `globalId` argument on the `@delete`, `@forceDelete` and `@restore` directives
+- Deprecate the `globalId` argument on the `@delete`, `@forceDelete` and `@restore` directives https://github.com/nuwave/lighthouse/pull/1660
 
 ### Fixed
 
-- Remove non-functional `globalId` argument definition from `@update`
+- Remove non-functional `globalId` argument definition from `@update` https://github.com/nuwave/lighthouse/pull/1660
 
 ## 5.0.2
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,6 +7,20 @@ This document provides guidance for upgrading between major versions of Lighthou
 The configuration options often change between major versions.
 Compare your `lighthouse.php` against the latest [default configuration](src/lighthouse.php).
 
+## v5 to v6
+
+### Use `@globalId` over `@delete(globalId: true)`
+
+The `@delete`, `@forceDelete` and `@restore` directives no longer offer the
+`globalId` argument. Use `@globalId` on the argument instead.
+
+```diff
+type Mutation {
+-   deleteUser(id: ID!): User! @delete(globalId: true)
++   deleteUser(id: ID! @globalId): User! @delete
+}
+```
+
 ## v4 to v5
 
 ### Update PHP, Laravel and PHPUnit

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2534,24 +2534,18 @@ class Person
 Update an Eloquent model with the input values of the field.
 """
 directive @update(
-  """
-  Specify the class name of the model to use.
-  This is only needed when the default model detection does not work.
-  """
-  model: String
+    """
+    Specify the class name of the model to use.
+    This is only needed when the default model detection does not work.
+    """
+    model: String
 
-  """
-  Set to `true` to use global ids for finding the model.
-  If set to `false`, regular non-global ids are used.
-  """
-  globalId: Boolean = false
-
-  """
-  Specify the name of the relation on the parent model.
-  This is only needed when using this directive as a nested arg
-  resolver and if the name of the relation is not the arg name.
-  """
-  relation: String
+    """
+    Specify the name of the relation on the parent model.
+    This is only needed when using this directive as a nested arg
+    resolver and if the name of the relation is not the arg name.
+    """
+    relation: String
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -580,24 +580,26 @@ Delete one or more models by their ID.
 The field must have a single non-null argument that may be a list.
 """
 directive @delete(
-  """
-  Set to `true` to use global ids for finding the model.
-  If set to `false`, regular non-global ids are used.
-  """
-  globalId: Boolean = false
+    """
+    DEPRECATED use @globalId, will be removed in v6
 
-  """
-  Specify the class name of the model to use.
-  This is only needed when the default model detection does not work.
-  """
-  model: String
+    Set to `true` to use global ids for finding the model.
+    If set to `false`, regular non-global ids are used.
+    """
+    globalId: Boolean = false
 
-  """
-  Specify the name of the relation on the parent model.
-  This is only needed when using this directive as a nested arg
-  resolver and if the name of the relation is not the arg name.
-  """
-  relation: String
+    """
+    Specify the class name of the model to use.
+    This is only needed when the default model detection does not work.
+    """
+    model: String
+
+    """
+    Specify the name of the relation on the parent model.
+    This is only needed when using this directive as a nested arg
+    resolver and if the name of the relation is not the arg name.
+    """
+    relation: String
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
@@ -609,12 +611,13 @@ type Mutation {
 }
 ```
 
-If you use global ids, you can set the `globalId` argument to `true`.
-Lighthouse will decode the id for you automatically.
+The `@delete`, `@forceDelete` and `@restore` directives no longer offer the
+`globalId` argument. Use `@globalId` on the argument instead.
 
-```graphql
+```diff
 type Mutation {
-  deletePost(id: ID!): Post @delete(globalId: true)
+-   deleteUser(id: ID!): User! @delete(globalId: true)
++   deleteUser(id: ID! @globalId): User! @delete
 }
 ```
 
@@ -819,17 +822,19 @@ Permanently remove one or more soft deleted models by their ID.
 The field must have a single non-null argument that may be a list.
 """
 directive @forceDelete(
-  """
-  Set to `true` to use global ids for finding the model.
-  If set to `false`, regular non-global ids are used.
-  """
-  globalId: Boolean = false
+    """
+    DEPRECATED use @globalId, will be removed in v6
 
-  """
-  Specify the class name of the model to use.
-  This is only needed when the default model detection does not work.
-  """
-  model: String
+    Set to `true` to use global ids for finding the model.
+    If set to `false`, regular non-global ids are used.
+    """
+    globalId: Boolean = false
+
+    """
+    Specify the class name of the model to use.
+    This is only needed when the default model detection does not work.
+    """
+    model: String
 ) on FIELD_DEFINITION
 ```
 
@@ -2054,17 +2059,19 @@ Un-delete one or more soft deleted models by their ID.
 The field must have a single non-null argument that may be a list.
 """
 directive @restore(
-  """
-  Set to `true` to use global ids for finding the model.
-  If set to `false`, regular non-global ids are used.
-  """
-  globalId: Boolean = false
+    """
+    DEPRECATED use @globalId, will be removed in v6
 
-  """
-  Specify the class name of the model to use.
-  This is only needed when the default model detection does not work.
-  """
-  model: String
+    Set to `true` to use global ids for finding the model.
+    If set to `false`, regular non-global ids are used.
+    """
+    globalId: Boolean = false
+
+    """
+    Specify the class name of the model to use.
+    This is only needed when the default model detection does not work.
+    """
+    model: String
 ) on FIELD_DEFINITION
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2534,18 +2534,18 @@ class Person
 Update an Eloquent model with the input values of the field.
 """
 directive @update(
-    """
-    Specify the class name of the model to use.
-    This is only needed when the default model detection does not work.
-    """
-    model: String
+  """
+  Specify the class name of the model to use.
+  This is only needed when the default model detection does not work.
+  """
+  model: String
 
-    """
-    Specify the name of the relation on the parent model.
-    This is only needed when using this directive as a nested arg
-    resolver and if the name of the relation is not the arg name.
-    """
-    relation: String
+  """
+  Specify the name of the relation on the parent model.
+  This is only needed when using this directive as a nested arg
+  resolver and if the name of the relation is not the arg name.
+  """
+  relation: String
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -580,26 +580,26 @@ Delete one or more models by their ID.
 The field must have a single non-null argument that may be a list.
 """
 directive @delete(
-    """
-    DEPRECATED use @globalId, will be removed in v6
+  """
+  DEPRECATED use @globalId, will be removed in v6
 
-    Set to `true` to use global ids for finding the model.
-    If set to `false`, regular non-global ids are used.
-    """
-    globalId: Boolean = false
+  Set to `true` to use global ids for finding the model.
+  If set to `false`, regular non-global ids are used.
+  """
+  globalId: Boolean = false
 
-    """
-    Specify the class name of the model to use.
-    This is only needed when the default model detection does not work.
-    """
-    model: String
+  """
+  Specify the class name of the model to use.
+  This is only needed when the default model detection does not work.
+  """
+  model: String
 
-    """
-    Specify the name of the relation on the parent model.
-    This is only needed when using this directive as a nested arg
-    resolver and if the name of the relation is not the arg name.
-    """
-    relation: String
+  """
+  Specify the name of the relation on the parent model.
+  This is only needed when using this directive as a nested arg
+  resolver and if the name of the relation is not the arg name.
+  """
+  relation: String
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
@@ -822,19 +822,19 @@ Permanently remove one or more soft deleted models by their ID.
 The field must have a single non-null argument that may be a list.
 """
 directive @forceDelete(
-    """
-    DEPRECATED use @globalId, will be removed in v6
+  """
+  DEPRECATED use @globalId, will be removed in v6
 
-    Set to `true` to use global ids for finding the model.
-    If set to `false`, regular non-global ids are used.
-    """
-    globalId: Boolean = false
+  Set to `true` to use global ids for finding the model.
+  If set to `false`, regular non-global ids are used.
+  """
+  globalId: Boolean = false
 
-    """
-    Specify the class name of the model to use.
-    This is only needed when the default model detection does not work.
-    """
-    model: String
+  """
+  Specify the class name of the model to use.
+  This is only needed when the default model detection does not work.
+  """
+  model: String
 ) on FIELD_DEFINITION
 ```
 
@@ -2059,19 +2059,19 @@ Un-delete one or more soft deleted models by their ID.
 The field must have a single non-null argument that may be a list.
 """
 directive @restore(
-    """
-    DEPRECATED use @globalId, will be removed in v6
+  """
+  DEPRECATED use @globalId, will be removed in v6
 
-    Set to `true` to use global ids for finding the model.
-    If set to `false`, regular non-global ids are used.
-    """
-    globalId: Boolean = false
+  Set to `true` to use global ids for finding the model.
+  If set to `false`, regular non-global ids are used.
+  """
+  globalId: Boolean = false
 
-    """
-    Specify the class name of the model to use.
-    This is only needed when the default model detection does not work.
-    """
-    model: String
+  """
+  Specify the class name of the model to use.
+  This is only needed when the default model detection does not work.
+  """
+  model: String
 ) on FIELD_DEFINITION
 ```
 

--- a/src/Schema/Directives/DeleteDirective.php
+++ b/src/Schema/Directives/DeleteDirective.php
@@ -25,6 +25,8 @@ The field must have a single non-null argument that may be a list.
 """
 directive @delete(
   """
+  DEPRECATED use @globalId, will be removed in v6
+
   Set to `true` to use global ids for finding the model.
   If set to `false`, regular non-global ids are used.
   """

--- a/src/Schema/Directives/MutationExecutorDirective.php
+++ b/src/Schema/Directives/MutationExecutorDirective.php
@@ -11,30 +11,19 @@ use Nuwave\Lighthouse\Execution\Arguments\ResolveNested;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\ArgResolver;
 use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
-use Nuwave\Lighthouse\Support\Contracts\GlobalId;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 use Nuwave\Lighthouse\Support\Utils;
 
 abstract class MutationExecutorDirective extends BaseDirective implements FieldResolver, ArgResolver
 {
     /**
-     * The database manager.
-     *
      * @var \Illuminate\Database\DatabaseManager
      */
     protected $databaseManager;
 
-    /**
-     * The GlobalId resolver.
-     *
-     * @var \Nuwave\Lighthouse\Support\Contracts\GlobalId
-     */
-    protected $globalId;
-
-    public function __construct(DatabaseManager $databaseManager, GlobalId $globalId)
+    public function __construct(DatabaseManager $databaseManager)
     {
         $this->databaseManager = $databaseManager;
-        $this->globalId = $globalId;
     }
 
     public function resolveField(FieldValue $fieldValue): FieldValue

--- a/src/Schema/Directives/UpdateDirective.php
+++ b/src/Schema/Directives/UpdateDirective.php
@@ -22,12 +22,6 @@ directive @update(
   model: String
 
   """
-  Set to `true` to use global ids for finding the model.
-  If set to `false`, regular non-global ids are used.
-  """
-  globalId: Boolean = false
-
-  """
   Specify the name of the relation on the parent model.
   This is only needed when using this directive as a nested arg
   resolver and if the name of the relation is not the arg name.

--- a/src/SoftDeletes/ForceDeleteDirective.php
+++ b/src/SoftDeletes/ForceDeleteDirective.php
@@ -21,6 +21,8 @@ The field must have a single non-null argument that may be a list.
 """
 directive @forceDelete(
   """
+  DEPRECATED use @globalId, will be removed in v6
+
   Set to `true` to use global ids for finding the model.
   If set to `false`, regular non-global ids are used.
   """

--- a/src/SoftDeletes/RestoreDirective.php
+++ b/src/SoftDeletes/RestoreDirective.php
@@ -22,6 +22,8 @@ The field must have a single non-null argument that may be a list.
 """
 directive @restore(
   """
+  DEPRECATED use @globalId, will be removed in v6
+
   Set to `true` to use global ids for finding the model.
   If set to `false`, regular non-global ids are used.
   """


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

### Deprecated

- Deprecate the `globalId` argument on the `@delete`, `@forceDelete` and `@restore` directives

### Fixed

- Remove non-functional `globalId` argument definition from `@update`

**Breaking changes**

Not breaking stuff now, but v6 will require changes:

The `@delete`, `@forceDelete` and `@restore` directives no longer offer the
`globalId` argument. Use `@globalId` on the argument instead.

```diff
type Mutation {
-   deleteUser(id: ID!): User! @delete(globalId: true)
+   deleteUser(id: ID! @globalId): User! @delete
}
```
