### PR TITLE
Add method `TestResponse::assertGraphQLDebugMessage()` to test internal errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- Add method `TestResponse::assertGraphQLDebugMessage()` to test internal errors
+
 ## v5.45.4
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Added
 
-- Add method `TestResponse::assertGraphQLDebugMessage()` to test internal errors
+- Add method `TestResponse::assertGraphQLDebugMessage()` to test internal errors https://github.com/nuwave/lighthouse/pull/2117
 
 ## v5.45.4
 

--- a/_ide_helper.php
+++ b/_ide_helper.php
@@ -80,6 +80,20 @@ namespace Illuminate\Testing {
         }
 
         /**
+         * Assert the response contains an error with the given debug message.
+         *
+         * Requires the config `lighthouse.debug` to include the option \GraphQL\Error\DebugFlag::INCLUDE_DEBUG_MESSAGE.
+         *
+         * @param  string  $message  the expected debug message
+         *
+         * @return $this
+         */
+        public function assertGraphQLDebugMessage(string $message): self
+        {
+            return $this;
+        }
+
+        /**
          * Assert the response contains no errors.
          *
          * @return $this

--- a/src/Testing/TestResponseMixin.php
+++ b/src/Testing/TestResponseMixin.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\Assert;
 use Throwable;
 
 /**
+ * TODO add stronger type hints once support for Illuminate\Foundation\Testing\TestResponse is no longer needed.
+ *
  * @mixin \Illuminate\Testing\TestResponse
  */
 class TestResponseMixin
@@ -76,6 +78,22 @@ class TestResponseMixin
                 $message,
                 $messages,
                 "Expected the GraphQL response to contain error message `{$message}`, got: " . \Safe\json_encode($messages)
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertGraphQLDebugMessage(): Closure
+    {
+        return function (string $message) {
+            $messages = $this->json('errors.*.debugMessage');
+
+            Assert::assertIsArray($messages, 'Expected the GraphQL response to contain errors, got none.');
+            Assert::assertContains(
+                $message,
+                $messages,
+                "Expected the GraphQL response to contain debug message `{$message}`, got: " . \Safe\json_encode($messages)
             );
 
             return $this;

--- a/tests/Integration/ErrorTest.php
+++ b/tests/Integration/ErrorTest.php
@@ -5,14 +5,17 @@ namespace Tests\Integration;
 use Exception;
 use GraphQL\Error\DebugFlag;
 use GraphQL\Error\Error;
+use GraphQL\Error\FormattedError;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Tests\TestCase;
 
-class ErrorTest extends TestCase
+final class ErrorTest extends TestCase
 {
     public function testMissingQuery(): void
     {
         $this->postGraphQL([])
+            ->assertStatus(200)
             ->assertGraphQLErrorMessage('GraphQL Request must include at least one of those two parameters: "query" or "queryId"')
             ->assertGraphQLErrorCategory('request');
     }
@@ -20,6 +23,7 @@ class ErrorTest extends TestCase
     public function testEmptyQuery(): void
     {
         $this->graphQL(/** @lang GraphQL */ '')
+            ->assertStatus(200)
             ->assertGraphQLErrorMessage('GraphQL Request must include at least one of those two parameters: "query" or "queryId"')
             ->assertGraphQLErrorCategory('request');
     }
@@ -31,6 +35,7 @@ class ErrorTest extends TestCase
             nonExistingField
         }
         ');
+        $result->assertStatus(200);
 
         $this->assertStringContainsString(
             'nonExistingField',
@@ -40,12 +45,12 @@ class ErrorTest extends TestCase
 
     public function testIgnoresInvalidJSONVariables(): void
     {
-        $result = $this->postGraphQL([
-            'query' => /** @lang GraphQL */ '{}',
-            'variables' => '{}',
-        ]);
-
-        $result->assertStatus(200);
+        $this
+            ->postGraphQL([
+                'query' => /** @lang GraphQL */ '{}',
+                'variables' => '{}',
+            ])
+            ->assertStatus(200);
     }
 
     public function testRejectsEmptyRequest(): void
@@ -82,6 +87,7 @@ class ErrorTest extends TestCase
                 foo
             }
             ')
+            ->assertStatus(200)
             ->assertJson([
                 'data' => [
                     'foo' => null,
@@ -91,14 +97,13 @@ class ErrorTest extends TestCase
                         'message' => $message,
                     ],
                 ],
-            ])
-            ->assertStatus(200);
+            ]);
     }
 
     public function testRethrowsInternalExceptions(): void
     {
-        /** @var \Illuminate\Contracts\Config\Repository $config */
         $config = $this->app->make(ConfigRepository::class);
+        assert($config instanceof ConfigRepository);
         $config->set('lighthouse.debug', DebugFlag::INCLUDE_DEBUG_MESSAGE);
 
         $this->mockResolver()
@@ -116,6 +121,7 @@ class ErrorTest extends TestCase
                 foo
             }
             ')
+            ->assertStatus(200)
             ->assertJsonCount(1, 'errors');
 
         $config->set('lighthouse.debug', DebugFlag::RETHROW_INTERNAL_EXCEPTIONS);
@@ -147,7 +153,37 @@ class ErrorTest extends TestCase
                 foo(input: {})
             }
             ')
+            ->assertStatus(200)
             ->assertGraphQLErrorMessage('Field TestInput.string of required type String! was not provided.')
             ->assertGraphQLErrorMessage('Field TestInput.integer of required type Int! was not provided.');
+    }
+
+    public function testAssertGraphQLDebugMessage(): void
+    {
+        $config = $this->app->make(ConfigRepository::class);
+        assert($config instanceof ConfigRepository);
+        $config->set('lighthouse.debug', DebugFlag::INCLUDE_DEBUG_MESSAGE);
+
+        $debugMessage = 'foo';
+
+        $this->mockResolver()
+            ->willThrowException(new ModelNotFoundException($debugMessage));
+
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo: ID @mock
+        }
+        ';
+
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            {
+                foo
+            }
+            ')
+            ->assertStatus(200)
+            /** @see FormattedError::$internalErrorMessage */
+            ->assertGraphQLErrorMessage('Internal server error')
+            ->assertGraphQLDebugMessage($debugMessage);
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Adds a new method to the `TestResponseMixin`, it allows to make assertions on internal error messages.

**Breaking changes**

None.