### PR TITLE
Fix broadcasting in the echo subscription driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 ### Added
 
 - Validate that `@with` and `@withCount` are not used on root fields https://github.com/nuwave/lighthouse/pull/1714
+- For `echo` driver based subscriptions, the event name will be 'lighthouse-subscription'. Echo driver will always broadcast through the `private` channel. If want to broadcast a sync event, it will not be queued anymore. Pusher driver can log entries if defined in the `broadcasting` config file. https://github.com/nuwave/lighthouse/pull/1733
 
 ## 5.2.0
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,6 +29,7 @@
     <php>
         <env name="LIGHTHOUSE_TEST_DB_DATABASE" value="test"/>
         <env name="LIGHTHOUSE_TEST_DB_HOST" value="mysql"/>
+        <env name="LIGHTHOUSE_TEST_DB_PORT" value="3306"/>
         <env name="LIGHTHOUSE_TEST_DB_USERNAME" value="root"/>
         <env name="LIGHTHOUSE_TEST_DB_PASSWORD" value=""/>
         <env name="LIGHTHOUSE_TEST_REDIS_HOST" value="redis"/>

--- a/src/Subscriptions/Authorizer.php
+++ b/src/Subscriptions/Authorizer.php
@@ -44,8 +44,6 @@ class Authorizer implements AuthorizesSubscriptions
                 return false;
             }
 
-            $channel = $this->sanitizeChannelName($channel);
-
             $subscriber = $this->storage->subscriberByChannel($channel);
             if ($subscriber === null) {
                 return false;
@@ -71,19 +69,5 @@ class Authorizer implements AuthorizesSubscriptions
 
             return false;
         }
-    }
-
-    /**
-     * Removes the prefix "presence-" from the channel name.
-     *
-     * Laravel Echo prefixes channel names with "presence-", but we don't.
-     */
-    private function sanitizeChannelName(string $channelName): string
-    {
-        if (Str::startsWith($channelName, 'presence-')) {
-            return Str::substr($channelName, 9);
-        }
-
-        return $channelName;
     }
 }

--- a/src/Subscriptions/Authorizer.php
+++ b/src/Subscriptions/Authorizer.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Subscriptions;
 
 use Exception;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Nuwave\Lighthouse\Subscriptions\Contracts\AuthorizesSubscriptions;
 use Nuwave\Lighthouse\Subscriptions\Contracts\StoresSubscriptions;
 use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionExceptionHandler;
@@ -43,6 +44,8 @@ class Authorizer implements AuthorizesSubscriptions
                 return false;
             }
 
+            $channel = $this->sanitizeChannelName($channel);
+
             $subscriber = $this->storage->subscriberByChannel($channel);
             if ($subscriber === null) {
                 return false;
@@ -68,5 +71,19 @@ class Authorizer implements AuthorizesSubscriptions
 
             return false;
         }
+    }
+
+    /**
+     * Removes the prefix "presence-" from the channel name.
+     *
+     * Laravel Echo prefixes channel names with "presence-", but we don't.
+     */
+    private function sanitizeChannelName(string $channelName): string
+    {
+        if (Str::startsWith($channelName, 'presence-')) {
+            return Str::substr($channelName, 9);
+        }
+
+        return $channelName;
     }
 }

--- a/src/Subscriptions/Authorizer.php
+++ b/src/Subscriptions/Authorizer.php
@@ -4,7 +4,6 @@ namespace Nuwave\Lighthouse\Subscriptions;
 
 use Exception;
 use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 use Nuwave\Lighthouse\Subscriptions\Contracts\AuthorizesSubscriptions;
 use Nuwave\Lighthouse\Subscriptions\Contracts\StoresSubscriptions;
 use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionExceptionHandler;

--- a/src/Subscriptions/BroadcastManager.php
+++ b/src/Subscriptions/BroadcastManager.php
@@ -8,6 +8,7 @@ use Nuwave\Lighthouse\Subscriptions\Broadcasters\LogBroadcaster;
 use Nuwave\Lighthouse\Subscriptions\Broadcasters\PusherBroadcaster;
 use Nuwave\Lighthouse\Subscriptions\Contracts\Broadcaster;
 use Nuwave\Lighthouse\Support\DriverManager;
+use Psr\Log\LoggerInterface;
 use Pusher\Pusher;
 use RuntimeException;
 
@@ -53,6 +54,10 @@ class BroadcastManager extends DriverManager
         $options = Arr::get($driverConfig, 'options', []);
 
         $pusher = new Pusher($appKey, $appSecret, $appId, $options);
+
+        if ($driverConfig['log'] ?? false) {
+            $pusher->setLogger($this->app->make(LoggerInterface::class));
+        }
 
         return new PusherBroadcaster($pusher);
     }

--- a/src/Subscriptions/Broadcasters/PusherBroadcaster.php
+++ b/src/Subscriptions/Broadcasters/PusherBroadcaster.php
@@ -11,8 +11,6 @@ use Pusher\Pusher;
 
 class PusherBroadcaster implements Broadcaster
 {
-    public const EVENT_NAME = 'lighthouse-subscription';
-
     /**
      * @var \Pusher\Pusher
      */

--- a/src/Subscriptions/Contracts/Broadcaster.php
+++ b/src/Subscriptions/Contracts/Broadcaster.php
@@ -7,6 +7,8 @@ use Nuwave\Lighthouse\Subscriptions\Subscriber;
 
 interface Broadcaster
 {
+    public const EVENT_NAME = 'lighthouse-subscription';
+
     /**
      * Handle authorized subscription request.
      *

--- a/src/Subscriptions/Events/EchoSubscriptionEvent.php
+++ b/src/Subscriptions/Events/EchoSubscriptionEvent.php
@@ -2,10 +2,11 @@
 
 namespace Nuwave\Lighthouse\Subscriptions\Events;
 
-use Illuminate\Broadcasting\PresenceChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Nuwave\Lighthouse\Subscriptions\Contracts\Broadcaster;
 
-class EchoSubscriptionEvent implements ShouldBroadcast
+class EchoSubscriptionEvent implements ShouldBroadcastNow
 {
     /**
      * @var string
@@ -26,9 +27,9 @@ class EchoSubscriptionEvent implements ShouldBroadcast
         $this->data = $data;
     }
 
-    public function broadcastOn(): PresenceChannel
+    public function broadcastOn(): Channel
     {
-        return new PresenceChannel($this->channel);
+        return new Channel($this->channel);
     }
 
     /**
@@ -38,6 +39,6 @@ class EchoSubscriptionEvent implements ShouldBroadcast
      */
     public function broadcastAs(): string
     {
-        return 'lighthouse.subscription';
+        return Broadcaster::EVENT_NAME;
     }
 }

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -50,6 +50,7 @@ abstract class DBTestCase extends TestCase
             'driver' => 'mysql',
             'database' => env('LIGHTHOUSE_TEST_DB_DATABASE', 'test'),
             'host' => env('LIGHTHOUSE_TEST_DB_HOST', 'mysql'),
+            'port' => env('LIGHTHOUSE_TEST_DB_PORT', '3306'),
             'username' => env('LIGHTHOUSE_TEST_DB_USERNAME', 'root'),
             'password' => env('LIGHTHOUSE_TEST_DB_PASSWORD', ''),
         ]);

--- a/tests/Integration/Subscriptions/EchoBroadcaster/AuthorizeRequestsTest.php
+++ b/tests/Integration/Subscriptions/EchoBroadcaster/AuthorizeRequestsTest.php
@@ -61,7 +61,7 @@ class AuthorizeRequestsTest extends TestCase
     {
         $response = $this->querySubscription();
 
-        $channel = $response->json('extensions.lighthouse_subscriptions.channels.taskUpdated');
+        $channel = $response->json('extensions.lighthouse_subscriptions.channel');
         $this
             ->postJson('graphql/subscriptions/auth', [
                 'channel_name' => 'anything-before-'.$channel,

--- a/tests/Integration/Subscriptions/EchoBroadcaster/AuthorizeRequestsTest.php
+++ b/tests/Integration/Subscriptions/EchoBroadcaster/AuthorizeRequestsTest.php
@@ -44,7 +44,7 @@ class AuthorizeRequestsTest extends TestCase
     {
         $response = $this->querySubscription();
 
-        $channel = $response->json('extensions.lighthouse_subscriptions.channels.taskUpdated');
+        $channel = $response->json('extensions.lighthouse_subscriptions.channel');
         $this
             ->postJson('graphql/subscriptions/auth', [
                 'channel_name' => 'presence-'.$channel,

--- a/tests/Integration/Subscriptions/EchoBroadcaster/AuthorizeRequestsTest.php
+++ b/tests/Integration/Subscriptions/EchoBroadcaster/AuthorizeRequestsTest.php
@@ -40,6 +40,35 @@ class AuthorizeRequestsTest extends TestCase
             ]);
     }
 
+    public function testEchoClientAuthorizesPresenceChannelForBackwardCompatibility(): void
+    {
+        $response = $this->querySubscription();
+
+        $channel = $response->json('extensions.lighthouse_subscriptions.channels.taskUpdated');
+        $this
+            ->postJson('graphql/subscriptions/auth', [
+                'channel_name' => 'presence-' . $channel,
+            ])
+            ->assertSuccessful()
+            ->assertJsonStructure([
+                'channel_data' => [
+                    'user_id', 'user_info',
+                ],
+            ]);
+    }
+
+    public function testEchoClientAuthorizationFailsOtherThanPresenceChannel(): void
+    {
+        $response = $this->querySubscription();
+
+        $channel = $response->json('extensions.lighthouse_subscriptions.channels.taskUpdated');
+        $this
+            ->postJson('graphql/subscriptions/auth', [
+                'channel_name' => 'anything-before-' . $channel,
+            ])
+            ->assertForbidden();
+    }
+
     public function testEchoClientAuthorizeFails(): void
     {
         $response = $this->querySubscription();

--- a/tests/Integration/Subscriptions/EchoBroadcaster/AuthorizeRequestsTest.php
+++ b/tests/Integration/Subscriptions/EchoBroadcaster/AuthorizeRequestsTest.php
@@ -47,7 +47,7 @@ class AuthorizeRequestsTest extends TestCase
         $channel = $response->json('extensions.lighthouse_subscriptions.channels.taskUpdated');
         $this
             ->postJson('graphql/subscriptions/auth', [
-                'channel_name' => 'presence-' . $channel,
+                'channel_name' => 'presence-'.$channel,
             ])
             ->assertSuccessful()
             ->assertJsonStructure([
@@ -64,7 +64,7 @@ class AuthorizeRequestsTest extends TestCase
         $channel = $response->json('extensions.lighthouse_subscriptions.channels.taskUpdated');
         $this
             ->postJson('graphql/subscriptions/auth', [
-                'channel_name' => 'anything-before-' . $channel,
+                'channel_name' => 'anything-before-'.$channel,
             ])
             ->assertForbidden();
     }

--- a/tests/Integration/Subscriptions/EchoBroadcaster/AuthorizeRequestsTest.php
+++ b/tests/Integration/Subscriptions/EchoBroadcaster/AuthorizeRequestsTest.php
@@ -30,7 +30,7 @@ class AuthorizeRequestsTest extends TestCase
         $channel = $response->json('extensions.lighthouse_subscriptions.channels.taskUpdated');
         $this
             ->postJson('graphql/subscriptions/auth', [
-                'channel_name' => 'presence-'.$channel,
+                'channel_name' => $channel,
             ])
             ->assertSuccessful()
             ->assertJsonStructure([
@@ -47,7 +47,7 @@ class AuthorizeRequestsTest extends TestCase
         $channel = $response->json('extensions.lighthouse_subscriptions.channels.taskUpdated');
         $this
             ->postJson('graphql/subscriptions/auth', [
-                'channel_name' => 'presence-'.$channel.'plain-wrong',
+                'channel_name' => $channel.'plain-wrong',
             ])
             ->assertForbidden();
     }
@@ -59,7 +59,7 @@ class AuthorizeRequestsTest extends TestCase
         $channel = $response->json('extensions.lighthouse_subscriptions.channels.taskUpdated');
         $this
             ->postJson('graphql/subscriptions/auth', [
-                'channel_name' => 'presence-'.$channel,
+                'channel_name' => $channel,
             ])
             ->assertSuccessful()
             ->assertJsonStructure([
@@ -71,7 +71,7 @@ class AuthorizeRequestsTest extends TestCase
 
         $this
             ->postJson('graphql/subscriptions/auth', [
-                'channel_name' => 'presence-'.$channel,
+                'channel_name' => $channel,
             ])
             ->assertForbidden();
     }

--- a/tests/Unit/Subscriptions/Broadcasters/EchoBroadcasterTest.php
+++ b/tests/Unit/Subscriptions/Broadcasters/EchoBroadcasterTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Subscriptions\Broadcasters;
 use Illuminate\Broadcasting\BroadcastManager;
 use Illuminate\Http\Request;
 use Nuwave\Lighthouse\Subscriptions\Broadcasters\EchoBroadcaster;
+use Nuwave\Lighthouse\Subscriptions\Contracts\Broadcaster;
 use Nuwave\Lighthouse\Subscriptions\Events\EchoSubscriptionEvent;
 use Nuwave\Lighthouse\Subscriptions\Subscriber;
 use PHPUnit\Framework\Constraint\Callback;
@@ -21,14 +22,30 @@ class EchoBroadcasterTest extends TestCase
         $broadcastManager->expects($this->once())
             ->method('event')
             ->with(new Callback(function (EchoSubscriptionEvent $event) {
-                return $event->broadcastAs() === 'lighthouse.subscription' &&
-                    $event->broadcastOn()->name === 'presence-test-123' &&
+                return $event->broadcastAs() === Broadcaster::EVENT_NAME &&
+                    $event->broadcastOn()->name === 'test-123' &&
                     $event->data === 'foo';
             }));
 
         $redisBroadcaster = new EchoBroadcaster($broadcastManager);
         $subscriber = $this->createMock(Subscriber::class);
         $subscriber->channel = 'test-123';
+
+        $redisBroadcaster->broadcast($subscriber, 'foo');
+    }
+
+    public function testBroadcastChannelNameIsNotModified(): void
+    {
+        $broadcastManager = $this->createMock(BroadcastManager::class);
+        $broadcastManager->expects($this->once())
+            ->method('event')
+            ->with(new Callback(function (EchoSubscriptionEvent $event) {
+                return $event->broadcastOn()->name === 'private-test-123';
+            }));
+
+        $redisBroadcaster = new EchoBroadcaster($broadcastManager);
+        $subscriber = $this->createMock(Subscriber::class);
+        $subscriber->channel = 'private-test-123';
 
         $redisBroadcaster->broadcast($subscriber, 'foo');
     }

--- a/tests/Unit/Subscriptions/Broadcasters/PusherBroadcasterTest.php
+++ b/tests/Unit/Subscriptions/Broadcasters/PusherBroadcasterTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit\Subscriptions\Broadcasters;
+
+use Nuwave\Lighthouse\Subscriptions\BroadcastManager;
+use Nuwave\Lighthouse\Subscriptions\Subscriber;
+use Psr\Log\LoggerInterface;
+use Tests\TestCase;
+use Tests\TestsSubscriptions;
+
+class PusherBroadcasterTest extends TestCase
+{
+    use TestsSubscriptions;
+
+    public function testPusherUsesLoggerInterface(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+
+        // Minimum cases: "create_curl", "trigger POST", "exec_curl response"
+        $logger->expects($this->atLeast(3))->method('log');
+
+        // Bind the mocked logger instance instead of the actual logger
+        app()->bind(LoggerInterface::class, function () use ($logger) {
+            return $logger;
+        });
+
+        // Enable logging for pusher
+        app('config')->set('broadcasting.connections.pusher.log', true);
+
+        $pusherBroadcaster = app(BroadcastManager::class)->driver('pusher');
+        $subscriber = $this->createMock(Subscriber::class);
+        $subscriber->channel = 'test-123';
+
+        $pusherBroadcaster->broadcast($subscriber, 'foo');
+    }
+
+    public function testPusherNeverUsesLoggerInterface(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $logger->expects($this->never())->method('log');
+
+        // Bind the mocked logger instance instead of the actual logger
+        app()->bind(LoggerInterface::class, function () use ($logger) {
+            return $logger;
+        });
+
+        $pusherBroadcaster = app(BroadcastManager::class)->driver('pusher');
+        $subscriber = $this->createMock(Subscriber::class);
+        $subscriber->channel = 'test-123';
+
+        $pusherBroadcaster->broadcast($subscriber, 'foo');
+    }
+}


### PR DESCRIPTION
- [x] Updated CHANGELOG.md
- [x] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
#1724 

**Changes**
- For `echo` driver-based subscriptions, the event name will be 'lighthouse-subscription'. 
- Echo driver will always broadcast through the `private` channel. 
- If want to broadcast a sync event, it will not be queued anymore. 
- Pusher driver can log entries if defined in the `broadcasting` config file.
<!-- Detail the changes in behavior this PR introduces. -->

**Breaking changes**
- The event name can be a breaking change `lighthouse-subscription`

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
