### PR TITLE
Add platform to mysql for Apple M1 support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
   mysql:
     # TODO switch to MySQL 8 https://github.com/nuwave/lighthouse/issues/1784
     image: mysql:5.7
+    platform: linux/amd64
     tmpfs: /var/lib/mysql
     environment:
       MYSQL_DATABASE: test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
   mysql:
     # TODO switch to MySQL 8 https://github.com/nuwave/lighthouse/issues/1784
     image: mysql:5.7
+    # Ensures compatibility with Apple M1
     platform: linux/amd64
     tmpfs: /var/lib/mysql
     environment:


### PR DESCRIPTION
I had to add a specific platform to mysql to run Docker installation on Apple M1 chip.