### PR TITLE
Prevent resolver being called when a cached field contains a falsy value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Allow integer zero, empty string and false as valid cached values with `@cache` https://github.com/nuwave/lighthouse/pull/1869
+
 ## v5.12.3
 
 ### Fixed

--- a/src/Schema/Directives/CacheDirective.php
+++ b/src/Schema/Directives/CacheDirective.php
@@ -91,6 +91,29 @@ GRAPHQL;
                 if ($value !== null) {
                     return $value;
                 }
+                // In Laravel cache, null is considered as "non-existant" value. As mentioned in laravel documentation,
+                // https://laravel.com/docs/8.x/cache#checking-for-item-existence
+                // > The `has` method [...] will also return false if the item exists but its value is null.
+                //
+                // If caching `null` value becomes something worthwhile, one possible way to achieve it is to
+                // encapsulate the `$result` at writing time :
+                //
+                //    $storeInCache = static function ($result) use ($cacheKey, $maxAge, $cache): void {
+                //        $value = ['rawValue' => $result];
+                //        $maxAge
+                //        ? $cache->put($cacheKey, $value, Carbon::now()->addSeconds($maxAge))
+                //        : $cache->forever($cacheKey, $value);
+                //    };
+                //
+                // and restoring original value back at reading :
+                //
+                //    if (is_array($value) && array_key_exists('rawValue', $value)) { // don't use isset !
+                //        return $value['rawValue'];
+                //    }
+                //
+                // Such a change would introduce some potential BC, if for instance cached value was already containing
+                // an object with a `rawValue` key prior the implementation change. A possible workaround is to choose a
+                // less collision-probable key instead of `rawValue` (eg. "com.lighthouse-php:rawValue" ?)
 
                 $resolved = $resolver($root, $args, $context, $resolveInfo);
 

--- a/src/Schema/Directives/CacheDirective.php
+++ b/src/Schema/Directives/CacheDirective.php
@@ -87,7 +87,8 @@ GRAPHQL;
 
                 // We found a matching value in the cache, so we can just return early
                 // without actually running the query
-                if ($value = $cache->get($cacheKey)) {
+                $value = $cache->get($cacheKey);
+                if ($value !== null) {
                     return $value;
                 }
 

--- a/tests/Integration/Schema/Directives/CacheDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/CacheDirectiveTest.php
@@ -390,11 +390,13 @@ class CacheDirectiveTest extends DBTestCase
         }
         ';
 
+        // TTL is required for laravel 5.7 and prior
+        // @see https://laravel.com/docs/5.8/upgrade#psr-16-conformity
         $this->cache->setMultiple([
             'user:1:field_boolean' => false,
             'user:1:field_string' => '',
             'user:1:field_integer' => 0,
-        ]);
+        ], 1);
 
         $this->graphQL(/** @lang GraphQL */ '
         {


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

When caching a boolean, string or integer value using `@cache` directive, falsy value like `false`, `0` or `""` aren't consider as valid cache. This PR resolves this issue.

**Breaking changes**

No
<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
