### PR TITLE
fix redis subscription store to pass correct syntax to redis to set ttl

### DIFF
--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -102,7 +102,8 @@ class RedisStorageManager implements StoresSubscriptions
             $this->serialize($subscriber),
         ];
         if ($this->ttl !== null) {
-            $setArguments [] = $this->ttl;
+            $setArguments[] = 'EX';
+            $setArguments[] = $this->ttl;
         }
         $this->connection->command('set', $setArguments);
     }

--- a/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
+++ b/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
@@ -90,6 +90,7 @@ class RedisStorageManagerTest extends TestCase
                         'channel' => $channel,
                         'topic' => 'some-topic',
                     ]).'}',
+                    'EX',
                     $ttl,
                 ]]
             );


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

Using redis with a ttl results in an error:

`ERR syntax error`

when trying to set a subscriber.

The problem is that predis expects the set with ttl as `command('set', [$key, $value, 'EX', $ttl])`
but the code is passing `command('set', [$key, $value, $ttl])`

This correctly sets a ttl on the items in redis.

**Breaking changes**

