### PR TITLE
Fix docs: explicit foreign key for `author_id`

### DIFF
--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -172,7 +172,7 @@ class Post extends Model
 {
     public function author(): BelongsTo
     {
-        return $this->belongsTo(User::class);
+        return $this->belongsTo(User::class, 'author_id');
     }
 
     public function comments(): HasMany


### PR DESCRIPTION
The "author_id" field is a foreign key with a custom name other than the default. It needs to be explicitly stated.

- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
