### PR TITLE
Include definition when generating directives via `artisan lighthouse:directive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.20.0
+
+### Added
+
+- Include definition when generating directives via `artisan lighthouse:directive`
+
 ## v5.19.0
 
 ### Added

--- a/docs/5/api-reference/commands.md
+++ b/docs/5/api-reference/commands.md
@@ -21,10 +21,7 @@ Create a class for a custom schema directive.
 
     php artisan lighthouse:directive
 
-Use the `--type`, `--field` and `--argument` options to create type, field and
-argument directives, respectively. The command will then ask you which
-interfaces the directive should implement and add the required method stubs and
-imports for you.
+Use the `--type`, `--field` and `--argument` options to define where your directive can be used.
 
 ## ide-helper
 

--- a/docs/5/api-reference/directives.md
+++ b/docs/5/api-reference/directives.md
@@ -519,52 +519,52 @@ When `injectArgs` and `args` are used together, the client given
 arguments will be passed before the static args.
 """
 directive @can(
-    """
-    The ability to check permissions for.
-    """
-    ability: String!
+  """
+  The ability to check permissions for.
+  """
+  ability: String!
 
-    """
-    Query for specific model instances to check the policy against, using arguments
-    with directives that add constraints to the query builder, such as `@eq`.
+  """
+  Query for specific model instances to check the policy against, using arguments
+  with directives that add constraints to the query builder, such as `@eq`.
 
-    Mutually exclusive with `find`.
-    """
-    query: Boolean = false
+  Mutually exclusive with `find`.
+  """
+  query: Boolean = false
 
-    """
-    Apply scopes to the underlying query.
-    """
-    scopes: [String!]
+  """
+  Apply scopes to the underlying query.
+  """
+  scopes: [String!]
 
-    """
-    Specify the class name of the model to use.
-    This is only needed when the default model detection does not work.
-    """
-    model: String
+  """
+  Specify the class name of the model to use.
+  This is only needed when the default model detection does not work.
+  """
+  model: String
 
-    """
-    Pass along the client given input data as arguments to `Gate::check`.
-    """
-    injectArgs: Boolean = false
+  """
+  Pass along the client given input data as arguments to `Gate::check`.
+  """
+  injectArgs: Boolean = false
 
-    """
-    Statically defined arguments that are passed to `Gate::check`.
+  """
+  Statically defined arguments that are passed to `Gate::check`.
 
-    You may pass pass arbitrary GraphQL literals,
-    e.g.: [1, 2, 3] or { foo: "bar" }
-    """
-    args: CanArgs
+  You may pass pass arbitrary GraphQL literals,
+  e.g.: [1, 2, 3] or { foo: "bar" }
+  """
+  args: CanArgs
 
-    """
-    If your policy checks against specific model instances, specify
-    the name of the field argument that contains its primary key(s).
+  """
+  If your policy checks against specific model instances, specify
+  the name of the field argument that contains its primary key(s).
 
-    You may pass the string in dot notation to use nested inputs.
+  You may pass the string in dot notation to use nested inputs.
 
-    Mutually exclusive with `search`.
-    """
-    find: String
+  Mutually exclusive with `search`.
+  """
+  find: String
 ) repeatable on FIELD_DEFINITION
 
 """

--- a/docs/5/security/authorization.md
+++ b/docs/5/security/authorization.md
@@ -94,10 +94,7 @@ before checking permissions against them:
 
 ```graphql
 type Query {
-  post(id: ID! @eq): Post
-    @can(ability: "view", query: true)
-    @find
-    @softDeletes
+  post(id: ID! @eq): Post @can(ability: "view", query: true) @find @softDeletes
 }
 ```
 

--- a/docs/master/api-reference/commands.md
+++ b/docs/master/api-reference/commands.md
@@ -21,10 +21,7 @@ Create a class for a custom schema directive.
 
     php artisan lighthouse:directive
 
-Use the `--type`, `--field` and `--argument` options to create type, field and
-argument directives, respectively. The command will then ask you which
-interfaces the directive should implement and add the required method stubs and
-imports for you.
+Use the `--type`, `--field` and `--argument` options to define where your directive can be used.
 
 ## ide-helper
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -519,52 +519,52 @@ When `injectArgs` and `args` are used together, the client given
 arguments will be passed before the static args.
 """
 directive @can(
-    """
-    The ability to check permissions for.
-    """
-    ability: String!
+  """
+  The ability to check permissions for.
+  """
+  ability: String!
 
-    """
-    Query for specific model instances to check the policy against, using arguments
-    with directives that add constraints to the query builder, such as `@eq`.
+  """
+  Query for specific model instances to check the policy against, using arguments
+  with directives that add constraints to the query builder, such as `@eq`.
 
-    Mutually exclusive with `find`.
-    """
-    query: Boolean = false
+  Mutually exclusive with `find`.
+  """
+  query: Boolean = false
 
-    """
-    Apply scopes to the underlying query.
-    """
-    scopes: [String!]
+  """
+  Apply scopes to the underlying query.
+  """
+  scopes: [String!]
 
-    """
-    Specify the class name of the model to use.
-    This is only needed when the default model detection does not work.
-    """
-    model: String
+  """
+  Specify the class name of the model to use.
+  This is only needed when the default model detection does not work.
+  """
+  model: String
 
-    """
-    Pass along the client given input data as arguments to `Gate::check`.
-    """
-    injectArgs: Boolean = false
+  """
+  Pass along the client given input data as arguments to `Gate::check`.
+  """
+  injectArgs: Boolean = false
 
-    """
-    Statically defined arguments that are passed to `Gate::check`.
+  """
+  Statically defined arguments that are passed to `Gate::check`.
 
-    You may pass pass arbitrary GraphQL literals,
-    e.g.: [1, 2, 3] or { foo: "bar" }
-    """
-    args: CanArgs
+  You may pass pass arbitrary GraphQL literals,
+  e.g.: [1, 2, 3] or { foo: "bar" }
+  """
+  args: CanArgs
 
-    """
-    If your policy checks against specific model instances, specify
-    the name of the field argument that contains its primary key(s).
+  """
+  If your policy checks against specific model instances, specify
+  the name of the field argument that contains its primary key(s).
 
-    You may pass the string in dot notation to use nested inputs.
+  You may pass the string in dot notation to use nested inputs.
 
-    Mutually exclusive with `search`.
-    """
-    find: String
+  Mutually exclusive with `search`.
+  """
+  find: String
 ) repeatable on FIELD_DEFINITION
 
 """

--- a/docs/master/security/authorization.md
+++ b/docs/master/security/authorization.md
@@ -94,10 +94,7 @@ before checking permissions against them:
 
 ```graphql
 type Query {
-  post(id: ID! @eq): Post
-    @can(ability: "view", query: true)
-    @find
-    @softDeletes
+  post(id: ID! @eq): Post @can(ability: "view", query: true) @find @softDeletes
 }
 ```
 

--- a/src/Console/DirectiveCommand.php
+++ b/src/Console/DirectiveCommand.php
@@ -187,7 +187,7 @@ class DirectiveCommand extends LighthouseGeneratorCommand
      */
     protected function askForInterfaces(array $availableInterfaces): void
     {
-        /** @var array<string> $usedLocations Because we set $multiple = true */
+        /** @var array<string> $implementedInterfaces Because we set $multiple = true */
         $implementedInterfaces = $this->choice(
             'Which interfaces should the directive implement?',
             $availableInterfaces,

--- a/src/Console/DirectiveCommand.php
+++ b/src/Console/DirectiveCommand.php
@@ -183,11 +183,11 @@ class DirectiveCommand extends LighthouseGeneratorCommand
     /**
      * Ask the user if the directive should implement any of the given interfaces.
      *
-     * @param  array<class-string> $availableInterfaces
+     * @param  array<class-string<\Nuwave\Lighthouse\Support\Contracts\Directive>> $availableInterfaces
      */
     protected function askForInterfaces(array $availableInterfaces): void
     {
-        /** @var array<string> $implementedInterfaces Because we set $multiple = true */
+        /** @var array<class-string<\Nuwave\Lighthouse\Support\Contracts\Directive>> $implementedInterfaces Because we set $multiple = true */
         $implementedInterfaces = $this->choice(
             'Which interfaces should the directive implement?',
             $availableInterfaces,

--- a/src/Console/DirectiveCommand.php
+++ b/src/Console/DirectiveCommand.php
@@ -110,7 +110,7 @@ class DirectiveCommand extends LighthouseGeneratorCommand
         $forArgument = $this->option('argument');
 
         if (! $forType && ! $forField && ! $forArgument) {
-            throw new \Exception('Must specify at least one of: --type, --field or --argument');
+            throw new \Exception('Must specify at least one of: --type, --field, --argument');
         }
 
         if ($forType) {
@@ -187,6 +187,7 @@ class DirectiveCommand extends LighthouseGeneratorCommand
      */
     protected function askForInterfaces(array $availableInterfaces): void
     {
+        /** @var array<string> $usedLocations Because we set $multiple = true */
         $implementedInterfaces = $this->choice(
             'Which interfaces should the directive implement?',
             $availableInterfaces,
@@ -205,8 +206,9 @@ class DirectiveCommand extends LighthouseGeneratorCommand
      */
     public function askForLocations(array $availableLocations): void
     {
+        /** @var array<string> $usedLocations Because we set $multiple = true */
         $usedLocations = $this->choice(
-            'On which locations can the directive be used?',
+            'In which schema locations can the directive be used?',
             $availableLocations,
             null,
             null,

--- a/src/Console/DirectiveCommand.php
+++ b/src/Console/DirectiveCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 class DirectiveCommand extends LighthouseGeneratorCommand
 {
+    /** @var array<int, class-string> */
     const ARGUMENT_INTERFACES = [
         ArgTransformerDirective::class,
         ArgBuilderDirective::class,
@@ -29,12 +30,14 @@ class DirectiveCommand extends LighthouseGeneratorCommand
         ArgManipulator::class,
     ];
 
+    /** @var array<int, class-string> */
     const FIELD_INTERFACES = [
         FieldResolver::class,
         FieldMiddleware::class,
         FieldManipulator::class,
     ];
 
+    /** @var array<int, class-string> */
     const TYPE_INTERFACES = [
         TypeManipulator::class,
         TypeMiddleware::class,
@@ -63,7 +66,7 @@ class DirectiveCommand extends LighthouseGeneratorCommand
     /**
      * The implemented interfaces.
      *
-     * @var \Illuminate\Support\Collection<class-string<\Nuwave\Lighthouse\Support\Contracts\Directive>>
+     * @var \Illuminate\Support\Collection<class-string>
      */
     protected $implements;
 
@@ -183,11 +186,11 @@ class DirectiveCommand extends LighthouseGeneratorCommand
     /**
      * Ask the user if the directive should implement any of the given interfaces.
      *
-     * @param  array<class-string<\Nuwave\Lighthouse\Support\Contracts\Directive>> $availableInterfaces
+     * @param  array<class-string> $availableInterfaces
      */
     protected function askForInterfaces(array $availableInterfaces): void
     {
-        /** @var array<class-string<\Nuwave\Lighthouse\Support\Contracts\Directive>> $implementedInterfaces Because we set $multiple = true */
+        /** @var array<class-string> $implementedInterfaces Because we set $multiple = true */
         $implementedInterfaces = $this->choice(
             'Which interfaces should the directive implement?',
             $availableInterfaces,

--- a/src/Console/stubs/directive.stub
+++ b/src/Console/stubs/directive.stub
@@ -9,4 +9,11 @@ class DummyClass extends BaseDirective implements {{ implements }}
 {
     // TODO implement the directive https://lighthouse-php.com/master/custom-directives/getting-started.html
 
+    public static function definition(): string
+    {
+        return /** @lang GraphQL */ <<<'GRAPHQL'
+directive @{{ name }} on {{ locations }}
+GRAPHQL;
+    }
+
 {{ methods }}}


### PR DESCRIPTION
- [x] Added or updated tests (manually)
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

The required method `definition()` is now included and reasonably populated by default.

**Breaking changes**

Use `choice()` for multi-select of interfaces.
