### PR TITLE
Failing test for required_without in array

### DIFF
--- a/tests/Integration/Validation/RequiredWithoutTest.php
+++ b/tests/Integration/Validation/RequiredWithoutTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Integration\Validation;
+
+use Tests\TestCase;
+
+class RequiredWithoutTest extends TestCase
+{
+    public function testValidatesRequiredWithoutInArray(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+            type Query {
+                createStuff(input: MyInput!): Int! @field(resolver: "Tests\\\\Utils\\\\Mutations\\\\Foo")
+            }
+
+            input MyInput @validator(class: "Tests\\\\Utils\\\\Validators\\\\RequiredWithoutInArrayValidator") {
+                items: [ItemInput!]!
+            }
+
+            input ItemInput {
+                thing: ThingInput!
+            }
+
+            input ThingInput {
+                an_id: ID
+                some_data: SomeDataInput
+            }
+
+            input SomeDataInput {
+                name: String!
+            }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+            {
+                createStuff(input: {
+                    items: [{
+                        thing: {
+                            some_data: {
+                                name: "foobar"
+                            }
+                        }
+                    }]
+                })
+            }
+        ')->assertGraphQLValidationPasses();
+    }
+}

--- a/tests/Utils/Validators/RequiredWithoutInArrayValidator.php
+++ b/tests/Utils/Validators/RequiredWithoutInArrayValidator.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Utils\Validators;
+
+use Nuwave\Lighthouse\Validation\Validator;
+
+class RequiredWithoutInArrayValidator extends Validator
+{
+    public function rules(): array
+    {
+        return [
+            'items.*.thing.an_id' => [
+                'required_without:items.*.thing.some_data',
+            ],
+            'items.*.thing.some_data' => [
+                'required_without:items.*.thing.an_id',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

The validation rule `required_without` doesn't seem to work properly (within arrays). I've added a test which should pass, but fails. This is not so much intended as an actual PR, but more as a demonstration of a bug. If it's not a bug, can someone tell me what I did wrong?

It produces the following error which shouldn't occur.
```json
{
    "errors": [
        {
            "message": "Validation failed for field [createStuff].",
            "extensions": {
                "validation": {
                    "input.items.0.thing.an_id": [
                        "The input.items.0.thing.an_id field is required when items.0.thing.some data is not present."
                    ]
                },
                "category": "validation"
            }
        }
    ]
}
```
