### PR TITLE
Cache directive arguments in BaseDirective

### DIFF
--- a/benchmarks/HugeResponseBench.php
+++ b/benchmarks/HugeResponseBench.php
@@ -10,9 +10,9 @@ class HugeResponseBench extends QueryBench
     /**
      * Cached value of parent with recursive children.
      *
-     * @var array{name: string, children: array<int, array{name: string, array<string, mixed>}>}
+     * @var array<string, mixed>
      */
-    protected $parent = null;
+    protected $parent;
 
     protected $schema = /** @lang GraphQL */ <<<'GRAPHQL'
 type Query {
@@ -36,11 +36,11 @@ GRAPHQL;
      * Resolves parent.
      *
      * @skip
-     * @return array{name: string, children: array<int, array{name: string, array<string, mixed>}>}
+     * @return array<string, mixed>
      */
     public function resolve(): array
     {
-        if ($this->parent) {
+        if (isset($this->parent)) {
             return $this->parent;
         }
 

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -93,12 +93,8 @@ abstract class BaseDirective implements Directive
     {
         $this->directiveArgs = [];
         foreach ($this->directiveNode->arguments as $node) {
-            if (! property_exists($node, 'name')) {
-                throw new Exception('Expected a Node with a name property, got: '.get_class($node));
-            }
-
             if (array_key_exists($node->name->value, $this->directiveArgs)) {
-                continue;
+                throw new DefinitionException("Directive {$this->directiveNode->name->value} has two arguments with the same name {$node->name->value}");
             }
 
             $this->directiveArgs[$node->name->value] = AST::valueFromASTUntyped($node->value);

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -46,9 +46,11 @@ abstract class BaseDirective implements Directive
     /**
      * Cached directive arguments.
      *
-     * @var array<string, mixed>|null
+     * Lazily initialized.
+     *
+     * @var array<string, mixed>
      */
-    protected $directiveArgs = null;
+    protected $directiveArgs;
 
     /**
      * Returns the name of the used directive.
@@ -68,7 +70,6 @@ abstract class BaseDirective implements Directive
     {
         $this->directiveNode = $directiveNode;
         $this->definitionNode = $definitionNode;
-        $this->directiveArgs = null;
 
         return $this;
     }
@@ -109,7 +110,7 @@ abstract class BaseDirective implements Directive
      */
     public function directiveHasArgument(string $name): bool
     {
-        if ($this->directiveArgs == null) {
+        if (! isset($this->directiveArgs)) {
             $this->loadArgValues();
         }
 
@@ -124,7 +125,7 @@ abstract class BaseDirective implements Directive
      */
     protected function directiveArgValue(string $name, $default = null)
     {
-        if ($this->directiveArgs == null) {
+        if (! isset($this->directiveArgs)) {
             $this->loadArgValues();
         }
 

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -63,7 +63,7 @@ abstract class BaseDirective implements Directive
     /**
      * The hydrate function is called when retrieving a directive from the directive registry.
      *
-     * @param  ScalarTypeDefinitionNode|ObjectTypeDefinitionNode|FieldDefinitionNode|InputValueDefinitionNode|InterfaceTypeDefinitionNode|UnionTypeDefinitionNode|EnumTypeDefinitionNode|EnumValueDefinitionNode|InputObjectTypeDefinitionNode $definitionNode
+     * @param  ScalarTypeDefinitionNode|ObjectTypeDefinitionNode|FieldDefinitionNode|InputValueDefinitionNode|InterfaceTypeDefinitionNode|UnionTypeDefinitionNode|EnumTypeDefinitionNode|EnumValueDefinitionNode|InputObjectTypeDefinitionNode  $definitionNode
      * @return $this
      */
     public function hydrate(DirectiveNode $directiveNode, Node $definitionNode): self
@@ -120,7 +120,7 @@ abstract class BaseDirective implements Directive
     /**
      * Get the value of an argument on the directive.
      *
-     * @param (mixed|null) $default
+     * @param  mixed|null  $default
      * @return mixed|null
      */
     protected function directiveArgValue(string $name, $default = null)
@@ -143,7 +143,7 @@ abstract class BaseDirective implements Directive
     /**
      * Get the model class from the `model` argument of the field.
      *
-     * @param string $argumentName The default argument name "model" may be overwritten
+     * @param  string  $argumentName The default argument name "model" may be overwritten
      * @return class-string<\Illuminate\Database\Eloquent\Model>
      *
      * @throws \Nuwave\Lighthouse\Exceptions\DefinitionException
@@ -190,7 +190,7 @@ abstract class BaseDirective implements Directive
     /**
      * Find a class name in a set of given namespaces.
      *
-     * @param array<string> $namespacesToTry
+     * @param  array<string>  $namespacesToTry
      * @return class-string
      *
      * @throws \Nuwave\Lighthouse\Exceptions\DefinitionException

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -3,7 +3,6 @@
 namespace Nuwave\Lighthouse\Schema\Directives;
 
 use Closure;
-use Exception;
 use GraphQL\Language\AST\DirectiveNode;
 use GraphQL\Language\AST\EnumTypeDefinitionNode;
 use GraphQL\Language\AST\EnumValueDefinitionNode;

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -63,7 +63,7 @@ abstract class BaseDirective implements Directive
     /**
      * The hydrate function is called when retrieving a directive from the directive registry.
      *
-     * @param ScalarTypeDefinitionNode|ObjectTypeDefinitionNode|FieldDefinitionNode|InputValueDefinitionNode|InterfaceTypeDefinitionNode|UnionTypeDefinitionNode|EnumTypeDefinitionNode|EnumValueDefinitionNode|InputObjectTypeDefinitionNode $definitionNode
+     * @param  ScalarTypeDefinitionNode|ObjectTypeDefinitionNode|FieldDefinitionNode|InputValueDefinitionNode|InterfaceTypeDefinitionNode|UnionTypeDefinitionNode|EnumTypeDefinitionNode|EnumValueDefinitionNode|InputObjectTypeDefinitionNode $definitionNode
      * @return $this
      */
     public function hydrate(DirectiveNode $directiveNode, Node $definitionNode): self
@@ -120,7 +120,7 @@ abstract class BaseDirective implements Directive
     /**
      * Get the value of an argument on the directive.
      *
-     * @param mixed|null $default
+     * @param (mixed|null) $default
      * @return mixed|null
      */
     protected function directiveArgValue(string $name, $default = null)

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -92,7 +92,7 @@ abstract class BaseDirective implements Directive
     {
         $this->directiveArgs = [];
         foreach ($this->directiveNode->arguments as $node) {
-            if (!property_exists($node, 'name')) {
+            if ( !property_exists($node, 'name')) {
                 throw new Exception('Expected a Node with a name property, got: ' . get_class($node));
             }
 
@@ -156,14 +156,14 @@ abstract class BaseDirective implements Directive
         $model = $this->directiveArgValue($argumentName);
 
         // Fallback to using information from the schema definition as the model name
-        if (!$model) {
+        if ( !$model) {
             if ($this->definitionNode instanceof FieldDefinitionNode) {
                 $returnTypeName = ASTHelper::getUnderlyingTypeName($this->definitionNode);
 
                 /** @var \Nuwave\Lighthouse\Schema\AST\DocumentAST $documentAST */
                 $documentAST = app(ASTBuilder::class)->documentAST();
 
-                if (!isset($documentAST->types[$returnTypeName])) {
+                if ( !isset($documentAST->types[$returnTypeName])) {
                     throw new DefinitionException(
                         "Type '$returnTypeName' on '{$this->nodeName()}' can not be found in the schema.'"
                     );
@@ -181,7 +181,7 @@ abstract class BaseDirective implements Directive
             }
         }
 
-        if (!$model) {
+        if ( !$model) {
             throw new DefinitionException(
                 "A `model` argument must be assigned to the '{$this->name()}'directive on '{$this->nodeName()}"
             );
@@ -212,7 +212,7 @@ abstract class BaseDirective implements Directive
             )
         );
 
-        if (!$determineMatch) {
+        if ( !$determineMatch) {
             $determineMatch = 'class_exists';
         }
 
@@ -222,7 +222,7 @@ abstract class BaseDirective implements Directive
             $determineMatch
         );
 
-        if (!$className) {
+        if ( !$className) {
             throw new DefinitionException(
                 "No class `{$classCandidate}` was found for directive `@{$this->name()}`"
             );

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -93,7 +93,7 @@ abstract class BaseDirective implements Directive
         $this->directiveArgs = [];
         foreach ($this->directiveNode->arguments as $node) {
             if (! property_exists($node, 'name')) {
-                throw new Exception('Expected a Node with a name property, got: ' . get_class($node));
+                throw new Exception('Expected a Node with a name property, got: '.get_class($node));
             }
 
             if (array_key_exists($node->name->value, $this->directiveArgs)) {

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -103,7 +103,7 @@ abstract class BaseDirective implements Directive
 
     /**
      * Does the current directive have an argument with the given name?
-     * TODO change to protected in v6
+     * TODO change to protected in v6.
      */
     public function directiveHasArgument(string $name): bool
     {

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -44,7 +44,7 @@ abstract class BaseDirective implements Directive
     protected $definitionNode;
 
     /**
-     * Cached directive arguments
+     * Cached directive arguments.
      *
      * @var array<string, mixed>|null
      */
@@ -86,13 +86,13 @@ abstract class BaseDirective implements Directive
     }
 
     /**
-     * Loads directive argument values from AST and caches them in $directiveArgs
+     * Loads directive argument values from AST and caches them in $directiveArgs.
      */
     protected function loadArgValues(): void
     {
         $this->directiveArgs = [];
         foreach ($this->directiveNode->arguments as $node) {
-            if ( !property_exists($node, 'name')) {
+            if (! property_exists($node, 'name')) {
                 throw new Exception('Expected a Node with a name property, got: ' . get_class($node));
             }
 
@@ -106,9 +106,6 @@ abstract class BaseDirective implements Directive
 
     /**
      * Does the current directive have an argument with the given name?
-     *
-     * @param string $name
-     * @return bool
      */
     public function directiveHasArgument(string $name): bool
     {
@@ -122,7 +119,6 @@ abstract class BaseDirective implements Directive
     /**
      * Get the value of an argument on the directive.
      *
-     * @param string $name
      * @param mixed|null $default
      * @return mixed|null
      */
@@ -156,14 +152,14 @@ abstract class BaseDirective implements Directive
         $model = $this->directiveArgValue($argumentName);
 
         // Fallback to using information from the schema definition as the model name
-        if ( !$model) {
+        if (! $model) {
             if ($this->definitionNode instanceof FieldDefinitionNode) {
                 $returnTypeName = ASTHelper::getUnderlyingTypeName($this->definitionNode);
 
                 /** @var \Nuwave\Lighthouse\Schema\AST\DocumentAST $documentAST */
                 $documentAST = app(ASTBuilder::class)->documentAST();
 
-                if ( !isset($documentAST->types[$returnTypeName])) {
+                if (! isset($documentAST->types[$returnTypeName])) {
                     throw new DefinitionException(
                         "Type '$returnTypeName' on '{$this->nodeName()}' can not be found in the schema.'"
                     );
@@ -181,7 +177,7 @@ abstract class BaseDirective implements Directive
             }
         }
 
-        if ( !$model) {
+        if (! $model) {
             throw new DefinitionException(
                 "A `model` argument must be assigned to the '{$this->name()}'directive on '{$this->nodeName()}"
             );
@@ -212,7 +208,7 @@ abstract class BaseDirective implements Directive
             )
         );
 
-        if ( !$determineMatch) {
+        if (! $determineMatch) {
             $determineMatch = 'class_exists';
         }
 
@@ -222,7 +218,7 @@ abstract class BaseDirective implements Directive
             $determineMatch
         );
 
-        if ( !$className) {
+        if (! $className) {
             throw new DefinitionException(
                 "No class `{$classCandidate}` was found for directive `@{$this->name()}`"
             );
@@ -279,7 +275,7 @@ abstract class BaseDirective implements Directive
          */
         $modelClass = $this->namespaceClassName(
             $modelClassCandidate,
-            (array)config('lighthouse.namespaces.models'),
+            (array) config('lighthouse.namespaces.models'),
             static function (string $classCandidate): bool {
                 return is_subclass_of($classCandidate, Model::class);
             }

--- a/src/Testing/MockDirective.php
+++ b/src/Testing/MockDirective.php
@@ -11,14 +11,14 @@ class MockDirective extends BaseDirective implements FieldResolver
     /**
      * @var array<string, callable>
      */
-    protected $mocks;
+    protected static $mocks;
 
     /**
      * Register a mock resolver that will be called through this resolver.
      */
-    public function register(callable $mock, string $key): void
+    public static function register(callable $mock, string $key): void
     {
-        $this->mocks[$key] = $mock;
+        self::$mocks[$key] = $mock;
     }
 
     /**
@@ -44,7 +44,7 @@ GRAPHQL;
         return $fieldValue->setResolver(
             function () {
                 $key = $this->directiveArgValue('key', 'default');
-                $resolver = $this->mocks[$key];
+                $resolver = self::$mocks[$key];
 
                 return $resolver(...func_get_args());
             }

--- a/src/Testing/MockDirective.php
+++ b/src/Testing/MockDirective.php
@@ -9,16 +9,12 @@ use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 class MockDirective extends BaseDirective implements FieldResolver
 {
     /**
-     * @var array<string, callable>
+     * @var MockResolverService
      */
-    protected static $mocks;
+    protected $mockResolverService;
 
-    /**
-     * Register a mock resolver that will be called through this resolver.
-     */
-    public static function register(callable $mock, string $key): void
-    {
-        self::$mocks[$key] = $mock;
+    public function __construct(MockResolverService $mockResolverService){
+        $this->mockResolverService = $mockResolverService;
     }
 
     /**
@@ -44,7 +40,7 @@ GRAPHQL;
         return $fieldValue->setResolver(
             function () {
                 $key = $this->directiveArgValue('key', 'default');
-                $resolver = self::$mocks[$key];
+                $resolver = $this->mockResolverService->get($key);
 
                 return $resolver(...func_get_args());
             }

--- a/src/Testing/MockDirective.php
+++ b/src/Testing/MockDirective.php
@@ -13,7 +13,8 @@ class MockDirective extends BaseDirective implements FieldResolver
      */
     protected $mockResolverService;
 
-    public function __construct(MockResolverService $mockResolverService){
+    public function __construct(MockResolverService $mockResolverService)
+    {
         $this->mockResolverService = $mockResolverService;
     }
 

--- a/src/Testing/MockResolverService.php
+++ b/src/Testing/MockResolverService.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Nuwave\Lighthouse\Testing;
-
 
 class MockResolverService
 {
@@ -21,11 +19,8 @@ class MockResolverService
 
     /**
      * Return a mock resolver that was previously registered
-     *
-     * @param  string  $key
-     * @return callable
      */
-    public function get(string $key) : callable
+    public function get(string $key): callable
     {
         return $this->mocks[$key];
     }

--- a/src/Testing/MockResolverService.php
+++ b/src/Testing/MockResolverService.php
@@ -18,7 +18,7 @@ class MockResolverService
     }
 
     /**
-     * Return a mock resolver that was previously registered
+     * Return a mock resolver that was previously registered.
      */
     public function get(string $key): callable
     {

--- a/src/Testing/MockResolverService.php
+++ b/src/Testing/MockResolverService.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace Nuwave\Lighthouse\Testing;
+
+
+class MockResolverService
+{
+    /**
+     * @var array<string, callable>
+     */
+    protected $mocks;
+
+    /**
+     * Register a mock resolver that will be called through this resolver.
+     */
+    public function register(callable $mock, string $key): void
+    {
+        $this->mocks[$key] = $mock;
+    }
+
+    /**
+     * Return a mock resolver that was previously registered
+     *
+     * @param  string  $key
+     * @return callable
+     */
+    public function get(string $key) : callable
+    {
+        return $this->mocks[$key];
+    }
+}

--- a/src/Testing/MocksResolvers.php
+++ b/src/Testing/MocksResolvers.php
@@ -48,6 +48,8 @@ trait MocksResolvers
      */
     protected function registerMockResolver(callable $mock, string $key): void
     {
-        MockDirective::register($mock, $key);
+        /** @var \Nuwave\Lighthouse\Testing\MockResolverService $mockResolverService */
+        $mockResolverService = app(MockResolverService::class);
+        $mockResolverService->register($mock, $key);
     }
 }

--- a/src/Testing/MocksResolvers.php
+++ b/src/Testing/MocksResolvers.php
@@ -48,8 +48,6 @@ trait MocksResolvers
      */
     protected function registerMockResolver(callable $mock, string $key): void
     {
-        /** @var \Nuwave\Lighthouse\Testing\MockDirective $mockDirective */
-        $mockDirective = app(MockDirective::class);
-        $mockDirective->register($mock, $key);
+        MockDirective::register($mock, $key);
     }
 }

--- a/src/Testing/TestingServiceProvider.php
+++ b/src/Testing/TestingServiceProvider.php
@@ -23,7 +23,7 @@ class TestingServiceProvider extends ServiceProvider
 
     public function register(): void
     {
-        $this->app->singleton(MockDirective::class);
+        $this->app->bind(MockDirective::class);
 
         if (class_exists('Illuminate\Testing\TestResponse')) {
             \Illuminate\Testing\TestResponse::mixin(new TestResponseMixin());

--- a/src/Testing/TestingServiceProvider.php
+++ b/src/Testing/TestingServiceProvider.php
@@ -23,7 +23,7 @@ class TestingServiceProvider extends ServiceProvider
 
     public function register(): void
     {
-        $this->app->bind(MockDirective::class);
+        $this->app->singleton(MockResolverService::class);
 
         if (class_exists('Illuminate\Testing\TestResponse')) {
             \Illuminate\Testing\TestResponse::mixin(new TestResponseMixin());

--- a/tests/Unit/Schema/Directives/BaseDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/BaseDirectiveTest.php
@@ -157,11 +157,13 @@ class BaseDirectiveTest extends TestCase
 
         $this->assertSame(
             'argValue',
+            /** @phpstan-ignore-next-line protected method is called via wrapper below */
             $directive->directiveArgValue('argName')
         );
 
         $this->assertSame(
             'argValue2',
+            /** @phpstan-ignore-next-line protected method is called via wrapper below */
             $directive->directiveArgValue('argName2')
         );
     }
@@ -171,6 +173,7 @@ class BaseDirectiveTest extends TestCase
         $directive = $this->constructFieldDirective('foo: ID @dummy(argName:"argValue", argName:"argValue2")');
 
         $this->expectException(DefinitionException::class);
+        /** @phpstan-ignore-next-line protected method is called via wrapper below */
         $directive->directiveArgValue('argName');
     }
 

--- a/tests/Unit/Schema/Directives/BaseDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/BaseDirectiveTest.php
@@ -151,6 +151,29 @@ class BaseDirectiveTest extends TestCase
         );
     }
 
+    public function testGetsArgumentFromDirective(): void
+    {
+        $directive = $this->constructFieldDirective('foo: ID @dummy(argName:"argValue", argName2:"argValue2")');
+
+        $this->assertSame(
+            'argValue',
+            $directive->directiveArgValue('argName')
+        );
+
+        $this->assertSame(
+            'argValue2',
+            $directive->directiveArgValue('argName2')
+        );
+    }
+
+    public function testTwoArgumentsWithSameName(): void
+    {
+        $directive = $this->constructFieldDirective('foo: ID @dummy(argName:"argValue", argName:"argValue2")');
+
+        $this->expectException(DefinitionException::class);
+        $directive->directiveArgValue('argName');
+    }
+
     protected function constructFieldDirective(string $definition): BaseDirective
     {
         $fieldDefinition = Parser::fieldDefinition($definition);


### PR DESCRIPTION
**Changes**

`BaseDirective` loads all arguments and caches them after the first `directiveHasArgument`/`directiveArgValue` call

**Breaking changes**

no