### PR TITLE
Request information in manipulate result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- Added a field for the current query to the `\Nuwave\Lighthouse\Events\ManipulateResult` event.
+
 ## 5.2.0
 
 ### Added

--- a/src/Events/ManipulateResult.php
+++ b/src/Events/ManipulateResult.php
@@ -19,8 +19,19 @@ class ManipulateResult
      */
     public $result;
 
-    public function __construct(ExecutionResult &$result)
+    /**
+     * @var \GraphQL\Language\AST\DocumentNode|string
+     */
+    public $query;
+
+    /**
+     * ManipulateResult constructor.
+     * @param ExecutionResult $result
+     * @param \GraphQL\Language\AST\DocumentNode|string $query
+     */
+    public function __construct(ExecutionResult &$result, $query)
     {
         $this->result = $result;
+        $this->query = $query;
     }
 }

--- a/src/Events/ManipulateResult.php
+++ b/src/Events/ManipulateResult.php
@@ -25,8 +25,6 @@ class ManipulateResult
     public $query;
 
     /**
-     * ManipulateResult constructor.
-     * @param ExecutionResult $result
      * @param \GraphQL\Language\AST\DocumentNode|string $query
      */
     public function __construct(ExecutionResult &$result, $query)

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -239,7 +239,7 @@ class GraphQL
 
         // Allow listeners to manipulate the result after each resolved query
         $this->eventDispatcher->dispatch(
-            new ManipulateResult($result)
+            new ManipulateResult($result, $query)
         );
 
         $this->cleanUp();

--- a/tests/Unit/Events/ManipulateResultTest.php
+++ b/tests/Unit/Events/ManipulateResultTest.php
@@ -14,6 +14,7 @@ class ManipulateResultTest extends TestCase
         Event::listen(
             ManipulateResult::class,
             function (ManipulateResult $manipulateResult): void {
+                $this->assertStringContainsString('foo', (string) $manipulateResult->query);
                 $manipulateResult->result->data = [
                     'foo' => Foo::THE_ANSWER + 1,
                 ];


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes *(N/A?)*
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

This adds a query field to the `ManipulateResult` event, so event listeners can know which query to manipulate the result for. We're using [a plugin that sends tracing to Apollo Studio](https://github.com/brightalley/lighthouse-apollo), which for Lighthouse v4 fetches the GraphQL request singleton, but for v5 that no longer exists.

**Breaking changes**

I guess technically it could be considered a breaking change that you now need to pass a second parameter to instantiate a `ManipulateResult`, though I imagine that's not really a typical use case. Let me know if you want me to add this to the breaking changes.