### PR TITLE
Test case for nested OR conditions for HAS relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Move Scout related classes into `\Nuwave\Lighthouse\Scout` https://github.com/nuwave/lighthouse/pull/1698
 - `BaseDirective` loads all arguments and caches them after the first `directiveHasArgument`/`directiveArgValue` call https://github.com/nuwave/lighthouse/pull/1707
 
+### Fixed
+
+- Fix nested `OR` conditions in `HAS` relations https://github.com/nuwave/lighthouse/pull/1713
+
 ### Deprecated
 
 - Specify `@guard(with: "api")` should be changed to `@guard(with: ["api"])`https://github.com/nuwave/lighthouse/pull/1705

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -90,11 +90,11 @@ class Utils
      */
     public static function applyEach(\Closure $callback, $valueOrValues)
     {
-        if (! is_array($valueOrValues)) {
-            return $callback($valueOrValues);
+        if (is_array($valueOrValues)) {
+            return array_map($callback, $valueOrValues);
         }
 
-        return array_map($callback, $valueOrValues);
+        return $callback($valueOrValues);
     }
 
     /**

--- a/src/WhereConditions/WhereConditionsBaseDirective.php
+++ b/src/WhereConditions/WhereConditionsBaseDirective.php
@@ -74,7 +74,7 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
                 $hasRelationConditions['relation'],
                 $hasRelationConditions['operator'],
                 $hasRelationConditions['amount'],
-                $hasRelationConditions['condition']
+                $hasRelationConditions['condition'] ?? null
             );
 
             // @phpstan-ignore-next-line Simply wrong, maybe from Larastan?

--- a/src/WhereConditions/WhereConditionsBaseDirective.php
+++ b/src/WhereConditions/WhereConditionsBaseDirective.php
@@ -9,6 +9,7 @@ use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Language\Parser;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
@@ -68,14 +69,16 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
         }
 
         if (($hasRelationConditions = $whereConditions['HAS'] ?? null) && $model) {
-            $this->handleHasCondition(
-                $builder,
+            $nestedBuilder = $this->handleHasCondition(
                 $model,
                 $hasRelationConditions['relation'],
-                $hasRelationConditions['condition'] ?? null,
-                $hasRelationConditions['amount'] ?? null,
-                $hasRelationConditions['operator'] ?? null
+                $hasRelationConditions['operator'],
+                $hasRelationConditions['amount'],
+                $hasRelationConditions['condition']
             );
+
+            // @phpstan-ignore-next-line Simply wrong, maybe from Larastan?
+            $builder->addNestedWhereQuery($nestedBuilder, $boolean);
         }
 
         if ($column = $whereConditions['column'] ?? null) {
@@ -88,35 +91,23 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
     }
 
     /**
-     * @param \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder $builder
      * @param array<string, mixed>|null $condition
      */
     public function handleHasCondition(
-        object $builder,
         Model $model,
         string $relation,
-        ?array $condition = null,
-        ?int $amount = null,
-        ?string $operator = null
-    ): void {
-        $additionalArguments = [];
-
-        if ($operator !== null) {
-            $additionalArguments[] = $operator;
-        }
-
-        if ($amount !== null) {
-            $additionalArguments[] = $amount;
-        }
-
-        /** @var \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model> $whereHasQuery */
-        $whereHasQuery = $model
+        string $operator,
+        int $amount,
+        ?array $condition = null
+    ): QueryBuilder {
+        return $model
+            ->newQuery()
             ->whereHas(
                 $relation,
-                function ($builder) use ($relation, $model, $condition): void {
-                    if ($condition) {
+                $condition
+                    ? function ($builder) use ($relation, $model, $condition): void {
                         $relatedModel = $this->nestedRelatedModel($model, $relation);
-
+    
                         $this->handleWhereConditions(
                             $builder,
                             $this->prefixConditionWithTableName(
@@ -126,12 +117,11 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
                             $relatedModel
                         );
                     }
-                },
-                ...$additionalArguments
+                    : null,
+                $operator,
+                $amount
             )
             ->getQuery();
-
-        $builder->addNestedWhereQuery($whereHasQuery);
     }
 
     public static function invalidColumnName(string $column): string

--- a/src/WhereConditions/WhereConditionsBaseDirective.php
+++ b/src/WhereConditions/WhereConditionsBaseDirective.php
@@ -107,7 +107,7 @@ abstract class WhereConditionsBaseDirective extends BaseDirective implements Arg
                 $condition
                     ? function ($builder) use ($relation, $model, $condition): void {
                         $relatedModel = $this->nestedRelatedModel($model, $relation);
-    
+
                         $this->handleWhereConditions(
                             $builder,
                             $this->prefixConditionWithTableName(

--- a/src/WhereConditions/WhereHasConditionsDirective.php
+++ b/src/WhereConditions/WhereHasConditionsDirective.php
@@ -56,11 +56,17 @@ GRAPHQL;
         }
         $model = $builder->getModel();
 
-        $this->handleHasCondition(
+        $this->handleWhereConditions(
             $builder,
-            $model,
-            $this->getRelationName(),
-            $whereConditions
+            [
+                'HAS' => [
+                    'relation' => $this->getRelationName(),
+                    'amount' => WhereConditionsServiceProvider::DEFAULT_HAS_AMOUNT,
+                    'operator' => '>=',
+                    'condition' => $whereConditions,
+                ],
+            ],
+            $model
         );
 
         return $builder;

--- a/tests/Integration/WhereConditions/WhereHasConditionsDirectiveTest.php
+++ b/tests/Integration/WhereConditions/WhereHasConditionsDirectiveTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Integration\WhereConditions;
 
+use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Facades\DB;
 use Nuwave\Lighthouse\WhereConditions\WhereConditionsServiceProvider;
 use Tests\DBTestCase;
@@ -203,17 +204,19 @@ class WhereHasConditionsDirectiveTest extends DBTestCase
         $user->roles()->attach($role);
 
         $this->graphQL(/** @lang GraphQL */ '
-        {
+        query ($id: Mixed!) {
             users(
                 hasRoles: {
                     column: "id",
-                    value: '.$role->getKey().'
+                    value: $id
                 }
             ) {
                 id
             }
         }
-        ')->assertExactJson([
+        ', [
+            'id' => $role->getKey(),
+        ])->assertExactJson([
             'data' => [
                 'users' => [
                     [

--- a/tests/Integration/WhereConditions/WhereHasConditionsDirectiveTest.php
+++ b/tests/Integration/WhereConditions/WhereHasConditionsDirectiveTest.php
@@ -2,8 +2,11 @@
 
 namespace Tests\Integration\WhereConditions;
 
+use Illuminate\Support\Facades\DB;
 use Nuwave\Lighthouse\WhereConditions\WhereConditionsServiceProvider;
 use Tests\DBTestCase;
+use Tests\Utils\Models\Category;
+use Tests\Utils\Models\Post;
 use Tests\Utils\Models\Role;
 use Tests\Utils\Models\User;
 
@@ -21,6 +24,13 @@ class WhereHasConditionsDirectiveTest extends DBTestCase
         id: ID!
         title: String
         body: String
+        categories: [Category!] @belongsToMany
+    }
+
+    type Category {
+        category_id: ID!
+        name: String
+        parent: Category @belongsTo
     }
 
     type Company {
@@ -36,6 +46,7 @@ class WhereHasConditionsDirectiveTest extends DBTestCase
     type Query {
         posts(
             hasUser: _ @whereHasConditions(relation: "user")
+            hasCategories: _ @whereHasConditions(relation: "categories")
         ): [Post!]! @all
 
         users(
@@ -210,6 +221,105 @@ class WhereHasConditionsDirectiveTest extends DBTestCase
                     ],
                 ],
             ],
+        ]);
+    }
+
+    public function testWhereHasBelongsToManyOrNestedConditions(): void
+    {
+        /*
+         * Categories
+         */
+
+        // Top-level category
+        $category1 = factory(Category::class)->create();
+
+        // 2nd level category, with a parent of previous category
+        $category2 = factory(Category::class)->create();
+        $category2->parent()->associate($category1);
+        $category2->save();
+
+        // 3rd level category, with a parent of previous category
+        $category3 = factory(Category::class)->create();
+        $category3->parent()->associate($category2);
+        $category3->save();
+
+        // 4th level category, with a parent of previous category
+        $category4 = factory(Category::class)->create();
+        $category4->parent()->associate($category3);
+        $category4->save();
+
+        // 5th level category, with a parent of previous category
+        $category5 = factory(Category::class)->create();
+        $category5->parent()->associate($category4);
+        $category5->save();
+        /*
+         * Posts
+         */
+        factory(Post::class)->create();
+
+        $post2 = factory(Post::class)->create();
+        $post2->categories()->attach($category2);
+
+        $post3 = factory(Post::class)->create();
+        $post3->categories()->attach($category3);
+
+        $post4 = factory(Post::class)->create();
+        $post4->categories()->attach($category4);
+
+        $post5 = factory(Post::class)->create();
+        $post5->categories()->attach($category5);
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            posts(
+                hasCategories: {
+                    OR: [
+                        {
+                            column: "categories.category_id",
+                            value: '.$category3->getKey().'
+                        },
+                        {
+                            HAS: {
+                                relation: "parent",
+                                condition: {
+                                    OR: [
+                                        {
+                                            column: "category_id",
+                                            value: '.$category3->getKey().'
+                                        },
+                                        {
+                                            HAS: {
+                                                relation: "parent",
+                                                condition: {
+                                                    column: "category_id",
+                                                    value: '.$category3->getKey().'
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                    ]
+                }
+            ) {
+                id
+            }
+        }
+        ')->assertExactJson([
+            'data' => [
+                'posts' => [
+                    [
+                        'id' => (string) $post3->getKey(),
+                    ],
+                    [
+                        'id' => (string) $post4->getKey(),
+                    ],
+                    [
+                        'id' => (string) $post5->getKey(),
+                    ]
+                ]
+            ]
         ]);
     }
 }

--- a/tests/Integration/WhereConditions/WhereHasConditionsDirectiveTest.php
+++ b/tests/Integration/WhereConditions/WhereHasConditionsDirectiveTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\Integration\WhereConditions;
 
-use Illuminate\Database\Events\QueryExecuted;
-use Illuminate\Support\Facades\DB;
 use Nuwave\Lighthouse\WhereConditions\WhereConditionsServiceProvider;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Category;
@@ -311,9 +309,9 @@ class WhereHasConditionsDirectiveTest extends DBTestCase
                     ],
                     [
                         'id' => (string) $post5->getKey(),
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ]);
     }
 }

--- a/tests/Utils/Models/Category.php
+++ b/tests/Utils/Models/Category.php
@@ -3,6 +3,8 @@
 namespace Tests\Utils\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
  * @property int $category_id
@@ -13,4 +15,16 @@ use Illuminate\Database\Eloquent\Model;
 class Category extends Model
 {
     protected $primaryKey = 'category_id';
+
+    protected $guarded = [];
+
+    public function parent(): BelongsTo
+    {
+    	return $this->belongsTo(Category::class, 'parent_id');
+    }
+
+    public function posts(): BelongsToMany
+    {
+        return $this->belongsToMany(Category::class, 'category_post', 'post_id', 'category_id');
+    }
 }

--- a/tests/Utils/Models/Category.php
+++ b/tests/Utils/Models/Category.php
@@ -18,7 +18,7 @@ class Category extends Model
 
     public function parent(): BelongsTo
     {
-    	return $this->belongsTo(Category::class, 'parent_id');
+        return $this->belongsTo(Category::class, 'parent_id');
     }
 
     public function posts(): BelongsToMany

--- a/tests/Utils/Models/Category.php
+++ b/tests/Utils/Models/Category.php
@@ -16,8 +16,6 @@ class Category extends Model
 {
     protected $primaryKey = 'category_id';
 
-    protected $guarded = [];
-
     public function parent(): BelongsTo
     {
     	return $this->belongsTo(Category::class, 'parent_id');

--- a/tests/Utils/Models/Post.php
+++ b/tests/Utils/Models/Post.php
@@ -4,6 +4,7 @@ namespace Tests\Utils\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
@@ -72,5 +73,10 @@ class Post extends Model
     public function images(): MorphMany
     {
         return $this->morphMany(Image::class, 'imageable');
+    }
+
+    public function categories(): BelongsToMany
+    {
+        return $this->belongsToMany(Category::class, 'category_post', 'category_id', 'post_id');
     }
 }

--- a/tests/database/migrations/2018_02_28_000000_create_testbench_companies_table.php
+++ b/tests/database/migrations/2018_02_28_000000_create_testbench_companies_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchCompaniesTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('companies', function (Blueprint $table): void {
@@ -19,9 +16,6 @@ class CreateTestbenchCompaniesTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('companies');

--- a/tests/database/migrations/2018_02_28_000000_create_testbench_images_table.php
+++ b/tests/database/migrations/2018_02_28_000000_create_testbench_images_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchImagesTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('images', function (Blueprint $table): void {
@@ -22,9 +19,6 @@ class CreateTestbenchImagesTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('images');

--- a/tests/database/migrations/2018_02_28_000001_create_testbench_teams_table.php
+++ b/tests/database/migrations/2018_02_28_000001_create_testbench_teams_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchTeamsTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('teams', function (Blueprint $table): void {
@@ -19,9 +16,6 @@ class CreateTestbenchTeamsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('teams');

--- a/tests/database/migrations/2018_02_28_000002_create_testbench_users_table.php
+++ b/tests/database/migrations/2018_02_28_000002_create_testbench_users_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchUsersTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('users', function (Blueprint $table): void {
@@ -27,9 +24,6 @@ class CreateTestbenchUsersTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('users');

--- a/tests/database/migrations/2018_02_28_000002_create_testbench_with_enums_table.php
+++ b/tests/database/migrations/2018_02_28_000002_create_testbench_with_enums_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchWithEnumsTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('with_enums', function (Blueprint $table): void {
@@ -18,9 +15,6 @@ class CreateTestbenchWithEnumsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('users');

--- a/tests/database/migrations/2018_02_28_000003_create_testbench_tasks_table.php
+++ b/tests/database/migrations/2018_02_28_000003_create_testbench_tasks_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchTasksTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('tasks', function (Blueprint $table): void {
@@ -26,9 +23,6 @@ class CreateTestbenchTasksTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('tasks');

--- a/tests/database/migrations/2018_02_28_000004_create_testbench_posts_table.php
+++ b/tests/database/migrations/2018_02_28_000004_create_testbench_posts_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchPostsTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('posts', function (Blueprint $table): void {
@@ -31,9 +28,6 @@ class CreateTestbenchPostsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('posts');

--- a/tests/database/migrations/2018_02_28_000005_create_testbench_comments_table.php
+++ b/tests/database/migrations/2018_02_28_000005_create_testbench_comments_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchCommentsTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('comments', function (Blueprint $table): void {
@@ -22,9 +19,6 @@ class CreateTestbenchCommentsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('comments');

--- a/tests/database/migrations/2018_09_30_000006_create_testbench_tags_table.php
+++ b/tests/database/migrations/2018_09_30_000006_create_testbench_tags_table.php
@@ -7,9 +7,6 @@ use Tests\Constants;
 
 class CreateTestbenchTagsTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('tags', function (Blueprint $table): void {
@@ -21,9 +18,6 @@ class CreateTestbenchTagsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('tags');

--- a/tests/database/migrations/2018_09_30_000007_create_testbench_taggables_table.php
+++ b/tests/database/migrations/2018_09_30_000007_create_testbench_taggables_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchTaggablesTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('taggables', function (Blueprint $table): void {
@@ -21,9 +18,6 @@ class CreateTestbenchTaggablesTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('taggables');

--- a/tests/database/migrations/2018_10_07_000008_create_testbench_acls_table.php
+++ b/tests/database/migrations/2018_10_07_000008_create_testbench_acls_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchAclsTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('acls', function (Blueprint $table): void {
@@ -20,9 +17,6 @@ class CreateTestbenchAclsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('acls');

--- a/tests/database/migrations/2018_10_07_000009_create_testbench_roles_table.php
+++ b/tests/database/migrations/2018_10_07_000009_create_testbench_roles_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchRolesTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('roles', function (Blueprint $table): void {
@@ -19,9 +16,6 @@ class CreateTestbenchRolesTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('roles');

--- a/tests/database/migrations/2018_10_07_000010_create_testbench_role_user_table.php
+++ b/tests/database/migrations/2018_10_07_000010_create_testbench_role_user_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchRoleUserTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('role_user', function (Blueprint $table): void {
@@ -20,9 +17,6 @@ class CreateTestbenchRoleUserTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('role_user');

--- a/tests/database/migrations/2018_11_25_000004_create_testbench_colors_table.php
+++ b/tests/database/migrations/2018_11_25_000004_create_testbench_colors_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchColorsTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('colors', function (Blueprint $table): void {
@@ -22,9 +19,6 @@ class CreateTestbenchColorsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('colors');

--- a/tests/database/migrations/2018_11_25_000005_create_testbench_products_table.php
+++ b/tests/database/migrations/2018_11_25_000005_create_testbench_products_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchProductsTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('products', function (Blueprint $table): void {
@@ -24,9 +21,6 @@ class CreateTestbenchProductsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('products');

--- a/tests/database/migrations/2018_12_08_000001_create_testbench_categories_table.php
+++ b/tests/database/migrations/2018_12_08_000001_create_testbench_categories_table.php
@@ -15,7 +15,11 @@ class CreateTestbenchCategoriesTable extends Migration
             $table->increments('category_id');
             $table->string('name');
 
+            $table->unsignedInteger('parent_id')->nullable();
+
             $table->timestamps();
+
+            $table->foreign('parent_id')->references('category_id')->on('categories');
         });
     }
 

--- a/tests/database/migrations/2018_12_08_000001_create_testbench_categories_table.php
+++ b/tests/database/migrations/2018_12_08_000001_create_testbench_categories_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchCategoriesTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('categories', function (Blueprint $table): void {
@@ -23,9 +20,6 @@ class CreateTestbenchCategoriesTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('categories');

--- a/tests/database/migrations/2019_11_04_000001_create_testbench_contractors_table.php
+++ b/tests/database/migrations/2019_11_04_000001_create_testbench_contractors_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchContractorsTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('contractors', function (Blueprint $table): void {
@@ -19,9 +16,6 @@ class CreateTestbenchContractorsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('contractors');

--- a/tests/database/migrations/2019_11_04_000001_create_testbench_employees_table.php
+++ b/tests/database/migrations/2019_11_04_000001_create_testbench_employees_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchEmployeesTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('employees', function (Blueprint $table): void {
@@ -19,9 +16,6 @@ class CreateTestbenchEmployeesTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('employees');

--- a/tests/database/migrations/2021_01_30_000000_create_testbench_category_post_table.php
+++ b/tests/database/migrations/2021_01_30_000000_create_testbench_category_post_table.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchCategoryPostTable extends Migration
 {
-   /**
+    /**
      * Run the migrations.
      */
     public function up(): void

--- a/tests/database/migrations/2021_01_30_000000_create_testbench_category_post_table.php
+++ b/tests/database/migrations/2021_01_30_000000_create_testbench_category_post_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateTestbenchCategoryPostTable extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('category_post', function (Blueprint $table): void {
@@ -16,15 +13,9 @@ class CreateTestbenchCategoryPostTable extends Migration
 
             $table->unsignedInteger('category_id');
             $table->unsignedInteger('post_id');
-
-            // $table->foreign('category_id')->references('category_id')->on('categories');
-            // $table->foreign('post_id')->references('id')->on('posts');
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::drop('category_post');

--- a/tests/database/migrations/2021_01_30_000000_create_testbench_category_post_table.php
+++ b/tests/database/migrations/2021_01_30_000000_create_testbench_category_post_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTestbenchCategoryPostTable extends Migration
+{
+   /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('category_post', function (Blueprint $table): void {
+            $table->increments('id');
+
+            $table->unsignedInteger('category_id');
+            $table->unsignedInteger('post_id');
+
+            // $table->foreign('category_id')->references('category_id')->on('categories');
+            // $table->foreign('post_id')->references('id')->on('posts');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::drop('category_post');
+    }
+}


### PR DESCRIPTION
Added failing test for issue [#1677](https://github.com/nuwave/lighthouse/issues/1677)

<!-- Please file a bug report only if you identified a problem within Lighthouse.
To get help on an issue or ask a question, consult Stack Overflow or Slack. -->

**Describe the bug**

I'm trying to query for products that are in a category or its subcategories. Categories can have one `parent`, and products can `belongToMany` `categories`. When using an array of `OR` conditions to apply to the relationship `categories` for for the `product` type, the query generated uses `AND` instead of `OR`. See the graphql query here and the SQL output further below.

```graphql
query ($where: WhereConditions) {		
  products(where: $where) {
    data {
      id
      title
    }
  }
} 

variables: {
  "where": {
    "HAS": {
      "relation": "categories",
      "condition": {
        "OR": [   // Currently both of these conditions must be met, which is incorrect and never returns products
          {
            "column": "categories.id",
            "value": 375          
          },
          {
            "HAS": {
              "relation": "parent",
              "condition": {
                "column": "id",
                "value": 375
              }
            }
          }
        ]
      }
    }
  }
}
```

If I remove one of the conditions in the `OR` array above, two different sets of products are returned, but I need the `OR` to properly apply these conditions so that I retrieve both sets of products together.

**Expected behavior/Solution**

I'd imagine this would be an update to use one of the Laravel query builder `orWhere..` clauses, but I haven't yet traced the code in lighthouse to see where the exact issue is. 

**Steps to Reproduce**

Run newly added test `Tests\Integration\WhereConditions\WhereHasConditionsDirectiveTest::testWhereHasBelongsToManyOrNestedConditions`

**Output/Logs**

<details><summary>Click to expand</summary>
  
  
The 2nd `AND` below should be an `OR` operator

```sql
SELECT count(*) AS AGGREGATE 
FROM `products` 
WHERE (EXISTS (
	SELECT * FROM `categories` 
	INNER JOIN `category_product` ON `categories`.`id` = `category_product`.`category_id` 
	WHERE `products`.`id` = `category_product`.`product_id` 
	AND (
		`categories`.`id` = 375 
		AND (EXISTS (
			SELECT * FROM `categories` AS `laravel_reserved_0` WHERE `laravel_reserved_0`.`id` = `categories`.`parent_id` AND `categories`.`id` = 375
		))
	)
))
```

</details></br>

**Lighthouse Version**

Lighthouse v5
