### PR TITLE
Properly handle any kind of deferred resolved value

### DIFF
--- a/src/Execution/Resolved.php
+++ b/src/Execution/Resolved.php
@@ -2,21 +2,21 @@
 
 namespace Nuwave\Lighthouse\Execution;
 
-use GraphQL\Deferred;
+use GraphQL\Executor\Promise\Adapter\SyncPromise;
 
 class Resolved
 {
     /**
-     * Apply the transform function to a result or chain it onto a Deferred.
+     * Apply the transform function to a result or chain it onto a SyncPromise.
      *
-     * @param  \GraphQL\Deferred|mixed  $resolved  The result of calling a resolver
+     * @param  \GraphQL\Executor\Promise\Adapter\SyncPromise|mixed  $resolved  The result of calling a resolver
      * @param  callable(mixed $result): mixed  $handle A function that takes that result and transforms it
      *
-     * @return \GraphQL\Deferred|mixed The transformed result or enhanced Deferred
+     * @return \GraphQL\Executor\Promise\Adapter\SyncPromise|mixed The transformed result or enhanced SyncPromise
      */
     public static function handle($resolved, callable $handle)
     {
-        if ($resolved instanceof Deferred) {
+        if ($resolved instanceof SyncPromise) {
             return $resolved->then($handle);
         }
 

--- a/tests/Integration/Schema/Directives/LimitDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/LimitDirectiveTest.php
@@ -3,33 +3,19 @@
 namespace Tests\Integration\Schema\Directives;
 
 use Tests\DBTestCase;
+use Tests\TestsSerialization;
 use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
 
 class LimitDirectiveTest extends DBTestCase
 {
-    /**
-     * @var \Illuminate\Contracts\Cache\Repository
-     */
-    protected $cache;
+    use TestsSerialization;
 
     protected function getEnvironmentSetUp($app): void
     {
         parent::getEnvironmentSetUp($app);
 
-        /** @var \Illuminate\Contracts\Config\Repository $config */
-        $config = $app->make('config');
-
-        $config->set('cache.default', 'file');
-
-        $this->cache = $app->make('cache');
-    }
-
-    protected function tearDown(): void
-    {
-        $this->cache->clear();
-
-        parent::tearDown();
+        $this->useSerializingArrayStore($app);
     }
 
     public function testLimitsResults(): void
@@ -177,7 +163,9 @@ class LimitDirectiveTest extends DBTestCase
                 }
             }');
 
-        $data = $this->cache->get('lighthouse:User:2:tasks:limit:1');
+        $cache = $this->app->make('cache');
+
+        $data = $cache->get('lighthouse:User:2:tasks:limit:1');
 
         $this->assertIsArray($data);
         $this->assertInstanceOf(Task::class, $data[0]);

--- a/tests/Integration/Schema/Directives/LimitDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/LimitDirectiveTest.php
@@ -154,34 +154,37 @@ class LimitDirectiveTest extends DBTestCase
 
         $this
             ->graphQL(/** @lang GraphQL */ '
-            query {
+            {
                 user {
                     id
                     tasks(limit: 1) {
                         id
                     }
                 }
-            }');
+            }
+            ');
 
         $cache = $this->app->make('cache');
-
         $data = $cache->get('lighthouse:User:2:tasks:limit:1');
 
         $this->assertIsArray($data);
-        $this->assertInstanceOf(Task::class, $data[0]);
-        $this->assertSame(3, $data[0]->id);
 
-        // get values from cache
+        $task = $data[0];
+        $this->assertInstanceOf(Task::class, $task);
+        $this->assertSame(3, $task->id);
+
         $this
             ->graphQL(/** @lang GraphQL */ '
-            query {
+            {
                 user {
                     id
                     tasks(limit: 1) {
                         id
                     }
                 }
-            }')->assertJson([
+            }
+            ')
+            ->assertJson([
                 'data' => [
                     'user' => [
                         [

--- a/tests/Integration/Schema/Directives/LimitDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/LimitDirectiveTest.php
@@ -201,7 +201,7 @@ class LimitDirectiveTest extends DBTestCase
                             'tasks' => [
                                 [
                                     'id' => 1,
-                                ]
+                                ],
                             ],
                         ],
                         [
@@ -209,7 +209,7 @@ class LimitDirectiveTest extends DBTestCase
                             'tasks' => [
                                 [
                                     'id' => 3,
-                                ]
+                                ],
                             ],
                         ],
                     ],


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [ ] Updated CHANGELOG.md

Resolves #1793

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->
When using the `@limit` in combination with the `@cache`, a SyncPromise object will be saved to the cache.
It will throw an exception in next same query.

With this change it will work fine.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
