### PR TITLE
Add `ValidationException::withMessage()`

### DIFF
--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -32,8 +32,13 @@ class ValidationException extends Exception implements RendersErrorsExtensions
     {
         return self::CATEGORY;
     }
-    
-    public static function withMessage(array $messages)
+
+    /**
+     * Handle with message
+     *
+     * @param array<string, string> $messages
+     */
+    public static function withMessage(array $messages): ValidationException
     {
         $validator = tap(ValidatorFacade::make([], []), function($validator) use ($messages) {
             foreach ($messages as $key => $value) {

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -2,8 +2,10 @@
 
 namespace Nuwave\Lighthouse\Exceptions;
 
+use Illuminate\Support\Arr;
 use Exception;
 use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Support\Facades\Validator as ValidatorFacade;
 
 class ValidationException extends Exception implements RendersErrorsExtensions
 {
@@ -29,6 +31,19 @@ class ValidationException extends Exception implements RendersErrorsExtensions
     public function getCategory(): string
     {
         return self::CATEGORY;
+    }
+    
+    public static function withMessage(array $messages)
+    {
+        $validator = tap(ValidatorFacade::make([], []), function($validator) use ($messages) {
+            foreach ($messages as $key => $value) {
+                foreach (Arr::wrap($value) as $message) {
+                    $validator->errors()->add($key, $message);
+                }
+            }
+        });
+
+        return new static('Validation Failed', $validator);
     }
 
     public function extensionsContent(): array

--- a/tests/Unit/Exceptions/ValidationExceptionTest.php
+++ b/tests/Unit/Exceptions/ValidationExceptionTest.php
@@ -7,7 +7,7 @@ use Tests\TestCase;
 
 class ValidationExceptionTest extends TestCase
 {
-    public function testWithMessage()
+    public function testWithMessage(): void
     {
         $this->expectException(ValidationException::class);
 

--- a/tests/Unit/Exceptions/ValidationExceptionTest.php
+++ b/tests/Unit/Exceptions/ValidationExceptionTest.php
@@ -11,8 +11,12 @@ class ValidationExceptionTest extends TestCase
     {
         $this->expectException(ValidationException::class);
 
-        throw ValidationException::withMessage([
+        $exception = ValidationException::withMessage([
             'email' => 'The email or password does not match',
         ]);
+
+        $this->assertArrayHasKey('email', $exception->extensionsContent()['validation']);
+
+        throw $exception;
     }
 }

--- a/tests/Unit/Exceptions/ValidationExceptionTest.php
+++ b/tests/Unit/Exceptions/ValidationExceptionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\Exceptions;
+
+use Nuwave\Lighthouse\Exceptions\ValidationException;
+use Tests\TestCase;
+
+class ValidationExceptionTest extends TestCase
+{
+    public function testWithMessage()
+    {
+        $this->expectException(ValidationException::class);
+
+        throw ValidationException::withMessage([
+            'email' => 'The email or password does not match',
+        ]);
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

Added a static method `withMessage` in [ValidationException](https://laravel.com/api/8.x/Illuminate/Validation/ValidationException.html#method_withMessages) like ValidationException of Laravel core. Sometimes we want to send a validation response with our custom text.

## We can now send validation response from any mutation like this
```
use Nuwave\Lighthouse\Exceptions\ValidationException

throw ValidationException::withMessage([
    'email' => 'The email or password does not match.',
]);
```
**Breaking changes**

Nothing