### PR TITLE
Handle `null` when encoding or decoding with `@globalId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Handle `null` when encoding or decoding with `@globalId` https://github.com/nuwave/lighthouse/pull/1862
+
 ## v5.12.1
 
 ### Fixed

--- a/src/GlobalId/GlobalIdDirective.php
+++ b/src/GlobalId/GlobalIdDirective.php
@@ -80,8 +80,8 @@ GRAPHQL;
     /**
      * Decodes a global id given as an argument.
      *
-     * @param  string  $argumentValue
-     * @return string|array<string>
+     * @param  string|null  $argumentValue
+     * @return string|array{0: string, 1: string}|null
      */
     public function sanitize($argumentValue)
     {

--- a/src/GlobalId/GlobalIdDirective.php
+++ b/src/GlobalId/GlobalIdDirective.php
@@ -67,6 +67,10 @@ GRAPHQL;
         $type = $fieldValue->getParentName();
 
         $fieldValue->resultHandler(function ($result) use ($type) {
+            if (null === $result) {
+                return null;
+            }
+
             return $this->globalId->encode($type, $result);
         });
 
@@ -81,7 +85,12 @@ GRAPHQL;
      */
     public function sanitize($argumentValue)
     {
-        if ($decode = $this->directiveArgValue('decode')) {
+        if (null === $argumentValue) {
+            return null;
+        }
+
+        $decode = $this->directiveArgValue('decode');
+        if (null !== $decode) {
             switch ($decode) {
                 case 'TYPE':
                     return $this->globalId->decodeType($argumentValue);

--- a/tests/Unit/GlobalId/GlobalIdDirectiveTest.php
+++ b/tests/Unit/GlobalId/GlobalIdDirectiveTest.php
@@ -40,6 +40,60 @@ class GlobalIdDirectiveTest extends TestCase
         ]);
     }
 
+    public function testNullableArgument(): void
+    {
+        $this->mockResolver(function ($root, array $args): ?string {
+            return $args['bar'] ?? null;
+        });
+
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo(bar: String @globalId): String @mock
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            foo
+        }
+        ')->assertJson([
+            'data' => [
+                'foo' => null,
+            ],
+        ]);
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            foo(bar: null)
+        }
+        ')->assertJson([
+            'data' => [
+                'foo' => null,
+            ],
+        ]);
+    }
+
+    public function testNullableResult(): void
+    {
+        $this->mockResolver();
+
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo: String @mock @globalId
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            foo
+        }
+        ')->assertJson([
+            'data' => [
+                'foo' => null,
+            ],
+        ]);
+    }
+
     public function testDecodesGlobalIdOnInput(): void
     {
         $this->mockResolver(


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves https://github.com/nuwave/lighthouse/issues/1861

**Changes**

Using `@globalId` on a nullable argument does not cause a crash now.

When using `@globalId` on a field, `null` is now encoded as `null`.

**Breaking changes**

The encoding for `null` has changed, but actually makes sense now.