### PR TITLE
Fix TODO 'Improve type hints in UniqueGenerator'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find and compare releases at the [GitHub release page](https://github.com/nuwave/lighthouse/releases).
 
 ## Unreleased
+- Removed and old TODO related to https://github.com/FakerPHP/Faker/pull/345
+  for a faker related static analysis issues
 
 ## v5.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find and compare releases at the [GitHub release page](https://github.com/nuwave/lighthouse/releases).
 
 ## Unreleased
-- Removed and old TODO related to https://github.com/FakerPHP/Faker/pull/345
-  for a faker related static analysis issues
 
 ## v5.23.0
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -62,6 +62,3 @@ parameters:
 
   # Ease transition for non-nullable properties towards native types https://github.com/phpstan/phpstan/issues/5150
   - '#Property .* in isset\(\) is not nullable\.#'
-
-  # TODO remove when https://github.com/FakerPHP/Faker/pull/345 is merged
-  - '#.* undefined .* Faker\\UniqueGenerator::.*#'


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->
This PR remove the rule to ignore undefined Faker\\UniqueGenerator::.* since the related [PR](https://github.com/FakerPHP/Faker/pull/345) was merged and the version 1.16.0 with fix was released how described on [this](https://github.com/FakerPHP/Faker/issues/365) issue. 

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
Will throw an error on old version of faker
