### PR TITLE
Allow lazy registration of types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- Allow lazy registration of types https://github.com/nuwave/lighthouse/pull/2086
+
 ## v5.42.3
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.43.0
+
 ### Added
 
 - Allow lazy registration of types https://github.com/nuwave/lighthouse/pull/2086

--- a/src/Schema/TypeRegistry.php
+++ b/src/Schema/TypeRegistry.php
@@ -207,7 +207,9 @@ class TypeRegistry
         }
 
         foreach ($this->lazyTypes as $name => $lazyType) {
-            $this->types[$name] = $lazyType();
+            if (! isset($this->types[$name])) {
+                $this->types[$name] = $lazyType();
+            }
         }
 
         return $this->types;

--- a/tests/Integration/Schema/Types/InterfaceTest.php
+++ b/tests/Integration/Schema/Types/InterfaceTest.php
@@ -5,7 +5,6 @@ namespace Tests\Integration\Schema\Types;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Team;
@@ -170,9 +169,7 @@ GRAPHQL;
 GRAPHQL;
 
         $this->expectExceptionObject(
-            new DefinitionException(
-                TypeRegistry::unresolvableAbstractTypeMapping(User::class, ['Foo', 'Team'])
-            )
+            TypeRegistry::unresolvableAbstractTypeMapping(User::class, ['Foo', 'Team'])
         );
         $this->graphQL(/** @lang GraphQL */ '
         {
@@ -207,9 +204,7 @@ GRAPHQL;
 GRAPHQL;
 
         $this->expectExceptionObject(
-            new DefinitionException(
-                TypeRegistry::unresolvableAbstractTypeMapping(User::class, [])
-            )
+            TypeRegistry::unresolvableAbstractTypeMapping(User::class, [])
         );
         $this->graphQL(/** @lang GraphQL */ '
         {

--- a/tests/Integration/Schema/Types/UnionTest.php
+++ b/tests/Integration/Schema/Types/UnionTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Integration\Schema\Types;
 
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Post;
@@ -112,9 +111,7 @@ GRAPHQL;
 GRAPHQL;
 
         $this->expectExceptionObject(
-            new DefinitionException(
-                TypeRegistry::unresolvableAbstractTypeMapping(User::class, ['Foo', 'Post'])
-            )
+            TypeRegistry::unresolvableAbstractTypeMapping(User::class, ['Foo', 'Post'])
         );
         $this->graphQL(/** @lang GraphQL */ '
         {
@@ -155,9 +152,7 @@ GRAPHQL;
 GRAPHQL;
 
         $this->expectExceptionObject(
-            new DefinitionException(
-                TypeRegistry::unresolvableAbstractTypeMapping(User::class, [])
-            )
+            TypeRegistry::unresolvableAbstractTypeMapping(User::class, [])
         );
         $this->graphQL(/** @lang GraphQL */ '
         {

--- a/tests/Unit/Schema/TypeRegistryTest.php
+++ b/tests/Unit/Schema/TypeRegistryTest.php
@@ -248,11 +248,13 @@ class TypeRegistryTest extends TestCase
 
     public function testPossibleTypes(): void
     {
-        $this->schema = /** @lang GraphQL */ '
-        type Foo {
+        $documentTypeName = 'Foo';
+
+        $this->schema = /** @lang GraphQL */ "
+        type {$documentTypeName} {
             foo: ID
         }
-        ' . self::PLACEHOLDER_QUERY;
+        " . self::PLACEHOLDER_QUERY;
 
         app()->forgetInstance(ASTBuilder::class);
         $astBuilder = app(ASTBuilder::class);
@@ -264,8 +266,44 @@ class TypeRegistryTest extends TestCase
             static function () use ($lazyTypeName): ObjectType { return new ObjectType(['name' => $lazyTypeName]); }
         );
 
+        $resolvedTypes = $this->typeRegistry->resolvedTypes();
+        $this->assertArrayNotHasKey($documentTypeName, $resolvedTypes);
+        $this->assertArrayNotHasKey($lazyTypeName, $resolvedTypes);
+
         $possibleTypes = $this->typeRegistry->possibleTypes();
-        $this->assertArrayHasKey('Foo', $possibleTypes);
+        $this->assertArrayHasKey($documentTypeName, $possibleTypes);
         $this->assertArrayHasKey($lazyTypeName, $possibleTypes);
+
+        $resolvedTypes = $this->typeRegistry->resolvedTypes();
+        $this->assertArrayHasKey($documentTypeName, $resolvedTypes);
+        $this->assertArrayHasKey($lazyTypeName, $resolvedTypes);
+    }
+
+    public function testPossibleTypesMaintainsSingletons(): void
+    {
+        $documentTypeName = 'Foo';
+
+        $this->schema = /** @lang GraphQL */ "
+        type {$documentTypeName} {
+            foo: ID
+        }
+        " . self::PLACEHOLDER_QUERY;
+
+        app()->forgetInstance(ASTBuilder::class);
+        $astBuilder = app(ASTBuilder::class);
+        $this->typeRegistry->setDocumentAST($astBuilder->documentAST());
+
+        $lazyTypeName = 'Bar';
+        $this->typeRegistry->registerLazy(
+            $lazyTypeName,
+            static function () use ($lazyTypeName): ObjectType { return new ObjectType(['name' => $lazyTypeName]); }
+        );
+
+        $documentType = $this->typeRegistry->get($documentTypeName);
+        $lazyType = $this->typeRegistry->get($lazyTypeName);
+        $possibleTypes = $this->typeRegistry->possibleTypes();
+
+        $this->assertSame($documentType, $possibleTypes[$documentTypeName]);
+        $this->assertSame($lazyType, $possibleTypes[$lazyTypeName]);
     }
 }

--- a/tests/Unit/Schema/TypeRegistryTest.php
+++ b/tests/Unit/Schema/TypeRegistryTest.php
@@ -195,8 +195,11 @@ class TypeRegistryTest extends TestCase
 
     public function testGetThrowsWhenMissingType(): void
     {
-        $this->expectException(DefinitionException::class);
-        $this->typeRegistry->get('ThisTypeDoesNotExist');
+        $nonExistingTypeName = 'ThisTypeDoesNotExist';
+        $this->expectExceptionObject(
+            TypeRegistry::failedToLoadType($nonExistingTypeName)
+        );
+        $this->typeRegistry->get($nonExistingTypeName);
     }
 
     public function testDeterminesIfHasType(): void
@@ -216,5 +219,17 @@ class TypeRegistryTest extends TestCase
 
         $this->expectException(DefinitionException::class);
         $this->typeRegistry->register($foo);
+    }
+
+    public function testRegisterLazy(): void
+    {
+        $name = 'Foo';
+        $foo = new ObjectType(['name' => $name]);
+        $this->typeRegistry->registerLazy(
+            $name,
+            static function () use ($foo): ObjectType { return $foo; }
+        );
+
+        $this->assertSame($foo, $this->typeRegistry->get($name));
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Adds `TypeRegistry::registerLazy()` and `TypeRegistry::overwriteLazy()` to allow for more performant registration of programmatic types.

**Breaking changes**

None.
