### PR TITLE
Revert breaking schema change in generate pagination types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.45.4
+
+### Fixed
+
+- Revert breaking schema change in generate pagination types
+
 ## v5.45.3
 
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -85,6 +85,14 @@ The setting `non_null_pagination_results` was removed and now always behaves as 
 This is generally more convenient for clients, but will
 cause validation errors to bubble further up in the result.
 
+### Nullability of pagination `first`
+
+Previously, the pagination argument `first` was either marked as non-nullable,
+or non-nullable with a default value.
+
+Now, it will always be marked as non-nullable, regardless if it has a default or not.
+This prevents clients from passing an invalid explicit `null`.
+
 ### Include field cost in `@complexity` calculation
 
 Previous to `v6`, the default query complexity calculation of fields with `@complexity`

--- a/src/Pagination/PaginationManipulator.php
+++ b/src/Pagination/PaginationManipulator.php
@@ -244,9 +244,9 @@ GRAPHQL
 
         // TODO always add ! in v6
         $definition = 'first: Int'
-            . $defaultCount
+            . ($defaultCount
                 ? " =  {$defaultCount}"
-                : '!';
+                : '!');
 
         return $description . $definition;
     }

--- a/src/Pagination/PaginationManipulator.php
+++ b/src/Pagination/PaginationManipulator.php
@@ -242,10 +242,11 @@ GRAPHQL
         }
         $description .= "\"\n";
 
-        $definition = 'first: Int!';
-        if ($defaultCount) {
-            $definition .= " =  {$defaultCount}";
-        }
+        // TODO always add ! in v6
+        $definition = 'first: Int'
+            . $defaultCount
+                ? " =  {$defaultCount}"
+                : '!';
 
         return $description . $definition;
     }

--- a/tests/Integration/Pagination/PaginateDirectiveDBTest.php
+++ b/tests/Integration/Pagination/PaginateDirectiveDBTest.php
@@ -9,16 +9,15 @@ use Tests\Utils\Models\Comment;
 use Tests\Utils\Models\Post;
 use Tests\Utils\Models\User;
 
-class PaginateDirectiveDBTest extends DBTestCase
+final class PaginateDirectiveDBTest extends DBTestCase
 {
-    public function testCreateQueryPaginators(): void
+    public function testPaginate(): void
     {
         factory(User::class, 3)->create();
 
         $this->schema = /** @lang GraphQL */ '
         type User {
             id: ID!
-            name: String!
         }
 
         type Query {
@@ -36,7 +35,6 @@ class PaginateDirectiveDBTest extends DBTestCase
                 }
                 data {
                     id
-                    name
                 }
             }
         }
@@ -61,7 +59,6 @@ class PaginateDirectiveDBTest extends DBTestCase
         $this->schema = /** @lang GraphQL */ '
         type User {
             id: ID!
-            name: String!
         }
 
         type Query {
@@ -93,18 +90,18 @@ class PaginateDirectiveDBTest extends DBTestCase
 
     public function testPaginateWithScopes(): void
     {
-        $namedUserName = 'A named user';
-        factory(User::class)->create([
-            'name' => $namedUserName,
+        $namedUser = factory(User::class)->create([
+            'name' => 'A named user',
         ]);
+        assert($namedUser instanceof User);
+
         factory(User::class)->create([
             'name' => null,
         ]);
 
         $this->schema = /** @lang GraphQL */ '
         type User {
-            id: ID!
-            name: String!
+            id: String!
         }
 
         type Query {
@@ -121,7 +118,7 @@ class PaginateDirectiveDBTest extends DBTestCase
                     currentPage
                 }
                 data {
-                    name
+                    id
                 }
             }
         }
@@ -135,7 +132,7 @@ class PaginateDirectiveDBTest extends DBTestCase
                     ],
                     'data' => [
                         [
-                            'name' => $namedUserName,
+                            'id' => "$namedUser->id",
                         ],
                     ],
                 ],
@@ -160,13 +157,10 @@ class PaginateDirectiveDBTest extends DBTestCase
 
         $this->schema = /** @lang GraphQL */ '
         type User {
-            id: ID!
-            name: String!
             posts: [Post!]! @paginate
         }
 
         type Post {
-            id: ID!
             comments: [Comment!]! @paginate
         }
 
@@ -243,7 +237,6 @@ class PaginateDirectiveDBTest extends DBTestCase
         $this->schema = /** @lang GraphQL */ '
         type User {
             id: ID!
-            name: String!
         }
 
         type Query {
@@ -260,7 +253,6 @@ class PaginateDirectiveDBTest extends DBTestCase
                 edges {
                     node {
                         id
-                        name
                     }
                 }
             }
@@ -281,7 +273,6 @@ class PaginateDirectiveDBTest extends DBTestCase
         $this->schema = /** @lang GraphQL */ '
         type User {
             id: ID!
-            name: String!
         }
 
         type Query {
@@ -305,7 +296,6 @@ class PaginateDirectiveDBTest extends DBTestCase
                 edges {
                     node {
                         id
-                        name
                     }
                 }
             }
@@ -383,7 +373,6 @@ class PaginateDirectiveDBTest extends DBTestCase
         $this->schema .= /** @lang GraphQL */ '
         type User {
             id: ID!
-            name: String!
         }
 
         extend type Query {
@@ -396,21 +385,19 @@ class PaginateDirectiveDBTest extends DBTestCase
             users(first: 1) {
                 data {
                     id
-                    name
                 }
             }
         }
         ')->assertJsonCount(1, 'data.users.data');
     }
 
-    public function testHaveADefaultPaginationCount(): void
+    public function testDefaultPaginationCount(): void
     {
         factory(User::class, 3)->create();
 
         $this->schema = /** @lang GraphQL */ '
         type User {
             id: ID!
-            name: String!
         }
 
         type Query {
@@ -428,7 +415,6 @@ class PaginateDirectiveDBTest extends DBTestCase
                 }
                 data {
                     id
-                    name
                 }
             }
         }

--- a/tests/Unit/Pagination/PaginateDirectiveTest.php
+++ b/tests/Unit/Pagination/PaginateDirectiveTest.php
@@ -11,7 +11,7 @@ use Nuwave\Lighthouse\Pagination\PaginationArgs;
 use Nuwave\Lighthouse\Pagination\PaginationType;
 use Tests\TestCase;
 
-class PaginateDirectiveTest extends TestCase
+final class PaginateDirectiveTest extends TestCase
 {
     public function testIncludesPaginationInfoObjectsInSchema(): void
     {
@@ -651,5 +651,32 @@ GRAPHQL
         $ast = $userPaginator->astNode;
 
         $this->assertCount(1, $ast->directives);
+    }
+
+    public function testDisallowFirstNull(): void
+    {
+        // TODO reenable in v6
+        $this->markTestSkipped('Will be fixed in v6');
+
+        // @phpstan-ignore-next-line unreachable
+        $this->schema = /** @lang GraphQL */ '
+        type User {
+            id: ID!
+        }
+
+        type Query {
+            users: [User!]! @paginate(defaultCount: 2)
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            users(first: null) {
+                data {
+                    id
+                }
+            }
+        }
+        ')->dump();
     }
 }


### PR DESCRIPTION
Reverts the breakage mentioned in https://github.com/nuwave/lighthouse/pull/2093/files/a5e76b202966e988b30760131a50a8fb2fe4989f#diff-76d791c7e3599495909ebc9bff7dc2d6cf89f30d8e33f9bf68d4eb91f935c9ca