### PR TITLE
Fixes in EnsureXHR middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Fix `EnsureXHR` middleware to handle additional fields in the `Content-type` header
+- Fix `EnsureXHR` middleware to handle method override via `_method` parameter
+
 ## v5.37.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Fix `EnsureXHR` middleware to handle additional fields in the `Content-type` header
-- Fix `EnsureXHR` middleware to handle method override via `_method` parameter
+- Fix `EnsureXHR` middleware to handle additional fields in the `Content-Type` header https://github.com/nuwave/lighthouse/pull/2036
+- Fix `EnsureXHR` middleware to handle method override via `_method` parameter https://github.com/nuwave/lighthouse/pull/2036
 
 ## v5.37.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.37.0
+
 ### Changed
 
 - Improve default schema https://github.com/nuwave/lighthouse/pull/2032

--- a/src/Federation/Types/Any.php
+++ b/src/Federation/Types/Any.php
@@ -14,6 +14,7 @@ class Any extends ScalarType
 {
     public const MESSAGE = 'Expected an input with a field `__typename` and matching fields, got: ';
 
+    // @phpstan-ignore-next-line Can't declare as string for PHP < 7.4
     public $name = '_Any';
 
     public $description = /** @lang Markdown */ <<<'DESCRIPTION'

--- a/src/Federation/Types/Any.php
+++ b/src/Federation/Types/Any.php
@@ -14,7 +14,6 @@ class Any extends ScalarType
 {
     public const MESSAGE = 'Expected an input with a field `__typename` and matching fields, got: ';
 
-    // @phpstan-ignore-next-line Can't declare as string for PHP < 7.4
     public $name = '_Any';
 
     public $description = /** @lang Markdown */ <<<'DESCRIPTION'

--- a/src/Support/Http/Middleware/EnsureXHR.php
+++ b/src/Support/Http/Middleware/EnsureXHR.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Support\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
@@ -47,10 +48,8 @@ class EnsureXHR
             throw new BadRequestHttpException('Content-Type header must be set');
         }
 
-        foreach (self::FORM_CONTENT_TYPES as $formContentType) {
-            if ('' !== $formContentType && 0 === strncmp($contentType, $formContentType, strlen($formContentType))) {
-                throw new BadRequestHttpException("Content-Type $contentType is forbidden");
-            }
+        if (Str::startsWith($contentType, self::FORM_CONTENT_TYPES)) {
+            throw new BadRequestHttpException("Content-Type $contentType is forbidden");
         }
 
         return $next($request);

--- a/src/Support/Http/Middleware/EnsureXHR.php
+++ b/src/Support/Http/Middleware/EnsureXHR.php
@@ -28,7 +28,7 @@ class EnsureXHR
      */
     public function handle(Request $request, Closure $next)
     {
-        $method = $request->getMethod();
+        $method = $request->getRealMethod();
 
         if ('GET' === $method) {
             throw new BadRequestHttpException('GET requests are forbidden');
@@ -47,8 +47,10 @@ class EnsureXHR
             throw new BadRequestHttpException('Content-Type header must be set');
         }
 
-        if (in_array($contentType, self::FORM_CONTENT_TYPES)) {
-            throw new BadRequestHttpException("Content-Type {$contentType} is forbidden");
+        foreach (self::FORM_CONTENT_TYPES as $formContentType) {
+            if ('' !== $formContentType && 0 === strncmp($contentType, $formContentType, strlen($formContentType))) {
+                throw new BadRequestHttpException("Content-Type $contentType is forbidden");
+            }
         }
 
         return $next($request);

--- a/tests/Unit/Support/Http/Middleware/EnsureXHRTest.php
+++ b/tests/Unit/Support/Http/Middleware/EnsureXHRTest.php
@@ -23,6 +23,23 @@ class EnsureXHRTest extends TestCase
         );
     }
 
+    public function testHandleMethodOverride(): void
+    {
+        $middleware = new EnsureXHR();
+
+        $request = new Request();
+        $request->setMethod('POST');
+        $request->headers->set('content-type', 'multipart/form-data');
+        $request->request->set('_method', 'PUT');
+        $request->enableHttpMethodParameterOverride();
+
+        $this->expectException(BadRequestHttpException::class);
+        $middleware->handle(
+            $request,
+            static function (): void {}
+        );
+    }
+
     public function testAllowNonStandardMethod(): void
     {
         $middleware = new EnsureXHR();
@@ -57,13 +74,17 @@ class EnsureXHRTest extends TestCase
     }
 
     /**
-     * @return iterable<int, array{string}>
+     * @return array{array{string}}
      */
-    public function formContentTypes(): iterable
+    public function formContentTypes(): array
     {
-        foreach (EnsureXHR::FORM_CONTENT_TYPES as $contentType) {
-            yield [$contentType];
-        }
+        return [
+            ['application/x-www-form-urlencoded'],
+            ['multipart/form-data'],
+            ['text/plain'],
+            ['multipart/form-data; boundary=-------12345'],
+            ['text/plain; encoding=utf-8'],
+        ];
     }
 
     public function testForbidEmptyContentType(): void


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

1. Laravel allows [spoofing request method](https://laravel.com/docs/8.x/routing#form-method-spoofing) via the `_method` parameter. I fixed the `EnsureXHR` middleware to handle it
2. Browsers may send additional fields in the `Content-type` header. For example, `multipart/form-data; boundary=-------12345` or `text/plain; encoding=utf-8`. These requests were wrongly considered as XHR. 

**Breaking changes**

No. 
