### PR TITLE
Use selected cache store on clear-cache command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Apply error handling and debug settings consistently https://github.com/nuwave/lighthouse/pull/1749
 - Fix typo `comparision` to `comparison` in generated input types for `@whereHas`
 - Fix redis `mget` being called with an empty list of subscriber ids https://github.com/nuwave/lighthouse/pull/1759
+- Fix `lighthouse:clear-cache` not clearing cache when a custom cache store is used https://github.com/nuwave/lighthouse/pull/1788
 
 ## 5.3.0
 

--- a/src/Console/ClearCacheCommand.php
+++ b/src/Console/ClearCacheCommand.php
@@ -12,11 +12,11 @@ class ClearCacheCommand extends Command
 
     protected $description = 'Clear the GraphQL schema cache.';
 
-    public function handle(CacheRepository $cache, ConfigRepository $config): void
+    public function handle(ConfigRepository $config): void
     {
-        $cache->forget(
-            $config->get('lighthouse.cache.key')
-        );
+        app('cache')
+            ->store($config->get('lighthouse.cache.store'))
+            ->forget($config->get('lighthouse.cache.key'));
 
         $this->info('GraphQL AST schema cache deleted.');
     }

--- a/src/Console/ClearCacheCommand.php
+++ b/src/Console/ClearCacheCommand.php
@@ -3,7 +3,6 @@
 namespace Nuwave\Lighthouse\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 
 class ClearCacheCommand extends Command

--- a/src/Console/ClearCacheCommand.php
+++ b/src/Console/ClearCacheCommand.php
@@ -3,6 +3,7 @@
 namespace Nuwave\Lighthouse\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 
 class ClearCacheCommand extends Command
@@ -11,9 +12,9 @@ class ClearCacheCommand extends Command
 
     protected $description = 'Clear the GraphQL schema cache.';
 
-    public function handle(ConfigRepository $config): void
+    public function handle(CacheFactory $cacheFactory, ConfigRepository $config): void
     {
-        app('cache')
+        $cacheFactory
             ->store($config->get('lighthouse.cache.store'))
             ->forget($config->get('lighthouse.cache.key'));
 

--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -13,6 +13,7 @@ use GraphQL\Language\AST\ObjectTypeExtensionNode;
 use GraphQL\Language\AST\TypeDefinitionNode;
 use GraphQL\Language\AST\TypeExtensionNode;
 use GraphQL\Language\Parser;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Support\Arr;
@@ -95,8 +96,10 @@ class ASTBuilder
         if (! isset($this->documentAST)) {
             $cacheConfig = $this->configRepository->get('lighthouse.cache');
             if ($cacheConfig['enable']) {
-                /** @var \Illuminate\Contracts\Cache\Repository $cache */
-                $cache = app('cache')->store($cacheConfig['store'] ?? null);
+                /** @var \Illuminate\Contracts\Cache\Factory $cacheFactory */
+                $cacheFactory = app(CacheFactory::class);
+                $cache = $cacheFactory->store($cacheConfig['store'] ?? null);
+
                 $this->documentAST = $cache->remember(
                     $cacheConfig['key'],
                     $cacheConfig['ttl'],


### PR DESCRIPTION
The current method only clears the cache for the default cache store of the application and did not read the (optional) custom cache store set in the Ligthouse config.

- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

The current method only clears the cache for the default cache store of the application and did not read the (optional) custom cache store set in the Ligthouse config.

I've used this code as "inspiration":

https://github.com/nuwave/lighthouse/blob/9e37fb38e0430f8594146466b29c6032dbc72650/src/Schema/AST/ASTBuilder.php#L99-L106

**Breaking changes**

None (well, actually clearing the cache now, but that is a good "breaking" change).
