### PR TITLE
Test PHP 8.1 fixes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,6 +67,10 @@ jobs:
         if: matrix.laravel-version != '^8'
         run: composer remove --dev laravel/legacy-factories --no-update
 
+      - name: "Remove laravel-enum on PHP 8.1"
+        if: matrix.php-version == '8.1'
+        run: composer remove --dev bensampo/laravel-enum --no-update
+
       - run: composer require illuminate/contracts:${{ matrix.laravel-version }} --no-interaction --prefer-dist --no-progress
 
       - run: vendor/bin/phpstan

--- a/tests/Integration/Schema/Types/LaravelEnumTypeDBTest.php
+++ b/tests/Integration/Schema/Types/LaravelEnumTypeDBTest.php
@@ -24,7 +24,7 @@ class LaravelEnumTypeDBTest extends DBTestCase
 
     public function testUseLaravelEnumType(): void
     {
-        if (!class_exists(\BenSampo\Enum\Enum::class)) {
+        if (! class_exists(\BenSampo\Enum\Enum::class)) {
             $this->markTestSkipped('BenSampo\Enum\Enum is not installed.');
         }
 
@@ -69,7 +69,7 @@ class LaravelEnumTypeDBTest extends DBTestCase
 
     public function testWhereJsonContainsUsingEnumType(): void
     {
-        if (!class_exists(\BenSampo\Enum\Enum::class)) {
+        if (! class_exists(\BenSampo\Enum\Enum::class)) {
             $this->markTestSkipped('BenSampo\Enum\Enum is not installed.');
         }
 
@@ -113,7 +113,7 @@ class LaravelEnumTypeDBTest extends DBTestCase
 
     public function testScopeUsingEnumType(): void
     {
-        if (!class_exists(\BenSampo\Enum\Enum::class)) {
+        if (! class_exists(\BenSampo\Enum\Enum::class)) {
             $this->markTestSkipped('BenSampo\Enum\Enum is not installed.');
         }
 

--- a/tests/Integration/Schema/Types/LaravelEnumTypeDBTest.php
+++ b/tests/Integration/Schema/Types/LaravelEnumTypeDBTest.php
@@ -24,6 +24,10 @@ class LaravelEnumTypeDBTest extends DBTestCase
 
     public function testUseLaravelEnumType(): void
     {
+        if (!class_exists(\BenSampo\Enum\Enum::class)) {
+            $this->markTestSkipped('BenSampo\Enum\Enum is not installed.');
+        }
+
         $this->schema = /** @lang GraphQL */ '
         type Query {
             withEnum(type: AOrB @eq): WithEnum @find
@@ -65,6 +69,10 @@ class LaravelEnumTypeDBTest extends DBTestCase
 
     public function testWhereJsonContainsUsingEnumType(): void
     {
+        if (!class_exists(\BenSampo\Enum\Enum::class)) {
+            $this->markTestSkipped('BenSampo\Enum\Enum is not installed.');
+        }
+
         // We use the "name" field to store the "type" JSON
         $this->schema = /** @lang GraphQL */ '
         type Query {
@@ -105,6 +113,10 @@ class LaravelEnumTypeDBTest extends DBTestCase
 
     public function testScopeUsingEnumType(): void
     {
+        if (!class_exists(\BenSampo\Enum\Enum::class)) {
+            $this->markTestSkipped('BenSampo\Enum\Enum is not installed.');
+        }
+
         $this->schema = /** @lang GraphQL */ '
         type Query {
             withEnum(

--- a/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
+++ b/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
@@ -20,7 +20,7 @@ class LaravelEnumTypeTest extends TestCase
     {
         parent::setUp();
 
-        if (!class_exists(\BenSampo\Enum\Enum::class)) {
+        if (! class_exists(\BenSampo\Enum\Enum::class)) {
             $this->markTestSkipped('BenSampo\Enum\Enum is not installed.');
         }
 

--- a/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
+++ b/tests/Unit/Schema/Types/LaravelEnumTypeTest.php
@@ -20,6 +20,10 @@ class LaravelEnumTypeTest extends TestCase
     {
         parent::setUp();
 
+        if (!class_exists(\BenSampo\Enum\Enum::class)) {
+            $this->markTestSkipped('BenSampo\Enum\Enum is not installed.');
+        }
+
         $this->typeRegistry = $this->app->make(TypeRegistry::class);
     }
 


### PR DESCRIPTION
Expand on #1954 to move forward with 8.1 support even when the dependencies of `bensampo/laravel-enum` does not support it yet.