### PR TITLE
Fix mget call with empty subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 - Apply error handling and debug settings consistently https://github.com/nuwave/lighthouse/pull/1749
 - Fix typo `comparision` to `comparison` in generated input types for `@whereHas`
+- Fix redis `mget` being called with an empty list of subscriber ids https://github.com/nuwave/lighthouse/pull/1759
 
 ## 5.3.0
 

--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -64,6 +64,9 @@ class RedisStorageManager implements StoresSubscriptions
         // Since we store the individual subscribers with a prefix,
         // but not in the set, we have to add the prefix here.
         $subscriberIds = array_map([$this, 'channelKey'], $subscriberIds);
+        if (empty($subscriberIds)) {
+            return new Collection();
+        }
 
         // Using the mget command, we can retrieve multiple values from redis.
         // This is like using multiple get calls (getSubscriber uses the get command).

--- a/tests/Integration/Subscriptions/Storage/RedisStorageManagerTest.php
+++ b/tests/Integration/Subscriptions/Storage/RedisStorageManagerTest.php
@@ -85,9 +85,11 @@ class RedisStorageManagerTest extends TestCase
         $this->querySubscription();
         $this->querySubscription('taskCreated');
 
+        $unknownSubscribers = $storage->subscribersByTopic('SOMETHING_UNKNOWN');
         $updatedSubscribers = $storage->subscribersByTopic('TASK_UPDATED');
         $createdSubscribers = $storage->subscribersByTopic('TASK_CREATED');
 
+        $this->assertCount(0, $unknownSubscribers);
         $this->assertCount(3, $updatedSubscribers);
         $this->assertCount(1, $createdSubscribers);
 


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves #1757 

**Changes**

Fix the mget call when there are no subscribers

