### PR TITLE
Fix combining `@lazyLoad` with paginated relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+- Allow LengthAwarePaginator as a parameter in LazyLoadDirective directive. https://github.com/nuwave/lighthouse/pull/1867
+
 ## v5.12.3
 
 ### Fixed

--- a/src/Schema/Directives/LazyLoadDirective.php
+++ b/src/Schema/Directives/LazyLoadDirective.php
@@ -6,6 +6,7 @@ use Closure;
 use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
@@ -34,11 +35,18 @@ GRAPHQL;
     {
         $relations = $this->directiveArgValue('relations');
 
-        $fieldValue->resultHandler(static function (Collection $items) use ($relations): Collection {
-            $items->load($relations);
+        $fieldValue->resultHandler(
+            /**
+             * @param Collection|LengthAwarePaginator $items
+             *
+             * @return Collection|LengthAwarePaginator
+             */
+            static function ($items) use ($relations) {
+                $items->load($relations);
 
-            return $items;
-        });
+                return $items;
+            }
+        );
 
         return $next($fieldValue);
     }

--- a/tests/Integration/Schema/Directives/LazyLoadDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/LazyLoadDirectiveTest.php
@@ -4,6 +4,8 @@ namespace Tests\Integration\Schema\Directives;
 
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Tests\DBTestCase;
+use Tests\Utils\Models\Task;
+use Tests\Utils\Models\User;
 
 class LazyLoadDirectiveTest extends DBTestCase
 {
@@ -25,6 +27,45 @@ class LazyLoadDirectiveTest extends DBTestCase
         $this->buildSchema(/** @lang GraphQL */ '
         type Query {
             foo: ID @lazyLoad(relations: [])
+        }
+        ');
+    }
+
+    public function testLazyLoadRelationsOnConnections(): void
+    {
+        /** @var \Tests\Utils\Models\User $user */
+        $user = factory(User::class)->create();
+
+        $user->tasks()->saveMany(factory(Task::class, 3)->make());
+
+        $this->schema = /** @lang GraphQL */ '
+        type User {
+            tasks: [Task!]!
+                @lazyLoad(relations: ["user"])
+                @hasMany(type: CONNECTION)
+        }
+
+        type Task {
+            id: ID!
+            user: User!
+        }
+
+        type Query {
+            user: User @first
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            user {
+                tasks(first: 3) {
+                    edges {
+                        node {
+                            id
+                        }
+                    }
+                }
+            }
         }
         ');
     }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Allow `LengthAwarePaginator` as a parameter in `LazyLoadDirective` directive.

**Breaking changes**

None.