### PR TITLE
Add `ValidationException::fromLaravel()` and `ValidationErrorHandler` to include validation messages in extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.16.0
+
+- Add `ValidationException::fromLaravel()` and `ValidationErrorHandler` to include validation messages in extensions
+
 ## v5.15.3
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## v5.16.0
 
-- Add `ValidationException::fromLaravel()` and `ValidationErrorHandler` to include validation messages in extensions
+- Add `ValidationException::fromLaravel()` and `ValidationErrorHandler` to include validation messages in extensions https://github.com/nuwave/lighthouse/pull/1899
 
 ## v5.15.3
 

--- a/src/Execution/ExtensionErrorHandler.php
+++ b/src/Execution/ExtensionErrorHandler.php
@@ -20,10 +20,9 @@ class ExtensionErrorHandler implements ErrorHandler
         }
 
         $underlyingException = $error->getPrevious();
-
         if ($underlyingException instanceof RendersErrorsExtensions) {
             // Reconstruct the error, passing in the extensions of the underlying exception
-            $error = new Error(
+            return $next(new Error(
                 $error->getMessage(),
                 // @phpstan-ignore-next-line graphql-php and phpstan disagree with themselves
                 $error->getNodes(),
@@ -32,7 +31,7 @@ class ExtensionErrorHandler implements ErrorHandler
                 $error->getPath(),
                 $underlyingException,
                 $underlyingException->extensionsContent()
-            );
+            ));
         }
 
         return $next($error);

--- a/src/Execution/ValidationErrorHandler.php
+++ b/src/Execution/ValidationErrorHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Nuwave\Lighthouse\Execution;
+
+use Closure;
+use GraphQL\Error\Error;
+use Illuminate\Validation\ValidationException as LaravelValidationException;
+use Nuwave\Lighthouse\Exceptions\ValidationException;
+
+/**
+ * Wrap native Laravel validation exceptions, adding structured data to extensions.
+ */
+class ValidationErrorHandler implements ErrorHandler
+{
+    public function __invoke(?Error $error, Closure $next): ?array
+    {
+        if ($error === null) {
+            return $next(null);
+        }
+
+        $underlyingException = $error->getPrevious();
+        if ($underlyingException instanceof LaravelValidationException) {
+            return $next(ValidationException::fromLaravel($underlyingException));
+        }
+
+        return $next($error);
+    }
+}

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -227,6 +227,7 @@ return [
     */
 
     'error_handlers' => [
+        \Nuwave\Lighthouse\Execution\ValidationErrorHandler::class,
         \Nuwave\Lighthouse\Execution\ExtensionErrorHandler::class,
         \Nuwave\Lighthouse\Execution\ReportingErrorHandler::class,
     ],

--- a/tests/Unit/Exceptions/ValidationExceptionTest.php
+++ b/tests/Unit/Exceptions/ValidationExceptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Exceptions;
 
+use Illuminate\Validation\ValidationException as LaravelValidationException;
 use Nuwave\Lighthouse\Exceptions\ValidationException;
 use Tests\TestCase;
 
@@ -12,6 +13,17 @@ class ValidationExceptionTest extends TestCase
         $rule = 'email';
         $message = 'The email or password does not match';
         $exception = ValidationException::withMessages([$rule => $message]);
+
+        $validation = $exception->extensionsContent()[ValidationException::CATEGORY];
+        $this->assertSame([$message], $validation[$rule]);
+    }
+
+    public function testFromLaravel(): void
+    {
+        $rule = 'email';
+        $message = 'The email or password does not match';
+        $laravelException = LaravelValidationException::withMessages([$rule => $message]);
+        $exception = ValidationException::fromLaravel($laravelException);
 
         $validation = $exception->extensionsContent()[ValidationException::CATEGORY];
         $this->assertSame([$message], $validation[$rule]);

--- a/tests/Unit/Execution/ValidationErrorHandlerTest.php
+++ b/tests/Unit/Execution/ValidationErrorHandlerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit\Execution;
+
+use GraphQL\Error\Error;
+use Illuminate\Validation\ValidationException as LaravelValidationException;
+use Nuwave\Lighthouse\Exceptions\ValidationException;
+use Nuwave\Lighthouse\Execution\ValidationErrorHandler;
+use Tests\TestCase;
+
+class ValidationErrorHandlerTest extends TestCase
+{
+    public function testWrapsLaravelValidation(): void
+    {
+        $handler = new ValidationErrorHandler();
+
+        $validationException = LaravelValidationException::withMessages([]);
+        $error = new Error('foo', null, null, [], null, $validationException);
+
+        $exception = null;
+        $next = function (ValidationException $e) use (&$exception) {
+            $exception = $e;
+        };
+
+        $handler($error, $next);
+        $this->assertInstanceOf(ValidationException::class, $exception);
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Native Laravel validation exceptions are now handled gracefully as client safe exceptions, holding the structured validation messages in `extensions.validation`.

**Breaking changes**

None.
