### PR TITLE
Add config option `subscriptions.exclude_empty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Add `GraphQLContext` to `StartExecution` event
 - Add `connect` and `disconnect` operations in nested mutations for HasMany and MorphMany relations https://github.com/nuwave/lighthouse/pull/1730
 - Add `ValidateSchema` event https://github.com/nuwave/lighthouse/pull/1764
+- Add config option `subscriptions.exclude_empty` (default false). When true, the subscriptions extension response will be excluded when a channel is not to be included.
 
 ### Changed
 

--- a/docs/master/subscriptions/getting-started.md
+++ b/docs/master/subscriptions/getting-started.md
@@ -62,6 +62,11 @@ your clients no longer depend on the redundant `channels` key from version 1.
 }
 ```
 
+### Empty response optimization
+
+Lighthouse returns the subscription channel as part of the response under `extensions`.
+If  `subscriptions.exclude_empty` in `lighthouse.php` is set to `true`, then API responses which exclude a subscription channel will exclude the subscriptions extension entirely as a performance optimization. Client implementations must anticipate this appropriately.
+
 ## Expiring Subscriptions
 
 Subscriptions do not expire by themselves.

--- a/docs/master/subscriptions/getting-started.md
+++ b/docs/master/subscriptions/getting-started.md
@@ -28,35 +28,10 @@ If you want to use the Laravel Echo driver, you need to set the env `LIGHTHOUSE_
 Lighthouse returns the subscription channel as part of the response under `extensions`.
 You can configure which format is used with `subscriptions.version` in `lighthouse.php`.
 
-For new applications, version 3 is recommended.
+For new applications, version 2 is recommended. When upgrading, make sure
+your clients no longer depend on the redundant `channels` key from version 1.
 
-**Version 3 (Recommended)**
-
-This is the same as version 2 (below), but a response with no new channel will exclude the subscription extension response as an optimization. When upgrading from version 2, make sure your client implementation expects the "lighthouse_subscription" extension will oftentimes be excluded.
-
-With a channel response included:
-```json
-{
-  "data": {...},
-  "extensions": {
-    "lighthouse_subscriptions": {
-      "version": 3,
-      "channel": "channel-name"
-    }
-  }
-}
-```
-
-When no channel is included:
-```json
-{
-  "data": {...},
-}
-```
-
-**Version 2**
-
-When upgrading from version 2, make sure your client implementation no longer depends on the redundant `channels` key from version 1.
+**Version 2 (Recommended)**
 
 ```json
 {

--- a/docs/master/subscriptions/getting-started.md
+++ b/docs/master/subscriptions/getting-started.md
@@ -28,10 +28,35 @@ If you want to use the Laravel Echo driver, you need to set the env `LIGHTHOUSE_
 Lighthouse returns the subscription channel as part of the response under `extensions`.
 You can configure which format is used with `subscriptions.version` in `lighthouse.php`.
 
-For new applications, version 2 is recommended. When upgrading, make sure
-your clients no longer depend on the redundant `channels` key from version 1.
+For new applications, version 3 is recommended.
 
-**Version 2 (Recommended)**
+**Version 3 (Recommended)**
+
+This is the same as version 2 (below), but a response with no new channel will exclude the subscription extension response as an optimization. When upgrading from version 2, make sure your client implementation expects the "lighthouse_subscription" extension will oftentimes be excluded.
+
+With a channel response included:
+```json
+{
+  "data": {...},
+  "extensions": {
+    "lighthouse_subscriptions": {
+      "version": 3,
+      "channel": "channel-name"
+    }
+  }
+}
+```
+
+When no channel is included:
+```json
+{
+  "data": {...},
+}
+```
+
+**Version 2**
+
+When upgrading from version 2, make sure your client implementation no longer depends on the redundant `channels` key from version 1.
 
 ```json
 {

--- a/src/Subscriptions/SubscriptionRegistry.php
+++ b/src/Subscriptions/SubscriptionRegistry.php
@@ -155,29 +155,23 @@ class SubscriptionRegistry
             ? reset($this->subscribers)
             : null;
 
-        $version = (int) config('lighthouse.subscriptions.version', 1);
-
-        if ($channel === null && $version === 3) {
-            return null;
-        }
-
-        switch ($version) {
+        $version = config('lighthouse.subscriptions.version', 1);
+        switch ((int) $version) {
             case 1:
                 $content = [
-                    'version' => $version,
+                    'version' => 1,
                     'channel' => $channel,
                     'channels' => $this->subscribers,
                 ];
                 break;
             case 2:
-            case 3:
                 $content = [
-                    'version' => $version,
+                    'version' => 2,
                     'channel' => $channel,
                 ];
                 break;
             default:
-                throw new DefinitionException("Expected lighthouse.subscriptions.version to be 1, 2 or 3, got: {$version}");
+                throw new DefinitionException("Expected lighthouse.subscriptions.version to be 1 or 2, got: {$version}");
         }
 
         return new ExtensionsResponse('lighthouse_subscriptions', $content);

--- a/src/Subscriptions/SubscriptionRegistry.php
+++ b/src/Subscriptions/SubscriptionRegistry.php
@@ -155,6 +155,10 @@ class SubscriptionRegistry
             ? reset($this->subscribers)
             : null;
 
+        if ($channel === null && config('lighthouse.subscriptions.exclude_empty', false)) {
+            return null;
+        }
+
         $version = config('lighthouse.subscriptions.version', 1);
         switch ((int) $version) {
             case 1:

--- a/src/Subscriptions/SubscriptionRegistry.php
+++ b/src/Subscriptions/SubscriptionRegistry.php
@@ -155,23 +155,29 @@ class SubscriptionRegistry
             ? reset($this->subscribers)
             : null;
 
-        $version = config('lighthouse.subscriptions.version', 1);
-        switch ((int) $version) {
+        $version = (int) config('lighthouse.subscriptions.version', 1);
+
+        if ($channel === null && $version === 3) {
+            return null;
+        }
+
+        switch ($version) {
             case 1:
                 $content = [
-                    'version' => 1,
+                    'version' => $version,
                     'channel' => $channel,
                     'channels' => $this->subscribers,
                 ];
                 break;
             case 2:
+            case 3:
                 $content = [
-                    'version' => 2,
+                    'version' => $version,
                     'channel' => $channel,
                 ];
                 break;
             default:
-                throw new DefinitionException("Expected lighthouse.subscriptions.version to be 1 or 2, got: {$version}");
+                throw new DefinitionException("Expected lighthouse.subscriptions.version to be 1, 2 or 3, got: {$version}");
         }
 
         return new ExtensionsResponse('lighthouse_subscriptions', $content);

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -362,6 +362,13 @@ return [
          * Allowed values: 1, 2
          */
         'version' => env('LIGHTHOUSE_SUBSCRIPTION_VERSION', 1),
+
+        /*
+         * When true, an API response without a subscription channel will exclude the subscription extension response as
+         * a performance optimization.
+         *
+         */
+        'exclude_empty' => env('LIGHTHOUSE_SUBSCRIPTION_EXCLUDE_EMPTY', false),
     ],
 
     /*

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -359,14 +359,7 @@ return [
 
         /*
          * Controls the format of the extensions response.
-         * Allowed values: 1, 2, 3
-         *
-         * Version 1: Channel returned in "channels" array, or empty array when none.
-         *
-         * Version 2: Channel returned as string "channel", or null when none.
-         *
-         * Version 3: Same as version 2, but entire extension response will be excluded when no channel is provided.
-         *
+         * Allowed values: 1, 2
          */
         'version' => env('LIGHTHOUSE_SUBSCRIPTION_VERSION', 1),
     ],

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -359,7 +359,14 @@ return [
 
         /*
          * Controls the format of the extensions response.
-         * Allowed values: 1, 2
+         * Allowed values: 1, 2, 3
+         *
+         * Version 1: Channel returned in "channels" array, or empty array when none.
+         *
+         * Version 2: Channel returned as string "channel", or null when none.
+         *
+         * Version 3: Same as version 2, but entire extension response will be excluded when no channel is provided.
+         *
          */
         'version' => env('LIGHTHOUSE_SUBSCRIPTION_VERSION', 1),
     ],

--- a/tests/Integration/Subscriptions/SubscriptionTest.php
+++ b/tests/Integration/Subscriptions/SubscriptionTest.php
@@ -142,8 +142,8 @@ GRAPHQL;
     {
         /** @var \Illuminate\Contracts\Config\Repository $config */
         $config = $this->app->make('config');
-        $config->set('subscriptions.exclude_empty', false);
-        $config->set('subscriptions.version', 2);
+        $config->set('lighthouse.subscriptions.exclude_empty', false);
+        $config->set('lighthouse.subscriptions.version', 2);
 
         $this->subscribe();
 
@@ -170,8 +170,8 @@ GRAPHQL;
     {
         /** @var \Illuminate\Contracts\Config\Repository $config */
         $config = $this->app->make('config');
-        $config->set('subscriptions.exclude_empty', true);
-        $config->set('subscriptions.version', 2);
+        $config->set('lighthouse.subscriptions.exclude_empty', true);
+        $config->set('lighthouse.subscriptions.version', 2);
 
         $this->subscribe();
 

--- a/tests/Integration/Subscriptions/SubscriptionTest.php
+++ b/tests/Integration/Subscriptions/SubscriptionTest.php
@@ -138,6 +138,56 @@ GRAPHQL;
         ]);
     }
 
+    public function testWithoutExcludeEmpty(): void
+    {
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = $this->app->make('config');
+        $config->set('subscriptions.exclude_empty', false);
+        $config->set('subscriptions.version', 2);
+
+        $this->subscribe();
+
+        $response = $this->graphQL(/** @lang GraphQL */ '
+        query foo {
+            foo
+        }
+        ');
+
+        $response->assertExactJson([
+            'data' => [
+                'foo' => null,
+            ],
+            'extensions' => [
+                'lighthouse_subscriptions' => [
+                    'version' => 2,
+                    'channel' => null,
+                ],
+            ],
+        ]);
+    }
+
+    public function testWithExcludeEmpty(): void
+    {
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = $this->app->make('config');
+        $config->set('subscriptions.exclude_empty', true);
+        $config->set('subscriptions.version', 2);
+
+        $this->subscribe();
+
+        $response = $this->graphQL(/** @lang GraphQL */ '
+        query foo {
+            foo
+        }
+        ');
+
+        $response->assertExactJson([
+            'data' => [
+                'foo' => null,
+            ],
+        ]);
+    }
+
     /**
      * @param  array<string, mixed>  $args
      * @return array<string, string>

--- a/tests/Integration/Subscriptions/SubscriptionTest.php
+++ b/tests/Integration/Subscriptions/SubscriptionTest.php
@@ -155,7 +155,7 @@ GRAPHQL;
 
         $response->assertExactJson([
             'data' => [
-                'foo' => null,
+                'foo' => '42',
             ],
             'extensions' => [
                 'lighthouse_subscriptions' => [
@@ -183,7 +183,7 @@ GRAPHQL;
 
         $response->assertExactJson([
             'data' => [
-                'foo' => null,
+                'foo' => '42',
             ],
         ]);
     }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Ref: https://github.com/nuwave/lighthouse/issues/1787

**Changes**

Adds config option 'subscriptions.exclude_empty' (default false). When true, and subscriptions are in use, an API response without a channel will exclude the 'lighthouse_subscriptions' extension response as a small performance optimization.

**Breaking changes**

None - default setting 'false' functions the same as before.