### PR TITLE
Resolve field middleware in lexical order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 ### Fixed
 
 - Remove non-functional `globalId` argument definition from `@update` https://github.com/nuwave/lighthouse/pull/1660
-- Resolve field middleware directives in lexical order
+- Resolve field middleware directives in lexical order https://github.com/nuwave/lighthouse/pull/1666
 
 ## 5.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 ### Fixed
 
 - Remove non-functional `globalId` argument definition from `@update` https://github.com/nuwave/lighthouse/pull/1660
+- Resolve field middleware directives in lexical order
 
 ## 5.0.2
 

--- a/src/Exceptions/AuthenticationException.php
+++ b/src/Exceptions/AuthenticationException.php
@@ -6,7 +6,8 @@ use Illuminate\Auth\AuthenticationException as IlluminateAuthenticationException
 
 class AuthenticationException extends IlluminateAuthenticationException implements RendersErrorsExtensions
 {
-    public const UNAUTHENTICATED = 'Unauthenticated.';
+    public const MESSAGE = 'Unauthenticated.';
+    public const CATEGORY = 'authentication';
 
     public function isClientSafe(): bool
     {
@@ -15,7 +16,7 @@ class AuthenticationException extends IlluminateAuthenticationException implemen
 
     public function getCategory(): string
     {
-        return 'authentication';
+        return self::CATEGORY;
     }
 
     /**

--- a/src/Schema/Directives/GuardDirective.php
+++ b/src/Schema/Directives/GuardDirective.php
@@ -98,7 +98,7 @@ GRAPHQL;
     protected function unauthenticated(array $guards): void
     {
         throw new AuthenticationException(
-            AuthenticationException::UNAUTHENTICATED,
+            AuthenticationException::MESSAGE,
             $guards
         );
     }

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -66,16 +66,16 @@ class FieldFactory
         $fieldMiddleware = $this->directiveFactory->associatedOfType($fieldDefinitionNode, FieldMiddleware::class);
 
         $globalFieldMiddleware = config('lighthouse.field_middleware');
-        // Middleware resolve in reversed order, so we reverse them
-        foreach (array_reverse($globalFieldMiddleware) as $globalFieldMiddlewareClass) {
-            $fieldMiddleware->push(
-                app($globalFieldMiddlewareClass)
-            );
-        }
+        $fieldMiddleware->push(...$globalFieldMiddleware);
 
         $resolverWithMiddleware = $this->pipeline
             ->send($fieldValue)
-            ->through($fieldMiddleware->all())
+            ->through(
+                $fieldMiddleware
+                    // Middleware resolve in reversed order
+                    ->reverse()
+                    ->all()
+            )
             ->via('handleField')
             // TODO replace when we cut support for Laravel 5.6
             //->thenReturn()

--- a/src/Schema/Factories/FieldFactory.php
+++ b/src/Schema/Factories/FieldFactory.php
@@ -63,19 +63,20 @@ class FieldFactory
             $fieldValue = $fieldValue->useDefaultResolver();
         }
 
-        $fieldMiddleware = $this->directiveFactory->associatedOfType($fieldDefinitionNode, FieldMiddleware::class);
+        // Middleware resolve in reversed order
 
-        $globalFieldMiddleware = config('lighthouse.field_middleware');
-        $fieldMiddleware->push(...$globalFieldMiddleware);
+        $globalFieldMiddleware = array_reverse(
+            config('lighthouse.field_middleware')
+        );
+
+        $fieldMiddleware = $this->directiveFactory
+            ->associatedOfType($fieldDefinitionNode, FieldMiddleware::class)
+            ->reverse()
+            ->all();
 
         $resolverWithMiddleware = $this->pipeline
             ->send($fieldValue)
-            ->through(
-                $fieldMiddleware
-                    // Middleware resolve in reversed order
-                    ->reverse()
-                    ->all()
-            )
+            ->through(array_merge($fieldMiddleware, $globalFieldMiddleware))
             ->via('handleField')
             // TODO replace when we cut support for Laravel 5.6
             //->thenReturn()

--- a/tests/Integration/FieldMiddlewareTest.php
+++ b/tests/Integration/FieldMiddlewareTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Integration;
 
+use Nuwave\Lighthouse\Exceptions\AuthenticationException;
 use Tests\TestCase;
 
 class FieldMiddlewareTest extends TestCase
@@ -31,5 +32,29 @@ class FieldMiddlewareTest extends TestCase
                 ],
             ],
         ]);
+    }
+
+    public function testFieldMiddlewareResolveInDefinitionOrder(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            user: User!
+                @guard
+                @can(ability: "adminOnly")
+                @mock
+        }
+
+        type User {
+            name: String
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            user {
+                name
+            }
+        }
+        ')->assertGraphQLErrorCategory(AuthenticationException::CATEGORY);
     }
 }

--- a/tests/Unit/Schema/Directives/GuardDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/GuardDirectiveTest.php
@@ -23,7 +23,7 @@ class GuardDirectiveTest extends TestCase
         ')->assertJson([
             'errors' => [
                 [
-                    'message' => AuthenticationException::UNAUTHENTICATED,
+                    'message' => AuthenticationException::MESSAGE,
                 ],
             ],
         ]);
@@ -44,7 +44,7 @@ class GuardDirectiveTest extends TestCase
         ')->assertJson([
             'errors' => [
                 [
-                    'message' => AuthenticationException::UNAUTHENTICATED,
+                    'message' => AuthenticationException::MESSAGE,
                     'extensions' => [
                         'guards' => [
                             'api',
@@ -58,6 +58,7 @@ class GuardDirectiveTest extends TestCase
     public function testPassesOneFieldButThrowsInAnother(): void
     {
         $this->be(new User());
+
         $this->schema = /** @lang GraphQL */ '
         type Query {
             foo: Int @guard
@@ -80,7 +81,7 @@ class GuardDirectiveTest extends TestCase
                     'path' => [
                         'bar',
                     ],
-                    'message' => AuthenticationException::UNAUTHENTICATED,
+                    'message' => AuthenticationException::MESSAGE,
                 ],
             ],
         ]);


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

It is expected that field middleware run in lexical order, as they are defined in the schema. This PR reverses their previous execution order to match that assumption.

**Breaking changes**

In most cases, this makes no difference. If this comes up, the implementation is likely bugged right now and will be fixed by this.

@ipalaus