### PR TITLE
Allow specifying headers in `MakesGraphQLRequests` and `MakesGraphQLRequestsLumen` test helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.26.0
+
+### Added
+
+- Allow specifying headers in `MakesGraphQLRequests` and `MakesGraphQLRequestsLumen` test helpers
+
 ## v5.25.1
 
 ### Fixed

--- a/src/Testing/MakesGraphQLRequests.php
+++ b/src/Testing/MakesGraphQLRequests.php
@@ -41,10 +41,15 @@ trait MakesGraphQLRequests
      * @param  string  $query  The GraphQL query to send
      * @param  array<string, mixed>  $variables  The variables to include in the query
      * @param  array<string, mixed>  $extraParams  Extra parameters to add to the JSON payload
+     * @param  array<string, mixed>  $headers  HTTP headers to pass to the POST request
      * @return \Illuminate\Testing\TestResponse
      */
-    protected function graphQL(string $query, array $variables = [], array $extraParams = [])
-    {
+    protected function graphQL(
+        string $query,
+        array $variables = [],
+        array $extraParams = [],
+        array $headers = []
+    ) {
         $params = ['query' => $query];
 
         if ($variables !== []) {
@@ -53,7 +58,7 @@ trait MakesGraphQLRequests
 
         $params += $extraParams;
 
-        return $this->postGraphQL($params);
+        return $this->postGraphQL($params, $headers);
     }
 
     /**
@@ -62,8 +67,8 @@ trait MakesGraphQLRequests
      * Use this over graphQL() when you need more control or want to
      * test how your server behaves on incorrect inputs.
      *
-     * @param  array<mixed, mixed>  $data
-     * @param  array<string, string>  $headers
+     * @param  array<mixed, mixed>  $data  JSON-serializable payload
+     * @param  array<string, string>  $headers  HTTP headers to pass to the POST request
      * @return \Illuminate\Testing\TestResponse
      */
     protected function postGraphQL(array $data, array $headers = [])
@@ -87,8 +92,12 @@ trait MakesGraphQLRequests
      * @param  array<string, string>  $headers  Will be merged with Content-Type: multipart/form-data
      * @return \Illuminate\Testing\TestResponse
      */
-    protected function multipartGraphQL(array $operations, array $map, array $files, array $headers = [])
-    {
+    protected function multipartGraphQL(
+        array $operations,
+        array $map,
+        array $files,
+        array $headers = []
+    ) {
         $parameters = [
             'operations' => json_encode($operations),
             'map' => json_encode($map),
@@ -181,15 +190,20 @@ trait MakesGraphQLRequests
      * @param  string  $query  The GraphQL query to send
      * @param  array<string, mixed>  $variables  The variables to include in the query
      * @param  array<string, mixed>  $extraParams  Extra parameters to add to the HTTP payload
+     * @param  array<string, mixed>  $headers  HTTP headers to pass to the POST request
      * @return array<int, mixed> The chunked results
      */
-    protected function streamGraphQL(string $query, array $variables = [], array $extraParams = []): array
-    {
+    protected function streamGraphQL(
+        string $query,
+        array $variables = [],
+        array $extraParams = [],
+        array $headers = []
+    ): array {
         if ($this->deferStream === null) {
             $this->setUpDeferStream();
         }
 
-        $response = $this->graphQL($query, $variables, $extraParams);
+        $response = $this->graphQL($query, $variables, $extraParams, $headers);
 
         if (! $response->baseResponse instanceof StreamedResponse) {
             Assert::fail('Expected the response to be a streamed response but got a regular response.');

--- a/src/Testing/MakesGraphQLRequestsLumen.php
+++ b/src/Testing/MakesGraphQLRequestsLumen.php
@@ -41,12 +41,17 @@ trait MakesGraphQLRequestsLumen
      * @param  string  $query  The GraphQL query to send
      * @param  array<string, mixed>  $variables  The variables to include in the query
      * @param  array<string, mixed>  $extraParams  Extra parameters to add to the JSON payload
+     * @param  array<string, mixed>  $headers  HTTP headers to pass to the POST request
      */
-    protected function graphQL(string $query, array $variables = [], array $extraParams = []): self
-    {
+    protected function graphQL(
+        string $query,
+        array $variables = [],
+        array $extraParams = [],
+        array $headers = []
+    ): self {
         $params = ['query' => $query];
 
-        if ($variables) {
+        if ($variables !== []) {
             $params += ['variables' => $variables];
         }
 
@@ -62,8 +67,8 @@ trait MakesGraphQLRequestsLumen
      * Use this over graphQL() when you need more control or want to
      * test how your server behaves on incorrect inputs.
      *
-     * @param  array<mixed, mixed>  $data
-     * @param  array<string, string>  $headers
+     * @param  array<mixed, mixed>  $data  JSON-serializable payload
+     * @param  array<string, string>  $headers  HTTP headers to pass to the POST request
      */
     protected function postGraphQL(array $data, array $headers = []): self
     {
@@ -83,16 +88,20 @@ trait MakesGraphQLRequestsLumen
      * https://github.com/jaydenseric/graphql-multipart-request-spec
      *
      * @param  array<string, mixed>|array<int, array<string, mixed>>  $operations
-     * @param  array<int|string, array<int, string>>  $map
-     * @param  array<int|string, \Illuminate\Http\Testing\File>|array<int|string, array>  $files
+     * @param  array<array<int, string>>  $map
+     * @param  array<\Illuminate\Http\Testing\File>|array<array<mixed>>  $files
      * @param  array<string, string>  $headers  Will be merged with Content-Type: multipart/form-data
      * @return $this
      */
-    protected function multipartGraphQL(array $operations, array $map, array $files, array $headers = [])
-    {
+    protected function multipartGraphQL(
+        array $operations,
+        array $map,
+        array $files,
+        array $headers = []
+    ): self {
         $parameters = [
-            'operations' => json_encode($operations),
-            'map' => json_encode($map),
+            'operations' => \Safe\json_encode($operations),
+            'map' => \Safe\json_encode($map),
         ];
 
         $this->call(
@@ -117,12 +126,10 @@ trait MakesGraphQLRequestsLumen
      */
     protected function introspect(): self
     {
-        if ($this->introspectionResult) {
-            return $this;
+        if (! isset($this->introspectionResult)) {
+            $this->graphQL(Introspection::getIntrospectionQuery());
+            $this->introspectionResult = $this->response;
         }
-
-        $this->graphQL(Introspection::getIntrospectionQuery());
-        $this->introspectionResult = $this->response;
 
         return $this;
     }
@@ -154,9 +161,7 @@ trait MakesGraphQLRequestsLumen
      */
     protected function introspectByName(string $path, string $name): ?array
     {
-        if (! $this->introspectionResult) {
-            $this->introspect();
-        }
+        $this->introspect();
 
         $results = data_get(
             json_decode($this->introspectionResult->getContent(), true),
@@ -188,15 +193,20 @@ trait MakesGraphQLRequestsLumen
      * @param  string  $query  The GraphQL query to send
      * @param  array<string, mixed>  $variables  The variables to include in the query
      * @param  array<string, mixed>  $extraParams  Extra parameters to add to the HTTP payload
+     * @param  array<string, mixed>  $headers  HTTP headers to pass to the POST request
      * @return array<int, mixed> The chunked results
      */
-    protected function streamGraphQL(string $query, array $variables = [], array $extraParams = []): array
-    {
-        if ($this->deferStream === null) {
+    protected function streamGraphQL(
+        string $query,
+        array $variables = [],
+        array $extraParams = [],
+        array $headers = []
+    ): array {
+        if (! isset($this->deferStream)) {
             $this->setUpDeferStream();
         }
 
-        $response = $this->graphQL($query, $variables, $extraParams);
+        $response = $this->graphQL($query, $variables, $extraParams, $headers);
 
         if (! $response->response instanceof StreamedResponse) {
             Assert::fail('Expected the response to be a streamed response but got a regular response.');
@@ -208,7 +218,7 @@ trait MakesGraphQLRequestsLumen
     }
 
     /**
-     * Set up the stream to make queries with @defer.
+     * Set up the stream to make queries with `@defer`.
      */
     protected function setUpDeferStream(): void
     {

--- a/tests/Unit/Testing/MakesGraphQLRequestsTest.php
+++ b/tests/Unit/Testing/MakesGraphQLRequestsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Testing;
 
 use GraphQL\Error\Error;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Http\Request;
 use Tests\TestCase;
 
 class MakesGraphQLRequestsTest extends TestCase
@@ -52,5 +53,37 @@ class MakesGraphQLRequestsTest extends TestCase
             foo
         }
         ');
+    }
+
+    public function testGraphQLWithHeaders(): void
+    {
+        /** @var \Illuminate\Http\Request|null $request */
+        $request = null;
+        $this->mockResolver(static function () use (&$request): void {
+            $request = app(Request::class);
+        });
+
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo: ID @mock
+        }
+        ';
+
+        $key = 'foo';
+        $value = 'bar';
+
+        $this->graphQL(
+            /** @lang GraphQL */ '
+            {
+                foo
+            }
+            ',
+            [],
+            [],
+            [$key => $value]
+        );
+
+        $this->assertInstanceOf(Request::class, $request);
+        $this->assertSame($value, $request->header($key));
     }
 }

--- a/tests/Unit/Testing/MakesGraphQLRequestsTest.php
+++ b/tests/Unit/Testing/MakesGraphQLRequestsTest.php
@@ -73,7 +73,7 @@ class MakesGraphQLRequestsTest extends TestCase
         $value = 'bar';
 
         $this->graphQL(
-            /** @lang GraphQL */ '
+/** @lang GraphQL */ '
             {
                 foo
             }


### PR DESCRIPTION
Implement https://github.com/nuwave/lighthouse/pull/1968 properly