### PR TITLE
`RelationDirective`/`batchload_relations` will consider `null` and default connection name the same connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- `RelationDirective`/`batchload_relations` will consider `null` and default connection name as the same connection.
+
 ## v5.47.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- `RelationDirective`/`batchload_relations` will consider `null` and default connection name as the same connection.
+- `RelationDirective`/`batchload_relations` will consider `null` and default connection name the same connection https://github.com/nuwave/lighthouse/pull/2125
+
 
 ## v5.47.0
 

--- a/src/Schema/Directives/RelationDirective.php
+++ b/src/Schema/Directives/RelationDirective.php
@@ -34,6 +34,7 @@ abstract class RelationDirective extends BaseDirective implements FieldResolver
     protected $lighthouseConfig;
 
     /**
+     * TODO use Illuminate\Database\ConnectionResolverInterface when we drop support for Laravel < 6
      * @var \Illuminate\Database\DatabaseManager
      */
     protected $database;

--- a/src/Schema/Directives/RelationDirective.php
+++ b/src/Schema/Directives/RelationDirective.php
@@ -192,10 +192,8 @@ abstract class RelationDirective extends BaseDirective implements FieldResolver
     protected function isSameConnection(Relation $relation): bool
     {
         $default = $this->database->getDefaultConnection();
-        $parent = $relation->getParent()->getConnectionName();
-        $parent = $parent !== $default ? $parent : null;
-        $related = $relation->getRelated()->getConnectionName();
-        $related = $related !== $default ? $related : null;
+        $parent = $relation->getParent()->getConnectionName() ?? $default;
+        $related = $relation->getRelated()->getConnectionName() ?? $default;
 
         return $parent === $related;
     }

--- a/src/Schema/Directives/RelationDirective.php
+++ b/src/Schema/Directives/RelationDirective.php
@@ -192,6 +192,7 @@ abstract class RelationDirective extends BaseDirective implements FieldResolver
     protected function isSameConnection(Relation $relation): bool
     {
         $default = $this->database->getDefaultConnection();
+
         $parent = $relation->getParent()->getConnectionName() ?? $default;
         $related = $relation->getRelated()->getConnectionName() ?? $default;
 

--- a/src/Schema/Directives/RelationDirective.php
+++ b/src/Schema/Directives/RelationDirective.php
@@ -6,7 +6,7 @@ use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
-use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -34,11 +34,11 @@ abstract class RelationDirective extends BaseDirective implements FieldResolver
     protected $lighthouseConfig;
 
     /**
-     * @var \Illuminate\Database\ConnectionResolverInterface
+     * @var \Illuminate\Database\DatabaseManager
      */
     protected $database;
 
-    public function __construct(ConfigRepository $configRepository, ConnectionResolverInterface $database)
+    public function __construct(ConfigRepository $configRepository, DatabaseManager $database)
     {
         $this->lighthouseConfig = $configRepository->get('lighthouse');
         $this->database = $database;

--- a/src/Schema/Directives/RelationDirective.php
+++ b/src/Schema/Directives/RelationDirective.php
@@ -6,7 +6,7 @@ use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
-use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -34,11 +34,11 @@ abstract class RelationDirective extends BaseDirective implements FieldResolver
     protected $lighthouseConfig;
 
     /**
-     * @var DatabaseManager
+     * @var \Illuminate\Database\ConnectionResolverInterface
      */
     protected $database;
 
-    public function __construct(ConfigRepository $configRepository, DatabaseManager $database)
+    public function __construct(ConfigRepository $configRepository, ConnectionResolverInterface $database)
     {
         $this->lighthouseConfig = $configRepository->get('lighthouse');
         $this->database = $database;

--- a/tests/Integration/Execution/DataLoader/RelationBatchLoaderTest.php
+++ b/tests/Integration/Execution/DataLoader/RelationBatchLoaderTest.php
@@ -9,6 +9,7 @@ use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 use Tests\DBTestCase;
 use Tests\Utils\BatchLoaders\UserLoader;
 use Tests\Utils\Models\AlternateConnection;
+use Tests\Utils\Models\NullConnection;
 use Tests\Utils\Models\Post;
 use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
@@ -170,6 +171,56 @@ final class RelationBatchLoaderTest extends DBTestCase
             ->assertJsonCount($alternateConnectionsPerUser, 'data.users.1.alternateConnections');
 
         $this->assertSame(3, $queryCount);
+    }
+
+    public function testDoesNotBatchloadRelationsWithNullDatabaseConnections(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type NullConnection {
+            users: [User!]! @hasMany
+        }
+        
+        type User {
+            id: ID
+        }
+
+        type Query {
+            nullConnections: [NullConnection!]! @all
+        }
+        ';
+
+        $nullConnectionsCount = 2;
+        $usersPerNullConnection = 3;
+        factory(NullConnection::class, $nullConnectionsCount)
+            ->create()
+            ->each(function (NullConnection $nullConnection) use ($usersPerNullConnection): void {
+                $nullConnection->users()->saveMany(
+                    factory(User::class, $usersPerNullConnection)->make()
+                );
+            });
+
+        config(['lighthouse.batchload_relations' => true]);
+
+        $queryCount = 0;
+        DB::listen(function () use (&$queryCount): void {
+            ++$queryCount;
+        });
+
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            {
+                nullConnections {
+                    users {
+                        id
+                    }
+                }
+            }
+            ')
+            ->assertJsonCount($nullConnectionsCount, 'data.nullConnections')
+            ->assertJsonCount($usersPerNullConnection, 'data.nullConnections.0.users')
+            ->assertJsonCount($usersPerNullConnection, 'data.nullConnections.1.users');
+
+        $this->assertSame(2, $queryCount);
     }
 
     /**

--- a/tests/Utils/Models/NullConnection.php
+++ b/tests/Utils/Models/NullConnection.php
@@ -5,22 +5,18 @@ namespace Tests\Utils\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
-use Tests\DBTestCase;
-
-use function var_dump;
-
 /**
  * Primary key.
  * @property int $id
  *
  * Relations
- * @property-read \Tests\Utils\Models\User|null $users
+ * @property-read \Illuminate\Database\Eloquent\Collection<\Tests\Utils\Models\User> $users
  */
 final class NullConnection extends Model
 {
     public $timestamps = false;
 
-    public function getConnectionName()
+    public function getConnectionName(): ?string
     {
         return null;
     }

--- a/tests/Utils/Models/NullConnection.php
+++ b/tests/Utils/Models/NullConnection.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Utils\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+use Tests\DBTestCase;
+
+use function var_dump;
+
+/**
+ * Primary key.
+ * @property int $id
+ *
+ * Relations
+ * @property-read \Tests\Utils\Models\User|null $users
+ */
+final class NullConnection extends Model
+{
+    public $timestamps = false;
+
+    public function getConnectionName()
+    {
+        return null;
+    }
+
+    public function users(): HasMany
+    {
+        return $this->hasMany(User::class, 'company_id');
+    }
+}

--- a/tests/database/factories/NullConnectionFactory.php
+++ b/tests/database/factories/NullConnectionFactory.php
@@ -1,0 +1,9 @@
+<?php
+
+use Faker\Generator as Faker;
+use Tests\Utils\Models\NullConnection;
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+$factory->define(NullConnection::class, function (Faker $faker): array {
+    return [];
+});

--- a/tests/database/migrations/2022_04_21_000000_create_testbench_null_connections_table.php
+++ b/tests/database/migrations/2022_04_21_000000_create_testbench_null_connections_table.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+final class CreateTestbenchNullConnectionsTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('null_connections', function (Blueprint $table): void {
+            $table->increments('id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::drop('null_connections');
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

In some cases `Model::getConnectionName()` may return `mysql` (= default connection name), but in other it will return `null` for default connection (not extactly sure when, one of the case `HasOneThrough` + Laravel v9.9.0). Current version will not use batchloading, in this case (because `null !== 'mysql'`). 


**Breaking changes**

Maybe, `RelationDirective::__construct` wants new parameter.
