### PR TITLE
Fix compatibility with Laravel Octane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.18.1
+
+### Fixed
+
+- Fix compatibility with Laravel Octane https://github.com/nuwave/lighthouse/pull/1911
+
 ## v5.18.0
 
 ### Changed

--- a/docs/5/api-reference/directives.md
+++ b/docs/5/api-reference/directives.md
@@ -1183,11 +1183,11 @@ users to still receive partial results.
 Used upon an object, it applies to all fields within.
 """
 directive @guard(
-    """
-    Specify which guards to use, e.g. ["api"].
-    When not defined, the default from `lighthouse.php` is used.
-    """
-    with: [String!]
+  """
+  Specify which guards to use, e.g. ["api"].
+  When not defined, the default from `lighthouse.php` is used.
+  """
+  with: [String!]
 ) repeatable on FIELD_DEFINITION | OBJECT
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -1183,11 +1183,11 @@ users to still receive partial results.
 Used upon an object, it applies to all fields within.
 """
 directive @guard(
-    """
-    Specify which guards to use, e.g. ["api"].
-    When not defined, the default from `lighthouse.php` is used.
-    """
-    with: [String!]
+  """
+  Specify which guards to use, e.g. ["api"].
+  When not defined, the default from `lighthouse.php` is used.
+  """
+  with: [String!]
 ) repeatable on FIELD_DEFINITION | OBJECT
 ```
 

--- a/src/Validation/ValidateDirective.php
+++ b/src/Validation/ValidateDirective.php
@@ -13,16 +13,6 @@ use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
 class ValidateDirective extends BaseDirective implements FieldMiddleware
 {
-    /**
-     * @var \Illuminate\Contracts\Validation\Factory
-     */
-    protected $validationFactory;
-
-    public function __construct(ValidationFactory $validationFactory)
-    {
-        $this->validationFactory = $validationFactory;
-    }
-
     public static function definition(): string
     {
         return /** @lang GraphQL */ <<<'GRAPHQL'
@@ -43,13 +33,16 @@ GRAPHQL;
                     $argumentSet = $resolveInfo->argumentSet;
                     $rulesGatherer = new RulesGatherer($argumentSet);
 
-                    $validator = $this->validationFactory
-                        ->make(
-                            $args,
-                            $rulesGatherer->rules,
-                            $rulesGatherer->messages,
-                            $rulesGatherer->attributes
-                        );
+                    /**
+                     * @var \Illuminate\Contracts\Validation\Factory $validationFactory
+                     */
+                    $validationFactory = app(ValidationFactory::class);
+                    $validator = $validationFactory->make(
+                        $args,
+                        $rulesGatherer->rules,
+                        $rulesGatherer->messages,
+                        $rulesGatherer->attributes
+                    );
 
                     if ($validator->fails()) {
                         $path = implode('.', $resolveInfo->path);


### PR DESCRIPTION
Constructor injection of `Illuminate\Contracts\Validation\Factory` seems to be problematic when using Octane.