### PR TITLE
Avoid conflicting relation batch loader overlaps when using dot notation in `@with`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.12.6
+
+### Fixed
+
+- Avoid conflicting relation batch loader overlaps when using dot notation in `@with` https://github.com/nuwave/lighthouse/pull/1871
+
 ## v5.12.5
 
 ### Fixed

--- a/src/Execution/BatchLoader/BatchLoaderRegistry.php
+++ b/src/Execution/BatchLoader/BatchLoaderRegistry.php
@@ -60,7 +60,10 @@ abstract class BatchLoaderRegistry
             }
         );
 
-        // Using . as the separator would combine nested relations
+        // Using . as the separator would combine relations in nested fields with
+        // higher up relations using dot notation, matching the field path.
+        // We might optimize this in the future to enable batching them anyways,
+        // but employ this solution for now, as it preserves correctness.
         return implode('|', $significantPathSegments);
     }
 }

--- a/src/Execution/BatchLoader/BatchLoaderRegistry.php
+++ b/src/Execution/BatchLoader/BatchLoaderRegistry.php
@@ -60,6 +60,7 @@ abstract class BatchLoaderRegistry
             }
         );
 
+        // Using . as the separator would combine nested relations
         return implode('|', $significantPathSegments);
     }
 }

--- a/src/Execution/BatchLoader/BatchLoaderRegistry.php
+++ b/src/Execution/BatchLoader/BatchLoaderRegistry.php
@@ -60,6 +60,6 @@ abstract class BatchLoaderRegistry
             }
         );
 
-        return implode('.', $significantPathSegments);
+        return implode('|', $significantPathSegments);
     }
 }

--- a/src/Execution/BatchLoader/RelationBatchLoader.php
+++ b/src/Execution/BatchLoader/RelationBatchLoader.php
@@ -35,17 +35,17 @@ class RelationBatchLoader
     }
 
     /**
-     * Schedule loading a relation off of a concrete parent.
+     * Schedule loading a relation off of a concrete model.
      *
      * This returns effectively a promise that will resolve to
      * the result of loading the relation.
      *
-     * As a side-effect, the parent will then hold the relation.
+     * As a side-effect, the model will then hold the relation.
      */
-    public function load(Model $parent): Deferred
+    public function load(Model $model): Deferred
     {
-        $modelKey = ModelKey::build($parent);
-        $this->parents[$modelKey] = $parent;
+        $modelKey = ModelKey::build($model);
+        $this->parents[$modelKey] = $model;
 
         return new Deferred(function () use ($modelKey) {
             if (! $this->hasResolved) {
@@ -54,7 +54,7 @@ class RelationBatchLoader
 
             // When we are deep inside a nested query, we can come across the
             // same model in two different paths, so this might be another
-            // model instance then $parent.
+            // model instance then $model.
             $parent = $this->parents[$modelKey];
 
             return $this->relationLoader->extract($parent);

--- a/src/Execution/ModelsLoader/SimpleModelsLoader.php
+++ b/src/Execution/ModelsLoader/SimpleModelsLoader.php
@@ -39,8 +39,8 @@ class SimpleModelsLoader implements ModelsLoader
         // Dot notation may be used to eager load nested relations
         $parts = explode('.', $this->relation);
 
-        // We just return the first level of relations for now. They
-        // hold the nested relations in case they are needed.
+        // We just return the first level of relations for now.
+        // They hold the nested relations in case they are needed.
         $firstRelation = $parts[0];
 
         return $model->getRelation($firstRelation);

--- a/tests/Integration/Execution/DataLoader/RelationBatchLoaderTest.php
+++ b/tests/Integration/Execution/DataLoader/RelationBatchLoaderTest.php
@@ -496,6 +496,8 @@ class RelationBatchLoaderTest extends DBTestCase
                 ]
             ]);
 
+        // TODO optimize this
+        $this->markTestIncomplete('The intermediary relation of dot notation is not batched with equivalent relations of fields.');
         $this->assertSame(3, $queries);
     }
 }

--- a/tests/Integration/Execution/DataLoader/RelationBatchLoaderTest.php
+++ b/tests/Integration/Execution/DataLoader/RelationBatchLoaderTest.php
@@ -498,6 +498,7 @@ class RelationBatchLoaderTest extends DBTestCase
 
         // TODO optimize this
         $this->markTestIncomplete('The intermediary relation of dot notation is not batched with equivalent relations of fields.');
+        // @phpstan-ignore-next-line Of course this terminates...
         $this->assertSame(3, $queries);
     }
 }

--- a/tests/Utils/Models/Task.php
+++ b/tests/Utils/Models/Task.php
@@ -102,4 +102,9 @@ class Task extends Model
             $query->whereIn('name', $tags);
         });
     }
+
+    public function postOwnerKey()
+    {
+        return $this->post->user->getKey();
+    }
 }

--- a/tests/Utils/Models/Task.php
+++ b/tests/Utils/Models/Task.php
@@ -102,9 +102,4 @@ class Task extends Model
             $query->whereIn('name', $tags);
         });
     }
-
-    public function postOwnerKey()
-    {
-        return $this->post->user->getKey();
-    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
