### PR TITLE
 Batchloading relations with different database connections #1252

### DIFF
--- a/src/Schema/Directives/RelationDirective.php
+++ b/src/Schema/Directives/RelationDirective.php
@@ -35,8 +35,11 @@ abstract class RelationDirective extends BaseDirective implements FieldResolver
                 /** @var \Illuminate\Database\Eloquent\Relations\Relation $relation */
                 $relation = $parent->{$relationName}();
          
-                $sameConnection = $relation->getParent()->getConnectionName() == $relation->getRelated()->getConnectionName();
-                if (config('lighthouse.batchload_relations') && $sameConnection) {
+                if (
+                    config('lighthouse.batchload_relations')
+                    // Batch loading joins across both models, thus only works if they are on the same connection
+                    && $relation->getParent()->getConnectionName() === $relation->getRelated()->getConnectionName()
+                ) {
                     /** @var \Nuwave\Lighthouse\Execution\BatchLoader\RelationBatchLoader $relationBatchLoader */
                     $relationBatchLoader = BatchLoaderRegistry::instance(
                         $this->qualifyPath($args, $resolveInfo),

--- a/src/Schema/Directives/RelationDirective.php
+++ b/src/Schema/Directives/RelationDirective.php
@@ -32,7 +32,11 @@ abstract class RelationDirective extends BaseDirective implements FieldResolver
                 $decorateBuilder = $this->makeBuilderDecorator($resolveInfo);
                 $paginationArgs = $this->paginationArgs($args);
 
-                if (config('lighthouse.batchload_relations')) {
+                /** @var \Illuminate\Database\Eloquent\Relations\Relation $relation */
+                $relation = $parent->{$relationName}();
+         
+                $sameConnection = $relation->getParent()->getConnectionName() == $relation->getRelated()->getConnectionName();
+                if (config('lighthouse.batchload_relations') && $sameConnection) {
                     /** @var \Nuwave\Lighthouse\Execution\BatchLoader\RelationBatchLoader $relationBatchLoader */
                     $relationBatchLoader = BatchLoaderRegistry::instance(
                         $this->qualifyPath($args, $resolveInfo),
@@ -47,9 +51,6 @@ abstract class RelationDirective extends BaseDirective implements FieldResolver
 
                     return $relationBatchLoader->load($parent);
                 }
-
-                /** @var \Illuminate\Database\Eloquent\Relations\Relation $relation */
-                $relation = $parent->{$relationName}();
 
                 $decorateBuilder($relation);
 


### PR DESCRIPTION
Make sure that we eager load relations when they are from another connection. So that we don't try to create an inner subquery that is impossible

- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #1252 "-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
