### PR TITLE
Fix model name determination when using interfaces

### DIFF
--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -9,6 +9,7 @@ use GraphQL\Language\AST\DirectiveDefinitionNode;
 use GraphQL\Language\AST\DirectiveNode;
 use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\InputValueDefinitionNode;
+use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
 use GraphQL\Language\AST\NamedTypeNode;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeList;
@@ -391,7 +392,7 @@ class ASTHelper
             $definitionNode = static::underlyingType($definitionNode);
         }
 
-        if ($definitionNode instanceof ObjectTypeDefinitionNode) {
+        if ($definitionNode instanceof ObjectTypeDefinitionNode || $definitionNode instanceof InterfaceTypeDefinitionNode) {
             return ModelDirective::modelClass($definitionNode)
                 ?? $definitionNode->name->value;
         }

--- a/src/Schema/Directives/ModelDirective.php
+++ b/src/Schema/Directives/ModelDirective.php
@@ -2,7 +2,7 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives;
 
-use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use GraphQL\Language\AST\Node;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 
 class ModelDirective extends BaseDirective
@@ -29,7 +29,7 @@ GRAPHQL;
     /**
      * Attempt to get the model class name from this directive.
      */
-    public static function modelClass(ObjectTypeDefinitionNode $node): ?string
+    public static function modelClass(Node $node): ?string
     {
         $modelDirective = ASTHelper::directiveDefinition($node, self::NAME);
         if ($modelDirective !== null) {

--- a/tests/Integration/Schema/Directives/UpsertDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/UpsertDirectiveTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Integration\Schema\Directives;
 
+use GraphQL\Type\Definition\Type;
+use Nuwave\Lighthouse\Schema\TypeRegistry;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
@@ -149,5 +151,54 @@ class UpsertDirectiveTest extends DBTestCase
                 ],
             ],
         ]);
+    }
+
+    public function testUpsertUsingInterface(): void
+    {
+        $this->schema .= /** @lang GraphQL */ <<<GRAPHQL
+        type Mutation {
+            upsertUser(input: UpsertUserInput! @spread): IUser @upsert
+        }
+
+        interface IUser
+        @interface(resolveType: "{$this->qualifyTestResolver('resolveType')}")
+        @model(class: "Tests\\\\Utils\\\\Models\\\\User") {
+            name: String
+        }
+
+        type Admin implements IUser {
+            id: ID!
+            name: String
+        }
+
+        input UpsertUserInput {
+            name: String
+        }
+GRAPHQL;
+
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            upsertUser(input: {
+                name: "foo"
+            }) {
+                ... on Admin {
+                    id
+                    name
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'upsertUser' => [
+                    'id' => 1,
+                    'name' => 'foo',
+                ],
+            ],
+        ]);
+    }
+
+    public function resolveType(): Type
+    {
+        return app(TypeRegistry::class)->get('Admin');
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

When using interfaces (and a `@model` directive attached to it), the `ASTHelper::modelName` function should also handle instances of `InterfaceTypeDefinitionNode`.

**Changes**

Allows `ASTHelper::modelName` function to also handle instances of `InterfaceTypeDefinitionNode` and change `ModelDirective::modelClass`'s `$node` arg type hint to `GraphQL\Language\AST\Node`.

**Breaking changes**

None.
