### PR TITLE
Add field `hasMorePages` for pagination type `SIMPLE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## Added
+
+- Display "hasMorePages" for `SIMPLE` pagination
+
 ## v5.38.1
 
 ### Fixed

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2276,7 +2276,7 @@ hold information about the total number of items.
 If you wish to use the `simplePaginate` method, set the `type` to `SIMPLE`.
 
 > Please note that the `SIMPLE` paginator does not have the attributes
-> `hasMorePages`, `lastPage` and `total`.
+> `lastPage` and `total`.
 >
 > If you need those fields, you should use the default `PAGINATOR`.
 
@@ -2324,6 +2324,9 @@ type SimplePaginatorInfo {
 
   "Number of items per page."
   perPage: Int!
+
+  "Are there more pages after this one?"
+  hasMorePages: Boolean!
 }
 ```
 

--- a/src/Pagination/PaginationServiceProvider.php
+++ b/src/Pagination/PaginationServiceProvider.php
@@ -82,6 +82,9 @@ class PaginationServiceProvider extends ServiceProvider
 
               "Number of items per page."
               perPage: Int!
+
+              "Are there more pages after this one?"
+              hasMorePages: Boolean!
             }
         ');
     }

--- a/src/Pagination/SimplePaginatorField.php
+++ b/src/Pagination/SimplePaginatorField.php
@@ -22,6 +22,7 @@ class SimplePaginatorField
             'firstItem' => $root->firstItem(),
             'lastItem' => $root->lastItem(),
             'perPage' => $root->perPage(),
+            'hasMorePages' => $root->hasMorePages(),
         ];
     }
 

--- a/tests/Unit/Pagination/PaginateDirectiveTest.php
+++ b/tests/Unit/Pagination/PaginateDirectiveTest.php
@@ -99,6 +99,9 @@ type SimplePaginatorInfo {
 
   """Number of items per page."""
   perPage: Int!
+
+  """Are there more pages after this one?"""
+  hasMorePages: Boolean!
 }
 GRAPHQL
             ,


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

As you can see in here, the `simplePaginate` method actually supports `hasMorePages` by just querying an additional line. So I added it (back) in :)

https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Eloquent/Builder.php#L833-L836
https://github.com/laravel/framework/blob/8.x/src/Illuminate/Pagination/Paginator.php#L70-L72

