### PR TITLE
throw http error 400 on wrong json in request

### DIFF
--- a/tests/Integration/GraphQLControllerTest.php
+++ b/tests/Integration/GraphQLControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Integration;
+
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Tests\TestCase;
+
+class GraphQLControllerTest extends TestCase
+{
+    public function testWrongJson(): void
+    {
+        $content = '{wrong json}';
+
+        $headers = [
+            'CONTENT_LENGTH' => mb_strlen($content, '8bit'),
+            'CONTENT_TYPE' => 'application/json',
+            'Accept' => 'application/json',
+        ];
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->call(
+            'POST',
+            $this->graphQLEndpointUrl(),
+            [],
+            [],
+            [],
+            $this->transformHeadersToServerVars($headers),
+            $content
+        );
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Updated CHANGELOG.md

**Changes**

Sending malformed json request to the graphql endpoint results is throwing `JsonException` by `Laragraph`. It is left uncaught and is shown to user as http error 500.

This error is not right as it means something wrong with the server while something wrong happens with the client.

This PR catches that exception (and another one that might be thrown by `Laragraph`) and wraps it into `BadRequestHttpException` so the client will receive http error 400. 

