### PR TITLE
Handle Laravel `AuthenticationException` and `AuthorizationException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- Add `AuthenticationException::fromLaravel()` and `AuthenticationErrorHandler` to handle laravel native `AuthenticationException` https://github.com/nuwave/lighthouse/pull/1922
+- Add `AuthorizationException::fromLaravel()` and `AuthorizationErrorHandler` to handle laravel native `AuthorizationException` https://github.com/nuwave/lighthouse/pull/1922
+
+
 ## v5.21.0
 
 ### Added

--- a/src/Exceptions/AuthenticationException.php
+++ b/src/Exceptions/AuthenticationException.php
@@ -27,7 +27,7 @@ class AuthenticationException extends IlluminateAuthenticationException implemen
         return ['guards' => $this->guards];
     }
 
-    public static function fromLaravel(IlluminateAuthenticationException $laravelException)
+    public static function fromLaravel(IlluminateAuthenticationException $laravelException): self
     {
         return new static($laravelException->getMessage(), $laravelException->guards());
     }

--- a/src/Exceptions/AuthenticationException.php
+++ b/src/Exceptions/AuthenticationException.php
@@ -26,4 +26,9 @@ class AuthenticationException extends IlluminateAuthenticationException implemen
     {
         return ['guards' => $this->guards];
     }
+
+    public static function fromLaravel(IlluminateAuthenticationException $laravelException)
+    {
+        return new static($laravelException->getMessage(), $laravelException->guards());
+    }
 }

--- a/src/Exceptions/AuthorizationException.php
+++ b/src/Exceptions/AuthorizationException.php
@@ -18,4 +18,9 @@ class AuthorizationException extends IlluminateAuthorizationException implements
     {
         return self::CATEGORY;
     }
+
+    public static function fromLaravel(IlluminateAuthorizationException $laravelException)
+    {
+        return new static($laravelException->getMessage(), $laravelException->getCode());
+    }
 }

--- a/src/Exceptions/AuthorizationException.php
+++ b/src/Exceptions/AuthorizationException.php
@@ -19,7 +19,7 @@ class AuthorizationException extends IlluminateAuthorizationException implements
         return self::CATEGORY;
     }
 
-    public static function fromLaravel(IlluminateAuthorizationException $laravelException)
+    public static function fromLaravel(IlluminateAuthorizationException $laravelException): self
     {
         return new static($laravelException->getMessage(), $laravelException->getCode());
     }

--- a/src/Execution/AuthenticationErrorHandler.php
+++ b/src/Execution/AuthenticationErrorHandler.php
@@ -8,7 +8,7 @@ use Illuminate\Auth\AuthenticationException as LaravelAuthenticationException;
 use Nuwave\Lighthouse\Exceptions\AuthenticationException;
 
 /**
- * Wrap native Laravel validation exceptions, adding structured data to extensions.
+ * Wrap native Laravel authentication exceptions, adding structured data to extensions.
  */
 class AuthenticationErrorHandler implements ErrorHandler
 {

--- a/src/Execution/AuthenticationErrorHandler.php
+++ b/src/Execution/AuthenticationErrorHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Nuwave\Lighthouse\Execution;
+
+use Closure;
+use GraphQL\Error\Error;
+use Illuminate\Auth\AuthenticationException as LaravelAuthenticationException;
+use Nuwave\Lighthouse\Exceptions\AuthenticationException;
+
+/**
+ * Wrap native Laravel validation exceptions, adding structured data to extensions.
+ */
+class AuthenticationErrorHandler implements ErrorHandler
+{
+    public function __invoke(?Error $error, Closure $next): ?array
+    {
+        if ($error === null) {
+            return $next(null);
+        }
+
+        $underlyingException = $error->getPrevious();
+        if ($underlyingException instanceof LaravelAuthenticationException) {
+            return $next(new Error(
+                $error->getMessage(),
+                // @phpstan-ignore-next-line graphql-php and phpstan disagree with themselves
+                $error->getNodes(),
+                $error->getSource(),
+                $error->getPositions(),
+                $error->getPath(),
+                AuthenticationException::fromLaravel($underlyingException)
+            ));
+        }
+
+        return $next($error);
+    }
+}

--- a/src/Execution/AuthorizationErrorHandler.php
+++ b/src/Execution/AuthorizationErrorHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Nuwave\Lighthouse\Execution;
+
+use Closure;
+use GraphQL\Error\Error;
+use Illuminate\Auth\Access\AuthorizationException as LaravelAuthorizationException;
+use Nuwave\Lighthouse\Exceptions\AuthorizationException;
+
+/**
+ * Wrap native Laravel validation exceptions, adding structured data to extensions.
+ */
+class AuthorizationErrorHandler implements ErrorHandler
+{
+    public function __invoke(?Error $error, Closure $next): ?array
+    {
+        if ($error === null) {
+            return $next(null);
+        }
+
+        $underlyingException = $error->getPrevious();
+        if ($underlyingException instanceof LaravelAuthorizationException) {
+            return $next(new Error(
+                $error->getMessage(),
+                // @phpstan-ignore-next-line graphql-php and phpstan disagree with themselves
+                $error->getNodes(),
+                $error->getSource(),
+                $error->getPositions(),
+                $error->getPath(),
+                AuthorizationException::fromLaravel($underlyingException)
+            ));
+        }
+
+        return $next($error);
+    }
+}

--- a/src/Execution/AuthorizationErrorHandler.php
+++ b/src/Execution/AuthorizationErrorHandler.php
@@ -8,7 +8,7 @@ use Illuminate\Auth\Access\AuthorizationException as LaravelAuthorizationExcepti
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 
 /**
- * Wrap native Laravel validation exceptions, adding structured data to extensions.
+ * Wrap native Laravel authorization exceptions, adding structured data to extensions.
  */
 class AuthorizationErrorHandler implements ErrorHandler
 {

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -227,6 +227,8 @@ return [
     */
 
     'error_handlers' => [
+        \Nuwave\Lighthouse\Execution\AuthenticationErrorHandler::class,
+        \Nuwave\Lighthouse\Execution\AuthorizationErrorHandler::class,
         \Nuwave\Lighthouse\Execution\ValidationErrorHandler::class,
         \Nuwave\Lighthouse\Execution\ExtensionErrorHandler::class,
         \Nuwave\Lighthouse\Execution\ReportingErrorHandler::class,

--- a/tests/Unit/Execution/AuthenticationErrorHandlerTest.php
+++ b/tests/Unit/Execution/AuthenticationErrorHandlerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Unit\Execution;
+
+use GraphQL\Error\Error;
+use Illuminate\Auth\AuthenticationException as LaravelAuthenticationException;
+use Nuwave\Lighthouse\Exceptions\AuthenticationException;
+use Nuwave\Lighthouse\Execution\AuthenticationErrorHandler;
+use Tests\TestCase;
+
+class AuthenticationErrorHandlerTest extends TestCase
+{
+    public function testWrapsLaravelAuthorizationException(): void
+    {
+        $handler = new AuthenticationErrorHandler();
+
+        $authenticationException = new LaravelAuthenticationException('Unauthenticated.', ['user']);
+        $original = new Error('foo', null, null, [], null, $authenticationException);
+
+        $error = null;
+        $next = function (Error $e) use (&$error) {
+            $error = $e;
+        };
+
+        $handler($original, $next);
+        $this->assertInstanceOf(Error::class, $error);
+        $this->assertInstanceOf(AuthenticationException::class, $error->getPrevious());
+        $this->assertEquals(['user'], $error->getPrevious()->guards());
+    }
+}

--- a/tests/Unit/Execution/AuthenticationErrorHandlerTest.php
+++ b/tests/Unit/Execution/AuthenticationErrorHandlerTest.php
@@ -10,7 +10,7 @@ use Tests\TestCase;
 
 class AuthenticationErrorHandlerTest extends TestCase
 {
-    public function testWrapsLaravelAuthorizationException(): void
+    public function testWrapsLaravelAuthenticationException(): void
     {
         $handler = new AuthenticationErrorHandler();
 
@@ -25,6 +25,6 @@ class AuthenticationErrorHandlerTest extends TestCase
         $handler($original, $next);
         $this->assertInstanceOf(Error::class, $error);
         $this->assertInstanceOf(AuthenticationException::class, $error->getPrevious());
-        $this->assertEquals(['user'], $error->getPrevious()->guards());
+        $this->assertSame(['user'], $error->getPrevious()->guards());
     }
 }

--- a/tests/Unit/Execution/AuthorizationErrorHandlerTest.php
+++ b/tests/Unit/Execution/AuthorizationErrorHandlerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit\Execution;
+
+use GraphQL\Error\Error;
+use Illuminate\Auth\Access\AuthorizationException as LaravelAuthorizationException;
+use Nuwave\Lighthouse\Exceptions\AuthorizationException;
+use Nuwave\Lighthouse\Execution\AuthorizationErrorHandler;
+use Tests\TestCase;
+
+class AuthorizationErrorHandlerTest extends TestCase
+{
+    public function testWrapsLaravelAuthorizationException(): void
+    {
+        $handler = new AuthorizationErrorHandler();
+
+        $authorizationException = new LaravelAuthorizationException();
+        $original = new Error('foo', null, null, [], null, $authorizationException);
+
+        $error = null;
+        $next = function (Error $e) use (&$error) {
+            $error = $e;
+        };
+
+        $handler($original, $next);
+        $this->assertInstanceOf(Error::class, $error);
+        $this->assertInstanceOf(AuthorizationException::class, $error->getPrevious());
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Handle gracefully laravel `AuthenticationException` and `AuthorizationException` like it has been done for `ValidationException` in #1899 

**Breaking changes**

None.
