### PR TITLE
Fix subscriptions renaming variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Resolve field middleware directives in lexical order https://github.com/nuwave/lighthouse/pull/1666
 - Ensure `Carbon\Carbon` is cast to `Illuminate\Support\Carbon` in date scalars https://github.com/nuwave/lighthouse/pull/1672
 - Fix Laravel 5.6 compatibility for `@withCount` and paginated relationship directives https://github.com/nuwave/lighthouse/pull/1528
+- Fix issue where argument names where used instead of variable names in subscription queries https://github.com/nuwave/lighthouse/pull/1683
 
 ## 5.0.2
 

--- a/src/Subscriptions/Subscriber.php
+++ b/src/Subscriptions/Subscriber.php
@@ -62,6 +62,13 @@ class Subscriber implements Serializable
     public $args;
 
     /**
+     * The variables passed to the subscription query.
+     *
+     * @var array<string, mixed>
+     */
+    public $variables;
+
+    /**
      * The context passed to the query.
      *
      * @var \Nuwave\Lighthouse\Support\Contracts\GraphQLContext
@@ -79,6 +86,7 @@ class Subscriber implements Serializable
         $this->fieldName = $resolveInfo->fieldName;
         $this->channel = self::uniqueChannelName();
         $this->args = $args;
+        $this->variables = $resolveInfo->variableValues;
         $this->context = $context;
 
         /**
@@ -112,6 +120,7 @@ class Subscriber implements Serializable
         );
         $this->fieldName = $data['field_name'];
         $this->args = $data['args'];
+        $this->variables = $data['variables'];
         $this->context = $this->contextSerializer()->unserialize(
             $data['context']
         );
@@ -130,6 +139,7 @@ class Subscriber implements Serializable
             ),
             'field_name' => $this->fieldName,
             'args' => $this->args,
+            'variables' => $this->variables,
             'context' => $this->contextSerializer()->serialize($this->context),
         ]);
     }

--- a/src/Subscriptions/SubscriptionBroadcaster.php
+++ b/src/Subscriptions/SubscriptionBroadcaster.php
@@ -86,7 +86,7 @@ class SubscriptionBroadcaster implements BroadcastsSubscriptions
                 $data = $this->graphQL->executeQuery(
                     $subscriber->query,
                     $subscriber->context,
-                    $subscriber->args,
+                    $subscriber->variables,
                     $subscriber
                 );
 


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

Resolves #1682 

**Changes**

The method expects variables, however we previously used arguments. This caused variables to change names before query execution. This is now fixed.

**Breaking changes**

None