### PR TITLE
Allow ScoutBuilder in @paginate directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Restored `Laravel\Scout\Builder` as a valid option for the `@paginate` directive https://github.com/nuwave/lighthouse/pull/2139
+
 ## v5.48.2
 
 ### Fixed

--- a/src/Pagination/PaginateDirective.php
+++ b/src/Pagination/PaginateDirective.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Laravel\Scout\Builder as ScoutBuilder;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
@@ -112,7 +113,7 @@ GRAPHQL;
 
                 $query = $builderResolver($root, $args, $context, $resolveInfo);
                 assert(
-                    $query instanceof QueryBuilder || $query instanceof EloquentBuilder || $query instanceof Relation,
+                    $query instanceof QueryBuilder || $query instanceof EloquentBuilder || $query instanceof ScoutBuilder || $query instanceof Relation,
                     "The method referenced by the builder argument of the @{$this->name()} directive on {$this->nodeName()} must return a Builder or Relation."
                 );
             } else {


### PR DESCRIPTION
An issue was not raised, as it seemed simpler to fix the issue.

Introduce in [this commit](https://github.com/nuwave/lighthouse/commit/6a9b5ac971edeef9a5b142d73902a5d4197b04c4), directive types were more strictly asserted. Causing the ScoutBuilder to be an invalid type in some directives.

While this PR only fixes this directive, it is likely there are others.

**Changes**

This PR _very_ simply allows the ScoutBuilder as a valid Builder type in the `@paginate` directive.

**Breaking changes**

None.
