### PR TITLE
Set and restore the Lighthouse guard name for authenticated subscription iterator

### DIFF
--- a/src/Subscriptions/Iterators/AuthenticatingSyncIterator.php
+++ b/src/Subscriptions/Iterators/AuthenticatingSyncIterator.php
@@ -37,6 +37,12 @@ class AuthenticatingSyncIterator implements SubscriptionIterator
         // Store the previous default guard name so we can restore it after we're done
         $previousGuardName = $this->configRepository->get('auth.defaults.guard');
 
+        // Store the previous default Ligthouse guard name so we can restore it after we're done
+        $defaultLighthouseGuardName = $this->configRepository->get('lighthouse.guard');
+
+        // Set our subscription guard as the default guard for Lighthouse
+        $this->configRepository->set('lighthouse.guard', SubscriptionGuard::GUARD_NAME);
+
         // Set our subscription guard as the default guard for the application
         $this->authFactory->shouldUse(SubscriptionGuard::GUARD_NAME);
 
@@ -63,6 +69,9 @@ class AuthenticatingSyncIterator implements SubscriptionIterator
                 $guard->reset();
             }
         });
+
+        // Restore the previous default Lighthouse guard name
+        $this->configRepository->set('lighthouse.guard', $defaultLighthouseGuardName);
 
         // Restore the previous default guard name
         $this->authFactory->shouldUse($previousGuardName);

--- a/tests/Integration/Schema/Types/UnionTest.php
+++ b/tests/Integration/Schema/Types/UnionTest.php
@@ -74,7 +74,7 @@ class UnionTest extends DBTestCase
             : '';
 
         return [
-            /** @lang GraphQL */ "
+/** @lang GraphQL */ "
             union Stuff {$customResolver} = {$prefix}User | {$prefix}Post
 
             type {$prefix}User {
@@ -89,7 +89,7 @@ class UnionTest extends DBTestCase
                 stuff: [Stuff!]! @field(resolver: \"{$this->qualifyTestResolver()}\")
             }
             ",
-            /** @lang GraphQL */ "
+/** @lang GraphQL */ "
             {
                 stuff {
                     ... on {$prefix}User {


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Resolves #1607.

**Changes**

This fixes subscription with `@guard` (without argument) not having the correct authentication context available.

I do however have a hard time thinking on how to test this to be honest so until I have the time to sit down for that I created this PR to at least have it documented since you can copy the class to your own app to start using these changes.

**Breaking changes**

I don't believe so since I consider this to be a bugfix.
