### PR TITLE
Fix TTL for subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Resolve field middleware directives in lexical order https://github.com/nuwave/lighthouse/pull/1666
 - Ensure `Carbon\Carbon` is cast to `Illuminate\Support\Carbon` in date scalars https://github.com/nuwave/lighthouse/pull/1672
 - Fix Laravel 5.6 compatibility for `@withCount` and paginated relationship directives https://github.com/nuwave/lighthouse/pull/1528
+- Fix issue with TTL breaking subscriptions https://github.com/nuwave/lighthouse/pull/1685
 
 ## 5.0.2
 

--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -94,11 +94,11 @@ class RedisStorageManager implements StoresSubscriptions
         }
 
         // Lastly, we store the subscriber as a serialized string...
-        $this->connection->command('set', array_merge([
+        $this->connection->command('set', [
             $this->channelKey($subscriber->channel),
             $this->serialize($subscriber),
-            // ...and set the EX option to set the ttl in one command.
-        ], $this->ttl ? ['EX', $this->ttl] : []));
+            $this->ttl,
+        ]);
     }
 
     public function deleteSubscriber(string $channel): ?Subscriber

--- a/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
+++ b/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
@@ -81,6 +81,7 @@ class RedisStorageManagerTest extends SubscriptionTestCase
                         'channel' => 'private-lighthouse-foo',
                         'topic' => 'some-topic',
                     ]).'}',
+                    null,
                 ]]
             );
 


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves #1684 

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

When creating a subscription, following exception was thrown:

`Redis::set() expects at most 3 parameters, 4 given`

Phpredis seems to [support simply appending the TTL in seconds](https://github.com/phpredis/phpredis#examples-4). 

Reduced arguments from 4 to 3, by removing "EX" from the Redis-command.

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

