### PR TITLE
Fix incorrect config key for subscriptions redis storage connection

### DIFF
--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -40,7 +40,7 @@ class RedisStorageManager implements StoresSubscriptions
     public function __construct(ConfigRepository $config, RedisFactory $redis)
     {
         $this->connection = $redis->connection(
-            $config->get('lighthouse.broadcasters.echo.connection') ?? 'default'
+            $config->get('lighthouse.subscriptions.broadcasters.echo.connection') ?? 'default'
         );
         $this->ttl = $config->get('lighthouse.subscriptions.storage_ttl');
     }


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

Fix incorrect config key for subscriptions redis storage connection.