### PR TITLE
Add `@throttle` directive to set field rate limit using Laravel rate limiting services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Allow using the `@builder` directive on fields https://github.com/nuwave/lighthouse/pull/1687
 - Add dedicated `\Nuwave\Lighthouse\Scout\ScoutBuilderDirective` https://github.com/nuwave/lighthouse/pull/1691
 - Allow `@eq` directive on fields https://github.com/nuwave/lighthouse/pull/1681
-- Add `@throttle` directive to set field rate limit using Laravel rate limiting services.
+- Add `@throttle` directive to set field rate limit using Laravel rate limiting services https://github.com/nuwave/lighthouse/pull/1708
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Allow using the `@builder` directive on fields https://github.com/nuwave/lighthouse/pull/1687
 - Add dedicated `\Nuwave\Lighthouse\Scout\ScoutBuilderDirective` https://github.com/nuwave/lighthouse/pull/1691
 - Allow `@eq` directive on fields https://github.com/nuwave/lighthouse/pull/1681
+- Add `@throttle` directive to set field rate limit using Laravel rate limiting services.
 
 ### Changed
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2600,7 +2600,7 @@ Sets rate limit to access the field. Does the same as ThrottleRequests Laravel M
 """
 directive @throttle (
     """
-    Named preconfigured rate limiter.
+    Named preconfigured rate limiter. Requires Larave 8.x or later.
     """
     name: String
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2598,7 +2598,7 @@ type Subscription {
 """
 Sets rate limit to access the field, just like Laravel's `ThrottleRequests` middleware.
 """
-directive @throttle (
+directive @throttle(
     """
     Named preconfigured rate limiter. Requires Laravel 8 or later.
     """

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2596,11 +2596,11 @@ type Subscription {
 
 ```graphql
 """
-Sets rate limit to access the field. Does the same as ThrottleRequests Laravel Middleware.
+Sets rate limit to access the field, just like Laravel's `ThrottleRequests` middleware.
 """
 directive @throttle (
     """
-    Named preconfigured rate limiter. Requires Larave 8.x or later.
+    Named preconfigured rate limiter. Requires Laravel 8 or later.
     """
     name: String
 
@@ -2618,7 +2618,6 @@ directive @throttle (
     Prefix to distinguish several field groups.
     """
     prefix: String
-
 ) on FIELD_DEFINITION
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2592,6 +2592,42 @@ type Subscription {
 }
 ```
 
+## @throttle
+
+```graphql
+"""
+Sets rate limit to access the field. Does the same as ThrottleRequests Laravel Middleware.
+"""
+directive @throttle (
+    """
+    Named preconfigured rate limiter.
+    """
+    name: String
+
+    """
+    Maximum number of attempts in a specified time interval.
+    """
+    maxAttempts: Int
+
+    """
+    Time in minutes to reset attempts.
+    """
+    decayMinutes: Float
+
+    """
+    Prefix to distinguish several field groups.
+    """
+    prefix: String
+
+) on FIELD_DEFINITION
+```
+
+Allows use Laravel throttling on a per-field basis. See [Laravel doc](https://laravel.com/docs/routing#rate-limiting) 
+on how to configure named limiters.
+
+Limiters that return `response` are not supported. Hashes are different from the ones of Laravel, so one can't use 
+one named limiter to limit both Laravel route and GraphQL field.
+
 ## @trashed
 
 ```graphql

--- a/src/Exceptions/RateLimitException.php
+++ b/src/Exceptions/RateLimitException.php
@@ -1,0 +1,45 @@
+<?php
+
+
+namespace Nuwave\Lighthouse\Exceptions;
+
+use GraphQL\Error\ClientAware;
+use RuntimeException;
+
+/**
+ * Thrown when the user have reached request rate limit.
+ */
+class RateLimitException extends RuntimeException implements ClientAware
+{
+    public const MESSAGE = 'Rate limit exceeded. Please try later.';
+    public const CATEGORY = 'rate-limit';
+
+    public function __construct()
+    {
+        parent::__construct(self::MESSAGE);
+    }
+
+    /**
+     * Returns true when exception message is safe to be displayed to a client.
+     *
+     * @api
+     * @return bool
+     */
+    public function isClientSafe(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Returns string describing a category of the error.
+     *
+     * Value "graphql" is reserved for errors produced by query parsing or validation, do not use it.
+     *
+     * @api
+     * @return string
+     */
+    public function getCategory(): string
+    {
+        return self::CATEGORY;
+    }
+}

--- a/src/Exceptions/RateLimitException.php
+++ b/src/Exceptions/RateLimitException.php
@@ -6,7 +6,7 @@ use GraphQL\Error\ClientAware;
 use RuntimeException;
 
 /**
- * Thrown when the user have reached request rate limit.
+ * Thrown when the user has reached the rate limit for a field.
  */
 class RateLimitException extends RuntimeException implements ClientAware
 {

--- a/src/Exceptions/RateLimitException.php
+++ b/src/Exceptions/RateLimitException.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Nuwave\Lighthouse\Exceptions;
 
 use GraphQL\Error\ClientAware;
@@ -23,7 +22,6 @@ class RateLimitException extends RuntimeException implements ClientAware
      * Returns true when exception message is safe to be displayed to a client.
      *
      * @api
-     * @return bool
      */
     public function isClientSafe(): bool
     {
@@ -36,7 +34,6 @@ class RateLimitException extends RuntimeException implements ClientAware
      * Value "graphql" is reserved for errors produced by query parsing or validation, do not use it.
      *
      * @api
-     * @return string
      */
     public function getCategory(): string
     {

--- a/src/Schema/Directives/ThrottleDirective.php
+++ b/src/Schema/Directives/ThrottleDirective.php
@@ -77,9 +77,11 @@ GRAPHQL;
         $limits = [];
         $name = $this->directiveArgValue('name') ?? null;
         if ($name !== null) {
+            /** @phpstan-ignore-next-line won't be executed on Laravel < 8 */
             $limiter = $this->limiter->limiter($name);
 
             $limiterResponse = $limiter($this->request);
+            /** @phpstan-ignore-next-line won't be executed on Laravel < 8 */
             if ($limiterResponse instanceof Unlimited) {
                 return $next($fieldValue);
             }
@@ -133,6 +135,7 @@ GRAPHQL;
                 throw new DefinitionException('Named limiter requires Laravel 8.x or later');
             }
 
+            /** @phpstan-ignore-next-line won't be executed on Laravel < 8 */
             $limiter = $this->limiter->limiter($name);
             /** @phpstan-ignore-next-line $limiter may be null although it's not specified in limiter() PHPDoc */
             if (is_null($limiter)) {

--- a/src/Schema/Directives/ThrottleDirective.php
+++ b/src/Schema/Directives/ThrottleDirective.php
@@ -76,8 +76,8 @@ GRAPHQL;
         $limits = [];
         $name = $this->directiveArgValue('name', null);
         if ($name !== null) {
-            if(!method_exists($this->limiter, 'limiter')){
-                throw new DirectiveException("Named limiter requires Laravel 8.x or later");
+            if (! method_exists($this->limiter, 'limiter')) {
+                throw new DirectiveException('Named limiter requires Laravel 8.x or later');
             }
 
             $limiter = $this->limiter->limiter($name);

--- a/src/Schema/Directives/ThrottleDirective.php
+++ b/src/Schema/Directives/ThrottleDirective.php
@@ -45,7 +45,7 @@ class ThrottleDirective extends BaseDirective implements FieldMiddleware, FieldM
 """
 Sets rate limit to access the field. Does the same as ThrottleRequests Laravel Middleware.
 """
-directive @throttle (
+directive @throttle(
     """
     Named preconfigured rate limiter. Requires Larave 8.x or later.
     """
@@ -109,10 +109,7 @@ GRAPHQL;
 
         return $next(
             $fieldValue->setResolver(
-                function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use (
-                    $originalResolver,
-                    $limits
-                ) {
+                function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($originalResolver, $limits) {
                     foreach ($limits as $limit) {
                         $this->handleLimit(
                             $limit['key'],
@@ -127,9 +124,9 @@ GRAPHQL;
         );
     }
 
-    public function manipulateFieldDefinition(DocumentAST &$documentAST, FieldDefinitionNode &$fieldDefinition, ObjectTypeDefinitionNode &$parentType)
+    public function manipulateFieldDefinition(DocumentAST &$documentAST, FieldDefinitionNode &$fieldDefinition, ObjectTypeDefinitionNode &$parentType): void
     {
-        $name = $this->directiveArgValue('name') ?? null;
+        $name = $this->directiveArgValue('name');
         if ($name !== null) {
             if (AppVersion::below(8.0)) {
                 throw new DefinitionException('Named limiter requires Laravel 8.x or later');

--- a/src/Schema/Directives/ThrottleDirective.php
+++ b/src/Schema/Directives/ThrottleDirective.php
@@ -4,7 +4,6 @@ namespace Nuwave\Lighthouse\Schema\Directives;
 
 use Closure;
 use GraphQL\Type\Definition\ResolveInfo;
-use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Unlimited;
 use Illuminate\Http\Request;
@@ -14,6 +13,7 @@ use Nuwave\Lighthouse\Exceptions\RateLimitException;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+use Symfony\Component\HttpFoundation\Response;
 
 class ThrottleDirective extends BaseDirective implements FieldMiddleware
 {
@@ -31,9 +31,6 @@ class ThrottleDirective extends BaseDirective implements FieldMiddleware
 
     /**
      * Create a new request throttler.
-     *
-     * @param  \Illuminate\Cache\RateLimiter  $limiter
-     * @param  \Illuminate\Http\Request  $request
      */
     public function __construct(RateLimiter $limiter, Request $request)
     {
@@ -43,7 +40,7 @@ class ThrottleDirective extends BaseDirective implements FieldMiddleware
 
     public static function definition(): string
     {
-        return <<<GRAPHQL
+        return <<<'GRAPHQL'
 """
 Sets rate limit to access the field. Does the same as ThrottleRequests Laravel Middleware.
 """
@@ -132,7 +129,7 @@ GRAPHQL;
     }
 
     /**
-     * Checks throttling limit
+     * Checks throttling limit.
      */
     protected function handleLimit(string $key, int $maxAttempts, float $decayMinutes): void
     {

--- a/src/Schema/Directives/ThrottleDirective.php
+++ b/src/Schema/Directives/ThrottleDirective.php
@@ -88,7 +88,7 @@ GRAPHQL;
 
             if ($limiterResponse instanceof Response) {
                 throw new DirectiveException(
-                    "Expected named limiter {$name} to return an array, got instance of " . get_class($limiterResponse)
+                    "Expected named limiter {$name} to return an array, got instance of ".get_class($limiterResponse)
                 );
             }
 

--- a/src/Schema/Directives/ThrottleDirective.php
+++ b/src/Schema/Directives/ThrottleDirective.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Directives;
+
+use Closure;
+use GraphQL\Type\Definition\ResolveInfo;
+use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Cache\RateLimiting\Unlimited;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Nuwave\Lighthouse\Exceptions\DirectiveException;
+use Nuwave\Lighthouse\Exceptions\RateLimitException;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+
+class ThrottleDirective extends BaseDirective implements FieldMiddleware
+{
+    /**
+     * The rate limiter instance.
+     *
+     * @var \Illuminate\Cache\RateLimiter
+     */
+    protected $limiter;
+
+    /**
+     * @var \Illuminate\Http\Request
+     */
+    protected $request;
+
+    /**
+     * Create a new request throttler.
+     *
+     * @param  \Illuminate\Cache\RateLimiter  $limiter
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function __construct(RateLimiter $limiter, Request $request)
+    {
+        $this->limiter = $limiter;
+        $this->request = $request;
+    }
+
+    public static function definition(): string
+    {
+        return <<<GRAPHQL
+"""
+Sets rate limit to access the field. Does the same as ThrottleRequests Laravel Middleware.
+"""
+directive @throttle (
+    """
+    Named preconfigured rate limiter.
+    """
+    name: String
+
+    """
+    Maximum number of attempts in a specified time interval.
+    """
+    maxAttempts: Int
+
+    """
+    Time in minutes to reset attempts.
+    """
+    decayMinutes: Float
+
+    """
+    Prefix to distinguish several field groups.
+    """
+    prefix: String
+
+) on FIELD_DEFINITION
+GRAPHQL;
+    }
+
+    public function handleField(FieldValue $fieldValue, Closure $next): FieldValue
+    {
+        $originalResolver = $fieldValue->getResolver();
+
+        $limits = [];
+        $name = $this->directiveArgValue('name', null);
+        if ($name !== null) {
+            $limiter = $this->limiter->limiter($name);
+            /** @phpstan-ignore-next-line $limiter may be null although it's not specified in limiter() PHPDoc */
+            if (is_null($limiter)) {
+                throw new DirectiveException("Named limiter $name is not found.");
+            }
+
+            $limiterResponse = call_user_func($limiter, $this->request);
+            if ($limiterResponse instanceof Unlimited) {
+                return $next($fieldValue);
+            }
+
+            if ($limiterResponse instanceof Response) {
+                throw new DirectiveException(
+                    "Named limiter $name returns instance of Responst which is not supported."
+                );
+            }
+
+            foreach (Arr::wrap($limiterResponse) as $limit) {
+                $limits[] = [
+                    'key' => sha1($name.$limit->key),
+                    'maxAttempts' => $limit->maxAttempts,
+                    'decayMinutes' => $limit->decayMinutes,
+                ];
+            }
+        } else {
+            $limits[] = [
+                'key' => sha1($this->directiveArgValue('prefix', '').$this->request->ip()),
+                'maxAttempts' => $this->directiveArgValue('maxAttempts', 60),
+                'decayMinutes' => $this->directiveArgValue('decayMinutes', 1),
+            ];
+        }
+
+        return $next(
+            $fieldValue->setResolver(
+                function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use (
+                    $originalResolver,
+                    $limits
+                ) {
+                    foreach ($limits as $limit) {
+                        $this->handleLimit(
+                            $limit['key'],
+                            $limit['maxAttempts'],
+                            $limit['decayMinutes']
+                        );
+                    }
+
+                    return $originalResolver($root, $args, $context, $resolveInfo);
+                }
+            )
+        );
+    }
+
+    /**
+     * Checks throttling limit
+     */
+    protected function handleLimit(string $key, int $maxAttempts, float $decayMinutes): void
+    {
+        if ($this->limiter->tooManyAttempts($key, $maxAttempts)) {
+            throw new RateLimitException();
+        }
+
+        $this->limiter->hit($key, (int) ($decayMinutes * 60));
+    }
+}

--- a/src/Schema/Directives/ThrottleDirective.php
+++ b/src/Schema/Directives/ThrottleDirective.php
@@ -46,7 +46,7 @@ Sets rate limit to access the field. Does the same as ThrottleRequests Laravel M
 """
 directive @throttle (
     """
-    Named preconfigured rate limiter.
+    Named preconfigured rate limiter. Requires Larave 8.x or later.
     """
     name: String
 
@@ -76,6 +76,10 @@ GRAPHQL;
         $limits = [];
         $name = $this->directiveArgValue('name', null);
         if ($name !== null) {
+            if(!method_exists($this->limiter, 'limiter')){
+                throw new DirectiveException("Named limiter requires Laravel 8.x or later");
+            }
+
             $limiter = $this->limiter->limiter($name);
             /** @phpstan-ignore-next-line $limiter may be null although it's not specified in limiter() PHPDoc */
             if (is_null($limiter)) {

--- a/src/Schema/Directives/ThrottleDirective.php
+++ b/src/Schema/Directives/ThrottleDirective.php
@@ -87,7 +87,7 @@ GRAPHQL;
             }
 
             $limiterResponse = call_user_func($limiter, $this->request);
-            if ($limiterResponse instanceof Unlimited) {
+            if (class_exists(Unlimited::class) && $limiterResponse instanceof Unlimited) {
                 return $next($fieldValue);
             }
 

--- a/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
@@ -77,7 +77,6 @@ class ThrottleDirectiveTest extends TestCase
         }
         ';
 
-
         $rateLimiter->for(
             'test',
             function () {

--- a/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
@@ -22,7 +22,7 @@ class ThrottleDirectiveTest extends TestCase
 
         $this->expectException(DirectiveException::class);
         $this->graphQL(
-        /** @lang GraphQL */ '
+/** @lang GraphQL */ '
         {
             foo
         }
@@ -53,7 +53,7 @@ class ThrottleDirectiveTest extends TestCase
 
         $this->expectException(DirectiveException::class);
         $this->graphQL(
-        /** @lang GraphQL */ '
+/** @lang GraphQL */ '
         {
             foo
         }
@@ -77,7 +77,7 @@ class ThrottleDirectiveTest extends TestCase
             // old Laravel, that doesn't support named limiters
             $this->expectException(DirectiveException::class);
             $this->graphQL(
-            /** @lang GraphQL */ '
+/** @lang GraphQL */ '
         {
             foo
         }
@@ -95,7 +95,7 @@ class ThrottleDirectiveTest extends TestCase
         );
 
         $this->graphQL(
-        /** @lang GraphQL */ '
+/** @lang GraphQL */ '
         {
             foo
         }
@@ -109,7 +109,7 @@ class ThrottleDirectiveTest extends TestCase
         );
 
         $this->graphQL(
-        /** @lang GraphQL */ '
+/** @lang GraphQL */ '
         {
             foo
         }
@@ -125,7 +125,6 @@ class ThrottleDirectiveTest extends TestCase
         );
     }
 
-
     public function testInlineLimiter(): void
     {
         $this->schema = /** @lang GraphQL */
@@ -136,7 +135,7 @@ class ThrottleDirectiveTest extends TestCase
         ';
 
         $this->graphQL(
-        /** @lang GraphQL */ '
+/** @lang GraphQL */ '
         {
             foo
         }
@@ -150,7 +149,7 @@ class ThrottleDirectiveTest extends TestCase
         );
 
         $this->graphQL(
-        /** @lang GraphQL */ '
+/** @lang GraphQL */ '
         {
             foo
         }

--- a/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
@@ -66,6 +66,10 @@ class ThrottleDirectiveTest extends TestCase
         /** @var RateLimiter $rateLimiter */
         $rateLimiter = $this->app->make(RateLimiter::class);
 
+        if (! method_exists($rateLimiter, 'for') || ! class_exists('Illuminate\Cache\RateLimiting\Limit')) {
+            return;
+        }
+
         $this->schema = /** @lang GraphQL */
             '
         type Query {
@@ -73,19 +77,6 @@ class ThrottleDirectiveTest extends TestCase
         }
         ';
 
-        if (! method_exists($rateLimiter, 'for')) {
-            // old Laravel, that doesn't support named limiters
-            $this->expectException(DirectiveException::class);
-            $this->graphQL(
-/** @lang GraphQL */ '
-        {
-            foo
-        }
-        '
-            );
-
-            return;
-        }
 
         $rateLimiter->for(
             'test',

--- a/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
@@ -15,21 +15,18 @@ class ThrottleDirectiveTest extends TestCase
 {
     public function testWrongLimiterName(): void
     {
-        $this->schema = /** @lang GraphQL */
-            '
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo: Int @throttle(name: "test")
         }
         ';
 
         $this->expectException(DefinitionException::class);
-        $this->graphQL(
-/** @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             foo
         }
-        '
-        );
+        ');
     }
 
     public function testNamedLimiterReturnsRequest(): void
@@ -38,8 +35,7 @@ class ThrottleDirectiveTest extends TestCase
             $this->markTestSkipped('Version less than 8.0 does not support named requests.');
         }
 
-        $this->schema = /** @lang GraphQL */
-            '
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo: Int @throttle(name: "test")
         }
@@ -50,19 +46,17 @@ class ThrottleDirectiveTest extends TestCase
         $this->assertTrue(method_exists($rateLimiter, 'for'));
         $rateLimiter->for(
             'test',
-            function () {
+            static function () {
                 return response('Custom response...', 429);
             }
         );
 
         $this->expectException(DirectiveException::class);
-        $this->graphQL(
-/** @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             foo
         }
-        '
-        );
+        ');
     }
 
     public function testNamedLimiter(): void
@@ -71,8 +65,7 @@ class ThrottleDirectiveTest extends TestCase
             $this->markTestSkipped('Version less than 8.0 does not support named requests.');
         }
 
-        $this->schema = /** @lang GraphQL */
-            '
+        $this->schema = /** @lang GraphQL */ '
         type Query {
             foo: Int @throttle(name: "test")
         }
@@ -83,19 +76,17 @@ class ThrottleDirectiveTest extends TestCase
         $this->assertTrue(method_exists($rateLimiter, 'for'));
         $rateLimiter->for(
             'test',
-            function () {
+            static function () {
                 /** @phpstan-ignore-next-line phpstan ignores markTestSkipped */
                 return Limit::perMinute(1);
             }
         );
 
-        $this->graphQL(
-/** @lang GraphQL */ '
+        $this->graphQL(/** @lang GraphQL */ '
         {
             foo
         }
-        '
-        )->assertJson(
+        ')->assertJson(
             [
                 'data' => [
                     'foo' => Foo::THE_ANSWER,

--- a/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
@@ -73,7 +73,7 @@ class ThrottleDirectiveTest extends TestCase
         }
         ';
 
-        if (! method_exists($rateLimiter, 'limiter')) {
+        if (! method_exists($rateLimiter, 'for')) {
             // old Laravel, that doesn't support named limiters
             $this->expectException(DirectiveException::class);
             $this->graphQL(

--- a/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
@@ -22,7 +22,7 @@ class ThrottleDirectiveTest extends TestCase
 
         $this->expectException(DirectiveException::class);
         $this->graphQL(
-        /** @lang GraphQL */ '
+/** @lang GraphQL */ '
         {
             foo
         }
@@ -40,7 +40,7 @@ class ThrottleDirectiveTest extends TestCase
         ';
 
         RateLimiter::for(
-            "test",
+            'test',
             function () {
                 return response('Custom response...', 429);
             }
@@ -48,7 +48,7 @@ class ThrottleDirectiveTest extends TestCase
 
         $this->expectException(DirectiveException::class);
         $this->graphQL(
-        /** @lang GraphQL */ '
+/** @lang GraphQL */ '
         {
             foo
         }
@@ -65,7 +65,7 @@ class ThrottleDirectiveTest extends TestCase
         ';
 
         RateLimiter::for(
-            "test",
+            'test',
             function () {
                 return Limit::perMinute(1);
             }
@@ -78,8 +78,8 @@ class ThrottleDirectiveTest extends TestCase
         ')->assertJson(
             [
                 'data' => [
-                    'foo' => Foo::THE_ANSWER
-                ]
+                    'foo' => Foo::THE_ANSWER,
+                ],
             ]
         );
 
@@ -92,8 +92,8 @@ class ThrottleDirectiveTest extends TestCase
                 'errors' => [
                     [
                         'message' => RateLimitException::MESSAGE,
-                    ]
-                ]
+                    ],
+                ],
             ]
         );
     }
@@ -113,8 +113,8 @@ class ThrottleDirectiveTest extends TestCase
         ')->assertJson(
             [
                 'data' => [
-                    'foo' => Foo::THE_ANSWER
-                ]
+                    'foo' => Foo::THE_ANSWER,
+                ],
             ]
         );
 
@@ -127,10 +127,9 @@ class ThrottleDirectiveTest extends TestCase
                 'errors' => [
                     [
                         'message' => RateLimitException::MESSAGE,
-                    ]
-                ]
+                    ],
+                ],
             ]
         );
     }
-
 }

--- a/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Integration\Schema\Directives;
+
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Support\Facades\RateLimiter;
+use Nuwave\Lighthouse\Exceptions\DirectiveException;
+use Nuwave\Lighthouse\Exceptions\RateLimitException;
+use Tests\TestCase;
+use Tests\Utils\Queries\Foo;
+
+class ThrottleDirectiveTest extends TestCase
+{
+    public function testWrongLimiterName(): void
+    {
+        $this->schema = /** @lang GraphQL */
+            '
+        type Query {
+            foo: Int @throttle(name: "test")
+        }
+        ';
+
+        $this->expectException(DirectiveException::class);
+        $this->graphQL(
+        /** @lang GraphQL */ '
+        {
+            foo
+        }
+        '
+        );
+    }
+
+    public function testNamedLimiterReturnsRequest(): void
+    {
+        $this->schema = /** @lang GraphQL */
+            '
+        type Query {
+            foo: Int @throttle(name: "test")
+        }
+        ';
+
+        RateLimiter::for(
+            "test",
+            function () {
+                return response('Custom response...', 429);
+            }
+        );
+
+        $this->expectException(DirectiveException::class);
+        $this->graphQL(
+        /** @lang GraphQL */ '
+        {
+            foo
+        }
+        '
+        );
+    }
+
+    public function testNamedLimiter(): void
+    {
+        $this->schema = /** @lang GraphQL */'
+        type Query {
+            foo: Int @throttle(name: "test")
+        }
+        ';
+
+        RateLimiter::for(
+            "test",
+            function () {
+                return Limit::perMinute(1);
+            }
+        );
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            foo
+        }
+        ')->assertJson(
+            [
+                'data' => [
+                    'foo' => Foo::THE_ANSWER
+                ]
+            ]
+        );
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            foo
+        }
+        ')->assertJson(
+            [
+                'errors' => [
+                    [
+                        'message' => RateLimitException::MESSAGE,
+                    ]
+                ]
+            ]
+        );
+    }
+
+    public function testInlineLimiter(): void
+    {
+        $this->schema = /** @lang GraphQL */'
+        type Query {
+            foo: Int @throttle(maxAttempts: 1)
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            foo
+        }
+        ')->assertJson(
+            [
+                'data' => [
+                    'foo' => Foo::THE_ANSWER
+                ]
+            ]
+        );
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            foo
+        }
+        ')->assertJson(
+            [
+                'errors' => [
+                    [
+                        'message' => RateLimitException::MESSAGE,
+                    ]
+                ]
+            ]
+        );
+    }
+
+}

--- a/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
@@ -4,6 +4,7 @@ namespace Tests\Integration\Schema\Directives;
 
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Limit;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Exceptions\RateLimitException;
 use Nuwave\Lighthouse\Support\AppVersion;
@@ -21,7 +22,7 @@ class ThrottleDirectiveTest extends TestCase
         }
         ';
 
-        $this->expectException(DirectiveException::class);
+        $this->expectException(DefinitionException::class);
         $this->graphQL(
 /** @lang GraphQL */ '
         {

--- a/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
@@ -80,6 +80,7 @@ class ThrottleDirectiveTest extends TestCase
         $rateLimiter->for(
             'test',
             function () {
+                /** @phpstan-ignore-next-line phpstan ignores class_exists */
                 return Limit::perMinute(1);
             }
         );

--- a/tests/Unit/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/ThrottleDirectiveTest.php
@@ -26,7 +26,7 @@ class ThrottleDirectiveTest extends TestCase
         $this->app->singleton(RateLimiter::class, function () use (&$queriedKeys) {
             $rateLimiter = $this->createMock(RateLimiter::class);
             /** @phpstan-ignore-next-line phpstan ignores markTestSkipped */
-            $rateLimiter->expects(self::once())
+            $rateLimiter->expects(self::atLeast(1))
                 ->method('limiter')
                 ->with('test')
                 ->willReturn(function () {
@@ -85,7 +85,7 @@ class ThrottleDirectiveTest extends TestCase
         $this->app->singleton(RateLimiter::class, function () {
             $rateLimiter = $this->createMock(RateLimiter::class);
             /** @phpstan-ignore-next-line phpstan ignores markTestSkipped */
-            $rateLimiter->expects(self::once())
+            $rateLimiter->expects(self::atLeast(1))
                 ->method('limiter')
                 ->with('test')
                 ->willReturn(function () {

--- a/tests/Unit/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/ThrottleDirectiveTest.php
@@ -13,7 +13,7 @@ class ThrottleDirectiveTest extends TestCase
     {
         /** @var RateLimiter $rateLimiter */
         $rateLimiter = $this->app->make(RateLimiter::class);
-        if (! method_exists($rateLimiter, 'limiter')) {
+        if (! method_exists($rateLimiter, 'limiter') || ! class_exists('Illuminate\Cache\RateLimiting\Limit')) {
             return;
         }
 
@@ -26,6 +26,7 @@ class ThrottleDirectiveTest extends TestCase
         $queriedKeys = [];
         $this->app->singleton(RateLimiter::class, function () use (&$queriedKeys) {
             $rateLimiter = $this->createMock(RateLimiter::class);
+            /** @phpstan-ignore-next-line error for old versions of Laravel */
             $rateLimiter->expects(self::once())
                 ->method('limiter')
                 ->with('test')
@@ -71,7 +72,7 @@ class ThrottleDirectiveTest extends TestCase
     {
         /** @var RateLimiter $rateLimiter */
         $rateLimiter = $this->app->make(RateLimiter::class);
-        if (! method_exists($rateLimiter, 'limiter')) {
+        if (! method_exists($rateLimiter, 'limiter') || ! class_exists('Illuminate\Cache\RateLimiting\Limit')) {
             return;
         }
 
@@ -83,6 +84,7 @@ class ThrottleDirectiveTest extends TestCase
 
         $this->app->singleton(RateLimiter::class, function () {
             $rateLimiter = $this->createMock(RateLimiter::class);
+            /** @phpstan-ignore-next-line error for old versions of Laravel */
             $rateLimiter->expects(self::once())
                 ->method('limiter')
                 ->with('test')

--- a/tests/Unit/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/ThrottleDirectiveTest.php
@@ -11,6 +11,12 @@ class ThrottleDirectiveTest extends TestCase
 {
     public function testNamedLimiter(): void
     {
+        /** @var RateLimiter $rateLimiter */
+        $rateLimiter = $this->app->make(RateLimiter::class);
+        if (! method_exists($rateLimiter, 'limiter')) {
+            return;
+        }
+
         $this->schema = /** @lang GraphQL */'
         type Query {
             foo: Int @throttle(name: "test")
@@ -63,6 +69,12 @@ class ThrottleDirectiveTest extends TestCase
 
     public function testUnlimitedNamedLimiter(): void
     {
+        /** @var RateLimiter $rateLimiter */
+        $rateLimiter = $this->app->make(RateLimiter::class);
+        if (! method_exists($rateLimiter, 'limiter')) {
+            return;
+        }
+
         $this->schema = /** @lang GraphQL */'
         type Query {
             foo: Int @throttle(name: "test")

--- a/tests/Unit/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/ThrottleDirectiveTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Schema\Directives;
 
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Limit;
+use Nuwave\Lighthouse\Support\AppVersion;
 use Tests\TestCase;
 use Tests\Utils\Queries\Foo;
 
@@ -11,10 +12,8 @@ class ThrottleDirectiveTest extends TestCase
 {
     public function testNamedLimiter(): void
     {
-        /** @var RateLimiter $rateLimiter */
-        $rateLimiter = $this->app->make(RateLimiter::class);
-        if (! method_exists($rateLimiter, 'limiter') || ! class_exists('Illuminate\Cache\RateLimiting\Limit')) {
-            return;
+        if (AppVersion::below(8.0)) {
+            $this->markTestSkipped('Version less than 8.0 does not support named requests.');
         }
 
         $this->schema = /** @lang GraphQL */'
@@ -26,17 +25,17 @@ class ThrottleDirectiveTest extends TestCase
         $queriedKeys = [];
         $this->app->singleton(RateLimiter::class, function () use (&$queriedKeys) {
             $rateLimiter = $this->createMock(RateLimiter::class);
-            /** @phpstan-ignore-next-line error for old versions of Laravel */
+            /** @phpstan-ignore-next-line phpstan ignores markTestSkipped */
             $rateLimiter->expects(self::once())
                 ->method('limiter')
                 ->with('test')
                 ->willReturn(function () {
                     return [
-                        /** @phpstan-ignore-next-line phpstan ignores class_exists */
+                        /** @phpstan-ignore-next-line phpstan ignores markTestSkipped */
                         Limit::perMinute(1),
-                        /** @phpstan-ignore-next-line phpstan ignores class_exists */
+                        /** @phpstan-ignore-next-line phpstan ignores markTestSkipped */
                         Limit::perMinute(2)->by('another_key'),
-                        /** @phpstan-ignore-next-line phpstan ignores class_exists */
+                        /** @phpstan-ignore-next-line phpstan ignores markTestSkipped */
                         Limit::perMinute(3),
                     ];
                 });
@@ -73,10 +72,8 @@ class ThrottleDirectiveTest extends TestCase
 
     public function testUnlimitedNamedLimiter(): void
     {
-        /** @var RateLimiter $rateLimiter */
-        $rateLimiter = $this->app->make(RateLimiter::class);
-        if (! method_exists($rateLimiter, 'limiter') || ! class_exists('Illuminate\Cache\RateLimiting\Limit')) {
-            return;
+        if (AppVersion::below(8.0)) {
+            $this->markTestSkipped('Version less than 8.0 does not support named requests.');
         }
 
         $this->schema = /** @lang GraphQL */'
@@ -87,12 +84,12 @@ class ThrottleDirectiveTest extends TestCase
 
         $this->app->singleton(RateLimiter::class, function () {
             $rateLimiter = $this->createMock(RateLimiter::class);
-            /** @phpstan-ignore-next-line error for old versions of Laravel */
+            /** @phpstan-ignore-next-line phpstan ignores markTestSkipped */
             $rateLimiter->expects(self::once())
                 ->method('limiter')
                 ->with('test')
                 ->willReturn(function () {
-                    /** @phpstan-ignore-next-line phpstan ignores class_exists */
+                    /** @phpstan-ignore-next-line phpstan ignores markTestSkipped */
                     return Limit::none();
                 });
 

--- a/tests/Unit/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/ThrottleDirectiveTest.php
@@ -32,8 +32,11 @@ class ThrottleDirectiveTest extends TestCase
                 ->with('test')
                 ->willReturn(function () {
                     return [
+                        /** @phpstan-ignore-next-line phpstan ignores class_exists */
                         Limit::perMinute(1),
+                        /** @phpstan-ignore-next-line phpstan ignores class_exists */
                         Limit::perMinute(2)->by('another_key'),
+                        /** @phpstan-ignore-next-line phpstan ignores class_exists */
                         Limit::perMinute(3),
                     ];
                 });
@@ -89,6 +92,7 @@ class ThrottleDirectiveTest extends TestCase
                 ->method('limiter')
                 ->with('test')
                 ->willReturn(function () {
+                    /** @phpstan-ignore-next-line phpstan ignores class_exists */
                     return Limit::none();
                 });
 

--- a/tests/Unit/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/ThrottleDirectiveTest.php
@@ -33,8 +33,9 @@ class ThrottleDirectiveTest extends TestCase
 
             $rateLimiter->expects(self::exactly(3))
                 ->method('tooManyAttempts')
-                ->willReturnCallback(function ($key, $maxAttempts) use (&$queriedKeys){
+                ->willReturnCallback(function ($key, $maxAttempts) use (&$queriedKeys) {
                     $queriedKeys[$maxAttempts] = $key;
+
                     return false;
                 });
 
@@ -51,8 +52,8 @@ class ThrottleDirectiveTest extends TestCase
         ')->assertJson(
             [
                 'data' => [
-                    'foo' => Foo::THE_ANSWER
-                ]
+                    'foo' => Foo::THE_ANSWER,
+                ],
             ]
         );
 
@@ -93,8 +94,8 @@ class ThrottleDirectiveTest extends TestCase
         ')->assertJson(
             [
                 'data' => [
-                    'foo' => Foo::THE_ANSWER
-                ]
+                    'foo' => Foo::THE_ANSWER,
+                ],
             ]
         );
     }

--- a/tests/Unit/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/ThrottleDirectiveTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Unit\Schema\Directives;
+
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Cache\RateLimiting\Limit;
+use Tests\TestCase;
+use Tests\Utils\Queries\Foo;
+
+class ThrottleDirectiveTest extends TestCase
+{
+    public function testNamedLimiter(): void
+    {
+        $this->schema = /** @lang GraphQL */'
+        type Query {
+            foo: Int @throttle(name: "test")
+        }
+        ';
+
+        $queriedKeys = [];
+        $this->app->singleton(RateLimiter::class, function () use (&$queriedKeys) {
+            $rateLimiter = $this->createMock(RateLimiter::class);
+            $rateLimiter->expects(self::once())
+                ->method('limiter')
+                ->with('test')
+                ->willReturn(function () {
+                    return [
+                        Limit::perMinute(1),
+                        Limit::perMinute(2)->by('another_key'),
+                        Limit::perMinute(3),
+                    ];
+                });
+
+            $rateLimiter->expects(self::exactly(3))
+                ->method('tooManyAttempts')
+                ->willReturnCallback(function ($key, $maxAttempts) use (&$queriedKeys){
+                    $queriedKeys[$maxAttempts] = $key;
+                    return false;
+                });
+
+            $rateLimiter->expects(self::exactly(3))
+                ->method('hit');
+
+            return $rateLimiter;
+        });
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            foo
+        }
+        ')->assertJson(
+            [
+                'data' => [
+                    'foo' => Foo::THE_ANSWER
+                ]
+            ]
+        );
+
+        $this->assertNotEquals($queriedKeys[1], $queriedKeys[2]);
+        $this->assertEquals($queriedKeys[1], $queriedKeys[3]);
+    }
+
+    public function testUnlimitedNamedLimiter(): void
+    {
+        $this->schema = /** @lang GraphQL */'
+        type Query {
+            foo: Int @throttle(name: "test")
+        }
+        ';
+
+        $this->app->singleton(RateLimiter::class, function () {
+            $rateLimiter = $this->createMock(RateLimiter::class);
+            $rateLimiter->expects(self::once())
+                ->method('limiter')
+                ->with('test')
+                ->willReturn(function () {
+                    return Limit::none();
+                });
+
+            $rateLimiter->expects(self::never())
+                ->method('tooManyAttempts');
+
+            $rateLimiter->expects(self::never())
+                ->method('hit');
+
+            return $rateLimiter;
+        });
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            foo
+        }
+        ')->assertJson(
+            [
+                'data' => [
+                    'foo' => Foo::THE_ANSWER
+                ]
+            ]
+        );
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Adds `@throttle` directive. It is adapted from Laravel and works on per-field basis.
