### PR TITLE
Use `StartExecution` event to determine per-operation Tracing timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.31.3
+
 ### Fixed
 
-- Use `StartExecution` event to determine per-operation Tracing timestamps
+- Use `StartExecution` event to determine per-operation Tracing timestamps https://github.com/nuwave/lighthouse/pull/2009
 
 ## v5.31.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Use `StartExecution` event to determine per-operation Tracing timestamps
+
 ## v5.31.2
 
 ### Fixed

--- a/src/Tracing/TracingDirective.php
+++ b/src/Tracing/TracingDirective.php
@@ -41,9 +41,9 @@ GRAPHQL;
         $previousResolver = $fieldValue->getResolver();
 
         $fieldValue->setResolver(function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($previousResolver) {
-            $start = $this->tracing->getTime();
+            $start = $this->tracing->timestamp();
             $result = $previousResolver($root, $args, $context, $resolveInfo);
-            $end = $this->tracing->getTime();
+            $end = $this->tracing->timestamp();
 
             Resolved::handle($result, function () use ($resolveInfo, $start, $end): void {
                 $this->tracing->record($resolveInfo, $start, $end);

--- a/src/Tracing/TracingServiceProvider.php
+++ b/src/Tracing/TracingServiceProvider.php
@@ -2,13 +2,14 @@
 
 namespace Nuwave\Lighthouse\Tracing;
 
+use GraphQL\Language\Parser;
 use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\BuildExtensionsResponse;
 use Nuwave\Lighthouse\Events\ManipulateAST;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 use Nuwave\Lighthouse\Events\StartExecution;
-use Nuwave\Lighthouse\Events\StartRequest;
+use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 
 class TracingServiceProvider extends ServiceProvider
 {
@@ -28,12 +29,12 @@ class TracingServiceProvider extends ServiceProvider
 
         $eventsDispatcher->listen(
             ManipulateAST::class,
-            Tracing::class . '@handleManipulateAST'
-        );
-
-        $eventsDispatcher->listen(
-            StartRequest::class,
-            Tracing::class . '@handleStartRequest'
+            static function (ManipulateAST $manipulateAST): void {
+                ASTHelper::attachDirectiveToObjectTypeFields(
+                    $manipulateAST->documentAST,
+                    Parser::constDirective('@tracing')
+                );
+            }
         );
 
         $eventsDispatcher->listen(

--- a/tests/Integration/Tracing/TracingExtensionTest.php
+++ b/tests/Integration/Tracing/TracingExtensionTest.php
@@ -76,8 +76,13 @@ class TracingExtensionTest extends TestCase
         $startTime2 = $result->json('1.extensions.tracing.startTime');
         $endTime2 = $result->json('1.extensions.tracing.endTime');
 
+        // Guaranteed by the usleep() in $this->resolve()
         $this->assertGreaterThan($startTime1, $endTime1);
-        $this->assertGreaterThan($endTime1, $startTime2);
+
+        // Might be the same timestamp if Lighthouse runs quickly in a given environment
+        $this->assertGreaterThanOrEqual($endTime1, $startTime2);
+
+        // Guaranteed by the usleep() in $this->resolve()
         $this->assertGreaterThan($startTime2, $endTime2);
 
         $this->assertCount(1, $result->json('0.extensions.tracing.execution.resolvers'));
@@ -86,7 +91,8 @@ class TracingExtensionTest extends TestCase
 
     public function resolve(): string
     {
-        usleep(20000); // 20 milliseconds
+        // Just enough to consistently change the resulting timestamp
+        usleep(1000);
 
         return 'bar';
     }

--- a/tests/Integration/Tracing/TracingExtensionTest.php
+++ b/tests/Integration/Tracing/TracingExtensionTest.php
@@ -7,11 +7,11 @@ use Tests\TestCase;
 
 class TracingExtensionTest extends TestCase
 {
-    protected $schema = <<<SCHEMA
-type Query {
-    foo: String! @field(resolver: "Tests\\\Integration\\\Tracing\\\TracingExtensionTest@resolve")
-}
-SCHEMA;
+    protected $schema = /** @lang GraphQL */ '
+    type Query {
+        foo: String! @field(resolver: "Tests\\\Integration\\\Tracing\\\TracingExtensionTest@resolve")
+    }
+    ';
 
     protected function getPackageProviders($app): array
     {
@@ -23,25 +23,27 @@ SCHEMA;
 
     public function testAddTracingExtensionMetaToResult(): void
     {
-        $this->graphQL('
-        {
-            foo
-        }
-        ')->assertJsonStructure([
-            'extensions' => [
-                'tracing' => [
-                    'execution' => [
-                        'resolvers',
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            {
+                foo
+            }
+            ')
+            ->assertJsonStructure([
+                'extensions' => [
+                    'tracing' => [
+                        'execution' => [
+                            'resolvers',
+                        ],
                     ],
                 ],
-            ],
-        ]);
+            ]);
     }
 
     public function testAddTracingExtensionMetaToBatchedResults(): void
     {
         $postData = [
-            'query' => '
+            'query' => /** @lang GraphQL */'
                 {
                     foo
                 }
@@ -56,24 +58,27 @@ SCHEMA;
                 ],
             ],
         ];
-        $result = $this->postGraphQL([
-            $postData,
-            $postData,
-        ])->assertJsonCount(2)
+
+        $result = $this
+            ->postGraphQL([
+                $postData,
+                $postData,
+            ])
+            ->assertJsonCount(2)
             ->assertJsonStructure([
                 $expectedResponse,
                 $expectedResponse,
             ]);
 
-        $this->assertSame(
-            $result->json('0.extensions.tracing.startTime'),
-            $result->json('1.extensions.tracing.startTime')
-        );
+        $startTime1 = $result->json('0.extensions.tracing.startTime');
+        $endTime1 = $result->json('0.extensions.tracing.endTime');
 
-        $this->assertNotSame(
-            $result->json('0.extensions.tracing.endTime'),
-            $result->json('1.extensions.tracing.endTime')
-        );
+        $startTime2 = $result->json('1.extensions.tracing.startTime');
+        $endTime2 = $result->json('1.extensions.tracing.endTime');
+
+        $this->assertGreaterThan($startTime1, $endTime1);
+        $this->assertGreaterThan($endTime1, $startTime2);
+        $this->assertGreaterThan($startTime2, $endTime2);
 
         $this->assertCount(1, $result->json('0.extensions.tracing.execution.resolvers'));
         $this->assertCount(1, $result->json('1.extensions.tracing.execution.resolvers'));


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves https://github.com/nuwave/lighthouse/issues/2007

**Changes**

Use `StartExection` over `StartRequest` to mark the beginning of an operation in tracing. This has two advantages:
- accurate timing when using batched requests
- works in a non-http context

**Breaking changes**

No, but the timing values will differ.