### PR TITLE
Avoid setting multiple `@model` directives on generated paginator types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## 5.8.1
+
+### Fixed
+
+- Avoid setting multiple `@model` directives on generated paginator types 
+
 ## 5.8.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Avoid setting multiple `@model` directives on generated paginator types 
+- Avoid setting multiple `@model` directives on generated paginator types https://github.com/nuwave/lighthouse/pull/1837
 
 ## 5.8.0
 

--- a/src/LighthouseServiceProvider.php
+++ b/src/LighthouseServiceProvider.php
@@ -97,7 +97,8 @@ class LighthouseServiceProvider extends ServiceProvider
 
         $this->app->bind(ProvidesResolver::class, ResolverProvider::class);
         $this->app->bind(ProvidesSubscriptionResolver::class, static function (): ProvidesSubscriptionResolver {
-            return new class implements ProvidesSubscriptionResolver {
+            return new class implements ProvidesSubscriptionResolver
+            {
                 public function provideSubscriptionResolver(FieldValue $fieldValue): Closure
                 {
                     throw new Exception(

--- a/src/Pagination/PaginateDirective.php
+++ b/src/Pagination/PaginateDirective.php
@@ -92,14 +92,13 @@ GRAPHQL;
             );
         }
 
-        $paginationManipulator
-            ->transformToPaginatedField(
-                $this->paginationType(),
-                $fieldDefinition,
-                $parentType,
-                $this->defaultCount(),
-                $this->paginateMaxCount()
-            );
+        $paginationManipulator->transformToPaginatedField(
+            $this->paginationType(),
+            $fieldDefinition,
+            $parentType,
+            $this->defaultCount(),
+            $this->paginateMaxCount()
+        );
     }
 
     public function resolveField(FieldValue $fieldValue): FieldValue

--- a/src/Pagination/PaginationManipulator.php
+++ b/src/Pagination/PaginationManipulator.php
@@ -8,6 +8,7 @@ use GraphQL\Language\Parser;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+use Nuwave\Lighthouse\Schema\Directives\ModelDirective;
 
 class PaginationManipulator
 {
@@ -154,7 +155,10 @@ GRAPHQL
             $objectType = $existingType;
         }
 
-        if ($this->modelClass) {
+        if (
+            $this->modelClass
+            && ! ASTHelper::hasDirective($objectType, ModelDirective::NAME)
+        ) {
             $objectType->directives [] = Parser::constDirective('@model(class: "'.addslashes($this->modelClass).'")');
         }
 

--- a/src/Schema/Directives/CacheDirective.php
+++ b/src/Schema/Directives/CacheDirective.php
@@ -142,7 +142,7 @@ GRAPHQL;
 
         // First priority: Look for a field with the @cacheKey directive
         foreach ($fieldDefinitions as $field) {
-            if (ASTHelper::hasDirective($field, 'cacheKey')) {
+            if (ASTHelper::hasDirective($field, CacheKeyDirective::NAME)) {
                 $typeValue->setCacheKey($field->name->value);
 
                 return;

--- a/src/Schema/Directives/CacheKeyDirective.php
+++ b/src/Schema/Directives/CacheKeyDirective.php
@@ -6,6 +6,8 @@ use Nuwave\Lighthouse\Support\Contracts\Directive;
 
 class CacheKeyDirective extends BaseDirective implements Directive
 {
+    public const NAME = 'cacheKey';
+
     public static function definition(): string
     {
         return /** @lang GraphQL */ <<<'GRAPHQL'

--- a/src/Schema/Directives/ModelDirective.php
+++ b/src/Schema/Directives/ModelDirective.php
@@ -7,6 +7,8 @@ use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 
 class ModelDirective extends BaseDirective
 {
+    const NAME = 'model';
+
     public static function definition(): string
     {
         return /** @lang GraphQL */ <<<'GRAPHQL'
@@ -29,7 +31,7 @@ GRAPHQL;
      */
     public static function modelClass(ObjectTypeDefinitionNode $node): ?string
     {
-        $modelDirective = ASTHelper::directiveDefinition($node, 'model');
+        $modelDirective = ASTHelper::directiveDefinition($node, self::NAME);
         if ($modelDirective !== null) {
             return ASTHelper::directiveArgValue($modelDirective, 'class');
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,7 @@ use Nuwave\Lighthouse\GraphQL;
 use Nuwave\Lighthouse\LighthouseServiceProvider;
 use Nuwave\Lighthouse\OrderBy\OrderByServiceProvider;
 use Nuwave\Lighthouse\Pagination\PaginationServiceProvider;
+use Nuwave\Lighthouse\Schema\SchemaBuilder;
 use Nuwave\Lighthouse\Scout\ScoutServiceProvider as LighthouseScoutServiceProvider;
 use Nuwave\Lighthouse\SoftDeletes\SoftDeletesServiceProvider;
 use Nuwave\Lighthouse\Support\AppVersion;
@@ -194,9 +195,10 @@ GRAPHQL;
     {
         $this->schema = $schema;
 
-        return $this->app
-            ->make(GraphQL::class)
-            ->prepSchema();
+        /** @var \Nuwave\Lighthouse\Schema\SchemaBuilder $schemaBuilder */
+        $schemaBuilder = $this->app->make(SchemaBuilder::class);
+
+        return $schemaBuilder->schema();
     }
 
     /**

--- a/tests/TestsSerialization.php
+++ b/tests/TestsSerialization.php
@@ -15,7 +15,8 @@ trait TestsSerialization
 {
     protected function fakeContextSerializer(Container $app): void
     {
-        $contextSerializer = new class implements ContextSerializer {
+        $contextSerializer = new class implements ContextSerializer
+        {
             public function serialize(GraphQLContext $context)
             {
                 return 'foo';
@@ -23,7 +24,8 @@ trait TestsSerialization
 
             public function unserialize(string $context)
             {
-                return new class implements GraphQLContext {
+                return new class implements GraphQLContext
+                {
                     public function user()
                     {
                         return new User();

--- a/tests/Unit/Pagination/PaginateDirectiveTest.php
+++ b/tests/Unit/Pagination/PaginateDirectiveTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Unit\Pagination;
 
-use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Type\Definition\FieldArgument;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\ObjectType;

--- a/tests/Unit/Pagination/PaginateDirectiveTest.php
+++ b/tests/Unit/Pagination/PaginateDirectiveTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Pagination;
 
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Type\Definition\FieldArgument;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\ObjectType;
@@ -351,5 +352,27 @@ class PaginateDirectiveTest extends TestCase
             users: [Query!] @paginate(builder: "NonexistingClass@notFound")
         }
         ');
+    }
+
+    public function testAllowsMultiplePaginatedFieldsOfTheSameModel(): void
+    {
+        $schema = $this->buildSchema(/** @lang GraphQL */ '
+        type Query {
+            users: [User!] @paginate
+            users2: [User!] @paginate
+        }
+
+        type User {
+            id: ID
+        }
+        ');
+
+        /** @var \GraphQL\Type\Definition\ObjectType $userPaginator */
+        $userPaginator = $schema->getType('UserPaginator');
+
+        /** @var \GraphQL\Language\AST\ObjectTypeDefinitionNode $ast */
+        $ast = $userPaginator->astNode;
+
+        $this->assertCount(1, $ast->directives);
     }
 }

--- a/tests/Unit/Schema/DirectiveLocatorTest.php
+++ b/tests/Unit/Schema/DirectiveLocatorTest.php
@@ -62,7 +62,8 @@ class DirectiveLocatorTest extends TestCase
             foo: String @foo
         ');
 
-        $directive = new class implements FieldMiddleware {
+        $directive = new class implements FieldMiddleware
+        {
             public static function definition(): string
             {
                 return /** @lang GraphQL */ 'foo';

--- a/tests/Unit/Schema/Directives/BaseDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/BaseDirectiveTest.php
@@ -181,7 +181,8 @@ class BaseDirectiveTest extends TestCase
     {
         $fieldDefinition = Parser::fieldDefinition($definition);
 
-        $directive = new class extends BaseDirective {
+        $directive = new class extends BaseDirective
+        {
             public static function definition(): string
             {
                 return /** @lang GraphQL */ 'directive @baseTest on FIELD_DEFINITION';

--- a/tests/Unit/Schema/Execution/ContextFactoryTest.php
+++ b/tests/Unit/Schema/Execution/ContextFactoryTest.php
@@ -15,7 +15,8 @@ class ContextFactoryTest extends TestCase
         parent::getEnvironmentSetUp($app);
 
         $app->singleton(CreatesContext::class, function (): CreatesContext {
-            return new class implements CreatesContext {
+            return new class implements CreatesContext
+            {
                 public function generate(Request $request): GraphQLContext
                 {
                     return new FooContext($request);

--- a/tests/Unit/Subscriptions/BroadcastManagerTest.php
+++ b/tests/Unit/Subscriptions/BroadcastManagerTest.php
@@ -42,7 +42,8 @@ class BroadcastManagerTest extends TestCase
     {
         $broadcasterConfig = [];
 
-        $broadcaster = new class implements Broadcaster {
+        $broadcaster = new class implements Broadcaster
+        {
             public function authorized(Request $request)
             {
                 return new Response();
@@ -79,7 +80,8 @@ class BroadcastManagerTest extends TestCase
     public function testThrowsIfDriverDoesNotImplementInterface(): void
     {
         $this->broadcastManager->extend('foo', function () {
-            return new class {
+            return new class
+            {
                 //
             };
         });

--- a/tests/Unit/Subscriptions/SubscriptionTest.php
+++ b/tests/Unit/Subscriptions/SubscriptionTest.php
@@ -94,7 +94,8 @@ class SubscriptionTest extends TestCase
 
     protected function subscription(): GraphQLSubscription
     {
-        return new class extends GraphQLSubscription {
+        return new class extends GraphQLSubscription
+        {
             public function authorize(Subscriber $subscriber, Request $request): bool
             {
                 return true;


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Fixes an issue reported by Chris Radigan in Slack.

When validating my schema I get this error:

```
Non-repeatable directive @model used more than once at the same location.
GraphQL request (1:1)
1: @model(class: "App\\Models\\User")
   ^
GraphQL request (1:1)
1: @model(class: "App\\Models\\User")
   ^
```

Seems to be caused by having multiple queries that use the same model resolver.

```graphql
type User{
  id
  email
  ...
}

type Query{
  users: [User] @paginate
  admins: [User] @paginate(scopes: ["admin"])
  ...
}
```

**Breaking changes**

No.
