### PR TITLE
Fix undefined array key with missing cache config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Prevent `Undefined array key` error when using cache version 2 and not having all version 1 configuration present https://github.com/nuwave/lighthouse/pull/1994
+
 ## v5.27.1
 
 ### Changed

--- a/docs/5/performance/schema-caching.md
+++ b/docs/5/performance/schema-caching.md
@@ -14,7 +14,7 @@ using the [cache](../api-reference/commands.md#cache) artisan command:
 
 The structure of the serialized schema can change between Lighthouse releases.
 In order to prevent errors, use cache version 2 and a deployment method that
-atomically updates both the cache file and the dependencies, e.g. K8s. 
+atomically updates both the cache file and the dependencies, e.g. K8s.
 
 ## Development
 

--- a/docs/master/performance/schema-caching.md
+++ b/docs/master/performance/schema-caching.md
@@ -14,7 +14,7 @@ using the [cache](../api-reference/commands.md#cache) artisan command:
 
 The structure of the serialized schema can change between Lighthouse releases.
 In order to prevent errors, use cache version 2 and a deployment method that
-atomically updates both the cache file and the dependencies, e.g. K8s. 
+atomically updates both the cache file and the dependencies, e.g. K8s.
 
 ## Development
 

--- a/src/Schema/AST/ASTCache.php
+++ b/src/Schema/AST/ASTCache.php
@@ -59,12 +59,12 @@ class ASTCache
         $this->enable = $cacheConfig['enable'];
 
         $version = $cacheConfig['version'] ?? 1;
-        
+
         switch ($version) {
             case 1:
                 $this->store = $cacheConfig['store'] ?? null;
-                $this->key   = $cacheConfig['key'];
-                $this->ttl   = $cacheConfig['ttl'];
+                $this->key = $cacheConfig['key'];
+                $this->ttl = $cacheConfig['ttl'];
                 break;
             case 2:
                 $this->path = $cacheConfig['path'] ?? base_path('bootstrap/cache/lighthouse-schema.php');

--- a/src/Schema/AST/ASTCache.php
+++ b/src/Schema/AST/ASTCache.php
@@ -59,18 +59,21 @@ class ASTCache
         $this->enable = $cacheConfig['enable'];
 
         $version = $cacheConfig['version'] ?? 1;
-        if (! in_array($version, [1, 2])) {
-            throw new UnknownCacheVersionException($version);
+        
+        switch ($version) {
+            case 1:
+                $this->store = $cacheConfig['store'] ?? null;
+                $this->key   = $cacheConfig['key'];
+                $this->ttl   = $cacheConfig['ttl'];
+                break;
+            case 2:
+                $this->path = $cacheConfig['path'] ?? base_path('bootstrap/cache/lighthouse-schema.php');
+                break;
+            default:
+                throw new UnknownCacheVersionException($version);
         }
+
         $this->version = $version;
-
-        // Version 1
-        $this->store = $cacheConfig['store'] ?? null;
-        $this->key = $cacheConfig['key'];
-        $this->ttl = $cacheConfig['ttl'];
-
-        // Version 2
-        $this->path = $cacheConfig['path'] ?? base_path('bootstrap/cache/lighthouse-schema.php');
     }
 
     public function isEnabled(): bool


### PR DESCRIPTION
- [ ] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

We have this config:

```php
    'cache' => [
        /*
         * Setting to true enables schema caching.
         */
        'enable'  => env('LIGHTHOUSE_CACHE_ENABLE', !env('APP_DEBUG', false)),

        /*
         * Allowed values:
         * - 1: uses the store, key and ttl config values to store the schema as a string in the given cache store.
         * - 2: uses the path config value to store the schema in a PHP file allowing OPcache to pick it up.
         */
        'version' => env('LIGHTHOUSE_CACHE_VERSION', 2),

        /*
         * File path to store the lighthouse schema.
         * Only relevant if version is set to 2.
         */
        'path'    => env('LIGHTHOUSE_CACHE_PATH', base_path('bootstrap/cache/lighthouse-schema.php')),
    ],
```

It's missing some keys for the v1 cache strategy which currently breaks even when using version 2.

Refactored it a bit to prevent that.

**Breaking changes**

None.
