### PR TITLE
Add: failing test for magic getters

### DIFF
--- a/tests/Integration/Schema/Directives/FindDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/FindDirectiveTest.php
@@ -196,4 +196,36 @@ class FindDirectiveTest extends DBTestCase
             ],
         ]);
     }
+
+    public function testReturnsMagicGetter()
+    {
+        $user = factory(User::class)->create();
+
+        $this->schema = '
+        type User {
+            id: ID!
+            magicGetterField: String!
+        }
+
+        type Query {
+            user(id: ID @eq): User @find(model: "User")
+        }
+        ';
+
+        $this->graphQL("
+        {
+            user(id: {$user->id}) {
+                id
+                magicGetterField
+            }
+        }
+        ")->assertJson([
+            'data' => [
+                'user' => [
+                    'id' => (string) $user->id,
+                    'magicGetterField' => 'Hello magicGetterField',
+                ],
+            ],
+        ]);
+    }
 }

--- a/tests/Utils/Models/User.php
+++ b/tests/Utils/Models/User.php
@@ -98,4 +98,13 @@ class User extends Authenticatable
                 ->first()
                 ->relationLoaded('comments');
     }
+
+    public function __get($key)
+    {
+        if ($key === 'magicGetterField') {
+            return 'Hello magicGetterField';
+        }
+
+        return parent::__get($key);
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

This PR adds a failing test to indicate that PHP's magic __get method is not supported.
