### PR TITLE
Add directive `@void` to unify the definition of fields with no return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.28.0
+
+### Added
+
+- Add directive `@void` to unify the definition of fields with no return value
+
 ## v5.27.1
 
 ### Changed

--- a/docs/5/performance/schema-caching.md
+++ b/docs/5/performance/schema-caching.md
@@ -14,7 +14,7 @@ using the [cache](../api-reference/commands.md#cache) artisan command:
 
 The structure of the serialized schema can change between Lighthouse releases.
 In order to prevent errors, use cache version 2 and a deployment method that
-atomically updates both the cache file and the dependencies, e.g. K8s. 
+atomically updates both the cache file and the dependencies, e.g. K8s.
 
 ## Development
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -3176,7 +3176,7 @@ Use this directive on mutations that return no value, see [motivation](https://g
 
 ```graphql
 type Mutation {
-    fireAndForget: Unit! @void
+  fireAndForget: Unit! @void
 }
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -3142,6 +3142,50 @@ directive @validator(
 
 Read more in the [validation docs](../security/validation.md#validator-classes).
 
+## @void
+
+```graphql
+"""
+Mark a field that returns no value.
+
+The return type of the field will be changed to `Unit!`, defined as `enum Unit { UNIT }`.
+Whatever result is returned from the resolver will be replaced with `UNIT`.
+"""
+directive @void on FIELD_DEFINITION
+```
+
+To enable this directive, add the service provider to your `config/app.php`:
+
+```php
+'providers' => [
+    \Nuwave\Lighthouse\Void\VoidServiceProvider::class,
+],
+```
+
+Lighthouse will register the following type in your schema:
+
+```graphql
+"Allows only one value and thus can hold no information."
+enum Unit {
+  "The only possible value."
+  UNIT
+}
+```
+
+Use this directive on mutations that return no value, see [motivation](https://github.com/graphql/graphql-spec/issues/906).
+
+```graphql
+type Mutation {
+    fireAndForget: Unit! @void
+}
+```
+
+If your field is defined to return any other type,
+Lighthouse will modify the schema definition to have it return `Unit!`.
+
+Now, no matter what you return from your resolver (or if you return anything at all),
+the resulting value will always be `UNIT`.
+
 ## @where
 
 ```graphql

--- a/docs/master/performance/schema-caching.md
+++ b/docs/master/performance/schema-caching.md
@@ -14,7 +14,7 @@ using the [cache](../api-reference/commands.md#cache) artisan command:
 
 The structure of the serialized schema can change between Lighthouse releases.
 In order to prevent errors, use cache version 2 and a deployment method that
-atomically updates both the cache file and the dependencies, e.g. K8s. 
+atomically updates both the cache file and the dependencies, e.g. K8s.
 
 ## Development
 

--- a/src/Void/VoidDirective.php
+++ b/src/Void/VoidDirective.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Nuwave\Lighthouse\Void;
+
+use Closure;
+use GraphQL\Language\AST\FieldDefinitionNode;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use GraphQL\Language\Parser;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
+use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
+
+class VoidDirective extends BaseDirective implements FieldManipulator, FieldMiddleware
+{
+    public static function definition(): string
+    {
+        return /** @lang GraphQL */ <<<'GRAPHQL'
+"""
+Mark a field that returns no value.
+
+The return type of the field will be changed to `Unit!`, defined as `enum Unit { UNIT }`.
+Whatever result is returned from the resolver will be replaced with `UNIT`.
+"""
+directive @void on FIELD_DEFINITION
+GRAPHQL;
+    }
+
+    public function manipulateFieldDefinition(DocumentAST &$documentAST, FieldDefinitionNode &$fieldDefinition, ObjectTypeDefinitionNode &$parentType)
+    {
+        $fieldDefinition->type = Parser::typeReference(/** @lang GraphQL */ 'Unit!');
+    }
+
+    public function handleField(FieldValue $fieldValue, Closure $next): FieldValue
+    {
+        $fieldValue->resultHandler(static function (): string {
+            return VoidServiceProvider::UNIT;
+        });
+
+        return $fieldValue;
+    }
+}

--- a/src/Void/VoidServiceProvider.php
+++ b/src/Void/VoidServiceProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Nuwave\Lighthouse\Void;
+
+use GraphQL\Language\Parser;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\ServiceProvider;
+use Nuwave\Lighthouse\Events\ManipulateAST;
+use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
+
+/**
+ * TODO include by default in v6.
+ */
+class VoidServiceProvider extends ServiceProvider
+{
+    public const UNIT = 'UNIT';
+
+    public function boot(Dispatcher $dispatcher): void
+    {
+        $dispatcher->listen(
+            ManipulateAST::class,
+            static function (ManipulateAST $manipulateAST): void {
+                $unit = self::UNIT;
+                $manipulateAST->documentAST->setTypeDefinition(
+                    Parser::enumTypeDefinition(/** @lang GraphQL */ <<<GRAPHQL
+"Allows only one value and thus can hold no information."
+enum Unit {
+  "The only possible value."
+  {$unit}
+}
+GRAPHQL
+)
+                );
+            }
+        );
+
+        $dispatcher->listen(
+            RegisterDirectiveNamespaces::class,
+            static function (): string {
+                return __NAMESPACE__;
+            }
+        );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,6 +23,7 @@ use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\MocksResolvers;
 use Nuwave\Lighthouse\Testing\UsesTestSchema;
 use Nuwave\Lighthouse\Validation\ValidationServiceProvider;
+use Nuwave\Lighthouse\Void\VoidServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Tests\Utils\Policies\AuthServiceProvider;
@@ -78,6 +79,7 @@ GRAPHQL;
             PaginationServiceProvider::class,
             SoftDeletesServiceProvider::class,
             ValidationServiceProvider::class,
+            VoidServiceProvider::class,
         ];
     }
 

--- a/tests/Unit/Void/VoidDirectiveTest.php
+++ b/tests/Unit/Void/VoidDirectiveTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit\Void;
+
+use Nuwave\Lighthouse\Void\VoidServiceProvider;
+use Tests\TestCase;
+
+class VoidDirectiveTest extends TestCase
+{
+    public function testVoid(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo: Int @void
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            foo
+        }
+        ')->assertJson([
+            'data' => [
+                'foo' => VoidServiceProvider::UNIT,
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

See https://github.com/graphql/graphql-spec/issues/906

**Changes**

- Add directive `@void` to unify the definition of fields with no return value

**Breaking changes**

None, since the service provider is optional. When added by default, it will reserve the directive name `@void` and the type name `Unit`.
