### PR TITLE
Add parallel-testing compatible way to refresh schema cache in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,15 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Added
 
-- Add testing trait `RefreshesSchemaCache`
+- Add testing trait `RefreshesSchemaCache` https://github.com/nuwave/lighthouse/pull/2076
 
 ### Fixed
 
-- Add proper error handling for invalid schema cache file contents
+- Add proper error handling for invalid schema cache file contents https://github.com/nuwave/lighthouse/pull/2076
 
 ### Deprecated
 
-- Deprecate testing trait `ClearsSchemaCache`
+- Deprecate testing trait `ClearsSchemaCache` https://github.com/nuwave/lighthouse/pull/2076
 
 ## v5.40.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- Add testing trait `RefreshesSchemaCache`
+
+### Fixed
+
+- Add proper error handling for invalid schema cache file contents
+
+### Deprecated
+
+- Deprecate testing trait `ClearsSchemaCache`
+
 ## v5.40.1
 
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -131,6 +131,30 @@ public function scopeByType(Builder $builder, AOrB $aOrB): Builder
 Use `parseAndExecuteQuery()` for executing a string query or `executeParsedQuery()` for 
 executing already parsed `DocumentNode`.
 
+### Use `RefreshesSchemaCache` over `ClearsSchemaCache`
+
+The `ClearsSchemaCache` testing trait was prone to race conditions when running tests in parallel.
+
+```diff
+-use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
++use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    use CreatesApplication;
+-   use ClearsSchemaCache;
++   use RefreshesSchemaCache;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+-       $this->bootClearsSchemaCache();
++       $this->bootRefreshesSchemaCache();
+     }
+}
+```
+
 ## v4 to v5
 
 ### Update PHP, Laravel and PHPUnit

--- a/docs/master/testing/phpunit.md
+++ b/docs/master/testing/phpunit.md
@@ -19,22 +19,21 @@ abstract class TestCase extends BaseTestCase
 ```
 
 Enabling the schema cache speeds up your tests. To ensure the schema is fresh
-before running tests, add the `ClearSchemaCache` trait to your test class and call it during set up.
+before running tests, add the `RefreshesSchemaCache` trait to your test class and call it during set up.
 
 ```diff
-+use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
++use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
-+   use ClearsSchemaCache;
-
++   use RefreshesSchemaCache;
 
     protected function setUp(): void
     {
         parent::setUp();
-+       $this->bootClearsSchemaCache();
++       $this->bootRefreshesSchemaCache();
      }
 }
 ```

--- a/src/Exceptions/InvalidSchemaCacheContentsException.php
+++ b/src/Exceptions/InvalidSchemaCacheContentsException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Nuwave\Lighthouse\Exceptions;
+
+use Exception;
+use GraphQL\Utils\Utils;
+
+class InvalidSchemaCacheContentsException extends Exception
+{
+    /**
+     * @param  mixed  $value the non-array result of `require $path`
+     */
+    public function __construct(string $path, $value)
+    {
+        $notArray = Utils::printSafe($value);
+
+        parent::__construct("Expected the file at {$path} to return an array representation of the schema AST, got: {$notArray}.");
+    }
+}

--- a/src/Schema/AST/ASTCache.php
+++ b/src/Schema/AST/ASTCache.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Filesystem\Filesystem;
+use Nuwave\Lighthouse\Exceptions\InvalidSchemaCacheContentsException;
 use Nuwave\Lighthouse\Exceptions\UnknownCacheVersionException;
 
 /**
@@ -118,7 +119,12 @@ class ASTCache
         }
 
         if ($this->filesystem()->exists($this->path)) {
-            return DocumentAST::fromArray(require $this->path);
+            $ast = require $this->path;
+            if (! is_array($ast)) {
+                throw new InvalidSchemaCacheContentsException($this->path, $ast);
+            }
+
+            return DocumentAST::fromArray($ast);
         }
 
         $documentAST = $build();

--- a/src/Testing/ClearsSchemaCache.php
+++ b/src/Testing/ClearsSchemaCache.php
@@ -6,6 +6,9 @@ namespace Nuwave\Lighthouse\Testing;
  * Clears the schema cache once before any tests are run.
  *
  * @mixin \Illuminate\Foundation\Testing\Concerns\InteractsWithConsole
+ *
+ * @deprecated not safe with parallel testing
+ * @see \Nuwave\Lighthouse\Testing\RefreshesSchemaCache
  */
 trait ClearsSchemaCache
 {

--- a/src/Testing/RefreshesSchemaCache.php
+++ b/src/Testing/RefreshesSchemaCache.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Nuwave\Lighthouse\Testing;
+
+/**
+ * Refreshes the schema cache once before any tests are run.
+ *
+ * @mixin \Illuminate\Foundation\Testing\Concerns\InteractsWithConsole
+ */
+trait RefreshesSchemaCache
+{
+    /**
+     * Marks that the schema cache was refreshed.
+     *
+     * Static variables persist during the execution of a single process.
+     * In parallel testing each process has a separate instance of this class.
+     *
+     * @var bool
+     */
+    protected static $schemaCacheWasRefreshed = false;
+
+    /**
+     * Path to the file used for coordinating exactly-one semantics.
+     *
+     * @var string
+     */
+    protected static $lockFilePath = __DIR__ . '/schema-cache-refreshing';
+
+    protected function bootRefreshesSchemaCache(): void
+    {
+        if (! static::$schemaCacheWasRefreshed) {
+            // We utilize the filesystem as shared mutable state to coordinate between processes,
+            // since the tests might be run in parallel, and we want to ensure the schema cache
+            // is refreshed exactly once before all tests.
+            touch(self::$lockFilePath);
+            $lockFile = fopen(self::$lockFilePath, 'r');
+
+            // Attempt to get an exclusive lock - first process wins
+            if (flock($lockFile, LOCK_EX | LOCK_NB)) {
+                // Since we are the single process that has an exclusive lock, we have to write the cache
+                $this->artisan('lighthouse:cache');
+            } else {
+                // If no exclusive lock is available, block until the first process is done and wrote the cache
+                flock($lockFile, LOCK_SH);
+            }
+
+            self::$schemaCacheWasRefreshed = true;
+        }
+    }
+}

--- a/tests/Integration/SchemaCachingTest.php
+++ b/tests/Integration/SchemaCachingTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Integration;
 
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Filesystem\Filesystem;
+use Nuwave\Lighthouse\Exceptions\InvalidSchemaCacheContentsException;
 use Nuwave\Lighthouse\Schema\AST\ASTBuilder;
 use Tests\TestCase;
 use Tests\TestsSchemaCache;
@@ -74,6 +76,25 @@ class SchemaCachingTest extends TestCase
                 ],
             ],
         ]);
+    }
+
+    public function testInvalidSchemaCacheContents(): void
+    {
+        $config = app(ConfigRepository::class);
+        assert($config instanceof ConfigRepository);
+        $config->set('lighthouse.cache.version', 2);
+
+        $filesystem = app(Filesystem::class);
+        assert($filesystem instanceof Filesystem);
+        $path = $config->get('lighthouse.cache.path');
+        $filesystem->put($path, '');
+
+        $this->expectExceptionObject(new InvalidSchemaCacheContentsException($path, 1));
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            foo
+        }
+        ');
     }
 
     protected function cacheSchema(): void


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

### Added

- Add testing trait `RefreshesSchemaCache` https://github.com/nuwave/lighthouse/pull/2076

### Fixed

- Add proper error handling for invalid schema cache file contents https://github.com/nuwave/lighthouse/pull/2076

### Deprecated

- Deprecate testing trait `ClearsSchemaCache` https://github.com/nuwave/lighthouse/pull/2076


**Breaking changes**

None.
