### PR TITLE
Fix webonyx.github.io/graphql-php documentation links

### DIFF
--- a/docs/5.3/api-reference/directives.md
+++ b/docs/5.3/api-reference/directives.md
@@ -2411,7 +2411,7 @@ directive @scalar(
 If you follow the namespace convention, you do not need this directive.
 Lighthouse looks into your configured scalar namespace for a class with the same name.
 
-[Learn how to implement your own scalar.](https://webonyx.github.io/graphql-php/type-system/scalar-types/)
+[Learn how to implement your own scalar.](https://webonyx.github.io/graphql-php/type-definitions/scalar-types/)
 
 ```graphql
 scalar DateTime @scalar(class: "DateTimeScalar")

--- a/docs/5.3/digging-deeper/adding-types-programmatically.md
+++ b/docs/5.3/digging-deeper/adding-types-programmatically.md
@@ -29,7 +29,7 @@ return $stitcher->getSchemaString();
 
 While Lighthouse is an SDL-first GraphQL server, you can also use native PHP type definitions.
 
-Check out the [webonyx/graphql-php documentation](https://webonyx.github.io/graphql-php/type-system/)
+Check out the [webonyx/graphql-php documentation](https://webonyx.github.io/graphql-php/concepts/#type-system)
 on how to define types.
 
 Note that you will not have access to a large portion of Lighthouse functionality
@@ -39,9 +39,9 @@ Because of this, we do not recommend you use native PHP types for complex object
 
 However, it can be advantageous to use native types for two use cases:
 
-- [Enum types](https://webonyx.github.io/graphql-php/type-system/enum-types/):
+- [Enum types](https://webonyx.github.io/graphql-php/type-definitions/enums/):
   Allows you to reuse existing constants in your code
-- [Custom Scalar types](https://webonyx.github.io/graphql-php/type-system/scalar-types/#writing-custom-scalar-types).
+- [Custom Scalar types](https://webonyx.github.io/graphql-php/type-definitions/scalar-types/#writing-custom-scalar-types).
   They will have to be implemented in PHP anyway
 
 ## Using the TypeRegistry

--- a/docs/5.3/the-basics/types.md
+++ b/docs/5.3/the-basics/types.md
@@ -52,7 +52,7 @@ Use the [@scalar](../api-reference/directives.md#scalar) directive to point to a
 scalar Email @scalar(class: "MLL\\GraphQLScalars\\Email")
 ```
 
-[Learn how to implement your own scalar.](https://webonyx.github.io/graphql-php/type-system/scalar-types/)
+[Learn how to implement your own scalar.](https://webonyx.github.io/graphql-php/type-definitions/scalar-types/)
 
 ## Enum
 
@@ -134,7 +134,7 @@ The PHP internal value of the field `ADMIN` will be `string('ADMIN')`.
 If you want to reuse enum definitions or constants from PHP, you can also
 register a native PHP enum type [through the TypeRegistry](../digging-deeper/adding-types-programmatically.md#native-php-types).
 
-Just define a [EnumType](https://webonyx.github.io/graphql-php/type-system/enum-types/) and
+Just define a [EnumType](https://webonyx.github.io/graphql-php/type-definitions/enums/) and
 register it:
 
 ```php
@@ -291,7 +291,7 @@ You can also provide a custom type resolver. Run `php artisan lighthouse:interfa
 a custom interface class. It is automatically put in the default namespace where Lighthouse can discover it by itself.
 
 Read more about them in the [GraphQL Reference](https://graphql.org/learn/schema/#interfaces) and the
-[docs for graphql-php](https://webonyx.github.io/graphql-php/type-system/interfaces/)
+[docs for graphql-php](https://webonyx.github.io/graphql-php/type-definitions/interfaces/)
 
 ## Union
 
@@ -317,4 +317,4 @@ own using `php artisan lighthouse:union <Union name>`.
 It is automatically put in the default namespace where Lighthouse can discover it by itself.
 
 Read more about them in the [GraphQL Reference](https://graphql.org/learn/schema/#union-types) and the
-[docs for graphql-php](https://webonyx.github.io/graphql-php/type-system/unions/)
+[docs for graphql-php](https://webonyx.github.io/graphql-php/type-definitions/unions/)

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2423,7 +2423,7 @@ directive @scalar(
 If you follow the namespace convention, you do not need this directive.
 Lighthouse looks into your configured scalar namespace for a class with the same name.
 
-[Learn how to implement your own scalar.](https://webonyx.github.io/graphql-php/type-system/scalar-types/)
+[Learn how to implement your own scalar.](https://webonyx.github.io/graphql-php/type-definitions/scalar-types/)
 
 ```graphql
 scalar DateTime @scalar(class: "DateTimeScalar")

--- a/docs/master/digging-deeper/adding-types-programmatically.md
+++ b/docs/master/digging-deeper/adding-types-programmatically.md
@@ -30,7 +30,7 @@ return $stitcher->getSchemaString();
 
 While Lighthouse is an SDL-first GraphQL server, you can also use native PHP type definitions.
 
-Check out the [webonyx/graphql-php documentation](https://webonyx.github.io/graphql-php/type-system/)
+Check out the [webonyx/graphql-php documentation](https://webonyx.github.io/graphql-php/concepts/#type-system)
 on how to define types.
 
 Note that you will not have access to a large portion of Lighthouse functionality
@@ -40,9 +40,9 @@ Because of this, we do not recommend you use native PHP types for complex object
 
 However, it can be advantageous to use native types for two use cases:
 
-- [Enum types](https://webonyx.github.io/graphql-php/type-system/enum-types/):
+- [Enum types](https://webonyx.github.io/graphql-php/type-definitions/enums/):
   Allows you to reuse existing constants in your code
-- [Custom Scalar types](https://webonyx.github.io/graphql-php/type-system/scalar-types/#writing-custom-scalar-types).
+- [Custom Scalar types](https://webonyx.github.io/graphql-php/type-definitions/scalar-types/#writing-custom-scalar-types).
   They will have to be implemented in PHP anyway
 
 ## Using the TypeRegistry

--- a/docs/master/the-basics/types.md
+++ b/docs/master/the-basics/types.md
@@ -52,7 +52,7 @@ Use the [@scalar](../api-reference/directives.md#scalar) directive to point to a
 scalar Email @scalar(class: "MLL\\GraphQLScalars\\Email")
 ```
 
-[Learn how to implement your own scalar.](https://webonyx.github.io/graphql-php/type-system/scalar-types/)
+[Learn how to implement your own scalar.](https://webonyx.github.io/graphql-php/type-definitions/scalar-types/)
 
 ## Enum
 
@@ -134,7 +134,7 @@ The PHP internal value of the field `ADMIN` will be `string('ADMIN')`.
 If you want to reuse enum definitions or constants from PHP, you can also
 register a native PHP enum type [through the TypeRegistry](../digging-deeper/adding-types-programmatically.md#native-php-types).
 
-Just define a [EnumType](https://webonyx.github.io/graphql-php/type-system/enum-types/) and
+Just define a [EnumType](https://webonyx.github.io/graphql-php/type-definitions/enums/) and
 register it:
 
 ```php
@@ -291,7 +291,7 @@ You can also provide a custom type resolver. Run `php artisan lighthouse:interfa
 a custom interface class. It is automatically put in the default namespace where Lighthouse can discover it by itself.
 
 Read more about them in the [GraphQL Reference](https://graphql.org/learn/schema/#interfaces) and the
-[docs for graphql-php](https://webonyx.github.io/graphql-php/type-system/interfaces/)
+[docs for graphql-php](https://webonyx.github.io/graphql-php/type-definitions/interfaces/)
 
 ## Union
 
@@ -317,4 +317,4 @@ own using `php artisan lighthouse:union <Union name>`.
 It is automatically put in the default namespace where Lighthouse can discover it by itself.
 
 Read more about them in the [GraphQL Reference](https://graphql.org/learn/schema/#union-types) and the
-[docs for graphql-php](https://webonyx.github.io/graphql-php/type-system/unions/)
+[docs for graphql-php](https://webonyx.github.io/graphql-php/type-definitions/unions/)


### PR DESCRIPTION
Hi, I have discovered that few 'webonyx.github.io/graphql-php' links are broken, I have fixed them for the master branch and for 5.3