### PR TITLE
Fix subscription redis storage for predis users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Fix typo `comparision` to `comparison` in generated input types for `@whereHas`
 - Fix redis `mget` being called with an empty list of subscriber ids https://github.com/nuwave/lighthouse/pull/1759
 - Fix `lighthouse:clear-cache` not clearing cache when a custom cache store is used https://github.com/nuwave/lighthouse/pull/1788
+- Fix subscription storage in redis for predis users https://github.com/nuwave/lighthouse/pull/1814
 
 ### Deprecated
 

--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -104,7 +104,7 @@ class RedisStorageManager implements StoresSubscriptions
         ];
         if ($this->ttl !== null) {
             $setCommand = 'setex';
-            array_splice($setArguments, 1, 0, $this->ttl);
+            array_splice($setArguments, 1, 0, [$this->ttl]);
         }
         $this->connection->command($setCommand, $setArguments);
     }

--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -97,14 +97,16 @@ class RedisStorageManager implements StoresSubscriptions
         }
 
         // Lastly, we store the subscriber as a serialized string...
+        $setCommand = 'set';
         $setArguments = [
             $this->channelKey($subscriber->channel),
             $this->serialize($subscriber),
         ];
         if ($this->ttl !== null) {
-            $setArguments [] = $this->ttl;
+            $setCommand = 'setex';
+            array_splice($setArguments, 1, 0, $this->ttl);
         }
-        $this->connection->command('set', $setArguments);
+        $this->connection->command($setCommand, $setArguments);
     }
 
     public function deleteSubscriber(string $channel): ?Subscriber

--- a/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
+++ b/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
@@ -97,6 +97,7 @@ class RedisStorageManagerTest extends TestCase
         $manager = new RedisStorageManager($config, $redisFactory);
         $manager->storeSubscriber($subscriber, 'some-topic');
     }
+
     public function testStoreSubscriberWithoutTtl(): void
     {
         $config = $this->createMock(ConfigRepository::class);

--- a/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
+++ b/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
@@ -84,13 +84,45 @@ class RedisStorageManagerTest extends TestCase
                     $topicKey,
                     $ttl,
                 ]],
+                ['setex', [
+                    'graphql.subscriber.private-lighthouse-foo',
+                    $ttl,
+                    'C:41:"Tests\Utils\Subscriptions\DummySubscriber":57:{'.\Safe\json_encode([
+                        'channel' => $channel,
+                        'topic' => 'some-topic',
+                    ]).'}',
+                ]]
+            );
+
+        $manager = new RedisStorageManager($config, $redisFactory);
+        $manager->storeSubscriber($subscriber, 'some-topic');
+    }
+    public function testStoreSubscriberWithoutTtl(): void
+    {
+        $config = $this->createMock(ConfigRepository::class);
+        $redisConnection = $this->createMock(RedisConnection::class);
+        $redisFactory = $this->getRedisFactory($redisConnection);
+
+        $ttl = null;
+        $config->method('get')->willReturn($ttl);
+
+        $channel = 'private-lighthouse-foo';
+        $subscriber = new DummySubscriber($channel, 'dummy-topic');
+
+        $topicKey = 'graphql.topic.some-topic';
+        $redisConnection->expects($this->exactly(2))
+            ->method('command')
+            ->withConsecutive(
+                ['sadd', [
+                    $topicKey,
+                    $channel,
+                ]],
                 ['set', [
                     'graphql.subscriber.private-lighthouse-foo',
                     'C:41:"Tests\Utils\Subscriptions\DummySubscriber":57:{'.\Safe\json_encode([
                         'channel' => $channel,
                         'topic' => 'some-topic',
                     ]).'}',
-                    $ttl,
                 ]]
             );
 


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves #1779 

**Changes**

Use [setex](https://redis.io/commands/setex) (SETEX is atomic) instead of set with multiple parameters which fails when using predis instead of phpredis (see #1779)

