### PR TITLE
Fix hasMany connect disconnect with non-default primary key

### DIFF
--- a/src/Execution/Arguments/NestedOneToMany.php
+++ b/src/Execution/Arguments/NestedOneToMany.php
@@ -75,7 +75,7 @@ class NestedOneToMany implements ArgResolver
             $children = $relation
                 ->make()
                 ->whereIn(
-                    self::getLocalKeyName($relation),
+                    self::getKeyName($relation),
                     $args->arguments['connect']->value
                 )
                 ->get();
@@ -89,7 +89,7 @@ class NestedOneToMany implements ArgResolver
             $children = $relation
                 ->make()
                 ->whereIn(
-                    self::getLocalKeyName($relation),
+                    self::getKeyName($relation),
                     $args->arguments['disconnect']->value
                 )
                 ->get();
@@ -105,17 +105,17 @@ class NestedOneToMany implements ArgResolver
     /**
      * TODO remove this horrible hack when we no longer support Laravel 5.6.
      */
-    protected static function getLocalKeyName(HasOneOrMany $relation): string
+    protected static function getKeyName(HasOneOrMany $relation): string
     {
-        $getLocalKeyName = Closure::bind(
+        $getKeyName = Closure::bind(
             function () {
                 // @phpstan-ignore-next-line This is a dirty hack
-                return $this->localKey;
+                return $this->make()->getKeyName();
             },
             $relation,
             get_class($relation)
         );
 
-        return $getLocalKeyName();
+        return $getKeyName();
     }
 }

--- a/tests/Integration/Execution/MutationExecutor/HasManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasManyTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Integration\Execution\MutationExecutor;
 
 use Tests\DBTestCase;
+use Tests\Utils\Models\CustomPrimaryKey;
 use Tests\Utils\Models\Role;
 use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
@@ -735,5 +736,113 @@ GRAPHQL
         ]);
 
         $this->assertEquals([2], $role->users()->pluck('users.id')->toArray());
+    }
+
+    public function testConnectModelWithCustomKey(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            user: User @first
+        }
+
+        type CustomPrimaryKey {
+            custom_primary_key_id: ID!
+            users: [User!] @belongsTo
+        }
+
+        type User {
+            id: ID!
+            name: String
+            customPrimaryKeys: [CustomPrimaryKey!] @hasMany
+        }
+
+        type Mutation {
+            createUser(input: CreateUserInput! @spread): User @create
+            updateUser(input: UpdateUserInput! @spread): User @update
+        }
+
+        input CreateUserInput {
+            name: String
+            customPrimaryKeys: UpdateCustomPrimaryKeyHasMany
+        }
+
+        input UpdateUserInput {
+            id: ID!
+            name: String
+            customPrimaryKeys: UpdateCustomPrimaryKeyHasMany
+        }
+    
+        input UpdateCustomPrimaryKeyHasMany {
+            connect: [ID!]
+            disconnect: [ID!]
+        }
+        ';
+
+        factory(CustomPrimaryKey::class, 3)->create();
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation {
+                createUser(input: {
+                    name: "foo"
+                    customPrimaryKeys: {
+                        connect: [1, 2, 3]
+                    }
+                }) {
+                    id
+                    name
+                    customPrimaryKeys {
+                        custom_primary_key_id
+                    }
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'createUser' => [
+                    'id' => '1',
+                    'name' => 'foo',
+                    'customPrimaryKeys' => [
+                        [
+                            'custom_primary_key_id' => '1',
+                        ],
+                        [
+                            'custom_primary_key_id' => '2',
+                        ],
+                        [
+                            'custom_primary_key_id' => '3',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation {
+                updateUser(input: {
+                    id: "1"
+                    name: "bar"
+                    customPrimaryKeys: {
+                        disconnect: [1, 2]
+                    }
+                }) {
+                    id
+                    name
+                    customPrimaryKeys {
+                        custom_primary_key_id
+                    }
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'updateUser' => [
+                    'id' => '1',
+                    'name' => 'bar',
+                    'customPrimaryKeys' => [
+                        [
+                            'custom_primary_key_id' => '3',
+                        ]
+                    ],
+                ],
+            ],
+        ]);
     }
 }

--- a/tests/Integration/Execution/MutationExecutor/HasManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasManyTest.php
@@ -839,7 +839,7 @@ GRAPHQL
                     'customPrimaryKeys' => [
                         [
                             'custom_primary_key_id' => '3',
-                        ]
+                        ],
                     ],
                 ],
             ],

--- a/tests/Utils/Models/CustomPrimaryKey.php
+++ b/tests/Utils/Models/CustomPrimaryKey.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Utils\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Primary key.
+ *
+ * @property int $custom_primary_key_id
+ *
+ * Foreign keys
+ * @property int|null $user_id
+ *
+ * Relations
+ * @property-read \Tests\Utils\Models\User|null $user
+ */
+class CustomPrimaryKey extends Model
+{
+    protected $primaryKey = 'custom_primary_key_id';
+
+    public $timestamps = false;
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/tests/Utils/Models/User.php
+++ b/tests/Utils/Models/User.php
@@ -100,7 +100,7 @@ class User extends Authenticatable
         return $this->belongsTo(Team::class);
     }
 
-    public function customPrimaryKeys(): hasMany
+    public function customPrimaryKeys(): HasMany
     {
         return $this->hasMany(CustomPrimaryKey::class, 'user_id');
     }

--- a/tests/Utils/Models/User.php
+++ b/tests/Utils/Models/User.php
@@ -100,6 +100,11 @@ class User extends Authenticatable
         return $this->belongsTo(Team::class);
     }
 
+    public function customPrimaryKeys(): hasMany
+    {
+        return $this->hasMany(CustomPrimaryKey::class, 'user_id');
+    }
+
     public function scopeCompanyName(Builder $query, array $args): Builder
     {
         return $query->whereHas('company', function (Builder $q) use ($args): void {

--- a/tests/database/factories/CustomPrimaryKeyFactory.php
+++ b/tests/database/factories/CustomPrimaryKeyFactory.php
@@ -1,0 +1,9 @@
+<?php
+
+use Faker\Generator as Faker;
+use Tests\Utils\Models\CustomPrimaryKey;
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+$factory->define(CustomPrimaryKey::class, function (Faker $faker): array {
+    return [];
+});

--- a/tests/database/migrations/2022_04_14_000000_create_testbench_custom_primary_keys_table.php
+++ b/tests/database/migrations/2022_04_14_000000_create_testbench_custom_primary_keys_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTestbenchCustomPrimaryKeysTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('custom_primary_keys', function (Blueprint $table): void {
+            $table->increments('custom_primary_key_id');
+
+            $table->unsignedInteger('user_id')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::drop('custom_primary_keys');
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

Resolves #1833 

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

Solution from #1833, `Changing self::getLocalKeyName($relation) to $relation->make()->getKeyName()`

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
