### PR TITLE
Deprecate `Serializable` implementation in favor of magic methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Deprecated
+
+- Deprecate `Serializable` implementation in favor of magic methods
+
 ## v5.26.1
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.27.0
+
+### Fixed
+
+- Avoid PHP 8.1 deprecation warning by implementing `__serialize()` and `__unserialize()` https://github.com/nuwave/lighthouse/pull/1987 
+
 ### Deprecated
 
-- Deprecate `Serializable` implementation in favor of magic methods
+- Deprecate `Serializable` implementation in favor of magic methods https://github.com/nuwave/lighthouse/pull/1987
 
 ## v5.26.1
 

--- a/src/Schema/AST/DocumentAST.php
+++ b/src/Schema/AST/DocumentAST.php
@@ -204,14 +204,36 @@ class DocumentAST implements Serializable, Arrayable
         return $documentAST;
     }
 
-    public function serialize(): string
+    /**
+     * @return array<string, mixed>
+     */
+    public function __serialize(): array
     {
-        return serialize($this->toArray());
+        return $this->toArray();
     }
 
+    /**
+     * @deprecated TODO remove in v6
+     */
+    public function serialize(): string
+    {
+        return serialize($this->__serialize());
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->hydrateFromArray($data);
+    }
+
+    /**
+     * @deprecated TODO remove in v6
+     */
     public function unserialize($data): void
     {
-        $this->hydrateFromArray(unserialize($data));
+        $this->__unserialize(unserialize($data));
     }
 
     /**

--- a/src/Schema/AST/DocumentAST.php
+++ b/src/Schema/AST/DocumentAST.php
@@ -221,7 +221,7 @@ class DocumentAST implements Serializable, Arrayable
     }
 
     /**
-     * @param array<string, mixed> $data
+     * @param  array<string, mixed>  $data
      */
     public function __unserialize(array $data): void
     {

--- a/src/Subscriptions/Subscriber.php
+++ b/src/Subscriptions/Subscriber.php
@@ -106,14 +106,36 @@ class Subscriber implements Serializable
     }
 
     /**
-     * Unserialize subscription from a JSON string.
-     *
-     * @param  string  $subscription
+     * @return array<string, mixed>
      */
-    public function unserialize($subscription): void
+    public function __serialize(): array
     {
-        $data = \Safe\json_decode($subscription, true);
+        return [
+            'channel' => $this->channel,
+            'topic' => $this->topic,
+            'query' => serialize(
+                AST::toArray($this->query)
+            ),
+            'field_name' => $this->fieldName,
+            'args' => $this->args,
+            'variables' => $this->variables,
+            'context' => $this->contextSerializer()->serialize($this->context),
+        ];
+    }
 
+    /**
+     * @deprecated TODO remove in v6
+     */
+    public function serialize(): string
+    {
+        return \Safe\json_encode($this->__serialize());
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __unserialize(array $data): void
+    {
         $this->channel = $data['channel'];
         $this->topic = $data['topic'];
 
@@ -135,21 +157,11 @@ class Subscriber implements Serializable
     }
 
     /**
-     * Convert this into a JSON string.
+     * @deprecated TODO remove in v6
      */
-    public function serialize(): string
+    public function unserialize($subscription): void
     {
-        return \Safe\json_encode([
-            'channel' => $this->channel,
-            'topic' => $this->topic,
-            'query' => serialize(
-                AST::toArray($this->query)
-            ),
-            'field_name' => $this->fieldName,
-            'args' => $this->args,
-            'variables' => $this->variables,
-            'context' => $this->contextSerializer()->serialize($this->context),
-        ]);
+        $this->__unserialize(\Safe\json_decode($subscription, true));
     }
 
     /**

--- a/src/Subscriptions/Subscriber.php
+++ b/src/Subscriptions/Subscriber.php
@@ -132,7 +132,7 @@ class Subscriber implements Serializable
     }
 
     /**
-     * @param array<string, mixed> $data
+     * @param  array<string, mixed>  $data
      */
     public function __unserialize(array $data): void
     {

--- a/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
+++ b/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
@@ -72,6 +72,9 @@ class RedisStorageManagerTest extends TestCase
         $channel = 'private-lighthouse-foo';
         $subscriber = new DummySubscriber($channel, 'dummy-topic');
 
+        $storedTopic = 'some-topic';
+        $subscriberUnderTopic = new DummySubscriber($channel, $storedTopic);
+
         $topicKey = 'graphql.topic.some-topic';
         $redisConnection->expects($this->exactly(3))
             ->method('command')
@@ -87,15 +90,12 @@ class RedisStorageManagerTest extends TestCase
                 ['setex', [
                     'graphql.subscriber.private-lighthouse-foo',
                     $ttl,
-                    'C:41:"Tests\Utils\Subscriptions\DummySubscriber":57:{'.\Safe\json_encode([
-                        'channel' => $channel,
-                        'topic' => 'some-topic',
-                    ]).'}',
+                    serialize($subscriberUnderTopic),
                 ]]
             );
 
         $manager = new RedisStorageManager($config, $redisFactory);
-        $manager->storeSubscriber($subscriber, 'some-topic');
+        $manager->storeSubscriber($subscriber, $storedTopic);
     }
 
     public function testStoreSubscriberWithoutTtl(): void
@@ -110,6 +110,9 @@ class RedisStorageManagerTest extends TestCase
         $channel = 'private-lighthouse-foo';
         $subscriber = new DummySubscriber($channel, 'dummy-topic');
 
+        $storedTopic = 'some-topic';
+        $subscriberUnderTopic = new DummySubscriber($channel, $storedTopic);
+
         $topicKey = 'graphql.topic.some-topic';
         $redisConnection->expects($this->exactly(2))
             ->method('command')
@@ -120,15 +123,12 @@ class RedisStorageManagerTest extends TestCase
                 ]],
                 ['set', [
                     'graphql.subscriber.private-lighthouse-foo',
-                    'C:41:"Tests\Utils\Subscriptions\DummySubscriber":57:{'.\Safe\json_encode([
-                        'channel' => $channel,
-                        'topic' => 'some-topic',
-                    ]).'}',
+                    serialize($subscriberUnderTopic)
                 ]]
             );
 
         $manager = new RedisStorageManager($config, $redisFactory);
-        $manager->storeSubscriber($subscriber, 'some-topic');
+        $manager->storeSubscriber($subscriber, $storedTopic);
     }
 
     public function testSubscribersByTopic(): void

--- a/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
+++ b/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
@@ -123,7 +123,7 @@ class RedisStorageManagerTest extends TestCase
                 ]],
                 ['set', [
                     'graphql.subscriber.private-lighthouse-foo',
-                    serialize($subscriberUnderTopic)
+                    serialize($subscriberUnderTopic),
                 ]]
             );
 

--- a/tests/Utils/Subscriptions/DummySubscriber.php
+++ b/tests/Utils/Subscriptions/DummySubscriber.php
@@ -12,22 +12,17 @@ class DummySubscriber extends Subscriber
         $this->topic = $topic;
     }
 
-    public function serialize(): string
+    public function __serialize(): array
     {
-        return \Safe\json_encode([
+        return [
             'channel' => $this->channel,
             'topic' => $this->topic,
-        ]);
+        ];
     }
 
-    /**
-     * @param  string  $subscription
-     */
-    public function unserialize($subscription): void
+    public function __unserialize(array $data): void
     {
-        $data = \Safe\json_decode($subscription);
-
-        $this->channel = $data->channel;
-        $this->topic = $data->topic;
+        $this->channel = $data['channel'];
+        $this->topic = $data['topic'];
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves https://github.com/nuwave/lighthouse/issues/1985

**Changes**

Adds magic methods and deprecates usage of interface.

**Breaking changes**

Not yet, but v6 will remove for pre-PHP 7.4 style serialization through `Serializable`.