### PR TITLE
Mark appropriate generated pagination types as non-nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Changed
 
-- Add config setting `non_null_pagination_results` to mark the generated result type of paginated lists as non-nullable
-- Improve descriptions of generated pagination types
+- Add config setting `non_null_pagination_results` to mark the generated result type of paginated lists as non-nullable https://github.com/nuwave/lighthouse/pull/1878
+- Improve descriptions of generated pagination types https://github.com/nuwave/lighthouse/pull/1878
 
 ## v5.12.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Changed
 
-- Mark appropriate generated pagination types as non-nullable
+- Add config setting `non_null_pagination_results` to mark the generated result type of paginated lists as non-nullable
 - Improve descriptions of generated pagination types
 
 ## v5.12.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.13.0
+
+### Changed
+
+- Mark appropriate generated pagination types as non-nullable
+- Improve descriptions of generated pagination types
+
 ## v5.12.7
 
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -77,6 +77,14 @@ The previous version 1 contained a redundant key `channels` and is no longer sup
 It is recommended to switch to version 2 before upgrading Lighthouse to give clients
 a smooth transition period.
 
+### Nullability of pagination results
+
+Generated result types of paginated lists are now always marked as non-nullable.
+The setting `non_null_pagination_results` was removed and is now always `true`.
+
+This is generally more convenient for clients, but will
+cause validation errors to bubble further up in the result.
+
 ## v4 to v5
 
 ### Update PHP, Laravel and PHPUnit

--- a/docs/5/api-reference/directives.md
+++ b/docs/5/api-reference/directives.md
@@ -2176,10 +2176,10 @@ The schema definition is automatically transformed to this:
 ```graphql
 type Query {
   posts(
-    "Limits number of fetched elements."
+    "Limits number of fetched items."
     first: Int!
 
-    "The offset from which elements are returned."
+    "The offset from which items are returned."
     page: Int
   ): PostPaginator
 }
@@ -2193,30 +2193,30 @@ type PostPaginator {
   paginatorInfo: PaginatorInfo!
 }
 
-"Pagination information about the corresponding list of items."
+"Information about pagination using a fully featured paginator."
 type PaginatorInfo {
-  "Count of available items in the page."
+  "Number of items in the current page."
   count: Int!
 
-  "Current pagination page."
+  "Index of the current page."
   currentPage: Int!
 
-  "Index of first item in the current page."
+  "Index of the first item in the current page."
   firstItem: Int
 
-  "If collection has more pages."
+  "Are there more pages after this one?"
   hasMorePages: Boolean!
 
-  "Index of last item in the current page."
+  "Index of the last item in the current page."
   lastItem: Int
 
-  "Last page number of the collection."
+  "Index of the last available page."
   lastPage: Int!
 
-  "Number of items per page in the collection."
+  "Number of items per page."
   perPage: Int!
 
-  "Total items available in the collection."
+  "Number of total available items."
   total: Int!
 }
 ```
@@ -2258,7 +2258,7 @@ The final schema will be transformed to this:
 ```graphql
 type Query {
   posts(
-    "Limits number of fetched elements."
+    "Limits number of fetched items."
     first: Int!
 
     "A cursor after which elements are returned."
@@ -2309,10 +2309,10 @@ The schema definition is automatically transformed to this:
 ```graphql
 type Query {
   posts(
-    "Limits number of fetched elements."
+    "Limits number of fetched items."
     first: Int!
 
-    "The offset from which elements are returned."
+    "The offset from which items are returned."
     page: Int
   ): PostSimplePaginator
 }
@@ -2326,21 +2326,21 @@ type PostSimplePaginator {
   paginatorInfo: SimplePaginatorInfo!
 }
 
-"Pagination information about the corresponding list of items."
+"Information about pagination using a simple paginator."
 type SimplePaginatorInfo {
-  "Count of available items in the page."
+  "Number of items in the current page."
   count: Int!
 
-  "Current pagination page."
+  "Index of the current page."
   currentPage: Int!
 
-  "Index of first item in the current page."
+  "Index of the first item in the current page."
   firstItem: Int
 
-  "Index of last item in the current page."
+  "Index of the last item in the current page."
   lastItem: Int
 
-  "Number of items per page in the collection."
+  "Number of items per page."
   perPage: Int!
 }
 ```

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2176,10 +2176,10 @@ The schema definition is automatically transformed to this:
 ```graphql
 type Query {
   posts(
-    "Limits number of fetched elements."
+    "Limits number of fetched items."
     first: Int!
 
-    "The offset from which elements are returned."
+    "The offset from which items are returned."
     page: Int
   ): PostPaginator
 }
@@ -2193,30 +2193,30 @@ type PostPaginator {
   paginatorInfo: PaginatorInfo!
 }
 
-"Pagination information about the corresponding list of items."
+"Information about pagination using a fully featured paginator."
 type PaginatorInfo {
-  "Count of available items in the page."
+  "Number of items in the current page."
   count: Int!
 
-  "Current pagination page."
+  "Index of the current page."
   currentPage: Int!
 
-  "Index of first item in the current page."
+  "Index of the first item in the current page."
   firstItem: Int
 
-  "If collection has more pages."
+  "Are there more pages after this one?"
   hasMorePages: Boolean!
 
-  "Index of last item in the current page."
+  "Index of the last item in the current page."
   lastItem: Int
 
-  "Last page number of the collection."
+  "Index of the last available page."
   lastPage: Int!
 
-  "Number of items per page in the collection."
+  "Number of items per page."
   perPage: Int!
 
-  "Total items available in the collection."
+  "Number of total available items."
   total: Int!
 }
 ```
@@ -2258,7 +2258,7 @@ The final schema will be transformed to this:
 ```graphql
 type Query {
   posts(
-    "Limits number of fetched elements."
+    "Limits number of fetched items."
     first: Int!
 
     "A cursor after which elements are returned."
@@ -2309,10 +2309,10 @@ The schema definition is automatically transformed to this:
 ```graphql
 type Query {
   posts(
-    "Limits number of fetched elements."
+    "Limits number of fetched items."
     first: Int!
 
-    "The offset from which elements are returned."
+    "The offset from which items are returned."
     page: Int
   ): PostSimplePaginator
 }
@@ -2326,21 +2326,21 @@ type PostSimplePaginator {
   paginatorInfo: SimplePaginatorInfo!
 }
 
-"Pagination information about the corresponding list of items."
+"Information about pagination using a simple paginator."
 type SimplePaginatorInfo {
-  "Count of available items in the page."
+  "Number of items in the current page."
   count: Int!
 
-  "Current pagination page."
+  "Index of the current page."
   currentPage: Int!
 
-  "Index of first item in the current page."
+  "Index of the first item in the current page."
   firstItem: Int
 
-  "Index of last item in the current page."
+  "Index of the last item in the current page."
   lastItem: Int
 
-  "Number of items per page in the collection."
+  "Number of items per page."
   perPage: Int!
 }
 ```

--- a/src/Pagination/ConnectionField.php
+++ b/src/Pagination/ConnectionField.php
@@ -22,10 +22,6 @@ class ConnectionField
         $lastItem = $paginator->lastItem();
 
         return [
-            'total' => $paginator->total(),
-            'count' => $paginator->count(),
-            'currentPage' => $paginator->currentPage(),
-            'lastPage' => $paginator->lastPage(),
             'hasNextPage' => $paginator->hasMorePages(),
             'hasPreviousPage' => $paginator->currentPage() > 1,
             'startCursor' => $firstItem !== null
@@ -34,6 +30,10 @@ class ConnectionField
             'endCursor' => $lastItem !== null
                 ? Cursor::encode($lastItem)
                 : null,
+            'total' => $paginator->total(),
+            'count' => $paginator->count(),
+            'currentPage' => $paginator->currentPage(),
+            'lastPage' => $paginator->lastPage(),
         ];
     }
 
@@ -45,13 +45,12 @@ class ConnectionField
      */
     public function edgeResolver(LengthAwarePaginator $paginator, array $args, GraphQLContext $context, ResolveInfo $resolveInfo): Collection
     {
-        // We know this must be a list, as it is constructed this way during schema manipulation
-        /** @var \GraphQL\Type\Definition\ListOfType $listOfType */
-        $listOfType = $resolveInfo->returnType;
-
-        // We also know this is one of those two return types
+        // We know those types because we manipulated them during PaginationManipulator
+        /** @var \GraphQL\Type\Definition\NonNull $nonNullList */
+        $nonNullList = $resolveInfo->returnType;
         /** @var \GraphQL\Type\Definition\ObjectType|\GraphQL\Type\Definition\InterfaceType $objectLikeType */
-        $objectLikeType = $listOfType->ofType;
+        $objectLikeType = $nonNullList->getWrappedType(true);
+
         $returnTypeFields = $objectLikeType->getFields();
 
         /** @var int|null $firstItem Laravel type-hints are inaccurate here */

--- a/src/Pagination/PaginationManipulator.php
+++ b/src/Pagination/PaginationManipulator.php
@@ -71,9 +71,6 @@ class PaginationManipulator
         }
     }
 
-    /**
-     * Register connection with schema.
-     */
     protected function registerConnection(
         FieldDefinitionNode &$fieldDefinition,
         ObjectTypeDefinitionNode &$parentType,
@@ -94,13 +91,13 @@ class PaginationManipulator
         $connectionFieldName = addslashes(ConnectionField::class);
 
         $connectionType = Parser::objectTypeDefinition(/** @lang GraphQL */ <<<GRAPHQL
-            "A paginated list of $fieldTypeName edges."
-            type $connectionTypeName {
+            "A paginated list of {$fieldTypeName} edges."
+            type {$connectionTypeName} {
                 "Pagination information about the list of edges."
                 pageInfo: PageInfo! @field(resolver: "{$connectionFieldName}@pageInfoResolver")
 
                 "A list of $fieldTypeName edges."
-                edges: [$connectionEdgeName] @field(resolver: "{$connectionFieldName}@edgeResolver")
+                edges: [{$connectionEdgeName}!]! @field(resolver: "{$connectionFieldName}@edgeResolver")
             }
 GRAPHQL
         );
@@ -112,7 +109,7 @@ GRAPHQL
                 "An edge that contains a node of type $fieldTypeName and a cursor."
                 type $connectionEdgeName {
                     "The $fieldTypeName node."
-                    node: $fieldTypeName
+                    node: $fieldTypeName!
 
                     "A unique cursor that can be used for pagination."
                     cursor: String!
@@ -130,20 +127,15 @@ after: String
 GRAPHQL
         );
 
-        $fieldDefinition->type = Parser::namedType($connectionTypeName);
+        $fieldDefinition->type = Parser::typeReference(/** @lang GraphQL */ "{$connectionTypeName}!");
         $parentType->fields = ASTHelper::mergeUniqueNodeList($parentType->fields, [$fieldDefinition], true);
     }
 
-    /**
-     * Add the wrapping type for paginated results.
-     *
-     * This merges preexisting definitions to preserve maximum information.
-     */
     protected function addPaginationWrapperType(ObjectTypeDefinitionNode $objectType): void
     {
         $typeName = $objectType->name->value;
 
-        // If the type already exists, we use that instead
+        // Reuse existing types to preserve directives or other modifications made to it
         $existingType = $this->documentAST->types[$typeName] ?? null;
         if ($existingType !== null) {
             if (! $existingType instanceof ObjectTypeDefinitionNode) {
@@ -159,15 +151,12 @@ GRAPHQL
             $this->modelClass
             && ! ASTHelper::hasDirective($objectType, ModelDirective::NAME)
         ) {
-            $objectType->directives [] = Parser::constDirective('@model(class: "'.addslashes($this->modelClass).'")');
+            $objectType->directives [] = Parser::constDirective(/** @lang GraphQL */'@model(class: "'.addslashes($this->modelClass).'")');
         }
 
         $this->documentAST->setTypeDefinition($objectType);
     }
 
-    /**
-     * Register paginator with schema.
-     */
     protected function registerPaginator(
         FieldDefinitionNode &$fieldDefinition,
         ObjectTypeDefinitionNode &$parentType,
@@ -179,13 +168,13 @@ GRAPHQL
         $paginatorFieldClassName = addslashes(PaginatorField::class);
 
         $paginatorType = Parser::objectTypeDefinition(/** @lang GraphQL */ <<<GRAPHQL
-            "A paginated list of $fieldTypeName items."
-            type $paginatorTypeName {
+            "A paginated list of {$fieldTypeName} items."
+            type {$paginatorTypeName} {
                 "Pagination information about the list of items."
                 paginatorInfo: PaginatorInfo! @field(resolver: "{$paginatorFieldClassName}@paginatorInfoResolver")
 
-                "A list of $fieldTypeName items."
-                data: [$fieldTypeName!]! @field(resolver: "{$paginatorFieldClassName}@dataResolver")
+                "A list of {$fieldTypeName} items."
+                data: [{$fieldTypeName}!]! @field(resolver: "{$paginatorFieldClassName}@dataResolver")
             }
 GRAPHQL
         );
@@ -195,18 +184,15 @@ GRAPHQL
             self::countArgument($defaultCount, $maxCount)
         );
         $fieldDefinition->arguments [] = Parser::inputValueDefinition(/** @lang GraphQL */ <<<'GRAPHQL'
-"The offset from which elements are returned."
+"The offset from which items are returned."
 page: Int
 GRAPHQL
 );
 
-        $fieldDefinition->type = Parser::namedType($paginatorTypeName);
+        $fieldDefinition->type = Parser::typeReference(/** @lang GraphQL */"{$paginatorTypeName}!");
         $parentType->fields = ASTHelper::mergeUniqueNodeList($parentType->fields, [$fieldDefinition], true);
     }
 
-    /**
-     * Register simple paginator with schema.
-     */
     protected function registerSimplePaginator(
         FieldDefinitionNode &$fieldDefinition,
         ObjectTypeDefinitionNode &$parentType,
@@ -218,13 +204,13 @@ GRAPHQL
         $paginatorFieldClassName = addslashes(SimplePaginatorField::class);
 
         $paginatorType = Parser::objectTypeDefinition(/** @lang GraphQL */ <<<GRAPHQL
-            "A paginated list of $fieldTypeName items."
-            type $paginatorTypeName {
+            "A paginated list of {$fieldTypeName} items."
+            type {$paginatorTypeName} {
                 "Pagination information about the list of items."
                 paginatorInfo: SimplePaginatorInfo! @field(resolver: "{$paginatorFieldClassName}@paginatorInfoResolver")
 
-                "A list of $fieldTypeName items."
-                data: [$fieldTypeName!]! @field(resolver: "{$paginatorFieldClassName}@dataResolver")
+                "A list of {$fieldTypeName} items."
+                data: [{$fieldTypeName}!]! @field(resolver: "{$paginatorFieldClassName}@dataResolver")
             }
 GRAPHQL
         );
@@ -234,12 +220,12 @@ GRAPHQL
             self::countArgument($defaultCount, $maxCount)
         );
         $fieldDefinition->arguments [] = Parser::inputValueDefinition(/** @lang GraphQL */ <<<'GRAPHQL'
-"The offset from which elements are returned."
+"The offset from which items are returned."
 page: Int
 GRAPHQL
         );
 
-        $fieldDefinition->type = Parser::namedType($paginatorTypeName);
+        $fieldDefinition->type = Parser::typeReference(/** @lang GraphQL */"{$paginatorTypeName}!");
         $parentType->fields = ASTHelper::mergeUniqueNodeList($parentType->fields, [$fieldDefinition], true);
     }
 
@@ -248,7 +234,7 @@ GRAPHQL
      */
     protected static function countArgument(?int $defaultCount = null, ?int $maxCount = null): string
     {
-        $description = '"Limits number of fetched elements.';
+        $description = '"Limits number of fetched items.';
         if ($maxCount) {
             $description .= ' Maximum allowed value: '.$maxCount.'.';
         }

--- a/src/Pagination/PaginationServiceProvider.php
+++ b/src/Pagination/PaginationServiceProvider.php
@@ -34,30 +34,30 @@ class PaginationServiceProvider extends ServiceProvider
     protected static function paginatorInfo(): ObjectTypeDefinitionNode
     {
         return Parser::objectTypeDefinition(/** @lang GraphQL */ '
-            "Pagination information about the corresponding list of items."
+            "Information about pagination using a fully featured paginator."
             type PaginatorInfo {
-              "Count of available items in the page."
+              "Number of items in the current page."
               count: Int!
 
-              "Current pagination page."
+              "Index of the current page."
               currentPage: Int!
 
-              "Index of first item in the current page."
+              "Index of the first item in the current page."
               firstItem: Int
 
-              "If collection has more pages."
+              "Are there more pages after this one?"
               hasMorePages: Boolean!
 
-              "Index of last item in the current page."
+              "Index of the last item in the current page."
               lastItem: Int
 
-              "Last page number of the collection."
+              "Index of the last available page."
               lastPage: Int!
 
-              "Number of items per page in the collection."
+              "Number of items per page."
               perPage: Int!
 
-              "Total items available in the collection."
+              "Number of total available items."
               total: Int!
             }
         ');
@@ -66,21 +66,21 @@ class PaginationServiceProvider extends ServiceProvider
     protected static function simplePaginatorInfo(): ObjectTypeDefinitionNode
     {
         return Parser::objectTypeDefinition(/** @lang GraphQL */ '
-            "Pagination information about the corresponding list of items."
+            "Information about pagination using a simple paginator."
             type SimplePaginatorInfo {
-              "Count of available items in the page."
+              "Number of items in the current page."
               count: Int!
 
-              "Current pagination page."
+              "Index of the current page."
               currentPage: Int!
 
-              "Index of first item in the current page."
+              "Index of the first item in the current page."
               firstItem: Int
 
-              "Index of last item in the current page."
+              "Index of the last item in the current page."
               lastItem: Int
 
-              "Number of items per page in the collection."
+              "Number of items per page."
               perPage: Int!
             }
         ');
@@ -89,7 +89,7 @@ class PaginationServiceProvider extends ServiceProvider
     protected static function pageInfo(): ObjectTypeDefinitionNode
     {
         return Parser::objectTypeDefinition(/** @lang GraphQL */ '
-            "Pagination information about the corresponding list of items."
+            "Information about pagination using a Relay style cursor connection."
             type PageInfo {
               "When paginating forwards, are there more items?"
               hasNextPage: Boolean!
@@ -97,23 +97,23 @@ class PaginationServiceProvider extends ServiceProvider
               "When paginating backwards, are there more items?"
               hasPreviousPage: Boolean!
 
-              "When paginating backwards, the cursor to continue."
+              "The cursor to continue paginating backwards."
               startCursor: String
 
-              "When paginating forwards, the cursor to continue."
+              "The cursor to continue paginating forwards."
               endCursor: String
 
-              "Total number of node in connection."
-              total: Int
+              "Total number of nodes in the paginated connection."
+              total: Int!
 
-              "Count of nodes in current request."
-              count: Int
+              "Number of nodes in the current page."
+              count: Int!
 
-              "Current page of request."
-              currentPage: Int
+              "Index of the current page."
+              currentPage: Int!
 
-              "Last page in connection."
-              lastPage: Int
+              "Index of the last available page."
+              lastPage: Int!
             }
         ');
     }

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -298,6 +298,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Non-Null Pagination Results
+    |--------------------------------------------------------------------------
+    |
+    | If set to true, the generated result type of paginated lists will be marked
+    | as non-nullable. This is generally more convenient for clients, but will
+    | cause validation errors to bubble further up in the result.
+    |
+    | This setting will be removed and always true in v6.
+    |
+    */
+
+    'non_null_pagination_results' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | GraphQL Subscriptions
     |--------------------------------------------------------------------------
     |

--- a/tests/Integration/Schema/Directives/HasManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/HasManyDirectiveTest.php
@@ -490,7 +490,7 @@ class HasManyDirectiveTest extends DBTestCase
         );
         $this->assertSame(
             $expectedConnectionName,
-            $tasks['type']['ofType']['name']
+            $tasks['type']/* TODO add back in in v6 ['ofType'] */['name']
         );
     }
 

--- a/tests/Integration/Schema/Directives/HasManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/HasManyDirectiveTest.php
@@ -288,22 +288,19 @@ class HasManyDirectiveTest extends DBTestCase
         }
         ';
 
-        $result = $this->graphQL(/** @lang GraphQL */ '
-        {
-            user {
-                tasks(first: 5) {
-                    data {
-                        id
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            {
+                user {
+                    tasks(first: 5) {
+                        data {
+                            id
+                        }
                     }
                 }
             }
-        }
-        ');
-
-        $this->assertSame(
-            PaginationArgs::requestedTooManyItems(3, 5),
-            $result->json('errors.0.message')
-        );
+            ')
+            ->assertGraphQLErrorMessage(PaginationArgs::requestedTooManyItems(3, 5));
     }
 
     public function testHandlesPaginationWithCountZero(): void
@@ -323,25 +320,20 @@ class HasManyDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            user {
-                id
-                tasks(first: 0) {
-                    data {
-                        id
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            {
+                user {
+                    id
+                    tasks(first: 0) {
+                        data {
+                            id
+                        }
                     }
                 }
             }
-        }
-        ')->assertJson([
-            'data' => [
-                'user' => [
-                    'id' => $this->user->id,
-                    'tasks' => null,
-                ],
-            ],
-        ])->assertGraphQLErrorCategory(Error::CATEGORY_GRAPHQL);
+            ')
+            ->assertGraphQLErrorMessage(PaginationArgs::requestedZeroOrLessItems(0));
     }
 
     public function testRelayTypeIsLimitedByMaxCountFromDirective(): void
@@ -488,8 +480,8 @@ class HasManyDirectiveTest extends DBTestCase
         );
 
         $user = $this->introspectType('User');
-
         $this->assertNotNull($user);
+
         /** @var array<string, mixed> $user */
         $tasks = Arr::first(
             $user['fields'],
@@ -499,7 +491,7 @@ class HasManyDirectiveTest extends DBTestCase
         );
         $this->assertSame(
             $expectedConnectionName,
-            $tasks['type']['name']
+            $tasks['type']['ofType']['name']
         );
     }
 

--- a/tests/Integration/Schema/Directives/HasManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/HasManyDirectiveTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Integration\Schema\Directives;
 
-use GraphQL\Error\Error;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Pagination\PaginationArgs;

--- a/tests/Integration/Schema/Directives/MorphManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/MorphManyDirectiveTest.php
@@ -330,27 +330,21 @@ class MorphManyDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/** @lang GraphQL */ "
-        {
-            post(id: {$this->post->id}) {
-                id
-                title
-                images(first: 0) {
-                    data {
-                        id
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            query ($id: ID!) {
+                post(id: $id) {
+                    images(first: 0) {
+                        data {
+                            id
+                        }
                     }
                 }
             }
-        }
-        ")->assertJson([
-            'data' => [
-                'post' => [
-                    'id' => $this->post->id,
-                    'title' => $this->post->title,
-                    'images' => null,
-                ],
-            ],
-        ])->assertGraphQLErrorCategory(Error::CATEGORY_GRAPHQL);
+            ', [
+                'id' => $this->post->id,
+            ])
+            ->assertGraphQLErrorMessage(PaginationArgs::requestedZeroOrLessItems(0));
     }
 
     public function testQueryMorphManyPaginatorWithADefaultCount(): void

--- a/tests/Integration/Schema/Directives/MorphManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/MorphManyDirectiveTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Integration\Schema\Directives;
 
 use Exception;
-use GraphQL\Error\Error;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Pagination\PaginationArgs;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -180,7 +180,7 @@ GRAPHQL;
     /**
      * Build an executable schema from a SDL string, adding on a default Query type.
      */
-    protected function buildSchemaWithPlaceholderQuery(string $schema): Schema
+    protected function buildSchemaWithPlaceholderQuery(string $schema = ''): Schema
     {
         return $this->buildSchema(
             $schema.self::PLACEHOLDER_QUERY

--- a/tests/Unit/Federation/SchemaBuilderTest.php
+++ b/tests/Unit/Federation/SchemaBuilderTest.php
@@ -54,6 +54,6 @@ class SchemaBuilderTest extends TestCase
     {
         $this->expectException(FederationException::class);
 
-        $this->buildSchemaWithPlaceholderQuery('');
+        $this->buildSchemaWithPlaceholderQuery();
     }
 }

--- a/tests/Unit/Pagination/PaginateDirectiveTest.php
+++ b/tests/Unit/Pagination/PaginateDirectiveTest.php
@@ -16,9 +16,9 @@ class PaginateDirectiveTest extends TestCase
     public function testIncludesPaginationInfoObjectsInSchema(): void
     {
         $schema = $this->buildSchemaWithPlaceholderQuery();
-        $schemaString= SchemaPrinter::doPrint($schema);
+        $schemaString = SchemaPrinter::doPrint($schema);
 
-        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<'GRAPHQL'
 """Information about pagination using a Relay style cursor connection."""
 type PageInfo {
   """When paginating forwards, are there more items?"""
@@ -49,7 +49,7 @@ GRAPHQL,
             $schemaString
         );
 
-        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<'GRAPHQL'
 """Information about pagination using a fully featured paginator."""
 type PaginatorInfo {
   """Number of items in the current page."""
@@ -80,7 +80,7 @@ GRAPHQL,
             $schemaString
         );
 
-        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<'GRAPHQL'
 """Information about pagination using a simple paginator."""
 type SimplePaginatorInfo {
   """Number of items in the current page."""
@@ -114,9 +114,9 @@ GRAPHQL,
             users: [User!]! @paginate
         }
         ');
-        $schemaString= SchemaPrinter::doPrint($schema);
+        $schemaString = SchemaPrinter::doPrint($schema);
 
-        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<'GRAPHQL'
 type Query {
   users(
     """Limits number of fetched items."""
@@ -130,7 +130,7 @@ GRAPHQL,
             $schemaString
         );
 
-        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<'GRAPHQL'
 """A paginated list of User items."""
 type UserPaginator {
   """Pagination information about the list of items."""
@@ -155,9 +155,9 @@ GRAPHQL,
             users: [User!]! @paginate(type: SIMPLE)
         }
         ');
-        $schemaString= SchemaPrinter::doPrint($schema);
+        $schemaString = SchemaPrinter::doPrint($schema);
 
-        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<'GRAPHQL'
 type Query {
   users(
     """Limits number of fetched items."""
@@ -171,7 +171,7 @@ GRAPHQL,
             $schemaString
         );
 
-        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<'GRAPHQL'
 """A paginated list of User items."""
 type UserSimplePaginator {
   """Pagination information about the list of items."""
@@ -196,9 +196,9 @@ GRAPHQL,
             users: [User!]! @paginate(type: CONNECTION)
         }
         ');
-        $schemaString= SchemaPrinter::doPrint($schema);
+        $schemaString = SchemaPrinter::doPrint($schema);
 
-        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<'GRAPHQL'
 type Query {
   users(
     """Limits number of fetched items."""
@@ -212,7 +212,7 @@ GRAPHQL,
             $schemaString
         );
 
-        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<'GRAPHQL'
 """A paginated list of User edges."""
 type UserConnection {
   """Pagination information about the list of edges."""
@@ -225,7 +225,7 @@ GRAPHQL,
             $schemaString
         );
 
-        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<'GRAPHQL'
 """An edge that contains a node of type User and a cursor."""
 type UserEdge {
   """The User node."""

--- a/tests/Unit/Pagination/PaginateDirectiveTest.php
+++ b/tests/Unit/Pagination/PaginateDirectiveTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Pagination;
 use GraphQL\Type\Definition\FieldArgument;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Utils\SchemaPrinter;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Pagination\PaginationArgs;
 use Nuwave\Lighthouse\Pagination\PaginationType;
@@ -12,6 +13,232 @@ use Tests\TestCase;
 
 class PaginateDirectiveTest extends TestCase
 {
+    public function testIncludesPaginationInfoObjectsInSchema(): void
+    {
+        $schema = $this->buildSchemaWithPlaceholderQuery();
+        $schemaString= SchemaPrinter::doPrint($schema);
+
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+"""Information about pagination using a Relay style cursor connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """The cursor to continue paginating backwards."""
+  startCursor: String
+
+  """The cursor to continue paginating forwards."""
+  endCursor: String
+
+  """Total number of nodes in the paginated connection."""
+  total: Int!
+
+  """Number of nodes in the current page."""
+  count: Int!
+
+  """Index of the current page."""
+  currentPage: Int!
+
+  """Index of the last available page."""
+  lastPage: Int!
+}
+GRAPHQL,
+            $schemaString
+        );
+
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+"""Information about pagination using a fully featured paginator."""
+type PaginatorInfo {
+  """Number of items in the current page."""
+  count: Int!
+
+  """Index of the current page."""
+  currentPage: Int!
+
+  """Index of the first item in the current page."""
+  firstItem: Int
+
+  """Are there more pages after this one?"""
+  hasMorePages: Boolean!
+
+  """Index of the last item in the current page."""
+  lastItem: Int
+
+  """Index of the last available page."""
+  lastPage: Int!
+
+  """Number of items per page."""
+  perPage: Int!
+
+  """Number of total available items."""
+  total: Int!
+}
+GRAPHQL,
+            $schemaString
+        );
+
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+"""Information about pagination using a simple paginator."""
+type SimplePaginatorInfo {
+  """Number of items in the current page."""
+  count: Int!
+
+  """Index of the current page."""
+  currentPage: Int!
+
+  """Index of the first item in the current page."""
+  firstItem: Int
+
+  """Index of the last item in the current page."""
+  lastItem: Int
+
+  """Number of items per page."""
+  perPage: Int!
+}
+GRAPHQL,
+            $schemaString
+        );
+    }
+
+    public function testManipulatesPaginator(): void
+    {
+        $schema = $this->buildSchema(/** @lang GraphQL */ '
+        type User {
+            id: ID!
+        }
+
+        type Query {
+            users: [User!]! @paginate
+        }
+        ');
+        $schemaString= SchemaPrinter::doPrint($schema);
+
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+type Query {
+  users(
+    """Limits number of fetched items."""
+    first: Int!
+
+    """The offset from which items are returned."""
+    page: Int
+  ): UserPaginator!
+}
+GRAPHQL,
+            $schemaString
+        );
+
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+"""A paginated list of User items."""
+type UserPaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of User items."""
+  data: [User!]!
+}
+GRAPHQL,
+            $schemaString
+        );
+    }
+
+    public function testManipulatesSimplePaginator(): void
+    {
+        $schema = $this->buildSchema(/** @lang GraphQL */ '
+        type User {
+            id: ID!
+        }
+
+        type Query {
+            users: [User!]! @paginate(type: SIMPLE)
+        }
+        ');
+        $schemaString= SchemaPrinter::doPrint($schema);
+
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+type Query {
+  users(
+    """Limits number of fetched items."""
+    first: Int!
+
+    """The offset from which items are returned."""
+    page: Int
+  ): UserSimplePaginator!
+}
+GRAPHQL,
+            $schemaString
+        );
+
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+"""A paginated list of User items."""
+type UserSimplePaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: SimplePaginatorInfo!
+
+  """A list of User items."""
+  data: [User!]!
+}
+GRAPHQL,
+            $schemaString
+        );
+    }
+
+    public function testManipulatesConnection(): void
+    {
+        $schema = $this->buildSchema(/** @lang GraphQL */ '
+        type User {
+            id: ID!
+        }
+
+        type Query {
+            users: [User!]! @paginate(type: CONNECTION)
+        }
+        ');
+        $schemaString= SchemaPrinter::doPrint($schema);
+
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+type Query {
+  users(
+    """Limits number of fetched items."""
+    first: Int!
+
+    """A cursor after which elements are returned."""
+    after: String
+  ): UserConnection!
+}
+GRAPHQL,
+            $schemaString
+        );
+
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+"""A paginated list of User edges."""
+type UserConnection {
+  """Pagination information about the list of edges."""
+  pageInfo: PageInfo!
+
+  """A list of User edges."""
+  edges: [UserEdge!]!
+}
+GRAPHQL,
+            $schemaString
+        );
+
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<GRAPHQL
+"""An edge that contains a node of type User and a cursor."""
+type UserEdge {
+  """The User node."""
+  node: User!
+
+  """A unique cursor that can be used for pagination."""
+  cursor: String!
+}
+GRAPHQL,
+            $schemaString
+        );
+    }
+
     public function testAliasRelayToConnection(): void
     {
         $connection = $this->getConnectionQueryField(PaginationType::CONNECTION);
@@ -129,7 +356,7 @@ class PaginateDirectiveTest extends TestCase
         $this->assertInstanceOf(FieldArgument::class, $defaultPaginatedAmountArg);
         /** @var \GraphQL\Type\Definition\FieldArgument $defaultPaginatedAmountArg */
         $this->assertSame(
-            'Limits number of fetched elements. Maximum allowed value: 5.',
+            'Limits number of fetched items. Maximum allowed value: 5.',
             $defaultPaginatedAmountArg->description
         );
 
@@ -140,7 +367,7 @@ class PaginateDirectiveTest extends TestCase
         $this->assertInstanceOf(FieldArgument::class, $defaultRelayFirstArg);
         /** @var \GraphQL\Type\Definition\FieldArgument $defaultRelayFirstArg */
         $this->assertSame(
-            'Limits number of fetched elements. Maximum allowed value: 5.',
+            'Limits number of fetched items. Maximum allowed value: 5.',
             $defaultRelayFirstArg->description
         );
 
@@ -151,7 +378,7 @@ class PaginateDirectiveTest extends TestCase
         $this->assertInstanceOf(FieldArgument::class, $defaultSimpleFirstArg);
         /** @var \GraphQL\Type\Definition\FieldArgument $defaultSimpleFirstArg */
         $this->assertSame(
-            'Limits number of fetched elements. Maximum allowed value: 5.',
+            'Limits number of fetched items. Maximum allowed value: 5.',
             $defaultSimpleFirstArg->description
         );
 
@@ -162,7 +389,7 @@ class PaginateDirectiveTest extends TestCase
         $this->assertInstanceOf(FieldArgument::class, $customPaginatedAmountArg);
         /** @var \GraphQL\Type\Definition\FieldArgument $customPaginatedAmountArg */
         $this->assertSame(
-            'Limits number of fetched elements. Maximum allowed value: 10.',
+            'Limits number of fetched items. Maximum allowed value: 10.',
             $customPaginatedAmountArg->description
         );
 
@@ -173,7 +400,7 @@ class PaginateDirectiveTest extends TestCase
         $this->assertInstanceOf(FieldArgument::class, $customRelayFirstArg);
         /** @var \GraphQL\Type\Definition\FieldArgument $customRelayFirstArg */
         $this->assertSame(
-            'Limits number of fetched elements. Maximum allowed value: 10.',
+            'Limits number of fetched items. Maximum allowed value: 10.',
             $customRelayFirstArg->description
         );
 
@@ -184,7 +411,7 @@ class PaginateDirectiveTest extends TestCase
         $this->assertInstanceOf(FieldArgument::class, $customSimpleFirstArg);
         /** @var \GraphQL\Type\Definition\FieldArgument $customSimpleFirstArg */
         $this->assertSame(
-            'Limits number of fetched elements. Maximum allowed value: 10.',
+            'Limits number of fetched items. Maximum allowed value: 10.',
             $customSimpleFirstArg->description
         );
     }
@@ -303,25 +530,17 @@ class PaginateDirectiveTest extends TestCase
         }
         ';
 
-        $result = $this->graphQL(/** @lang GraphQL */ '
-        {
-            users(first: 0) {
-                data {
-                    id
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            {
+                users(first: 0) {
+                    data {
+                        id
+                    }
                 }
             }
-        }
-        ')
-        ->assertJson([
-            'data' => [
-                'users' => null,
-            ],
-        ]);
-
-        $this->assertSame(
-            PaginationArgs::requestedZeroOrLessItems(0),
-            $result->json('errors.0.message')
-        );
+            ')
+            ->assertGraphQLErrorMessage(PaginationArgs::requestedZeroOrLessItems(0));
     }
 
     public function testDoesNotRequireModelWhenUsingBuilder(): void

--- a/tests/Unit/Pagination/PaginateDirectiveTest.php
+++ b/tests/Unit/Pagination/PaginateDirectiveTest.php
@@ -45,7 +45,8 @@ type PageInfo {
   """Index of the last available page."""
   lastPage: Int!
 }
-GRAPHQL,
+GRAPHQL
+            ,
             $schemaString
         );
 
@@ -76,7 +77,8 @@ type PaginatorInfo {
   """Number of total available items."""
   total: Int!
 }
-GRAPHQL,
+GRAPHQL
+            ,
             $schemaString
         );
 
@@ -98,7 +100,8 @@ type SimplePaginatorInfo {
   """Number of items per page."""
   perPage: Int!
 }
-GRAPHQL,
+GRAPHQL
+            ,
             $schemaString
         );
     }
@@ -134,7 +137,8 @@ type Query {
     page: Int
   ): UserPaginator{$nonNull}
 }
-GRAPHQL,
+GRAPHQL
+            ,
             $schemaString
         );
 
@@ -147,7 +151,8 @@ type UserPaginator {
   """A list of User items."""
   data: [User!]!
 }
-GRAPHQL,
+GRAPHQL
+            ,
             $schemaString
         );
     }
@@ -183,7 +188,8 @@ type Query {
     page: Int
   ): UserSimplePaginator{$nonNull}
 }
-GRAPHQL,
+GRAPHQL
+            ,
             $schemaString
         );
 
@@ -196,7 +202,8 @@ type UserSimplePaginator {
   """A list of User items."""
   data: [User!]!
 }
-GRAPHQL,
+GRAPHQL
+            ,
             $schemaString
         );
     }
@@ -232,7 +239,8 @@ type Query {
     after: String
   ): UserConnection{$nonNull}
 }
-GRAPHQL,
+GRAPHQL
+            ,
             $schemaString
         );
 
@@ -245,7 +253,8 @@ type UserConnection {
   """A list of User edges."""
   edges: [UserEdge!]!
 }
-GRAPHQL,
+GRAPHQL
+            ,
             $schemaString
         );
 
@@ -258,7 +267,8 @@ type UserEdge {
   """A unique cursor that can be used for pagination."""
   cursor: String!
 }
-GRAPHQL,
+GRAPHQL
+            ,
             $schemaString
         );
     }

--- a/tests/Unit/Schema/SchemaBuilderTest.php
+++ b/tests/Unit/Schema/SchemaBuilderTest.php
@@ -17,7 +17,7 @@ class SchemaBuilderTest extends TestCase
 {
     public function testGeneratesValidSchema(): void
     {
-        $schema = $this->buildSchemaWithPlaceholderQuery(/** @lang GraphQL */ '');
+        $schema = $this->buildSchemaWithPlaceholderQuery();
 
         $this->assertInstanceOf(Schema::class, $schema);
         // This would throw if the schema were invalid
@@ -174,7 +174,7 @@ class SchemaBuilderTest extends TestCase
 
     public function testResolveQueries(): void
     {
-        $schema = $this->buildSchemaWithPlaceholderQuery(/** @lang GraphQL */ '');
+        $schema = $this->buildSchemaWithPlaceholderQuery();
 
         /** @var \GraphQL\Type\Definition\ObjectType $queryObjectType */
         $queryObjectType = $schema->getType(RootType::QUERY);


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves https://github.com/nuwave/lighthouse/issues/1877

**Changes**

- Add config setting `non_null_pagination_results` to mark the generated result type of paginated lists as non-nullable
- Improve descriptions of generated pagination types

**Breaking changes**

Generated types were changed, but only towards more non-nullability.

A config setting was introduced to preserve the current nullability of paginated result types, as validation errors would bubble further up the query when set non-nullable. Lighthouse v6 will always generate them as non-nullable.
