### PR TITLE
`@spread`: resolver and array/list support

### DIFF
--- a/src/Execution/Arguments/ArgumentSet.php
+++ b/src/Execution/Arguments/ArgumentSet.php
@@ -85,11 +85,12 @@ class ArgumentSet
             if ($value instanceof self) {
                 // Recurse down first, as that resolves the more deeply nested spreads first
                 $value = $value->spread();
-
-                if ($argument->directives->contains(
+                $directive = $argument->directives->first(
                     Utils::instanceofMatcher(SpreadDirective::class)
-                )) {
-                    $argumentSet->arguments += $value->arguments;
+                );
+
+                if ($directive) {
+                    $argumentSet->arguments += $directive->transformArguments($name, $value->arguments);
                     continue;
                 }
             }

--- a/src/Execution/Arguments/ArgumentSet.php
+++ b/src/Execution/Arguments/ArgumentSet.php
@@ -92,21 +92,17 @@ class ArgumentSet
                 $argument->value
             );
 
-            // Spread arguments
-            if ($argument->value instanceof self) {
-                /** @var \Nuwave\Lighthouse\Schema\Directives\SpreadDirective $directive */
-                $directive = $argument->directives->first(
-                    Utils::instanceofMatcher(SpreadDirective::class)
-                );
+            // Transform
+            /** @var \Nuwave\Lighthouse\Schema\Directives\SpreadDirective $directive */
+            $directive = $argument->directives->first(
+                Utils::instanceofMatcher(SpreadDirective::class)
+            );
 
-                if ($directive) {
-                    $argumentSet->arguments += $directive->transformArguments($name, $argument->value->arguments);
-                    continue;
-                }
+            if ($directive) {
+                $argumentSet = $directive->transformArgumentSet($argumentSet, $name, $argument);
+            } else {
+                $argumentSet->arguments[$name] = $argument;
             }
-
-            // Copy as is
-            $argumentSet->arguments[$name] = $argument;
         }
 
         return $argumentSet;

--- a/src/Schema/Directives/SpreadDirective.php
+++ b/src/Schema/Directives/SpreadDirective.php
@@ -40,4 +40,14 @@ GRAPHQL;
             )
         );
     }
+
+    /**
+     * @param array<string, \Nuwave\Lighthouse\Execution\Arguments\Argument> $arguments
+     *
+     * @return array<string, \Nuwave\Lighthouse\Execution\Arguments\Argument>
+     */
+    public function transformArguments(string $name, array $arguments): array
+    {
+        return $arguments;
+    }
 }

--- a/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
@@ -40,4 +40,44 @@ class SpreadDirectiveTest extends TestCase
         }
         ');
     }
+
+    public function testNestedSpreadWithResolver(): void
+    {
+        $this->mockResolver()
+            ->with(null, [
+                'foo' => 1,
+                'bar__baz' => 2,
+            ]);
+
+        $resolver = $this->qualifyTestResolver('spread');
+        $this->schema = /** @lang GraphQL */ "
+        type Query {
+            foo(input: Foo @spread): Int @mock
+        }
+
+        input Foo {
+            foo: Int
+            bar: Bar @spread(resolver: \"{$resolver}\")
+        }
+
+        input Bar {
+            baz: Int
+        }
+        ";
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            foo(input: {
+                foo: 1
+                bar: {
+                    baz: 2
+                }
+            })
+        }
+        ');
+    }
+
+    public function spread(string $parent, string $current): string {
+        return "{$parent}__{$current}";
+    }
 }

--- a/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
@@ -13,18 +13,30 @@ class SpreadDirectiveTest extends TestCase
                 'foo' => 1,
                 'baz' => 2,
                 'qux__baz' => 3,
+                'quuz__qux__baz' => 4,
+                'quux' => [
+                    [
+                        'foo' => 1,
+                        'baz' => 2,
+                        'qux__baz' => 3,
+                    ],
+                    [
+                        'quuz__qux__baz' => 4,
+                    ]
+                ],
             ]);
 
         $resolver = $this->qualifyTestResolver('spread');
         $this->schema = /** @lang GraphQL */ "
         type Query {
-            foo(input: Foo @spread): Int @mock
+            foo(input: Foo @spread, quux: [Foo!]!): Int @mock
         }
 
         input Foo {
             foo: Int
             bar: Bar @spread
             qux: Bar @spread(resolver: \"{$resolver}\")
+            quuz: Foo @spread(resolver: \"{$resolver}\")
         }
 
         input Bar {
@@ -34,15 +46,40 @@ class SpreadDirectiveTest extends TestCase
 
         $this->graphQL(/** @lang GraphQL */ '
         {
-            foo(input: {
-                foo: 1
-                bar: {
-                    baz: 2
+            foo(
+                input: {
+                    foo: 1
+                    bar: {
+                        baz: 2
+                    }
+                    qux: {
+                        baz: 3
+                    }
+                    quuz: {
+                        qux: {
+                            baz: 4
+                        }
+                    }
                 }
-                qux: {
-                    baz: 3
-                }
-            })
+                quux: [
+                    {
+                        foo: 1
+                        bar: {
+                            baz: 2
+                        }
+                        qux: {
+                            baz: 3
+                        }
+                    }
+                    {
+                        quuz: {
+                            qux: {
+                                baz: 4
+                            }
+                        }
+                    }
+                ]
+            )
         }
         ');
     }

--- a/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/SpreadDirectiveTest.php
@@ -12,41 +12,7 @@ class SpreadDirectiveTest extends TestCase
             ->with(null, [
                 'foo' => 1,
                 'baz' => 2,
-            ]);
-
-        $this->schema = /** @lang GraphQL */ '
-        type Query {
-            foo(input: Foo @spread): Int @mock
-        }
-
-        input Foo {
-            foo: Int
-            bar: Bar @spread
-        }
-
-        input Bar {
-            baz: Int
-        }
-        ';
-
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            foo(input: {
-                foo: 1
-                bar: {
-                    baz: 2
-                }
-            })
-        }
-        ');
-    }
-
-    public function testNestedSpreadWithResolver(): void
-    {
-        $this->mockResolver()
-            ->with(null, [
-                'foo' => 1,
-                'bar__baz' => 2,
+                'qux__baz' => 3,
             ]);
 
         $resolver = $this->qualifyTestResolver('spread');
@@ -57,7 +23,8 @@ class SpreadDirectiveTest extends TestCase
 
         input Foo {
             foo: Int
-            bar: Bar @spread(resolver: \"{$resolver}\")
+            bar: Bar @spread
+            qux: Bar @spread(resolver: \"{$resolver}\")
         }
 
         input Bar {
@@ -71,6 +38,9 @@ class SpreadDirectiveTest extends TestCase
                 foo: 1
                 bar: {
                     baz: 2
+                }
+                qux: {
+                    baz: 3
                 }
             })
         }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

### Motivation

We have some models with a lot of prefixed attributes eg `a_*`, `b_*` etc, in the GraphQL they returned as the objects (`A {a: Int,b: Int}, B {a: Int,b: Int}`). We also want to sort by these properties but with the same structure of types instead of real properties (= client should not know that `A` refers to the prefixed properties `a_*`). The problem is [`@sortBy`](https://github.com/LastDragon-ru/lara-asp/tree/master/packages/graphql#sortby-directive) cannot distinguish relations and prefixed properties. So I thought maybe we can use `@spread`? Unfortunately, `@spread` doesn't support prefixes and arrays.

### Changes

1. Support for arrays (`@spread` will be processed recursive inside arrays)
2. Support for `@spread(resolver: class)` that can change the name of the attribute (eg it can convert it the `snake_case` or `camelCase` or etc)

###  Examples

I our case will be possible:

```graphql
type Query {
  objects(
      order: ObjectsSort @sortBy
    ): [Object!]!
}

type Object {
  id: ID!
}

type ObjectsSort {
   a: ASort @spread(resolver: "App\\GraphQL\\SpreadResolver")
}

type ASort {
  a: string
  b: string
}
```

```php
<?php declare(strict_types = 1);

namespace App\GraphQL\SpreadResolver;

class Spread {
    public function __invoke(string $parent, string $name): string {
        return "{$parent}_{$name}";
    }
}
```

And 🥳 (`@sortBy` will receive `['a_a': 'desc']`)
```graphql
query {
  objects(order: {a: {a: desc}}) {
      id
  }
}
```

Or for example from the docs:
```
type Mutation {
  updatePost(id: ID!, input: PostInput! @spread): Post @update
}

input PostInput {
  title: String!
  image: PostImage @spread(resolver: `CamelCaseResolver`)
}

input PostContent {
  url: String
}
```

```
[
    'id' => 12,
    'title' => 'My awesome title',
    'imageUrl' = 'https://some.site/image.jpg',
]
```

**Breaking changes**

`@spread` will be processed inside List/array.


_PS: `@rename` and `@spread` are very similar now, probably the new interface can be added, eg `ArgSetTransformerDirective`._
