### PR TITLE
Fix overly eager validation of repeatable directive usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Fix overly eager validation of repeatable directive usage by requiring `webonyx/graphql-php:^14.6.1` https://github.com/nuwave/lighthouse/pull/1824
+- Fix overly eager validation of repeatable directive usage by requiring `webonyx/graphql-php:^14.6.2` https://github.com/nuwave/lighthouse/pull/1824
 
 ## 5.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Fix overly eager validation of repeatable directive usage by requiring `webonyx/graphql-php:^14.6.1`
+- Fix overly eager validation of repeatable directive usage by requiring `webonyx/graphql-php:^14.6.1` https://github.com/nuwave/lighthouse/pull/1824
 
 ## 5.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## 5.6.1
+
+### Fixed
+
+- Fix overly eager validation of repeatable directive usage by requiring `webonyx/graphql-php:^14.6.1`
+
 ## 5.6.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 ### Fixed
 
 - Fix overly eager validation of repeatable directive usage by requiring `webonyx/graphql-php:^14.6.2` https://github.com/nuwave/lighthouse/pull/1824
+- Fix conversion of `repeatable` directive nodes into executable definitions https://github.com/nuwave/lighthouse/pull/1824
 
 ## 5.6.0
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "illuminate/validation": "5.6.* || 5.7.* || 5.8.* || ^6 || ^7 || ^8",
         "laragraph/utils": "^1",
         "thecodingmachine/safe": "^1",
-        "webonyx/graphql-php": "^14.5"
+        "webonyx/graphql-php": "^14.6.1"
     },
     "require-dev": {
         "bensampo/laravel-enum": "^1.28.3 || ^2 || ^3",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "illuminate/validation": "5.6.* || 5.7.* || 5.8.* || ^6 || ^7 || ^8",
         "laragraph/utils": "^1",
         "thecodingmachine/safe": "^1",
-        "webonyx/graphql-php": "^14.6.1"
+        "webonyx/graphql-php": "^14.6.2"
     },
     "require-dev": {
         "bensampo/laravel-enum": "^1.28.3 || ^2 || ^3",

--- a/src/Schema/Factories/DirectiveFactory.php
+++ b/src/Schema/Factories/DirectiveFactory.php
@@ -56,6 +56,7 @@ class DirectiveFactory
             'description' => data_get($directive->description, 'value'),
             'locations' => $locations,
             'args' => $arguments,
+            'isRepeatable' => $directive->repeatable,
             'astNode' => $directive,
         ]);
     }

--- a/tests/Unit/Schema/DirectiveLocatorTest.php
+++ b/tests/Unit/Schema/DirectiveLocatorTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Unit\Schema;
+
+use Closure;
+use GraphQL\Language\Parser;
+use Nuwave\Lighthouse\Exceptions\DirectiveException;
+use Nuwave\Lighthouse\Schema\DirectiveLocator;
+use Nuwave\Lighthouse\Schema\Directives\FieldDirective;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
+use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
+use ReflectionProperty;
+use Tests\TestCase;
+
+class DirectiveLocatorTest extends TestCase
+{
+    /**
+     * @var \Nuwave\Lighthouse\Schema\DirectiveLocator
+     */
+    protected $directiveFactory;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->directiveFactory = app(DirectiveLocator::class);
+    }
+
+    public function testRegistersLighthouseDirectives(): void
+    {
+        $this->assertInstanceOf(
+            FieldDirective::class,
+            $this->directiveFactory->create('field')
+        );
+    }
+
+    public function testHydratesBaseDirectives(): void
+    {
+        $fieldDefinition = Parser::fieldDefinition(/** @lang GraphQL */ '
+            foo: String @field
+        ');
+
+        /** @var \Nuwave\Lighthouse\Schema\Directives\FieldDirective $fieldDirective */
+        $fieldDirective = $this
+            ->directiveFactory
+            ->associated($fieldDefinition)
+            ->first();
+
+        $definitionNode = new ReflectionProperty($fieldDirective, 'definitionNode');
+        $definitionNode->setAccessible(true);
+
+        $this->assertSame(
+            $fieldDefinition,
+            $definitionNode->getValue($fieldDirective)
+        );
+    }
+
+    public function testSkipsHydrationForNonBaseDirectives(): void
+    {
+        $fieldDefinition = Parser::fieldDefinition(/** @lang GraphQL */ '
+            foo: String @foo
+        ');
+
+        $directive = new class implements FieldMiddleware {
+            public static function definition(): string
+            {
+                return /** @lang GraphQL */ 'foo';
+            }
+
+            public function handleField(FieldValue $fieldValue, Closure $next): FieldValue
+            {
+                return $fieldValue;
+            }
+        };
+
+        $this->directiveFactory->setResolved('foo', get_class($directive));
+
+        $directive = $this
+            ->directiveFactory
+            ->associated($fieldDefinition)
+            ->first();
+
+        $this->assertObjectNotHasAttribute('definitionNode', $directive);
+    }
+
+    public function testThrowsIfDirectiveNameCanNotBeResolved(): void
+    {
+        $this->expectException(DirectiveException::class);
+
+        $this->directiveFactory->create('bar');
+    }
+
+    public function testCreateSingleDirective(): void
+    {
+        $fieldDefinition = Parser::fieldDefinition(/** @lang GraphQL */ '
+            foo: [Foo!]! @hasMany
+        ');
+
+        $resolver = $this->directiveFactory->exclusiveOfType($fieldDefinition, FieldResolver::class);
+        $this->assertInstanceOf(FieldResolver::class, $resolver);
+    }
+
+    public function testThrowsExceptionWhenMultipleFieldResolverDirectives(): void
+    {
+        $this->expectException(DirectiveException::class);
+        $this->expectExceptionMessage("Node bar can only have one directive of type Nuwave\Lighthouse\Support\Contracts\FieldResolver but found [@hasMany, @belongsTo].");
+
+        $fieldDefinition = Parser::fieldDefinition(/** @lang GraphQL */ '
+            bar: [Bar!]! @hasMany @belongsTo
+        ');
+
+        $this->directiveFactory->exclusiveOfType($fieldDefinition, FieldResolver::class);
+    }
+
+    public function testCreateMultipleDirectives(): void
+    {
+        $fieldDefinition = Parser::fieldDefinition(/** @lang GraphQL */ '
+            bar: String @can(if: ["viewBar"]) @event
+        ');
+
+        $middleware = $this->directiveFactory->associatedOfType($fieldDefinition, FieldMiddleware::class);
+        $this->assertCount(2, $middleware);
+    }
+}


### PR DESCRIPTION
Requires `webonyx/graphql-php:^14.6.2`, see https://github.com/webonyx/graphql-php/pull/848