### PR TITLE
Feature/update can directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find and compare releases at the [GitHub release page](https://github.com/nuwave/lighthouse/releases).
 
 ## Unreleased
+- Allow the @can directive to resolve models by a custom key https://github.com/nuwave/lighthouse/issues/1916
 
 ## v5.18.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find and compare releases at the [GitHub release page](https://github.com/nuwave/lighthouse/releases).
 
 ## Unreleased
-- Allow the @can directive to resolve models by a custom key https://github.com/nuwave/lighthouse/issues/1916
+- Allow the `@can` directive to resolve models by a custom key https://github.com/nuwave/lighthouse/issues/1916
 
 ## v5.18.1
 

--- a/src/Schema/Directives/CanDirective.php
+++ b/src/Schema/Directives/CanDirective.php
@@ -56,6 +56,11 @@ directive @can(
   find: String
 
   """
+  If you need to resolve your model by a different primary key than the default one.
+  """
+  field: String
+
+  """
   Specify the class name of the model to use.
   This is only needed when the default model detection does not work.
   """
@@ -151,7 +156,11 @@ GRAPHQL;
                     Utils::instanceofMatcher(TrashedDirective::class)
                 );
 
-                $modelOrModels = $enhancedBuilder->findOrFail($findValue);
+                if ($field = $this->directiveArgValue('field')) {
+                    $modelOrModels = $enhancedBuilder->where($field, $findValue)->firstOrFail();
+                } else {
+                    $modelOrModels = $enhancedBuilder->findOrFail($findValue);
+                }
             } catch (ModelNotFoundException $exception) {
                 throw new Error($exception->getMessage());
             }


### PR DESCRIPTION
- [ ] Added or updated tests
- [X] Documented user facing changes
- [X] Updated CHANGELOG.md

Resolves #1916

**Changes**
Added a `field` argument to the `@can` directive which allows for models to be resolved by a custom key.
See the issue for more details.