### PR TITLE
Prepend directives when transferring them from types to fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Changed
 
-- Prepend directives when transferring them from types to fields
+- Prepend directives when transferring them from types to fields https://github.com/nuwave/lighthouse/pull/1734
 
 ## 5.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 - Validate that `@with` and `@withCount` are not used on root fields https://github.com/nuwave/lighthouse/pull/1714
 
+### Changed
+
+- Prepend directives when transferring them from types to fields
+
 ## 5.2.0
 
 ### Added

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -1078,6 +1078,18 @@ on all of them at once.
 extend type Query @guard { ... }
 ```
 
+The `@guard` directive will be prepended to other directives defined on the fields
+and thus executes before them.
+
+```graphql
+extend type Query {
+  user: User!
+    @guard
+    @can(ability: "adminOnly")
+  ...
+}
+```
+
 ## @hash
 
 ```graphql

--- a/docs/master/custom-directives/field-directives.md
+++ b/docs/master/custom-directives/field-directives.md
@@ -68,7 +68,7 @@ Field middleware run in lexical definition order.
 
 ```graphql
 type Query {
-    foo: ID @first @second
+  foo: ID @first @second
 }
 ```
 

--- a/docs/master/custom-directives/field-directives.md
+++ b/docs/master/custom-directives/field-directives.md
@@ -64,6 +64,14 @@ GRAPHQL;
 }
 ```
 
+Field middleware run in lexical definition order.
+
+```graphql
+type Query {
+    foo: ID @first @second
+}
+```
+
 ## FieldBuilderDirective
 
 A [`\Nuwave\Lighthouse\Support\Contracts\FieldBuilderDirective`](https://github.com/nuwave/lighthouse/blob/master/src/Support/Contracts/FieldBuilderDirective.php)

--- a/docs/master/security/authentication.md
+++ b/docs/master/security/authentication.md
@@ -71,8 +71,7 @@ to add a CSRF token](https://github.com/mll-lab/laravel-graphql-playground#confi
 
 ## Guard selected fields
 
-If you want to guard only selected fields, you can use the [@guard](../api-reference/directives.md#guard)
-directive to require authentication for accessing them.
+Use the [@guard](../api-reference/directives.md#guard) directive to require authentication for a single field.
 
 ```graphql
 type Query {
@@ -80,13 +79,25 @@ type Query {
 }
 ```
 
-If you need to guard multiple fields, just use [@guard](../api-reference/directives.md#guard)
+If you need to guard multiple fields, use [@guard](../api-reference/directives.md#guard)
 on a `type` or an `extend type` definition. It will be applied to all fields within that type.
 
 ```graphql
-extend type Query @guard
+extend type Query @guard {
   adminInfo: Secrets
   nukeCodes: [NukeCode!]!
+}
+```
+
+The `@guard` directive will be prepended to other directives defined on the fields
+and thus executes before them.
+
+```graphql
+extend type Query {
+  user: User!
+    @guard
+    @can(ability: "adminOnly")
+  ...
 }
 ```
 

--- a/docs/master/the-basics/directives.md
+++ b/docs/master/the-basics/directives.md
@@ -53,10 +53,10 @@ type Query {
     "Search by title"
     title: String @like(template: "%{}%")
   ): [Post!]!
-    # Resolve as a paginated list
-    @paginate
     # Require authentication
     @guard
+    # Resolve as a paginated list
+    @paginate
 }
 ```
 

--- a/docs/master/the-basics/fields.md
+++ b/docs/master/the-basics/fields.md
@@ -176,7 +176,7 @@ of `App\Model\User`.
 
 Next, the field sub-selection will be resolved - the two requested fields are `id` and `name`.
 Since we already resolved the User in the parent field, we do not want to fetch it again
-to get it's attributes.
+to get its attributes.
 
 Conveniently, the first argument of each resolver is the return value of the parent
 field, in this case a User model.

--- a/php.dockerfile
+++ b/php.dockerfile
@@ -25,8 +25,6 @@ RUN pecl install \
 
 RUN echo 'memory_limit=-1' > /usr/local/etc/php/conf.d/lighthouse.ini
 
-RUN echo "alias phpunit='vendor/bin/phpunit'" >> ~/.bashrc
-
 ARG USER
 ARG USER_ID
 ARG GROUP_ID

--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -71,6 +71,24 @@ class ASTHelper
         return $merged;
     }
 
+    /**
+     * @template TNode of \GraphQL\Language\AST\Node
+     * @param  \GraphQL\Language\AST\NodeList<TNode>  $nodeList
+     * @param  TNode  $node
+     * @return \GraphQL\Language\AST\NodeList<TNode>
+     */
+    public static function prepend(NodeList $nodeList, Node $node): NodeList
+    {
+        /**
+         * Since we did not modify the passed in lists, the types did not change.
+         *
+         * @var \GraphQL\Language\AST\NodeList<TNode> $merged
+         */
+        $merged = (new NodeList([$node]))->merge($nodeList);
+
+        return $merged;
+    }
+
     public static function duplicateDefinition(string $oldName): string
     {
         return "Duplicate definition {$oldName} found when merging.";
@@ -106,22 +124,6 @@ class ASTHelper
         }
 
         return self::getUnderlyingNamedTypeNode($type);
-    }
-
-    /**
-     * Does the given field have an argument of the given name?
-     */
-    public static function fieldHasArgument(FieldDefinitionNode $fieldDefinition, string $name): bool
-    {
-        return self::firstByName($fieldDefinition->arguments, $name) !== null;
-    }
-
-    /**
-     * Does the given directive have an argument of the given name?
-     */
-    public static function directiveHasArgument(DirectiveNode $directiveDefinition, string $name): bool
-    {
-        return self::firstByName($directiveDefinition->arguments, $name) !== null;
     }
 
     /**
@@ -237,7 +239,7 @@ class ASTHelper
                 /** @var iterable<\GraphQL\Language\AST\FieldDefinitionNode> $fieldDefinitions */
                 $fieldDefinitions = $typeDefinition->fields;
                 foreach ($fieldDefinitions as $fieldDefinition) {
-                    $fieldDefinition->directives [] = $directive;
+                    $fieldDefinition->directives = static::prepend($fieldDefinition->directives, $directive);
                 }
             }
         }
@@ -287,7 +289,7 @@ class ASTHelper
                 continue;
             }
 
-            $fieldDefinition->directives [] = $directiveNode;
+            $fieldDefinition->directives = static::prepend($fieldDefinition->directives, $directiveNode);
         }
     }
 

--- a/tests/Unit/Schema/Directives/GuardDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/GuardDirectiveTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Unit\Schema\Directives;
 
 use Nuwave\Lighthouse\Exceptions\AuthenticationException;
-use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Tests\TestCase;
 use Tests\Utils\Models\User;
 use Tests\Utils\Queries\Foo;

--- a/tests/Unit/Schema/Directives/GuardDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/GuardDirectiveTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Schema\Directives;
 
 use Nuwave\Lighthouse\Exceptions\AuthenticationException;
+use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Tests\TestCase;
 use Tests\Utils\Models\User;
 use Tests\Utils\Queries\Foo;
@@ -115,5 +116,30 @@ class GuardDirectiveTest extends TestCase
                 ],
             ],
         ]);
+    }
+
+    public function testGuardHappensBeforeOtherDirectivesIfAddedFromType(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query @guard {
+            user: User!
+                @can(ability: "adminOnly")
+                @mock
+        }
+
+        type User {
+            name: String
+        }
+        ';
+
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            {
+                user {
+                    name
+                }
+            }
+            ')
+            ->assertGraphQLErrorCategory(AuthenticationException::CATEGORY);
     }
 }


### PR DESCRIPTION
Resolves https://github.com/nuwave/lighthouse/issues/1709

- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

When directives are transferred from the application on a `type` to the contained fields, they are now prepended to the existing directives instead of appending them.

```graphql
type Query @guard {
  user: User!
    @can(ability: "adminOnly")
}
```

Before this PR:

```graphql
type Query {
  user: User!
    @can(ability: "adminOnly")
    @guard
}
```

After this PR:

```graphql
type Query {
  user: User!
    @guard
    @can(ability: "adminOnly")
}
```

**Breaking changes**

Rather unbreaking #1666.
