### PR TITLE
Make `TestReponse::assertGraphQLValidationError()` work for fields with multiple messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+- Update behavior of `TestReponse::assertGraphQLValidationError` to work when multiple messages are present for a field https://github.com/nuwave/lighthouse/pull/1926
+
 ## v5.22.2
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
-- Update behavior of `TestReponse::assertGraphQLValidationError` to work when multiple messages are present for a field https://github.com/nuwave/lighthouse/pull/1926
+### Fixed
+
+- Make `TestReponse::assertGraphQLValidationError()` work for fields with multiple messages https://github.com/nuwave/lighthouse/pull/1926
 
 ## v5.22.2
 

--- a/src/Schema/Directives/GuardDirective.php
+++ b/src/Schema/Directives/GuardDirective.php
@@ -83,6 +83,7 @@ GRAPHQL;
     {
         foreach ($guards as $guard) {
             if ($this->auth->guard($guard)->check()) {
+                // @phpstan-ignore-next-line passing null works fine here
                 $this->auth->shouldUse($guard);
 
                 return;

--- a/src/Schema/Directives/GuardDirective.php
+++ b/src/Schema/Directives/GuardDirective.php
@@ -75,7 +75,7 @@ GRAPHQL;
     /**
      * Determine if the user is logged in to any of the given guards.
      *
-     * @param  array<string>  $guards
+     * @param  array<string|null>  $guards
      *
      * @throws \Illuminate\Auth\AuthenticationException
      */

--- a/src/Testing/TestResponseMixin.php
+++ b/src/Testing/TestResponseMixin.php
@@ -3,8 +3,6 @@
 namespace Nuwave\Lighthouse\Testing;
 
 use Closure;
-use Illuminate\Support\Arr;
-use Nuwave\Lighthouse\Exceptions\ValidationException;
 use PHPUnit\Framework\Assert;
 
 /**

--- a/src/Testing/TestResponseMixin.php
+++ b/src/Testing/TestResponseMixin.php
@@ -15,9 +15,8 @@ class TestResponseMixin
     public function assertGraphQLValidationError(): Closure
     {
         return function (string $key, ?string $message) {
-            $errors = TestResponseUtils::extractValidationErrors($this) ?? [];
-
-            $validation = Arr::get($errors, 'extensions.validation', []);
+            $validation = TestResponseUtils::extractValidationErrors($this);
+            Assert::assertNotNull($validation, 'Expected the query to return an error with extensions.validation.');
 
             Assert::assertArrayHasKey(
                 $key,
@@ -39,17 +38,11 @@ class TestResponseMixin
     {
         return function (array $keys) {
             $validation = TestResponseUtils::extractValidationErrors($this);
+            Assert::assertNotNull($validation, 'Expected the query to return an error with extensions.validation.');
 
-            Assert::assertNotNull($validation, 'Expected the query to return validation errors for specific fields.');
-            /** @var array<string, mixed> $validation */
-            Assert::assertArrayHasKey('extensions', $validation);
-            $extensions = $validation['extensions'];
-
-            Assert::assertNotNull($extensions, 'Expected the query to return validation errors for specific fields.');
-            /** @var array<string, mixed> $extensions */
             Assert::assertSame(
                 $keys,
-                array_keys($extensions[ValidationException::CATEGORY]),
+                array_keys($validation),
                 'Expected the query to return validation errors for specific fields.'
             );
 
@@ -61,7 +54,6 @@ class TestResponseMixin
     {
         return function () {
             $validation = TestResponseUtils::extractValidationErrors($this);
-
             Assert::assertNull($validation, 'Expected the query to have no validation errors.');
 
             return $this;

--- a/src/Testing/TestResponseUtils.php
+++ b/src/Testing/TestResponseUtils.php
@@ -20,6 +20,7 @@ class TestResponseUtils
     {
         $errors = $response->json('errors') ?? [];
 
+        // @phpstan-ignore-next-line PHPStan 0.11 fails with "Empty array passed to foreach" TODO remove once no longer supporting Laravel 6
         foreach ($errors as $error) {
             $validation = $error['extensions'][ValidationException::CATEGORY]
                 ?? null;

--- a/src/Testing/TestResponseUtils.php
+++ b/src/Testing/TestResponseUtils.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Testing;
 
-use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Exceptions\ValidationException;
 
 /**
@@ -14,16 +13,22 @@ class TestResponseUtils
 {
     /**
      * @param  \Illuminate\Testing\TestResponse  $response
+     *
+     * @return array<string, array<int, string>>|null
      */
     public static function extractValidationErrors($response): ?array
     {
         $errors = $response->json('errors') ?? [];
 
-        return Arr::first(
-            $errors,
-            function (array $error): bool {
-                return Arr::get($error, 'extensions.category') === ValidationException::CATEGORY;
+        foreach ($errors as $error) {
+            $validation = $error['extensions'][ValidationException::CATEGORY]
+                ?? null;
+
+            if (is_array($validation)) {
+                return $validation;
             }
-        );
+        }
+
+        return null;
     }
 }

--- a/tests/Integration/Execution/FieldBuilderDirectiveTest.php
+++ b/tests/Integration/Execution/FieldBuilderDirectiveTest.php
@@ -55,7 +55,7 @@ class FieldBuilderDirectiveTest extends DBTestCase
                 @all
                 @whereAuth(
                     relation: "user"
-                    guard: "api"
+                    guard: "web"
                 )
         }
         ';
@@ -66,7 +66,7 @@ class FieldBuilderDirectiveTest extends DBTestCase
         factory(Post::class, 3)->create();
 
         $authFactory = $this->app->make(AuthFactory::class);
-        $authFactory->guard('api')->setUser($user);
+        $authFactory->guard('web')->setUser($user);
 
         $response = $this
             ->graphQL(/** @lang GraphQL */ '

--- a/tests/Integration/Validation/ValidationTest.php
+++ b/tests/Integration/Validation/ValidationTest.php
@@ -587,4 +587,32 @@ class ValidationTest extends TestCase
             ')
             ->assertGraphQLValidationError('input.foo', FooClosureValidator::notFoo('input.foo'));
     }
+
+    public function testReturnsMultipleValidationErrorsPerField(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo(
+                input: FooInput
+            ): Int
+        }
+
+        input FooInput {
+            email: String @rules(apply: ["email", "min:16"])
+        }
+        ';
+
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            {
+                foo(
+                    input: {
+                        email: "invalid"
+                    }
+                )
+            }
+            ')
+            ->assertGraphQLValidationError('input.email', 'The input.email must be a valid email address.')
+            ->assertGraphQLValidationError('input.email', 'The input.email must be at least 16 characters.');
+    }
 }

--- a/tests/Unit/Schema/Directives/AuthDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/AuthDirectiveTest.php
@@ -45,7 +45,7 @@ class AuthDirectiveTest extends TestCase
         $user->name = 'foo';
 
         $authFactory = $this->app->make(AuthFactory::class);
-        $authFactory->guard('api')->setUser($user);
+        $authFactory->guard('web')->setUser($user);
 
         $this->schema = /** @lang GraphQL */ '
         type User {
@@ -53,7 +53,7 @@ class AuthDirectiveTest extends TestCase
         }
 
         type Query {
-            user: User! @auth(guard: "api")
+            user: User! @auth(guard: "web")
         }
         ';
 

--- a/tests/Unit/Schema/Directives/GuardDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/GuardDirectiveTest.php
@@ -28,7 +28,7 @@ class GuardDirectiveTest extends TestCase
     {
         $this->schema = /** @lang GraphQL */ '
         type Query {
-            foo: Int @guard(with: ["api"])
+            foo: Int @guard(with: ["web"])
         }
         ';
 
@@ -42,7 +42,7 @@ class GuardDirectiveTest extends TestCase
                     'message' => AuthenticationException::MESSAGE,
                     'extensions' => [
                         'guards' => [
-                            'api',
+                            'web',
                         ],
                     ],
                 ],
@@ -57,7 +57,7 @@ class GuardDirectiveTest extends TestCase
     {
         $this->schema = /** @lang GraphQL */ '
         type Query {
-            foo: Int @guard(with: "api")
+            foo: Int @guard(with: "web")
         }
         ';
 
@@ -71,7 +71,7 @@ class GuardDirectiveTest extends TestCase
                     'message' => AuthenticationException::MESSAGE,
                     'extensions' => [
                         'guards' => [
-                            'api',
+                            'web',
                         ],
                     ],
                 ],
@@ -81,12 +81,10 @@ class GuardDirectiveTest extends TestCase
 
     public function testPassesOneFieldButThrowsInAnother(): void
     {
-        $this->be(new User());
-
         $this->schema = /** @lang GraphQL */ '
         type Query {
-            foo: Int @guard
-            bar: String @guard(with: ["api"])
+            foo: Int
+            bar: String @guard
         }
         ';
 

--- a/tests/Unit/Schema/Directives/GuardDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/GuardDirectiveTest.php
@@ -4,7 +4,6 @@ namespace Tests\Unit\Schema\Directives;
 
 use Nuwave\Lighthouse\Exceptions\AuthenticationException;
 use Tests\TestCase;
-use Tests\Utils\Models\User;
 use Tests\Utils\Queries\Foo;
 
 class GuardDirectiveTest extends TestCase


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md