### PR TITLE
Fix undefined array key with interfaces and two renamed models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Prevent possible `Undefined array key 0` error when there's an interface implemented by two renamed models https://github.com/nuwave/lighthouse/pull/1997
+
 ## v5.27.2
 
 ### Fixed

--- a/src/Schema/TypeRegistry.php
+++ b/src/Schema/TypeRegistry.php
@@ -489,7 +489,7 @@ EOL
                         );
                     }
 
-                    return $this->get($actuallyPossibleTypes[0]);
+                    return $this->get(array_pop($actuallyPossibleTypes));
                 }
 
                 return $this->get(class_basename($root));

--- a/src/Schema/TypeRegistry.php
+++ b/src/Schema/TypeRegistry.php
@@ -489,7 +489,7 @@ EOL
                         );
                     }
 
-                    return $this->get(array_pop($actuallyPossibleTypes));
+                    return $this->get(end($actuallyPossibleTypes));
                 }
 
                 return $this->get(class_basename($root));

--- a/tests/Integration/Schema/Types/InterfaceTest.php
+++ b/tests/Integration/Schema/Types/InterfaceTest.php
@@ -148,7 +148,6 @@ GRAPHQL;
         ');
     }
 
-
     public function testThrowsOnAmbiguousSchemaMapping(): void
     {
         // This creates one team with it

--- a/tests/Integration/Schema/Types/InterfaceTest.php
+++ b/tests/Integration/Schema/Types/InterfaceTest.php
@@ -125,12 +125,10 @@ GRAPHQL;
 
         type Foo implements Nameable @model(class: "Team") {
             name: String!
-            users: [User!]! @hasMany
         }
 
         type Bar implements Nameable @model(class: "User") {
             name: String!
-            id: ID!
         }
 
         type Query {


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

In `TypeRegistry->typeResolverFallback`, use `array_pop` instead of `[0]`, as `array_intersect` might return an array with a key that isn't 0.
This can happen with two renamed models that implement an interface, and a result with the second model is returned (which has key `1`)

**Breaking changes**

None.
