### PR TITLE
Fix GlobalId query if SanitizeDirective is not listed in field_directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- add `@sanitize` to the `node` field definition if `SanitizeDirective` is not listed in the global `field_middleware` list
+- Add `@sanitize` to the `node` field definition if `SanitizeDirective` is not listed in the global `field_middleware` list
 
 ## 5.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Clarify semantics of combining `@search` with other directives https://github.com/nuwave/lighthouse/pull/1691
 - Move Scout related classes into `\Nuwave\Lighthouse\Scout` https://github.com/nuwave/lighthouse/pull/1698
 
+### Fixed
+
+- add `@sanitize` to the `node` field definition if `SanitizeDirective` is not listed in the global `field_middleware` list
+
 ## 5.1.0
 
 ### Added

--- a/src/GlobalId/GlobalIdServiceProvider.php
+++ b/src/GlobalId/GlobalIdServiceProvider.php
@@ -64,7 +64,7 @@ GRAPHQL
             )
         );
 
-        if(in_array(SanitizeDirective::class, config('lighthouse.field_middleware'))){
+        if (in_array(SanitizeDirective::class, config('lighthouse.field_middleware'))) {
             $fieldDefinition = /** @lang GraphQL */ '
                 node(id: ID! @globalId): Node @field(resolver: "Nuwave\\\Lighthouse\\\GlobalId\\\NodeRegistry@resolve")
             ';


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Updated CHANGELOG.md

**The problem**

If `SanitizeDirective` is disabled in `lighthouse.field_directives`, there is no way to use `node` query. `GlobalIdServiceProvider` overwrites it, so the user can't add `@sanitize` to it.

**Changes**

`GlobalIdServiceProvider` checks if `lighthouse.field_directives` has `SanitizeDirective` disabled and if so adds `@sanitize` to the `node` query.