### PR TITLE
Omit non-nullable arguments in `@convertEmptyStringsToNull`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.48.1
+
+### Fixed
+
+- Omit non-nullable arguments in `@convertEmptyStringsToNull` https://github.com/nuwave/lighthouse/pull/2130
+
 ## v5.48.0
 
 ### Changed

--- a/src/Execution/Arguments/Argument.php
+++ b/src/Execution/Arguments/Argument.php
@@ -49,6 +49,23 @@ class Argument
         return static::toPlainRecursive($this->value);
     }
 
+    public function namedType(): ?NamedType
+    {
+        return static::namedTypeRecursive($this->type);
+    }
+
+    /**
+     * @param \Nuwave\Lighthouse\Execution\Arguments\ListType|\Nuwave\Lighthouse\Execution\Arguments\NamedType|null $type
+     */
+    protected static function namedTypeRecursive($type): ?NamedType
+    {
+        if ($type instanceof ListType) {
+            return static::namedTypeRecursive($type->type);
+        }
+
+        return $type;
+    }
+
     /**
      * Convert the given value to plain PHP values recursively.
      *

--- a/src/Schema/Directives/ConvertEmptyStringsToNullDirective.php
+++ b/src/Schema/Directives/ConvertEmptyStringsToNullDirective.php
@@ -4,7 +4,9 @@ namespace Nuwave\Lighthouse\Schema\Directives;
 
 use Closure;
 use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\ScalarType;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
+use Nuwave\Lighthouse\Execution\Arguments\NamedType;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\ArgDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgSanitizerDirective;
@@ -57,6 +59,11 @@ GRAPHQL;
     protected function transformArgumentSet(ArgumentSet $argumentSet): ArgumentSet
     {
         foreach ($argumentSet->arguments as $argument) {
+            $namedType = $argument->namedType();
+            if ($namedType !== null && $namedType->name === ScalarType::STRING) {
+                continue;
+            }
+
             $argument->value = $this->sanitize($argument->value);
         }
 

--- a/src/Schema/Directives/ConvertEmptyStringsToNullDirective.php
+++ b/src/Schema/Directives/ConvertEmptyStringsToNullDirective.php
@@ -6,7 +6,6 @@ use Closure;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\ScalarType;
 use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
-use Nuwave\Lighthouse\Execution\Arguments\NamedType;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\ArgDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgSanitizerDirective;

--- a/src/Schema/Directives/ConvertEmptyStringsToNullDirective.php
+++ b/src/Schema/Directives/ConvertEmptyStringsToNullDirective.php
@@ -59,7 +59,7 @@ GRAPHQL;
     {
         foreach ($argumentSet->arguments as $argument) {
             $namedType = $argument->namedType();
-            if ($namedType !== null && $namedType->name === ScalarType::STRING) {
+            if (null !== $namedType && ScalarType::STRING === $namedType->name) {
                 continue;
             }
 

--- a/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
@@ -29,6 +29,29 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
         ]);
     }
 
+    public function testMatrix(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo(bar: [[[String]]] @convertEmptyStringsToNull): [[[String]]] @mock
+        }
+        ';
+
+        $this->mockResolver(function ($_, array $args): ?array {
+            return $args['bar'];
+        });
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            foo(bar: [[["", null, "baz"]]])
+        }
+        ')->assertJson([
+            'data' => [
+                'foo' => [[[null, null, "baz"]]],
+            ],
+        ]);
+    }
+
     public function testFieldInputs(): void
     {
         $this->mockResolver(static function ($root, array $args): array {

--- a/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
@@ -108,7 +108,6 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
             ) {
                 foo
                 bar
-                baz
             }
         }
         ')->assertJson([

--- a/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
@@ -47,7 +47,7 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
         }
         ')->assertJson([
             'data' => [
-                'foo' => [[[null, null, "baz"]]],
+                'foo' => [[[null, null, 'baz']]],
             ],
         ]);
     }

--- a/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
@@ -113,12 +113,14 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
         type Foo {
             foo: String!
             bar: [String!]!
+            baz: [[[String!]]]!
         }
 
         type Query {
             foo(
                 foo: String!
                 bar: [String!]
+                baz: [[[String!]]]
             ): Foo! @convertEmptyStringsToNull @mock
         }
         ';
@@ -128,9 +130,11 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
             foo(
                 foo: ""
                 bar: [""]
+                baz: [[[""]]]
             ) {
                 foo
                 bar
+                baz
             }
         }
         ')->assertJson([
@@ -138,6 +142,7 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
                 'foo' => [
                     'foo' => '',
                     'bar' => [''],
+                    'baz' => [[['']]],
                 ],
             ],
         ]);


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

https://github.com/nuwave/lighthouse/issues/1459#issuecomment-1106598749

@LastDragon-ru

**Changes**

Omit non-nullable arguments in `@convertEmptyStringsToNull`.

**Breaking changes**

Behavioural fix.