### PR TITLE
Allow using date validation rules that reference other arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.16.2
+
+### Fixed
+
+- Fix using date validation with other fields as comparison
+
 ## v5.16.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Fix using date validation with other fields as comparison
+- Allow using date validation rules that reference other arguments
 
 ## v5.16.1
 

--- a/src/Validation/RulesGatherer.php
+++ b/src/Validation/RulesGatherer.php
@@ -2,8 +2,8 @@
 
 namespace Nuwave\Lighthouse\Validation;
 
-use Carbon\Carbon;
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\DateFactory;
 use Illuminate\Validation\ValidationRuleParser;
@@ -15,6 +15,7 @@ use Nuwave\Lighthouse\Support\Contracts\ArgumentSetValidation;
 use Nuwave\Lighthouse\Support\Contracts\ArgumentValidation;
 use Nuwave\Lighthouse\Support\Traits\HasArgumentValue;
 use Nuwave\Lighthouse\Support\Utils;
+use Throwable;
 
 class RulesGatherer
 {

--- a/src/Validation/RulesGatherer.php
+++ b/src/Validation/RulesGatherer.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Validation;
 
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Validation\ValidationRuleParser;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Nuwave\Lighthouse\Execution\Arguments\ListType;
@@ -269,6 +270,20 @@ class RulesGatherer
                         },
                         $args
                     );
+                }
+
+                // Rules where the first argument is a date or a field reference
+                if (is_string($args[0] ?? null) && in_array($name, [
+                    'After',
+                    'AfterOrEqual',
+                    'Before',
+                    'BeforeOrEqual',
+                ])) {
+                    try {
+                        Date::parse($args[0]);
+                    } catch (\Exception $e) {
+                        $args[0] = implode('.', array_merge($argumentPath, [$args[0]]));
+                    }
                 }
 
                 // Laravel expects the rule to be a flat array of name, arg1, arg2, ...

--- a/src/Validation/RulesGatherer.php
+++ b/src/Validation/RulesGatherer.php
@@ -4,7 +4,7 @@ namespace Nuwave\Lighthouse\Validation;
 
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Date;
+use Illuminate\Support\DateFactory;
 use Illuminate\Validation\ValidationRuleParser;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Nuwave\Lighthouse\Execution\Arguments\ListType;
@@ -280,7 +280,7 @@ class RulesGatherer
                     'BeforeOrEqual',
                 ])) {
                     try {
-                        Date::parse($args[0]);
+                        (new DateFactory())->parse($args[0]);
                     } catch (\Exception $e) {
                         $args[0] = implode('.', array_merge($argumentPath, [$args[0]]));
                     }

--- a/src/Validation/RulesGatherer.php
+++ b/src/Validation/RulesGatherer.php
@@ -5,7 +5,6 @@ namespace Nuwave\Lighthouse\Validation;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
-use Illuminate\Support\DateFactory;
 use Illuminate\Validation\ValidationRuleParser;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Nuwave\Lighthouse\Execution\Arguments\ListType;

--- a/src/Validation/RulesGatherer.php
+++ b/src/Validation/RulesGatherer.php
@@ -2,7 +2,7 @@
 
 namespace Nuwave\Lighthouse\Validation;
 
-use Throwable;
+use Carbon\Carbon;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Collection;
 use Illuminate\Support\DateFactory;
@@ -281,7 +281,7 @@ class RulesGatherer
                     'BeforeOrEqual',
                 ])) {
                     try {
-                        (new DateFactory())->parse($args[0]);
+                        Carbon::parse($args[0]);
                     } catch (Throwable $argumentIsNotADate) {
                         $args[0] = implode('.', array_merge($argumentPath, [$args[0]]));
                     }

--- a/src/Validation/RulesGatherer.php
+++ b/src/Validation/RulesGatherer.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Validation;
 
+use Throwable;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Collection;
 use Illuminate\Support\DateFactory;
@@ -281,7 +282,7 @@ class RulesGatherer
                 ])) {
                     try {
                         (new DateFactory())->parse($args[0]);
-                    } catch (\Exception $e) {
+                    } catch (Throwable $argumentIsNotADate) {
                         $args[0] = implode('.', array_merge($argumentPath, [$args[0]]));
                     }
                 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

The Laravel date validation rules (after, after_or_equal, before,
before_or_equal) allow the user to specify a date or another field from
the request to compare.
This didn't work with Lighthouse because the full path to the field
wasn't added to the rule arguments.
In this commit the argument is checked, if it is a date then nothing
happens, otherwise it is assumed to be another field from the request
and so adds the full argument path.

**Breaking changes**

This shouldn't break any existing projects as it uses the same check that Laravel uses when seeing if the argument is a date or a field reference, so it should behave in the same way.
