### PR TITLE
Deprecate `BenSampo\Enum\Enum` unboxing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Added
 
-- Add setting `unbox_bensampo_enum_enum_instances` to turn off `BenSampo\Enum\Enum` unboxing
+- Add setting `unbox_bensampo_enum_enum_instances` to turn off `BenSampo\Enum\Enum` unboxing https://github.com/nuwave/lighthouse/pull/1971
 
 ### Deprecated
 
-- Deprecate `BenSampo\Enum\Enum` unboxing
+- Deprecate `BenSampo\Enum\Enum` unboxing https://github.com/nuwave/lighthouse/pull/1971
 
 ## v5.24.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.25.0
+
+### Added
+
+- Add setting `unbox_bensampo_enum_enum_instances` to turn off `BenSampo\Enum\Enum` unboxing
+
+### Deprecated
+
+- Deprecate `BenSampo\Enum\Enum` unboxing
+
 ## v5.24.0
 
 ### Added

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -80,7 +80,7 @@ a smooth transition period.
 ### Nullability of pagination results
 
 Generated result types of paginated lists are now always marked as non-nullable.
-The setting `non_null_pagination_results` was removed and is now always `true`.
+The setting `non_null_pagination_results` was removed and now always behaves as if it were `true`.
 
 This is generally more convenient for clients, but will
 cause validation errors to bubble further up in the result.
@@ -94,6 +94,37 @@ In the future, a value of `1` will be added to represent the complexity more acc
 This change will increase the complexity of queries on fields using `@complexity` without
 a custom complexity resolver. If you configured `security.max_query_complexity`, complex
 queries that previously passed might now fail.
+
+### Passing of BenSampo\Enum\Enum instances to ArgBuilderDirective::handleBuilder()
+
+Previous to `v6`, Lighthouse would extract the internal `$value` from instances of
+`BenSampo\Enum\Enum` before passing it to `ArgBuilderDirective::handleBuilder()`
+if the setting `unbox_bensampo_enum_enum_instances` was `true`.
+
+This is generally unnecessary, because Laravel automagically calls the Enum's `__toString()`
+method when using it in a query. This might affect users who use an `ArgBuilderDirective`
+that delegates to a method that relies on an internal value being passed.
+
+```graphql
+type Query {
+    withEnum(byType: AOrB @scope): WithEnum @find
+}
+```
+
+```php
+// WithEnum.php
+public function scopeByType(Builder $builder, int $aOrB): Builder
+{
+    return $builder->where('type', $aOrB);
+}
+```
+
+In the future, Lighthouse will pass the actual Enum instance along. You can opt in to
+the new behaviour before upgrading by setting `unbox_bensampo_enum_enum_instances` to `false`. 
+
+```php
+public function scopeByType(Builder $builder, AOrB $aOrB): Builder
+```
 
 ## v4 to v5
 

--- a/src/Execution/Arguments/ArgumentSet.php
+++ b/src/Execution/Arguments/ArgumentSet.php
@@ -141,7 +141,7 @@ class ArgumentSet
      */
     protected static function applyArgBuilderDirectives(self $argumentSet, object &$builder, Closure $directiveFilter = null): void
     {
-        $unboxBenSampoEnumEnumInstances = config('unbox_bensampo_enum_enum_instances');
+        $unboxBenSampoEnumEnumInstances = config('lighthouse.unbox_bensampo_enum_enum_instances');
 
         foreach ($argumentSet->arguments as $argument) {
             $value = $argument->toPlain();

--- a/src/Execution/Arguments/ArgumentSet.php
+++ b/src/Execution/Arguments/ArgumentSet.php
@@ -148,7 +148,7 @@ class ArgumentSet
 
             // TODO remove in v6, Laravel automagically calls the Enum's __toString() method
             // Unbox Enum values to ensure their underlying value is used for queries
-            if (is_a($value, '\BenSampo\Enum\Enum') && $unboxBenSampoEnumEnumInstances) {
+            if ($unboxBenSampoEnumEnumInstances && is_a($value, '\BenSampo\Enum\Enum')) {
                 $value = $value->value;
             }
 

--- a/src/Execution/Arguments/ArgumentSet.php
+++ b/src/Execution/Arguments/ArgumentSet.php
@@ -141,12 +141,14 @@ class ArgumentSet
      */
     protected static function applyArgBuilderDirectives(self $argumentSet, object &$builder, Closure $directiveFilter = null): void
     {
+        $unboxBenSampoEnumEnumInstances = config('unbox_bensampo_enum_enum_instances');
+
         foreach ($argumentSet->arguments as $argument) {
             $value = $argument->toPlain();
 
-            // TODO switch to instanceof when we require bensampo/laravel-enum
+            // TODO remove in v6, Laravel automagically calls the Enum's __toString() method
             // Unbox Enum values to ensure their underlying value is used for queries
-            if (is_a($value, '\BenSampo\Enum\Enum')) {
+            if (is_a($value, '\BenSampo\Enum\Enum') && $unboxBenSampoEnumEnumInstances) {
                 $value = $value->value;
             }
 

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -348,7 +348,6 @@ return [
 
     'unbox_bensampo_enum_enum_instances' => true,
 
-
     /*
     |--------------------------------------------------------------------------
     | GraphQL Subscriptions

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -324,11 +324,30 @@ return [
     | as non-nullable. This is generally more convenient for clients, but will
     | cause validation errors to bubble further up in the result.
     |
-    | This setting will be removed and always true in v6.
+    | This setting will be removed and always behave as if it were true in v6.
     |
     */
 
     'non_null_pagination_results' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Unbox BenSampo\Enum\Enum instances
+    |--------------------------------------------------------------------------
+    |
+    | If set to true, Lighthouse will extract the internal $value from instances of
+    | BenSampo\Enum\Enum before passing it to ArgBuilderDirective::handleBuilder().
+    |
+    | This setting will be removed and always behave as if it were false in v6.
+    |
+    | It is only here to preserve compatibility, e.g. when expecting the internal
+    | value to be passed to a scope when using @scope, but not needed due to Laravel
+    | calling the Enum's __toString() method automagically when used in a query.
+    |
+    */
+
+    'unbox_bensampo_enum_enum_instances' => true,
+
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Integration/Schema/Types/LaravelEnumTypeDBTest.php
+++ b/tests/Integration/Schema/Types/LaravelEnumTypeDBTest.php
@@ -102,4 +102,64 @@ class LaravelEnumTypeDBTest extends DBTestCase
             ],
         ]);
     }
+
+    public function testScopeUsingEnumType(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            withEnum(
+                byType: AOrB @scope
+                byTypeInternal: AOrB @scope # TODO remove in v6
+            ): WithEnum @find
+        }
+
+        type WithEnum {
+            type: AOrB
+        }
+        ';
+
+        $this->typeRegistry->register(
+            new LaravelEnumType(AOrB::class)
+        );
+
+        $a = AOrB::A();
+
+        $withEnum = new WithEnum();
+        $withEnum->type = $a;
+        $withEnum->save();
+
+        // TODO remove in v6
+        $this->graphQL(/** @lang GraphQL */ '
+        query ($type: AOrB) {
+            withEnum(byTypeInternal: $type) {
+                type
+            }
+        }
+        ', [
+            'type' => $a->key,
+        ])->assertJson([
+            'data' => [
+                'withEnum' => [
+                    'type' => $a->key,
+                ]
+            ]
+        ]);
+        config(['unbox_bensampo_enum_enum_instances' => false]);
+
+        $this->graphQL(/** @lang GraphQL */ '
+        query ($type: AOrB) {
+            withEnum(byType: $type) {
+                type
+            }
+        }
+        ', [
+            'type' => $a->key,
+        ])->assertJson([
+            'data' => [
+                'withEnum' => [
+                    'type' => $a->key,
+                ]
+            ]
+        ]);
+    }
 }

--- a/tests/Integration/Schema/Types/LaravelEnumTypeDBTest.php
+++ b/tests/Integration/Schema/Types/LaravelEnumTypeDBTest.php
@@ -144,7 +144,7 @@ class LaravelEnumTypeDBTest extends DBTestCase
                 ],
             ],
         ]);
-        config(['unbox_bensampo_enum_enum_instances' => false]);
+        config(['lighthouse.unbox_bensampo_enum_enum_instances' => false]);
 
         $this->graphQL(/** @lang GraphQL */ '
         query ($type: AOrB) {

--- a/tests/Integration/Schema/Types/LaravelEnumTypeDBTest.php
+++ b/tests/Integration/Schema/Types/LaravelEnumTypeDBTest.php
@@ -141,8 +141,8 @@ class LaravelEnumTypeDBTest extends DBTestCase
             'data' => [
                 'withEnum' => [
                     'type' => $a->key,
-                ]
-            ]
+                ],
+            ],
         ]);
         config(['unbox_bensampo_enum_enum_instances' => false]);
 
@@ -158,8 +158,8 @@ class LaravelEnumTypeDBTest extends DBTestCase
             'data' => [
                 'withEnum' => [
                     'type' => $a->key,
-                ]
-            ]
+                ],
+            ],
         ]);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -161,6 +161,8 @@ GRAPHQL;
         ]);
 
         $config->set('lighthouse.cache.enable', false);
+
+        $config->set('lighthouse.unbox_bensampo_enum_enum_instances', true);
     }
 
     /**

--- a/tests/Utils/LaravelEnums/AOrB.php
+++ b/tests/Utils/LaravelEnums/AOrB.php
@@ -4,6 +4,10 @@ namespace Tests\Utils\LaravelEnums;
 
 use BenSampo\Enum\Enum;
 
+/**
+ * @method static static A()
+ * @method static static B()
+ */
 final class AOrB extends Enum
 {
     public const A = 'A';

--- a/tests/Utils/Models/WithEnum.php
+++ b/tests/Utils/Models/WithEnum.php
@@ -3,6 +3,7 @@
 namespace Tests\Utils\Models;
 
 use BenSampo\Enum\Traits\CastsEnums;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Tests\Utils\LaravelEnums\AOrB;
 
@@ -14,6 +15,10 @@ use Tests\Utils\LaravelEnums\AOrB;
  * Attributes
  * @property string|null $name
  * @property AOrB|null $type
+ *
+ * Scopes
+ * @method static \Illuminate\Database\Eloquent\Builder&static byType(AOrB $aOrB)
+ * @method static \Illuminate\Database\Eloquent\Builder&static byTypeInternal(string $aOrB) TODO remove in v6
  */
 class WithEnum extends Model
 {
@@ -27,4 +32,17 @@ class WithEnum extends Model
     protected $enumCasts = [
         'type' => AOrB::class,
     ];
+
+    public function scopeByType(Builder $builder, AOrB $aOrB): Builder
+    {
+        return $builder->where('type', $aOrB);
+    }
+
+    /**
+     * TODO remove in v6
+     */
+    public function scopeByTypeInternal(Builder $builder, string $aOrB): Builder
+    {
+        return $builder->where('type', $aOrB);
+    }
 }

--- a/tests/Utils/Models/WithEnum.php
+++ b/tests/Utils/Models/WithEnum.php
@@ -17,6 +17,7 @@ use Tests\Utils\LaravelEnums\AOrB;
  * @property AOrB|null $type
  *
  * Scopes
+ *
  * @method static \Illuminate\Database\Eloquent\Builder&static byType(AOrB $aOrB)
  * @method static \Illuminate\Database\Eloquent\Builder&static byTypeInternal(string $aOrB) TODO remove in v6
  */
@@ -39,7 +40,7 @@ class WithEnum extends Model
     }
 
     /**
-     * TODO remove in v6
+     * TODO remove in v6.
      */
     public function scopeByTypeInternal(Builder $builder, string $aOrB): Builder
     {


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Previous to `v6`, Lighthouse would extract the internal `$value` from instances of
`BenSampo\Enum\Enum` before passing it to `ArgBuilderDirective::handleBuilder()`
if the setting `unbox_bensampo_enum_enum_instances` was `true`.

This is generally unnecessary, because Laravel automagically calls the Enum's `__toString()`
method when using it in a query. This might affect users who use an `ArgBuilderDirective`
that delegates to a method that relies on an internal value being passed.

```graphql
type Query {
    withEnum(byType: AOrB @scope): WithEnum @find
}
```

```php
// WithEnum.php
public function scopeByType(Builder $builder, int $aOrB): Builder
{
    return $builder->where('type', $aOrB);
}
```

In the future, Lighthouse will pass the actual Enum instance along. You can opt in to
the new behaviour before upgrading by setting `unbox_bensampo_enum_enum_instances` to `false`. 

```php
public function scopeByType(Builder $builder, AOrB $aOrB): Builder
```

**Breaking changes**

Not yet, but will be in v6.