### PR TITLE
Normalize rules input to ensure Laravel 9 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Normalize rules input to ensure Laravel 9 support https://github.com/nuwave/lighthouse/pull/2070
+
 ## v5.40.1
 
 ### Fixed

--- a/src/Validation/RulesGatherer.php
+++ b/src/Validation/RulesGatherer.php
@@ -218,13 +218,13 @@ class RulesGatherer
      * @param  array<int, mixed>  $rules
      * @param  array<int|string>  $argumentPath
      *
-     * @return array<int, array<int, mixed>|object>
+     * @return array<int, object|string>
      */
     protected function qualifyArgumentReferences(array $rules, array $argumentPath): array
     {
         return array_map(
             /**
-             * @return object|array<int, mixed>
+             * @return object|string
              */
             static function ($rule) use ($argumentPath) {
                 if (is_object($rule)) {
@@ -311,13 +311,10 @@ class RulesGatherer
                     }
                 }
 
-                // Laravel expects the rule to be a flat array of name, arg1, arg2, ...
-                $flatArgs = [$name];
-                foreach ($args as $arg) {
-                    $flatArgs[] = $arg;
-                }
-
-                return $flatArgs;
+                // Convert back to the Laravel rule definition style rule:arg1,arg2
+                return count($args) > 0
+                    ? $name . ':' . implode(',', $args)
+                    : $name;
             },
             $rules
         );

--- a/src/Validation/ValidateDirective.php
+++ b/src/Validation/ValidateDirective.php
@@ -38,7 +38,7 @@ GRAPHQL;
                     assert($validationFactory instanceof ValidationFactory);
                     $validator = $validationFactory->make(
                         $args,
-                        self::normalizeRules($rulesGatherer->rules),
+                        $rulesGatherer->rules,
                         $rulesGatherer->messages,
                         $rulesGatherer->attributes
                     );
@@ -53,28 +53,5 @@ GRAPHQL;
                 }
             )
         );
-    }
-
-    /**
-     * Ensure rules follow the standard definition format that Laravel expects.
-     *
-     * @param  array<string, array<int, array<int, string>|object>>  $rulesMap
-     *
-     * @return array<string, array<int, string|object>>
-     */
-    private static function normalizeRules(array $rulesMap): array
-    {
-        foreach ($rulesMap as &$rulesForField) {
-            foreach ($rulesForField as &$rule) {
-                if (is_array($rule)) {
-                    $name = Arr::pull($rule, 0);
-                    $rule = count($rule) > 0
-                        ? $name . ':' . implode(',', $rule)
-                        : $name;
-                }
-            }
-        }
-
-        return $rulesMap;
     }
 }

--- a/src/Validation/ValidateDirective.php
+++ b/src/Validation/ValidateDirective.php
@@ -39,7 +39,7 @@ GRAPHQL;
                     $validationFactory = app(ValidationFactory::class);
                     $validator = $validationFactory->make(
                         $args,
-                        $rulesGatherer->rules,
+                        self::normalizeRules($rulesGatherer->rules),
                         $rulesGatherer->messages,
                         $rulesGatherer->attributes
                     );
@@ -54,5 +54,32 @@ GRAPHQL;
                 }
             )
         );
+    }
+
+    /**
+     * @param array<string, array<int, array<int, string>|object>> $rules
+     * @return array<string, array<int, string|object>>
+     */
+    private static function normalizeRules(array $rules): array
+    {
+        $transformed = [];
+        foreach ($rules as $key => $value) {
+            $transformed[$key] = array_map(function ($rule) {
+                if (is_array($rule)) {
+                    $name = $rule[0];
+                    $parameters = array_slice($rule, 1, 100);
+
+                    if ($parameters) {
+                        return $name . ':' . implode(',', $parameters);
+                    }
+
+                    return $name;
+                }
+
+                return $rule;
+            }, $value);
+        }
+
+        return $transformed;
     }
 }

--- a/tests/Integration/Validation/ValidatorDirectiveTest.php
+++ b/tests/Integration/Validation/ValidatorDirectiveTest.php
@@ -84,7 +84,7 @@ class ValidatorDirectiveTest extends TestCase
             ->assertGraphQLValidationError('input.rules', 'The input.rules must be a valid email address.');
     }
 
-    public function testNestedInputsRulesReceiveParameters()
+    public function testNestedInputsRulesReceiveParameters(): void
     {
         $this->schema = /** @lang GraphQL */ '
         type Query {

--- a/tests/Integration/Validation/ValidatorDirectiveTest.php
+++ b/tests/Integration/Validation/ValidatorDirectiveTest.php
@@ -106,12 +106,13 @@ class ValidatorDirectiveTest extends TestCase
                 foo(
                     input: {
                         foo: {
-                            bar: ["input"]
+                            bar: ["only 1 item"]
                         }
                     }
                 )
             }
-            ')->assertSuccessful();
+            ')
+            ->assertGraphQLValidationError('input.foo.0.bar', 'The input.foo.0.bar must contain 2 items.');
     }
 
     public function testCustomMessage(): void

--- a/tests/Integration/Validation/ValidatorDirectiveTest.php
+++ b/tests/Integration/Validation/ValidatorDirectiveTest.php
@@ -84,6 +84,36 @@ class ValidatorDirectiveTest extends TestCase
             ->assertGraphQLValidationError('input.rules', 'The input.rules must be a valid email address.');
     }
 
+    public function testNestedInputsRulesReceiveParameters()
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo(input: RulesWithParameters): ID
+        }
+
+        input RuleWithParameter {
+            bar: [String!]!
+        }
+
+        input RulesWithParameters @validator {
+            foo: [RuleWithParameter]!
+        }
+        ';
+
+        $response = $this
+            ->graphQL(/** @lang GraphQL */ '
+            {
+                foo(
+                    input: {
+                        foo: {
+                            bar: ["input"]
+                        }
+                    }
+                )
+            }
+            ')->assertSuccessful();
+    }
+
     public function testCustomMessage(): void
     {
         $this->schema = /** @lang GraphQL */ '

--- a/tests/Integration/Validation/ValidatorDirectiveTest.php
+++ b/tests/Integration/Validation/ValidatorDirectiveTest.php
@@ -100,7 +100,7 @@ class ValidatorDirectiveTest extends TestCase
         }
         ';
 
-        $response = $this
+        $this
             ->graphQL(/** @lang GraphQL */ '
             {
                 foo(

--- a/tests/Utils/Validators/RulesWithParametersValidator.php
+++ b/tests/Utils/Validators/RulesWithParametersValidator.php
@@ -11,7 +11,7 @@ class RulesWithParametersValidator extends Validator
         return [
             'foo.*.bar' => [
                 'array',
-                'size:1',
+                'size:2',
             ],
         ];
     }

--- a/tests/Utils/Validators/RulesWithParametersValidator.php
+++ b/tests/Utils/Validators/RulesWithParametersValidator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Utils\Validators;
+
+use Nuwave\Lighthouse\Validation\Validator;
+
+class RulesWithParametersValidator extends Validator
+{
+    public function rules(): array
+    {
+        return [
+            'foo.*.bar' => [
+                'array',
+                'size:1',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
I recently updated to Laravel 9.0 in my application, and these kind of inputs started failing.

`validatesAttributes@validateSize` does not receive correct `$parameters`. Its just receives an empty array.