### PR TITLE
Fix assert for builder argument on @all & @paginate directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Allow returning a Eloquent Relation from custom builder on `@all` and `@paginate` directive https://github.com/nuwave/lighthouse/pull/2120
+
 ## v5.46.2
 
 ### Fixed

--- a/src/Execution/Arguments/ArgumentSet.php
+++ b/src/Execution/Arguments/ArgumentSet.php
@@ -68,14 +68,14 @@ class ArgumentSet
     /**
      * Apply ArgBuilderDirectives and scopes to the builder.
      *
-     * @template TBuilder of \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder
+     * @template TBuilder of \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Relations\Relation
      *
-     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $builder
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Relations\Relation  $builder
      * @phpstan-param  TBuilder  $builder
      *
      * @param  array<string>  $scopes
      *
-     * @return \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Laravel\Scout\Builder
+     * @return \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Relations\Relation|\Laravel\Scout\Builder
      * @phpstan-return TBuilder|\Laravel\Scout\Builder
      */
     public function enhanceBuilder(object $builder, array $scopes, Closure $directiveFilter = null): object

--- a/src/Pagination/PaginateDirective.php
+++ b/src/Pagination/PaginateDirective.php
@@ -7,7 +7,7 @@ use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
-use Illuminate\Database\Eloquent\Relations\Relation as EloquentRelation;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
@@ -112,7 +112,7 @@ GRAPHQL;
 
                 $query = $builderResolver($root, $args, $context, $resolveInfo);
                 assert(
-                    $query instanceof QueryBuilder || $query instanceof EloquentBuilder || $query instanceof EloquentRelation,
+                    $query instanceof QueryBuilder || $query instanceof EloquentBuilder || $query instanceof Relation,
                     "The method referenced by the builder argument of the @{$this->name()} directive on {$this->nodeName()} must return a Builder or Relation."
                 );
             } else {

--- a/src/Pagination/PaginateDirective.php
+++ b/src/Pagination/PaginateDirective.php
@@ -7,6 +7,7 @@ use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Relations\Relation as EloquentRelation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
@@ -111,8 +112,8 @@ GRAPHQL;
 
                 $query = $builderResolver($root, $args, $context, $resolveInfo);
                 assert(
-                    $query instanceof QueryBuilder || $query instanceof EloquentBuilder,
-                    "The method referenced by the builder argument of the @{$this->name()} directive on {$this->nodeName()} must return a Builder."
+                    $query instanceof QueryBuilder || $query instanceof EloquentBuilder || $query instanceof EloquentRelation,
+                    "The method referenced by the builder argument of the @{$this->name()} directive on {$this->nodeName()} must return a Builder or Relation."
                 );
             } else {
                 $query = $this->getModelClass()::query();

--- a/src/Schema/Directives/AllDirective.php
+++ b/src/Schema/Directives/AllDirective.php
@@ -4,7 +4,7 @@ namespace Nuwave\Lighthouse\Schema\Directives;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
-use Illuminate\Database\Eloquent\Relations\Relation as EloquentRelation;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
@@ -48,7 +48,7 @@ GRAPHQL;
 
                 $query = $builderResolver($root, $args, $context, $resolveInfo);
                 assert(
-                    $query instanceof QueryBuilder || $query instanceof EloquentBuilder || $query instanceof EloquentRelation,
+                    $query instanceof QueryBuilder || $query instanceof EloquentBuilder || $query instanceof Relation,
                     "The method referenced by the builder argument of the @{$this->name()} directive on {$this->nodeName()} must return a Builder or Relation."
                 );
             } else {

--- a/src/Schema/Directives/AllDirective.php
+++ b/src/Schema/Directives/AllDirective.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Schema\Directives;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Relations\Relation as EloquentRelation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
@@ -47,8 +48,8 @@ GRAPHQL;
 
                 $query = $builderResolver($root, $args, $context, $resolveInfo);
                 assert(
-                    $query instanceof QueryBuilder || $query instanceof EloquentBuilder,
-                    "The method referenced by the builder argument of the @{$this->name()} directive on {$this->nodeName()} must return a Builder."
+                    $query instanceof QueryBuilder || $query instanceof EloquentBuilder || $query instanceof EloquentRelation,
+                    "The method referenced by the builder argument of the @{$this->name()} directive on {$this->nodeName()} must return a Builder or Relation."
                 );
             } else {
                 $query = $this->getModelClass()::query();

--- a/src/Scout/ScoutEnhancer.php
+++ b/src/Scout/ScoutEnhancer.php
@@ -18,7 +18,7 @@ class ScoutEnhancer
     protected $argumentSet;
 
     /**
-     * @var \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder
+     * @var \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Relations\Relation
      */
     protected $builder;
 
@@ -44,7 +44,7 @@ class ScoutEnhancer
     protected $argumentsWithScoutBuilderDirectives = [];
 
     /**
-     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $builder
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Relations\Relation  $builder
      */
     public function __construct(ArgumentSet $argumentSet, object $builder)
     {

--- a/tests/Integration/Pagination/PaginateDirectiveDBTest.php
+++ b/tests/Integration/Pagination/PaginateDirectiveDBTest.php
@@ -91,7 +91,11 @@ final class PaginateDirectiveDBTest extends DBTestCase
 
     public function testSpecifyCustomBuilderForRelation(): void
     {
-        $post = factory(Post::class)->create();
+        $user = factory(User::class)->create();
+        assert($user instanceof User);
+
+        $posts = factory(Post::class, 2)->create();
+        $user->posts()->saveMany($posts);
 
         $this->schema = /** @lang GraphQL */ '
         type Post {
@@ -104,15 +108,15 @@ final class PaginateDirectiveDBTest extends DBTestCase
         }
 
         type Query {
-            user(id: ID!): User @find
+            user(id: ID! @eq): User @find
         }
         ';
 
         // The custom builder is supposed to change the sort order
         $this->graphQL(/** @lang GraphQL */ "
         {
-            user(id: {$post->user_id}) {
-                posts(first: 1) {
+            user(id: {$user->id}) {
+                posts(first: 10) {
                     data {
                         id
                     }
@@ -124,6 +128,9 @@ final class PaginateDirectiveDBTest extends DBTestCase
                 'user' => [
                     'posts' => [
                         'data' => [
+                            [
+                                'id' => '2',
+                            ],
                             [
                                 'id' => '1',
                             ],

--- a/tests/Integration/Schema/Directives/AllDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/AllDirectiveTest.php
@@ -203,7 +203,11 @@ class AllDirectiveTest extends DBTestCase
 
     public function testSpecifyCustomBuilderForRelation(): void
     {
-        $post = factory(Post::class)->create();
+        $user = factory(User::class)->create();
+        assert($user instanceof User);
+
+        $posts = factory(Post::class, 2)->make();
+        $user->posts()->saveMany($posts);
 
         $this->schema = /** @lang GraphQL */ '
         type Post {
@@ -216,14 +220,14 @@ class AllDirectiveTest extends DBTestCase
         }
 
         type Query {
-            user(id: ID!): User @find
+            user(id: ID! @eq): User @find
         }
         ';
 
         // The custom builder is supposed to change the sort order
         $this->graphQL(/** @lang GraphQL */ "
         {
-            user(id: {$post->user_id}) {
+            user(id: {$user->id}) {
                 posts {
                     id
                 }
@@ -233,6 +237,9 @@ class AllDirectiveTest extends DBTestCase
             'data' => [
                 'user' => [
                     'posts' => [
+                        [
+                            'id' => '2',
+                        ],
                         [
                             'id' => '1',
                         ],

--- a/tests/Unit/Schema/Source/SchemaStitcherTest.php
+++ b/tests/Unit/Schema/Source/SchemaStitcherTest.php
@@ -17,7 +17,7 @@ class SchemaStitcherTest extends TestCase
         parent::setUp();
 
         // @phpstan-ignore-next-line using the Safe variant crashes PHPStan
-        exec('mkdir --parents ' . self::SCHEMA_PATH);
+        exec('mkdir -p ' . self::SCHEMA_PATH);
     }
 
     protected function tearDown(): void

--- a/tests/Unit/Schema/Source/SchemaStitcherTest.php
+++ b/tests/Unit/Schema/Source/SchemaStitcherTest.php
@@ -16,7 +16,7 @@ class SchemaStitcherTest extends TestCase
     {
         parent::setUp();
 
-        // @phpstan-ignore-next-line using the Safe variant crashes PHPStan
+        // @phpstan-ignore-next-line using the Safe variant crashes PHPStan (uses the short `-p` because `--parent` is not available on macOS)
         exec('mkdir -p ' . self::SCHEMA_PATH);
     }
 


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Recently an assert was added to `@all` & `@paginate` that was incomplete, it was missing the `Relation` type which should also be allowed.

Unrelated, this also fixes the use of `mkdir --parents` that doesn't work under macOS, changed to `mkdir -p` to work on both macOS and Linux OSs.

**Breaking changes**

None.