### PR TITLE
Support `pusher/pusher-php-server` version 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Add events to cover the lifecycle of a GraphQL request: `EndExecution`, `EndRequest` https://github.com/nuwave/lighthouse/pull/1726
 - Include the client given query, variables and operation name in the `StartExecution` event https://github.com/nuwave/lighthouse/pull/1726
 - Apply `log` option from the `broadcasting` config to the Pusher subscription driver https://github.com/nuwave/lighthouse/pull/1733
+- Support for `pusher/pusher-php-server` version 5.0 https://github.com/nuwave/lighthouse/pull/1741
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Add events to cover the lifecycle of a GraphQL request: `EndExecution`, `EndRequest` https://github.com/nuwave/lighthouse/pull/1726
 - Include the client given query, variables and operation name in the `StartExecution` event https://github.com/nuwave/lighthouse/pull/1726
 - Apply `log` option from the `broadcasting` config to the Pusher subscription driver https://github.com/nuwave/lighthouse/pull/1733
-- Support for `pusher/pusher-php-server` version 5.0 https://github.com/nuwave/lighthouse/pull/1741
+- Support `pusher/pusher-php-server` version 5 https://github.com/nuwave/lighthouse/pull/1741
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "phpstan/phpstan-phpunit": "^0.12.17",
         "phpunit/phpunit": "^7.5 || ^8.4 || ^9",
         "predis/predis": "^1.1",
-        "pusher/pusher-php-server": "^4",
+        "pusher/pusher-php-server": "^4|^5",
         "rector/rector": "^0.9",
         "thecodingmachine/phpstan-safe-rule": "^1.0"
     },
@@ -62,7 +62,8 @@
         "bensampo/laravel-enum": "Convenient enum definitions that can easily be registered in your Schema",
         "laravel/scout": "Required for the @search directive",
         "mll-lab/graphql-php-scalars": "Useful scalar types, required for @whereConditions",
-        "mll-lab/laravel-graphql-playground": "GraphQL IDE for better development workflow - integrated with Laravel"
+        "mll-lab/laravel-graphql-playground": "GraphQL IDE for better development workflow - integrated with Laravel",
+        "pusher/pusher-php-server": "Required when using the Pusher Subscriptions driver"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "phpstan/phpstan-phpunit": "^0.12.17",
         "phpunit/phpunit": "^7.5 || ^8.4 || ^9",
         "predis/predis": "^1.1",
-        "pusher/pusher-php-server": "^4|^5",
+        "pusher/pusher-php-server": "^4 || ^5",
         "rector/rector": "^0.9",
         "thecodingmachine/phpstan-safe-rule": "^1.0"
     },

--- a/src/Subscriptions/BroadcastManager.php
+++ b/src/Subscriptions/BroadcastManager.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Subscriptions;
 
+use Illuminate\Contracts\Debug\ExceptionHandler as LaravelExceptionHandler;
 use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Subscriptions\Broadcasters\EchoBroadcaster;
 use Nuwave\Lighthouse\Subscriptions\Broadcasters\LogBroadcaster;
@@ -59,7 +60,7 @@ class BroadcastManager extends DriverManager
             $pusher->setLogger($this->app->make(LoggerInterface::class));
         }
 
-        return new PusherBroadcaster($pusher);
+        return new PusherBroadcaster($pusher, $this->app->make(LaravelExceptionHandler::class));
     }
 
     /**


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Pusher 5 now throws an exception when triggering the broadcast fails, we catch that exception and report it to the framework so the user can debug.

See changes: https://github.com/pusher/pusher-http-php/blob/master/CHANGELOG.md#500-2021-02-19

As far is I can tell the catch with the new exception has no actual effect when the exception class doesn't exist and it has no negative effects having it there for 5.x, code still works fine with 4.x (it just doesn't enter the "catch" ever).

**Breaking changes**

None.
