### PR TITLE
Use gate response in authorization errors of `@can` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Clarify semantics of combining `@search` with other directives https://github.com/nuwave/lighthouse/pull/1691
 - Move Scout related classes into `\Nuwave\Lighthouse\Scout` https://github.com/nuwave/lighthouse/pull/1698
 - `BaseDirective` loads all arguments and caches them after the first `directiveHasArgument`/`directiveArgValue` call https://github.com/nuwave/lighthouse/pull/1707
+- `@can` will pass the message given in a `\Illuminate\Auth\Access\AuthorizationException` response returned by a policy method to the thrown GraphQL error https://github.com/nuwave/lighthouse/pull/1715
 
 ### Deprecated
 

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -176,21 +176,16 @@ GRAPHQL;
         // should be [modelClassName, additionalArg, additionalArg...]
         array_unshift($arguments, $model);
 
-        if (is_array($ability)) {
-            foreach ($ability as $ab) {
+        Utils::applyEach(
+            function ($ab) use ($gate, $arguments) {
                 $response = $gate->inspect($ab, $arguments);
 
                 if ($response->denied()) {
                     throw new AuthorizationException($response->message(), $response->code());
                 }
-            }
-        } else {
-            $response = $gate->inspect($ability, $arguments);
-
-            if ($response->denied()) {
-                throw new AuthorizationException($response->message(), $response->code());
-            }
-        }
+            },
+            $ability
+        );
     }
 
     /**

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -176,10 +176,20 @@ GRAPHQL;
         // should be [modelClassName, additionalArg, additionalArg...]
         array_unshift($arguments, $model);
 
-        if (! $gate->check($ability, $arguments)) {
-            throw new AuthorizationException(
-                "You are not authorized to access {$this->nodeName()}"
-            );
+        if (is_array($ability)) {
+            foreach ($ability as $ab) {
+                $response = $gate->inspect($ab, $arguments);
+
+                if ($response->denied()) {
+                    throw new AuthorizationException($response->message());
+                }
+            }
+        } else {
+            $response = $gate->inspect($ability, $arguments);
+
+            if ($response->denied()) {
+                throw new AuthorizationException($response->message());
+            }
         }
     }
 

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -182,7 +182,7 @@ GRAPHQL;
             Utils::applyEach(
                 function ($ab) use ($gate, $arguments) {
                     $response = $gate->inspect($ab, $arguments);
-    
+
                     if ($response->denied()) {
                         throw new AuthorizationException($response->message(), $response->code());
                     }

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -181,14 +181,14 @@ GRAPHQL;
                 $response = $gate->inspect($ab, $arguments);
 
                 if ($response->denied()) {
-                    throw new AuthorizationException($response->message());
+                    throw new AuthorizationException($response->message(), $response->code());
                 }
             }
         } else {
             $response = $gate->inspect($ability, $arguments);
 
             if ($response->denied()) {
-                throw new AuthorizationException($response->message());
+                throw new AuthorizationException($response->message(), $response->code());
             }
         }
     }

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -37,6 +37,10 @@ class CanDirectiveTest extends TestCase
 
     public function testThrowsWithCustomMessageIfNotAuthorized(): void
     {
+        if (AppVersion::below(6.0)) {
+            $this->markTestSkipped('Version less than 6.0 do not support gate responses.');
+        }
+
         $this->be(new User);
 
         $this->schema = /** @lang GraphQL */ '
@@ -70,6 +74,10 @@ class CanDirectiveTest extends TestCase
 
     public function testThrowsFirstWithCustomMessageIfNotAuthorized(): void
     {
+        if (AppVersion::below(6.0)) {
+            $this->markTestSkipped('Version less than 6.0 do not support gate responses.');
+        }
+
         $this->be(new User);
 
         $this->schema = /** @lang GraphQL */ '

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -62,7 +62,7 @@ class CanDirectiveTest extends TestCase
         $response->assertJson([
             'errors' => [
                 [
-                    'message' => 'Only super admins allowed',
+                    'message' => UserPolicy::SUPER_ADMINS_ONLY_MESSAGE,
                 ],
             ],
         ]);
@@ -95,7 +95,7 @@ class CanDirectiveTest extends TestCase
         $response->assertJson([
             'errors' => [
                 [
-                    'message' => 'Only super admins allowed',
+                    'message' => UserPolicy::SUPER_ADMINS_ONLY_MESSAGE,
                 ],
             ],
         ]);

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -68,6 +68,39 @@ class CanDirectiveTest extends TestCase
         ]);
     }
 
+    public function testThrowsFirstWithCustomMessageIfNotAuthorized(): void
+    {
+        $this->be(new User);
+
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            user: User!
+                @can(ability: ["superAdminOnly", "adminOnly"])
+                @mock
+        }
+
+        type User {
+            name: String
+        }
+        ';
+
+        $response = $this->graphQL(/** @lang GraphQL */ '
+        {
+            user {
+                name
+            }
+        }
+        ');
+        $response->assertGraphQLErrorCategory(AuthorizationException::CATEGORY);
+        $response->assertJson([
+            'errors' => [
+                [
+                    'message' => 'Only super admins allowed',
+                ],
+            ],
+        ]);
+    }
+
     public function testPassesAuthIfAuthorized(): void
     {
         $user = new User;

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -35,6 +35,39 @@ class CanDirectiveTest extends TestCase
         ')->assertGraphQLErrorCategory(AuthorizationException::CATEGORY);
     }
 
+    public function testThrowsWithCustomMessageIfNotAuthorized(): void
+    {
+        $this->be(new User);
+
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            user: User!
+                @can(ability: "superAdminOnly")
+                @mock
+        }
+
+        type User {
+            name: String
+        }
+        ';
+
+        $response = $this->graphQL(/** @lang GraphQL */ '
+        {
+            user {
+                name
+            }
+        }
+        ');
+        $response->assertGraphQLErrorCategory(AuthorizationException::CATEGORY);
+        $response->assertJson([
+            'errors' => [
+                [
+                    'message' => 'Only super admins allowed'
+                ]
+            ]
+        ]);
+    }
+
     public function testPassesAuthIfAuthorized(): void
     {
         $user = new User;

--- a/tests/Unit/Schema/Directives/CanDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/CanDirectiveTest.php
@@ -62,9 +62,9 @@ class CanDirectiveTest extends TestCase
         $response->assertJson([
             'errors' => [
                 [
-                    'message' => 'Only super admins allowed'
-                ]
-            ]
+                    'message' => 'Only super admins allowed',
+                ],
+            ],
         ]);
     }
 

--- a/tests/Utils/Policies/UserPolicy.php
+++ b/tests/Utils/Policies/UserPolicy.php
@@ -18,10 +18,10 @@ class UserPolicy
     public function superAdminOnly(User $user): Response
     {
         if ($user->name === self::SUPER_ADMIN) {
-            return true;
+            return Response::allow();
         }
 
-        return new Response(false, 'Only super admins allowed');
+        return Response::deny('Only super admins allowed');
     }
 
     public function alwaysTrue(): bool

--- a/tests/Utils/Policies/UserPolicy.php
+++ b/tests/Utils/Policies/UserPolicy.php
@@ -2,15 +2,26 @@
 
 namespace Tests\Utils\Policies;
 
+use Illuminate\Auth\Access\Response;
 use Tests\Utils\Models\User;
 
 class UserPolicy
 {
+    public const SUPER_ADMIN = 'super admin';
     public const ADMIN = 'admin';
 
     public function adminOnly(User $user): bool
     {
         return $user->name === self::ADMIN;
+    }
+
+    public function superAdminOnly(User $user): Response
+    {
+        if ($user->name === self::SUPER_ADMIN) {
+            return true;
+        }
+
+        return new Response(false, 'Only super admins allowed');
     }
 
     public function alwaysTrue(): bool

--- a/tests/Utils/Policies/UserPolicy.php
+++ b/tests/Utils/Policies/UserPolicy.php
@@ -10,6 +10,8 @@ class UserPolicy
     public const SUPER_ADMIN = 'super admin';
     public const ADMIN = 'admin';
 
+    public const SUPER_ADMINS_ONLY_MESSAGE = 'Only super admins allowed';
+
     public function adminOnly(User $user): bool
     {
         return $user->name === self::ADMIN;
@@ -21,7 +23,7 @@ class UserPolicy
             return Response::allow();
         }
 
-        return Response::deny('Only super admins allowed');
+        return Response::deny(self::SUPER_ADMINS_ONLY_MESSAGE);
     }
 
     public function alwaysTrue(): bool


### PR DESCRIPTION
- [X] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
In order to allow field authorization failures (especially in mutation queries) to return a detailed failure message, this PR changes the `@can` directive in a way, that it uses the `$gate->inspect` method (instead of `$gate->check`, which just returns a boolean) to receive an authorization response, which may hold a custom message returned by a policy method. Those Laravel responses are documented [here](https://laravel.com/docs/8.x/authorization#gate-responses).

This also changes the default error message from `You are not authorized to access {$this->nodeName()}` to the default error message of a Laravel auth access response `This action is unauthorized.` (found [here](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Auth/Access/AuthorizationException.php#L27)). I'm pretty sure this default message does not fit the context it is used in, but just wanted to get an opinion about this PR for now.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
