### PR TITLE
Fix ASTCache with `LIGHTHOUSE_CACHE_VERSION=1` in env

### DIFF
--- a/src/Schema/AST/ASTCache.php
+++ b/src/Schema/AST/ASTCache.php
@@ -58,7 +58,7 @@ class ASTCache
 
         $this->enable = $cacheConfig['enable'];
 
-        $version = $cacheConfig['version'] ?? 1;
+        $version = (int) ($cacheConfig['version'] ?? 1);
 
         switch ($version) {
             case 1:

--- a/src/Schema/AST/ASTCache.php
+++ b/src/Schema/AST/ASTCache.php
@@ -58,7 +58,7 @@ class ASTCache
 
         $this->enable = $cacheConfig['enable'];
 
-        $version = (int) ($cacheConfig['version'] ?? 1);
+        $version = $cacheConfig['version'] ?? 1;
 
         switch ($version) {
             case 1:
@@ -73,7 +73,7 @@ class ASTCache
                 throw new UnknownCacheVersionException($version);
         }
 
-        $this->version = $version;
+        $this->version = (int) $version;
     }
 
     public function isEnabled(): bool


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

This PR cast explicitly the cache version as an integer in `ASTCache`, resolving a "Path cannot be empty" error in `ASTCache::put` method when using `LIGHTHOUSE_CACHE_VERSION=1` in `.env` file.

Why this issue wasn't seen before ?

1. Most of user using cache version 1 just use the provided configuration file without any particular `env` override. In this situation, `config('lighthouse.cache.version') === 1`, because of the default value used in config file.
2. In the meantime, users using `LIGHTHOUSE_CACHE_VERSION=2` ends up with a `config('lighthouse.cache.version') === "2"`, which pass fine the switch/case statement in `ASTCache::__construct`, and also isn't an issue, for `if (1 === $this->version)` comparison, because so far 1 != "2".

So when is it an issue ?

This issue is easily reproductible if you set `LIGHTHOUSE_CACHE_VERSION=1` in your `.env` file. In this situation `config('lighthouse.cache.version') === "1"`, (as a string not an int) which still pass fine the switch/case statement, but not any other ASTCache method relying on a `===` comparison. 

Also, In my case, I used `LIGHTHOUSE_CACHE_VERSION=2` in `.env`, but for my Unit test, and I chosen to override this environnement variable with a `<server name="LIGHTHOUSE_CACHE_VERSION" value="1" />` in my `phpunit.xml`. This time also, I ended up with a `config('lighthouse.cache.version') === "1"`

**Breaking changes**

This is bugfix and code wasn't working in the described condition.
