### PR TITLE
Support schema without `Query` type when using federation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Support schema without `Query` type when using federation https://github.com/nuwave/lighthouse/pull/1925
+
 ## v5.22.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.22.2
+
 ### Fixed
 
 - Support schema without `Query` type when using federation https://github.com/nuwave/lighthouse/pull/1925

--- a/src/Console/MutationCommand.php
+++ b/src/Console/MutationCommand.php
@@ -2,13 +2,15 @@
 
 namespace Nuwave\Lighthouse\Console;
 
+use Nuwave\Lighthouse\Schema\RootType;
+
 class MutationCommand extends FieldGeneratorCommand
 {
     protected $name = 'lighthouse:mutation';
 
     protected $description = 'Create a class for a single field on the root Mutation type.';
 
-    protected $type = 'Mutation';
+    protected $type = RootType::MUTATION;
 
     protected function namespaceConfigKey(): string
     {

--- a/src/Console/QueryCommand.php
+++ b/src/Console/QueryCommand.php
@@ -2,13 +2,15 @@
 
 namespace Nuwave\Lighthouse\Console;
 
+use Nuwave\Lighthouse\Schema\RootType;
+
 class QueryCommand extends FieldGeneratorCommand
 {
     protected $name = 'lighthouse:query';
 
     protected $description = 'Create a class for a single field on the root Query type.';
 
-    protected $type = 'Query';
+    protected $type = RootType::QUERY;
 
     protected function namespaceConfigKey(): string
     {

--- a/src/Console/SubscriptionCommand.php
+++ b/src/Console/SubscriptionCommand.php
@@ -2,13 +2,15 @@
 
 namespace Nuwave\Lighthouse\Console;
 
+use Nuwave\Lighthouse\Schema\RootType;
+
 class SubscriptionCommand extends LighthouseGeneratorCommand
 {
     protected $name = 'lighthouse:subscription';
 
     protected $description = 'Create a class for a single field on the root Subscription type.';
 
-    protected $type = 'Subscription';
+    protected $type = RootType::SUBSCRIPTION;
 
     protected function namespaceConfigKey(): string
     {

--- a/src/Federation/ASTManipulator.php
+++ b/src/Federation/ASTManipulator.php
@@ -2,8 +2,11 @@
 
 namespace Nuwave\Lighthouse\Federation;
 
+use GraphQL\Language\AST\NameNode;
+use GraphQL\Language\AST\NodeList;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Language\Parser;
+use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Events\ManipulateAST;
 use Nuwave\Lighthouse\Exceptions\FederationException;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
@@ -73,6 +76,15 @@ class ASTManipulator
 
     protected function addRootFields(DocumentAST &$documentAST): void
     {
+        if (! Arr::has($documentAST->types, 'Query')) {
+            $documentAST->setTypeDefinition(new ObjectTypeDefinitionNode([
+                'name' => new NameNode(['value' => 'Query']),
+                'interfaces' => new NodeList([]),
+                'directives' => new NodeList([]),
+                'fields' => new NodeList([]),
+            ]));
+        }
+
         /** @var \GraphQL\Language\AST\ObjectTypeDefinitionNode $queryType */
         $queryType = $documentAST->types['Query'];
 

--- a/src/Federation/FederationPrinter.php
+++ b/src/Federation/FederationPrinter.php
@@ -54,16 +54,28 @@ class FederationPrinter
         }
 
         $originalQueryType = Arr::pull($types, 'Query');
-        $config->setQuery(new ObjectType([
-            'name' => 'Query',
-            'fields' => array_filter(
-                $originalQueryType->getFields(),
-                static function (FieldDefinition $field): bool {
-                    return ! in_array($field->name, static::FEDERATION_FIELDS);
-                }
-            ),
-            'interfaces' => $originalQueryType->getInterfaces(),
-        ]));
+
+        $newQueryFields = array_filter(
+            $originalQueryType->getFields(),
+            static function (FieldDefinition $field): bool {
+                return ! in_array($field->name, static::FEDERATION_FIELDS);
+            }
+        );
+
+        if (count($newQueryFields ?? []) === 0) {
+            $config->setQuery(null);
+        } else {
+            $config->setQuery(new ObjectType([
+                'name' => 'Query',
+                'fields' => array_filter(
+                    $originalQueryType->getFields(),
+                    static function (FieldDefinition $field): bool {
+                        return ! in_array($field->name, static::FEDERATION_FIELDS);
+                    }
+                ),
+                'interfaces' => $originalQueryType->getInterfaces(),
+            ]));
+        }
 
         $config->setMutation(Arr::pull($types, 'Mutation'));
 

--- a/src/Federation/FederationPrinter.php
+++ b/src/Federation/FederationPrinter.php
@@ -21,6 +21,7 @@ use Nuwave\Lighthouse\Federation\Directives\ExternalDirective;
 use Nuwave\Lighthouse\Federation\Directives\KeyDirective;
 use Nuwave\Lighthouse\Federation\Directives\ProvidesDirective;
 use Nuwave\Lighthouse\Federation\Directives\RequiresDirective;
+use Nuwave\Lighthouse\Schema\RootType;
 
 class FederationPrinter
 {
@@ -53,33 +54,26 @@ class FederationPrinter
             unset($types[$type]);
         }
 
-        $originalQueryType = Arr::pull($types, 'Query');
-
-        $newQueryFields = array_filter(
+        /** @var \GraphQL\Type\Definition\ObjectType $originalQueryType */
+        $originalQueryType = Arr::pull($types, RootType::QUERY);
+        $queryFieldsWithoutFederation = array_filter(
             $originalQueryType->getFields(),
             static function (FieldDefinition $field): bool {
                 return ! in_array($field->name, static::FEDERATION_FIELDS);
             }
         );
-
-        if (count($newQueryFields ?? []) === 0) {
-            $config->setQuery(null);
-        } else {
-            $config->setQuery(new ObjectType([
-                'name' => 'Query',
-                'fields' => array_filter(
-                    $originalQueryType->getFields(),
-                    static function (FieldDefinition $field): bool {
-                        return ! in_array($field->name, static::FEDERATION_FIELDS);
-                    }
-                ),
+        $newQueryType = count($queryFieldsWithoutFederation) > 0
+            ? new ObjectType([
+                'name' => RootType::QUERY,
+                'fields' => $queryFieldsWithoutFederation,
                 'interfaces' => $originalQueryType->getInterfaces(),
-            ]));
-        }
+            ])
+            : null;
+        $config->setQuery($newQueryType);
 
-        $config->setMutation(Arr::pull($types, 'Mutation'));
+        $config->setMutation(Arr::pull($types, RootType::MUTATION));
 
-        $config->setSubscription(Arr::pull($types, 'Subscription'));
+        $config->setSubscription(Arr::pull($types, RootType::SUBSCRIPTION));
 
         $config->setTypes($types);
 

--- a/tests/Integration/Federation/FederationSchemaTest.php
+++ b/tests/Integration/Federation/FederationSchemaTest.php
@@ -41,6 +41,24 @@ GRAPHQL;
         $this->assertStringContainsString($query, $sdl);
     }
 
+    public function testServiceQueryShouldReturnValidSdlWithoutQuery(): void
+    {
+        $foo = /** @lang GraphQL */ <<<'GRAPHQL'
+type Foo @key(fields: "id") {
+  id: ID! @external
+  foo: String!
+}
+
+GRAPHQL;
+
+        $this->schema = $foo;
+
+        $sdl = $this->_serviceSdl();
+
+        $this->assertStringContainsString($foo, $sdl);
+        $this->assertStringNotContainsString('type Query', $sdl);
+    }
+
     public function testFederatedSchemaShouldContainCorrectEntityUnion(): void
     {
         $schema = $this->buildSchema(/** @lang GraphQL */ '

--- a/tests/Integration/Federation/FederationSchemaTest.php
+++ b/tests/Integration/Federation/FederationSchemaTest.php
@@ -56,7 +56,7 @@ GRAPHQL;
         $sdl = $this->_serviceSdl();
 
         $this->assertStringContainsString($foo, $sdl);
-        $this->assertStringNotContainsString('type Query', $sdl);
+        $this->assertStringNotContainsString(/** @lang GraphQL */ 'type Query', $sdl);
     }
 
     public function testFederatedSchemaShouldContainCorrectEntityUnion(): void

--- a/tests/Unit/Federation/SchemaBuilderTest.php
+++ b/tests/Unit/Federation/SchemaBuilderTest.php
@@ -44,6 +44,28 @@ class SchemaBuilderTest extends TestCase
         $this->assertTrue($queryType->hasField('_service'));
     }
 
+    public function testAllowSchemaWithoutQueryType(): void
+    {
+        $schema = $this->buildSchema(/** @lang GraphQL */ '
+        type Foo @key(fields: "id") {
+            id: ID!
+            foo: String!
+        }
+        ');
+
+        $this->assertTrue($schema->hasType('_Entity'));
+        $this->assertTrue($schema->hasType('_Service'));
+
+        $this->assertTrue($schema->hasType('_Any'));
+        $this->assertTrue($schema->hasType('_FieldSet'));
+
+        $queryType = $schema->getQueryType();
+        $this->assertInstanceOf(ObjectType::class, $queryType);
+
+        $this->assertTrue($queryType->hasField('_entities'));
+        $this->assertTrue($queryType->hasField('_service'));
+    }
+
     /**
      * At least one type needs to be defined with the @key directive.
      *

--- a/tests/Unit/Federation/SchemaBuilderTest.php
+++ b/tests/Unit/Federation/SchemaBuilderTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit\Federation;
 
-use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Schema;
 use Nuwave\Lighthouse\Exceptions\FederationException;
 use Nuwave\Lighthouse\Federation\FederationServiceProvider;
 use Tests\TestCase;
@@ -37,14 +37,10 @@ class SchemaBuilderTest extends TestCase
         $this->assertTrue($schema->hasType('_Any'));
         $this->assertTrue($schema->hasType('_FieldSet'));
 
-        $queryType = $schema->getQueryType();
-        $this->assertInstanceOf(ObjectType::class, $queryType);
-
-        $this->assertTrue($queryType->hasField('_entities'));
-        $this->assertTrue($queryType->hasField('_service'));
+        $this->assertSchemaHasQueryTypeWithFederationFields($schema);
     }
 
-    public function testAllowSchemaWithoutQueryType(): void
+    public function testAddsQueryTypeIfNotDefined(): void
     {
         $schema = $this->buildSchema(/** @lang GraphQL */ '
         type Foo @key(fields: "id") {
@@ -53,12 +49,11 @@ class SchemaBuilderTest extends TestCase
         }
         ');
 
-        $this->assertTrue($schema->hasType('_Entity'));
-        $this->assertTrue($schema->hasType('_Service'));
+        $this->assertSchemaHasQueryTypeWithFederationFields($schema);
+    }
 
-        $this->assertTrue($schema->hasType('_Any'));
-        $this->assertTrue($schema->hasType('_FieldSet'));
-
+    protected function assertSchemaHasQueryTypeWithFederationFields(Schema $schema): void
+    {
         $queryType = $schema->getQueryType();
         $this->assertInstanceOf(ObjectType::class, $queryType);
 


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

When using federation it is possible to have a schema without the `Query` type and only types extensions.
With this change it is possible to omit the `Query` type

**Breaking changes**

none.
