### PR TITLE
Add method `rethrowGraphQLErrors()` to testing helper to leverage PHPUnit exception testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- Add method `rethrowGraphQLErrors()` to testing helper to leverage PHPUnit exception testing
+
 ## v5.14.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Added
 
-- Add method `rethrowGraphQLErrors()` to testing helper to leverage PHPUnit exception testing
+- Add method `rethrowGraphQLErrors()` to testing helper to leverage PHPUnit exception testing https://github.com/nuwave/lighthouse/pull/1885
 
 ## v5.14.0
 

--- a/docs/master/digging-deeper/error-handling.md
+++ b/docs/master/digging-deeper/error-handling.md
@@ -17,10 +17,10 @@ Head over their [Error Handling docs](https://webonyx.github.io/graphql-php/erro
 ## Additional Error Information
 
 The interface [`\Nuwave\Lighthouse\Exceptions\RendersErrorsExtensions`](https://github.com/nuwave/lighthouse/blob/master/src/Exceptions/RendersErrorsExtensions.php)
-may be extended to add more information then just an error message to the rendered error output.
+may be extended to add more information than just an error message to the rendered error output.
 
 Let's say you want to have a custom exception type that contains information about
-the reason why the exception was thrown.
+the reason the exception was thrown.
 
 ```php
 <?php
@@ -132,7 +132,7 @@ A query that produces an error will render like this:
 
 ## Registering Error Handlers
 
-Error handlers receive the Errors that occur during GraphQL execution.
+Error handlers receive the errors that occur during GraphQL execution.
 They can be used to log, filter or format the errors.
 
 Add them to your `lighthouse.php` config file, for example:
@@ -191,3 +191,7 @@ try {
 
 return $result;
 ```
+
+## Testing Errors
+
+See [PHPUnit - Testing Errors](../testing/phpunit.md#testing-errors).

--- a/docs/master/testing/phpunit.md
+++ b/docs/master/testing/phpunit.md
@@ -147,6 +147,39 @@ $this
     ->assertGraphQLValidationKeys(['email']);
 ```
 
+## Testing Errors
+
+Depending on your debug and error handling configuration, Lighthouse catches most if
+not all errors produced within queries and includes them within the result.
+
+One way to test for errors is to examine the `TestResponse`, either by looking
+at the JSON response manually or by using the provided [assertion mixins](#testresponse-assertion-mixins)
+such as `assertGraphQLErrorMessage()`:
+
+```php
+$this
+    ->graphQL(/** @lang GraphQL */ '
+    mutation {
+        shouldTriggerSomeError
+    }
+    ')
+    ->assertGraphQLErrorMessage($expectedMessage);
+```
+
+Another way is to leverage PHPUnit's built-in methods such as `expectException()`.
+You must disable Lighthouse's error handling with `rethrowGraphQLErrors()` to ensure errors reach your test:
+
+```php
+$this->rethrowGraphQLErrors();
+
+$this->expectException(SomethingWentWrongException::class);
+$this->graphQL(/** @lang GraphQL */ '
+{
+    oops
+}
+');
+```
+
 ## Simulating File Uploads
 
 Lighthouse allows you to [upload files](../digging-deeper/file-uploads.md) through GraphQL.

--- a/src/Testing/MakesGraphQLRequests.php
+++ b/src/Testing/MakesGraphQLRequests.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Testing;
 
 use GraphQL\Type\Introspection;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Support\Contracts\CanStreamResponse;
 use Nuwave\Lighthouse\Support\Http\Responses\MemoryStream;
@@ -168,7 +169,10 @@ trait MakesGraphQLRequests
      */
     protected function graphQLEndpointUrl(): string
     {
-        return route(config('lighthouse.route.name'));
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = app(ConfigRepository::class);
+
+        return route($config->get('lighthouse.route.name'));
     }
 
     /**
@@ -206,5 +210,12 @@ trait MakesGraphQLRequests
         Container::getInstance()->singleton(CanStreamResponse::class, function (): MemoryStream {
             return $this->deferStream;
         });
+    }
+
+    protected function rethrowGraphQLErrors(): void
+    {
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = app(ConfigRepository::class);
+        $config->set('lighthouse.error_handlers', [RethrowingErrorHandler::class]);
     }
 }

--- a/src/Testing/MakesGraphQLRequestsLumen.php
+++ b/src/Testing/MakesGraphQLRequestsLumen.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Testing;
 
 use GraphQL\Type\Introspection;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Support\Contracts\CanStreamResponse;
 use Nuwave\Lighthouse\Support\Http\Responses\MemoryStream;
@@ -179,7 +180,10 @@ trait MakesGraphQLRequestsLumen
      */
     protected function graphQLEndpointUrl(): string
     {
-        return route(config('lighthouse.route.name'));
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = app(ConfigRepository::class);
+
+        return route($config->get('lighthouse.route.name'));
     }
 
     /**
@@ -217,5 +221,12 @@ trait MakesGraphQLRequestsLumen
         Container::getInstance()->singleton(CanStreamResponse::class, function (): MemoryStream {
             return $this->deferStream;
         });
+    }
+
+    protected function rethrowGraphQLErrors(): void
+    {
+        /** @var \Illuminate\Contracts\Config\Repository $config */
+        $config = app(ConfigRepository::class);
+        $config->set('lighthouse.error_handlers', [RethrowingErrorHandler::class]);
     }
 }

--- a/src/Testing/RethrowingErrorHandler.php
+++ b/src/Testing/RethrowingErrorHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Nuwave\Lighthouse\Testing;
+
+use Closure;
+use GraphQL\Error\Error;
+use Nuwave\Lighthouse\Execution\ErrorHandler;
+
+/**
+ * Used to essentially disable Lighthouse + graphql-php error handling.
+ */
+class RethrowingErrorHandler implements ErrorHandler
+{
+    public function __invoke(?Error $error, Closure $next): ?array
+    {
+        if ($error === null) {
+            return $next(null);
+        }
+
+        throw $error;
+    }
+}

--- a/tests/Integration/ErrorHandlersTest.php
+++ b/tests/Integration/ErrorHandlersTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Integration;
 
+use Exception;
 use Tests\TestCase;
 use Tests\Utils\NullErrorHandler;
 
@@ -13,8 +14,8 @@ class ErrorHandlersTest extends TestCase
             NullErrorHandler::class,
         ]]);
 
-        $this->mockResolver(function () {
-            throw new \Exception();
+        $this->mockResolver(static function (): void {
+            throw new Exception();
         });
 
         $this->schema = /** @lang GraphQL */ '


### PR DESCRIPTION
Resolves https://github.com/nuwave/lighthouse/issues/1884

- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md
