### PR TITLE
Fix subscription extension version default value

### DIFF
--- a/src/Subscriptions/SubscriptionRegistry.php
+++ b/src/Subscriptions/SubscriptionRegistry.php
@@ -155,7 +155,7 @@ class SubscriptionRegistry
             ? reset($this->subscribers)
             : null;
 
-        $version = config('lighthouse.subscriptions.version');
+        $version = config('lighthouse.subscriptions.version', 1);
         switch ((int) $version) {
             case 1:
                 $content = [


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Define a default for when `config('lighthouse.subscriptions.version')` returns `null`.

This will most likely happen for all users with existing `lighthouse.php` files since Laravel does not merge config files deep so although we have defined a default in our own `lighthouse.php` because the user has a `subscriptions` key in their own `lighthouse.php` you need to define `version` otherwise exception is being thrown.

You can consider this behaviour a breaking change so that's why a default must be provided so users don't have to change their config files to prevent an exception.

**Breaking changes**

This fixed a "breaking change", but doesn't introduce a new one.
