### PR TITLE
Add `connect` and `disconnect` operations in nested mutations for HasMany and MorphMany relations

### DIFF
--- a/docs/master/eloquent/nested-mutations.md
+++ b/docs/master/eloquent/nested-mutations.md
@@ -512,6 +512,8 @@ input UpdatePostsHasMany {
   update: [UpdatePostInput!]
   upsert: [UpsertPostInput!]
   delete: [ID!]
+  connect: [ID!]
+  disconnect: [ID!]
 }
 
 input CreatePostInput {
@@ -539,6 +541,8 @@ mutation {
         create: [{ title: "A new post" }]
         update: [{ id: 45, title: "This post is updated" }]
         delete: [8]
+        connect: [1, 2, 3]
+        disconnect: [6]
       }
     }
   ) {


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Add `connect` and `disconnect` to HasMany and MorphMany relations so now you can connect and disconnect objects as you like.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
