### PR TITLE
Update authentication code block to reflect documentation

### DIFF
--- a/docs/master/security/authentication.md
+++ b/docs/master/security/authentication.md
@@ -55,9 +55,10 @@ to `sanctum` and register Sanctum's `EnsureFrontendRequestsAreStateful` as first
     'route' => [
         // ...
         'middleware' => [
+            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+
             // ... other middleware
 
-            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
         ],
     ],
     'guard' => 'sanctum',


### PR DESCRIPTION
The docs say to put the sanctum middleware as the first middleware in the lighthouse route, but the example code lists it last.

**Changes**

This simple updates the example code to reflect the documentation.