### PR TITLE
Add --federation option to lighthouse:print-schema command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- Add `--federation` option to `lighthouse:print-schema` command to print the schema with federation directives and without federation spec additions, like `_service.sdl`  https://github.com/nuwave/lighthouse/pull/1932
+
+
 ## v5.22.5
 
 ### Fixed

--- a/src/Console/PrintSchemaCommand.php
+++ b/src/Console/PrintSchemaCommand.php
@@ -7,17 +7,20 @@ use GraphQL\Type\Schema;
 use GraphQL\Utils\SchemaPrinter;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Filesystem\Filesystem;
+use Nuwave\Lighthouse\Federation\FederationPrinter;
 use Nuwave\Lighthouse\Schema\SchemaBuilder;
 
 class PrintSchemaCommand extends Command
 {
     public const GRAPHQL_FILENAME = 'lighthouse-schema.graphql';
+    public const GRAPHQL_FEDERATION_FILENAME = 'lighthouse-schema-federation.graphql';
     public const JSON_FILENAME = 'lighthouse-schema.json';
 
     protected $signature = <<<'SIGNATURE'
 lighthouse:print-schema
 {--W|write : Write the output to a file}
 {--json : Output JSON instead of GraphQL SDL}
+{--federation : Output federation subgraph schema}
 SIGNATURE;
 
     protected $description = 'Compile the GraphQL schema and print the result.';
@@ -28,12 +31,22 @@ SIGNATURE;
         $this->callSilent(ClearCacheCommand::NAME);
 
         $schema = $schemaBuilder->schema();
-        if ($this->option('json')) {
-            $filename = self::JSON_FILENAME;
-            $schemaString = $this->toJson($schema);
+
+        if ($this->option('federation')) {
+            if ($this->option('json')) {
+                $this->error('--json option is not supported with --federation');
+                return;
+            }
+            $filename = self::GRAPHQL_FEDERATION_FILENAME;
+            $schemaString = FederationPrinter::print($schema);
         } else {
-            $filename = self::GRAPHQL_FILENAME;
-            $schemaString = SchemaPrinter::doPrint($schema);
+            if ($this->option('json')) {
+                $filename = self::JSON_FILENAME;
+                $schemaString = $this->toJson($schema);
+            } else {
+                $filename = self::GRAPHQL_FILENAME;
+                $schemaString = SchemaPrinter::doPrint($schema);
+            }
         }
 
         if ($this->option('write')) {
@@ -55,7 +68,7 @@ Check if your schema is correct with:
     php artisan lighthouse:validate-schema
 
 MESSAGE
-);
+            );
         }
 
         return \Safe\json_encode($introspectionResult);

--- a/src/Console/PrintSchemaCommand.php
+++ b/src/Console/PrintSchemaCommand.php
@@ -35,6 +35,7 @@ SIGNATURE;
         if ($this->option('federation')) {
             if ($this->option('json')) {
                 $this->error('--json option is not supported with --federation');
+
                 return;
             }
             $filename = self::GRAPHQL_FEDERATION_FILENAME;

--- a/src/Console/PrintSchemaCommand.php
+++ b/src/Console/PrintSchemaCommand.php
@@ -20,7 +20,7 @@ class PrintSchemaCommand extends Command
 lighthouse:print-schema
 {--W|write : Write the output to a file}
 {--json : Output JSON instead of GraphQL SDL}
-{--federation : Output federation subgraph schema}
+{--federation : Include federation directives and exclude federation spec additions, like _service.sdl}
 SIGNATURE;
 
     protected $description = 'Compile the GraphQL schema and print the result.';

--- a/tests/Console/PrintFederationSchemaCommandTest.php
+++ b/tests/Console/PrintFederationSchemaCommandTest.php
@@ -48,11 +48,11 @@ GRAPHQL;
     {
         $this->schema = self::SCHEMA_TYPE.self::SCHEMA_QUERY;
 
-        $storage = Storage::fake();
+        Storage::fake();
         $tester = $this->commandTester(new PrintSchemaCommand());
         $tester->execute(['--federation' => true, '--write' => true]);
 
-        $fileContent = $storage->get(PrintSchemaCommand::GRAPHQL_FEDERATION_FILENAME);
+        $fileContent = Storage::get(PrintSchemaCommand::GRAPHQL_FEDERATION_FILENAME);
 
         $this->assertStringContainsString(self::SCHEMA_TYPE, $fileContent);
         $this->assertStringContainsString(self::SCHEMA_QUERY, $fileContent);

--- a/tests/Console/PrintFederationSchemaCommandTest.php
+++ b/tests/Console/PrintFederationSchemaCommandTest.php
@@ -49,7 +49,7 @@ GRAPHQL;
     {
         $this->schema = self::SCHEMA_TYPE.self::SCHEMA_QUERY;
 
-        Storage::fake();
+        $storage = Storage::fake();
         $tester = $this->commandTester(new PrintSchemaCommand());
         $tester->execute(['--federation' => true, '--write' => true]);
 

--- a/tests/Console/PrintFederationSchemaCommandTest.php
+++ b/tests/Console/PrintFederationSchemaCommandTest.php
@@ -53,7 +53,7 @@ GRAPHQL;
         $tester = $this->commandTester(new PrintSchemaCommand());
         $tester->execute(['--federation' => true, '--write' => true]);
 
-        $fileContent = Storage::get(PrintSchemaCommand::GRAPHQL_FEDERATION_FILENAME);
+        $fileContent = $storage->get(PrintSchemaCommand::GRAPHQL_FEDERATION_FILENAME);
 
         $this->assertStringContainsString(self::SCHEMA_TYPE, $fileContent);
         $this->assertStringContainsString(self::SCHEMA_QUERY, $fileContent);

--- a/tests/Console/PrintFederationSchemaCommandTest.php
+++ b/tests/Console/PrintFederationSchemaCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Console;
+
+use Illuminate\Support\Facades\Storage;
+use Nuwave\Lighthouse\Console\PrintSchemaCommand;
+use Nuwave\Lighthouse\Federation\FederationServiceProvider;
+use Tests\TestCase;
+
+class PrintFederationSchemaCommandTest extends TestCase
+{
+    protected const SCHEMA_TYPE = /** @lang GraphQL */
+        <<<'GRAPHQL'
+type Foo @key(fields: "id") {
+  id: ID! @external
+  foo: String!
+}
+
+GRAPHQL;
+
+    protected const SCHEMA_QUERY = /** @lang GraphQL */
+        <<<'GRAPHQL'
+type Query {
+  foo: Int!
+}
+GRAPHQL;
+
+
+    protected function getPackageProviders($app): array
+    {
+        return array_merge(
+            parent::getPackageProviders($app),
+            [FederationServiceProvider::class]
+        );
+    }
+
+    public function testPrintsSchemaAsGraphQLSDL(): void
+    {
+        $this->schema = self::SCHEMA_TYPE.self::SCHEMA_QUERY;
+
+        $tester = $this->commandTester(new PrintSchemaCommand());
+        $tester->execute(['--federation' => true]);
+
+        $this->assertStringContainsString(self::SCHEMA_TYPE, $tester->getDisplay());
+        $this->assertStringContainsString(self::SCHEMA_QUERY, $tester->getDisplay());
+    }
+
+    public function testWritesSchema(): void
+    {
+        $this->schema = self::SCHEMA_TYPE.self::SCHEMA_QUERY;
+
+        Storage::fake();
+        $tester = $this->commandTester(new PrintSchemaCommand());
+        $tester->execute(['--federation' => true, '--write' => true]);
+
+        $fileContent = Storage::get(PrintSchemaCommand::GRAPHQL_FEDERATION_FILENAME);
+
+        $this->assertStringContainsString(self::SCHEMA_TYPE, $fileContent);
+        $this->assertStringContainsString(self::SCHEMA_QUERY, $fileContent);
+    }
+}

--- a/tests/Console/PrintFederationSchemaCommandTest.php
+++ b/tests/Console/PrintFederationSchemaCommandTest.php
@@ -25,7 +25,6 @@ type Query {
 }
 GRAPHQL;
 
-
     protected function getPackageProviders($app): array
     {
         return array_merge(


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**
Added a `--federation` option to the `lighthouse:print-schema` command to print the federation subgraph sdl (the same that is returned from `_service { sdl }` query.

This can be useful to statically build the supergraph schema for apollo gateway or to push the subgraph schema to a managed service like apollo studio

Right now I implemented only the sdl output and not the json one (maybe the json output doesn't event make sense for this case)

**Breaking changes**
none
