### PR TITLE
Allow `@builder` in combination with `@search`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Allow `@builder` in combination with `@search`
+- Allow `@builder` in combination with `@search` https://github.com/nuwave/lighthouse/pull/1850
 
 ## 5.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## 5.8.2
+
+### Fixed
+
+- Allow `@builder` in combination with `@search`
+
 ## 5.8.1
 
 ### Fixed

--- a/src/Schema/Directives/BuilderDirective.php
+++ b/src/Schema/Directives/BuilderDirective.php
@@ -2,10 +2,12 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives;
 
+use Laravel\Scout\Builder as ScoutBuilder;
+use Nuwave\Lighthouse\Scout\ScoutBuilderDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldBuilderDirective;
 
-class BuilderDirective extends BaseDirective implements ArgBuilderDirective, FieldBuilderDirective
+class BuilderDirective extends BaseDirective implements ArgBuilderDirective, ScoutBuilderDirective, FieldBuilderDirective
 {
     public static function definition(): string
     {
@@ -37,14 +39,21 @@ GRAPHQL;
 
     public function handleBuilder($builder, $value): object
     {
-        $resolver = $this->getResolverFromArgument('method');
+        $resolver = $this->resolver();
+
+        return $resolver($builder, $value, $this->definitionNode);
+    }
+
+    public function handleScoutBuilder(ScoutBuilder $builder, $value): ScoutBuilder
+    {
+        $resolver = $this->resolver();
 
         return $resolver($builder, $value, $this->definitionNode);
     }
 
     public function handleFieldBuilder(object $builder): object
     {
-        $resolver = $this->getResolverFromArgument('method');
+        $resolver = $this->resolver();
 
         if ($this->directiveHasArgument('value')) {
             return $resolver(
@@ -54,5 +63,10 @@ GRAPHQL;
         }
 
         return $resolver($builder);
+    }
+
+    protected function resolver(): \Closure
+    {
+        return $this->getResolverFromArgument('method');
     }
 }

--- a/tests/Integration/Scout/SearchDirectiveTest.php
+++ b/tests/Integration/Scout/SearchDirectiveTest.php
@@ -137,6 +137,51 @@ class SearchDirectiveTest extends DBTestCase
         ]);
     }
 
+    public function testSearchWithBuilder(): void
+    {
+        $id = 1;
+
+        $this->engine
+            ->shouldReceive('map')
+            ->withArgs(function (ScoutBuilder $builder) use ($id): bool {
+                return $builder->wheres === ['from_custom_builder' => $id];
+            })
+            ->andReturn(new EloquentCollection())
+            ->once();
+
+        $this->schema = /** @lang GraphQL */ '
+        type Post {
+            id: Int!
+        }
+
+        type Query {
+            posts(
+                id: Int @builder(method: "'.$this->qualifyTestResolver('customBuilderMethod').'")
+                search: String @search
+            ): [Post!]! @all
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        query ($id: Int) {
+            posts(id: $id, search: "greatness") {
+                id
+            }
+        }
+        ', [
+            'id' => $id,
+        ])->assertJson([
+            'data' => [
+                'posts' => [],
+            ],
+        ]);
+    }
+
+    public function customBuilderMethod(ScoutBuilder $builder, $value): ScoutBuilder
+    {
+        return $builder->where('from_custom_builder', $value);
+    }
+
     public function testSearchWithTrashed(): void
     {
         $this->engine

--- a/tests/Integration/Scout/SearchDirectiveTest.php
+++ b/tests/Integration/Scout/SearchDirectiveTest.php
@@ -177,7 +177,7 @@ class SearchDirectiveTest extends DBTestCase
         ]);
     }
 
-    public function customBuilderMethod(ScoutBuilder $builder, $value): ScoutBuilder
+    public function customBuilderMethod(ScoutBuilder $builder, int $value): ScoutBuilder
     {
         return $builder->where('from_custom_builder', $value);
     }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves https://github.com/nuwave/lighthouse/issues/1846

**Changes**

Make the `BuilderDirective` implement the `ScoutBuilderDirective` interface to allow usage with `@search`.

**Breaking changes**

No.