### PR TITLE
Call lighthouse:clear-cache in other commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.15.1
+
+### Fixed
+
+- Call `lighthouse:clear-cache` in other commands to handle schema cache version 2 https://github.com/nuwave/lighthouse/pull/1894
+
 ## v5.15.0
 
 ### Added

--- a/src/Console/ClearCacheCommand.php
+++ b/src/Console/ClearCacheCommand.php
@@ -11,7 +11,7 @@ use Nuwave\Lighthouse\Exceptions\UnknownCacheVersionException;
 class ClearCacheCommand extends Command
 {
     /**
-     * TODO remove once we require Laravel 6 which allows $this->call(ClearCacheCommand::class)
+     * TODO remove once we require Laravel 6 which allows $this->call(ClearCacheCommand::class).
      */
     const NAME = 'lighthouse:clear-cache';
 

--- a/src/Console/ClearCacheCommand.php
+++ b/src/Console/ClearCacheCommand.php
@@ -10,7 +10,12 @@ use Nuwave\Lighthouse\Exceptions\UnknownCacheVersionException;
 
 class ClearCacheCommand extends Command
 {
-    protected $name = 'lighthouse:clear-cache';
+    /**
+     * TODO remove once we require Laravel 6 which allows $this->call(ClearCacheCommand::class)
+     */
+    const NAME = 'lighthouse:clear-cache';
+
+    protected $name = self::NAME;
 
     protected $description = 'Clear the GraphQL schema cache.';
 

--- a/src/Console/PrintSchemaCommand.php
+++ b/src/Console/PrintSchemaCommand.php
@@ -25,7 +25,7 @@ SIGNATURE;
     public function handle(Filesystem $storage, SchemaBuilder $schemaBuilder): void
     {
         // Clear the cache so this always gets the current schema
-        $this->callSilent(ClearCacheCommand::class);
+        $this->callSilent(ClearCacheCommand::NAME);
 
         $schema = $schemaBuilder->schema();
         if ($this->option('json')) {

--- a/src/Console/PrintSchemaCommand.php
+++ b/src/Console/PrintSchemaCommand.php
@@ -25,7 +25,7 @@ SIGNATURE;
     public function handle(Filesystem $storage, SchemaBuilder $schemaBuilder): void
     {
         // Clear the cache so this always gets the current schema
-        $this->call(ClearCacheCommand::class);
+        $this->callSilent(ClearCacheCommand::class);
 
         $schema = $schemaBuilder->schema();
         if ($this->option('json')) {

--- a/src/Console/PrintSchemaCommand.php
+++ b/src/Console/PrintSchemaCommand.php
@@ -5,9 +5,7 @@ namespace Nuwave\Lighthouse\Console;
 use GraphQL\Type\Introspection;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\SchemaPrinter;
-use Illuminate\Cache\Repository as CacheRepository;
 use Illuminate\Console\Command;
-use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Nuwave\Lighthouse\Schema\SchemaBuilder;
 
@@ -24,12 +22,10 @@ SIGNATURE;
 
     protected $description = 'Compile the GraphQL schema and print the result.';
 
-    public function handle(CacheRepository $cache, ConfigRepository $config, Filesystem $storage, SchemaBuilder $schemaBuilder): void
+    public function handle(Filesystem $storage, SchemaBuilder $schemaBuilder): void
     {
         // Clear the cache so this always gets the current schema
-        $cache->forget(
-            $config->get('lighthouse.cache.key')
-        );
+        $this->call(ClearCacheCommand::class);
 
         $schema = $schemaBuilder->schema();
         if ($this->option('json')) {

--- a/src/Console/ValidateSchemaCommand.php
+++ b/src/Console/ValidateSchemaCommand.php
@@ -25,7 +25,7 @@ class ValidateSchemaCommand extends Command
         TypeRegistry $typeRegistry
     ): void {
         // Clear the cache so this always validates the current schema
-        $this->call(ClearCacheCommand::class);
+        $this->call(ClearCacheCommand::NAME);
 
         $originalSchema = $schemaBuilder->schema();
         $schemaConfig = $originalSchema->getConfig();

--- a/src/Console/ValidateSchemaCommand.php
+++ b/src/Console/ValidateSchemaCommand.php
@@ -4,8 +4,6 @@ namespace Nuwave\Lighthouse\Console;
 
 use GraphQL\Type\Schema;
 use Illuminate\Console\Command;
-use Illuminate\Contracts\Cache\Repository as CacheRepository;
-use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Nuwave\Lighthouse\Events\ValidateSchema;
 use Nuwave\Lighthouse\Schema\DirectiveLocator;
@@ -21,17 +19,13 @@ class ValidateSchemaCommand extends Command
     protected $description = 'Validate the GraphQL schema definition.';
 
     public function handle(
-        CacheRepository $cache,
-        ConfigRepository $config,
         EventsDispatcher $eventsDispatcher,
         SchemaBuilder $schemaBuilder,
         DirectiveLocator $directiveLocator,
         TypeRegistry $typeRegistry
     ): void {
         // Clear the cache so this always validates the current schema
-        $cache->forget(
-            $config->get('lighthouse.cache.key')
-        );
+        $this->call(ClearCacheCommand::class);
 
         $originalSchema = $schemaBuilder->schema();
         $schemaConfig = $originalSchema->getConfig();

--- a/src/LighthouseServiceProvider.php
+++ b/src/LighthouseServiceProvider.php
@@ -50,6 +50,25 @@ use Nuwave\Lighthouse\Testing\TestingServiceProvider;
 
 class LighthouseServiceProvider extends ServiceProvider
 {
+    /**
+     * @var array<int, class-string<\Illuminate\Console\Command>
+     */
+    const COMMANDS = [
+        CacheCommand::class,
+        ClearCacheCommand::class,
+        DirectiveCommand::class,
+        IdeHelperCommand::class,
+        InterfaceCommand::class,
+        MutationCommand::class,
+        PrintSchemaCommand::class,
+        QueryCommand::class,
+        ScalarCommand::class,
+        SubscriptionCommand::class,
+        UnionCommand::class,
+        ValidateSchemaCommand::class,
+        ValidatorCommand::class,
+    ];
+
     public function register(): void
     {
         $this->mergeConfigFrom(__DIR__.'/lighthouse.php', 'lighthouse');
@@ -104,21 +123,7 @@ class LighthouseServiceProvider extends ServiceProvider
         });
 
         if ($this->app->runningInConsole()) {
-            $this->commands([
-                CacheCommand::class,
-                ClearCacheCommand::class,
-                DirectiveCommand::class,
-                IdeHelperCommand::class,
-                InterfaceCommand::class,
-                MutationCommand::class,
-                PrintSchemaCommand::class,
-                QueryCommand::class,
-                ScalarCommand::class,
-                SubscriptionCommand::class,
-                UnionCommand::class,
-                ValidateSchemaCommand::class,
-                ValidatorCommand::class,
-            ]);
+            $this->commands(self::COMMANDS);
         }
 
         if ($this->app->runningUnitTests()) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -217,9 +217,13 @@ GRAPHQL;
     protected function commandTester(Command $command): CommandTester
     {
         $command->setLaravel($this->app);
-        $command->setApplication($this->app->make(ConsoleApplication::class, [
+
+        /** @var \Illuminate\Console\Application $console */
+        $console = $this->app->make(ConsoleApplication::class, [
             'version' => $this->app->version(),
-        ]));
+        ]);
+        $console->resolveCommands(LighthouseServiceProvider::COMMANDS);
+        $command->setApplication($console);
 
         return new CommandTester($command);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -217,13 +217,9 @@ GRAPHQL;
     protected function commandTester(Command $command): CommandTester
     {
         $command->setLaravel($this->app);
-
-        /** @var \Illuminate\Console\Application $console */
-        $console = $this->app->make(ConsoleApplication::class, [
+        $command->setApplication($this->app->make(ConsoleApplication::class, [
             'version' => $this->app->version(),
-        ]);
-        $console->resolveCommands(LighthouseServiceProvider::COMMANDS);
-        $command->setApplication($console);
+        ]));
 
         return new CommandTester($command);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use GraphQL\Error\DebugFlag;
 use GraphQL\Type\Schema;
+use Illuminate\Console\Application as ConsoleApplication;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
@@ -216,6 +217,9 @@ GRAPHQL;
     protected function commandTester(Command $command): CommandTester
     {
         $command->setLaravel($this->app);
+        $command->setApplication($this->app->make(ConsoleApplication::class, [
+            'version' => $this->app->version(),
+        ]));
 
         return new CommandTester($command);
     }


### PR DESCRIPTION
- [ ] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Actually clears the cache in `lighthouse:validate-schema` and `lighthouse:print-schema` when using schema cache version 2.

**Breaking changes**

None
