### PR TITLE
Provide additional information about detected usages of deprecated elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Added
 
-- Provide additional information about detected usages of deprecated elements
+- Provide additional information about detected usages of deprecated elements https://github.com/nuwave/lighthouse/pull/2141
 
 ## v5.48.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.49.0
+
+### Added
+
+- Provide additional information about detected usages of deprecated elements
+
 ## v5.48.2
 
 ### Fixed

--- a/docs/5/api-reference/directives.md
+++ b/docs/5/api-reference/directives.md
@@ -736,14 +736,14 @@ type Mutation {
 }
 ```
 
-Non-nullable arguments will *not* be converted when this directive is used on a field,
+Non-nullable arguments will _not_ be converted when this directive is used on a field,
 but will be converted when it is used directly on the argument.
 
 ```graphql
 type Mutation {
   createPost(
-      willBeConvertedBecauseExplicitlyMarked: String! @convertEmptyStringsToNull
-      willNotBeConvertedToMaintainInvariants: String!
+    willBeConvertedBecauseExplicitlyMarked: String! @convertEmptyStringsToNull
+    willNotBeConvertedToMaintainInvariants: String!
   ): Post! @convertEmptyStringsToNull
 }
 ```

--- a/docs/5/digging-deeper/deprecation.md
+++ b/docs/5/digging-deeper/deprecation.md
@@ -20,8 +20,8 @@ use Nuwave\Lighthouse\Deprecation\DetectDeprecatedUsage;
 
 DetectDeprecatedUsage::handle(function (array $deprecations): void {
     app()->terminating(function () use ($deprecations) {
-        foreach ($deprecations as $element => $_) {
-            someMethodToReportDeprecations("Deprecated GraphQL element used: {$element}.");
+        foreach ($deprecations as $element => $deprecatedUsage) {
+            someMethodToReportDeprecations("Deprecated GraphQL element {$element} used {$deprecatedUsage->count} times. {$deprecatedUsage->reason}");
         }
     });
 });

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -736,14 +736,14 @@ type Mutation {
 }
 ```
 
-Non-nullable arguments will *not* be converted when this directive is used on a field,
+Non-nullable arguments will _not_ be converted when this directive is used on a field,
 but will be converted when it is used directly on the argument.
 
 ```graphql
 type Mutation {
   createPost(
-      willBeConvertedBecauseExplicitlyMarked: String! @convertEmptyStringsToNull
-      willNotBeConvertedToMaintainInvariants: String!
+    willBeConvertedBecauseExplicitlyMarked: String! @convertEmptyStringsToNull
+    willNotBeConvertedToMaintainInvariants: String!
   ): Post! @convertEmptyStringsToNull
 }
 ```

--- a/docs/master/digging-deeper/deprecation.md
+++ b/docs/master/digging-deeper/deprecation.md
@@ -20,8 +20,8 @@ use Nuwave\Lighthouse\Deprecation\DetectDeprecatedUsage;
 
 DetectDeprecatedUsage::handle(function (array $deprecations): void {
     app()->terminating(function () use ($deprecations) {
-        foreach ($deprecations as $element => $_) {
-            someMethodToReportDeprecations("Deprecated GraphQL element used: {$element}.");
+        foreach ($deprecations as $element => $deprecatedUsage) {
+            someMethodToReportDeprecations("Deprecated GraphQL element {$element} used {$deprecatedUsage->count} times. {$deprecatedUsage->reason}");
         }
     });
 });

--- a/src/Deprecation/DeprecatedUsage.php
+++ b/src/Deprecation/DeprecatedUsage.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Nuwave\Lighthouse\Deprecation;
+
+class DeprecatedUsage
+{
+    /**
+     * How often was the element used?
+     *
+     * @var int
+     */
+    public $count;
+
+    /**
+     * Why is the element deprecated?
+     *
+     * @var string
+     */
+    public $reason;
+
+    public function __construct(string $reason)
+    {
+        $this->reason = $reason;
+    }
+}

--- a/src/Deprecation/DetectDeprecatedUsage.php
+++ b/src/Deprecation/DetectDeprecatedUsage.php
@@ -14,12 +14,12 @@ use GraphQL\Validator\ValidationContext;
 /**
  * @experimental not enabled by default, not guaranteed to be stable
  *
- * @phpstan-type DeprecationHandler callable(array<string, DeprecatedUsage>): void
+ * @phpstan-type DeprecationHandler callable(array<string, \Nuwave\Lighthouse\Deprecation\DeprecatedUsage>): void
  */
 class DetectDeprecatedUsage extends ValidationRule
 {
     /**
-     * @var array<string, true>
+     * @var array<string, \Nuwave\Lighthouse\Deprecation\DeprecatedUsage>
      */
     protected $deprecations = [];
 

--- a/src/Deprecation/DetectDeprecatedUsage.php
+++ b/src/Deprecation/DetectDeprecatedUsage.php
@@ -88,7 +88,7 @@ class DetectDeprecatedUsage extends ValidationRule
         ];
     }
 
-    protected function registerDeprecation(string $element, string $reason)
+    protected function registerDeprecation(string $element, string $reason): void
     {
         if (! isset($this->deprecations[$element])) {
             $this->deprecations[$element] = new DeprecatedUsage($reason);

--- a/src/Deprecation/DetectDeprecatedUsage.php
+++ b/src/Deprecation/DetectDeprecatedUsage.php
@@ -55,7 +55,7 @@ class DetectDeprecatedUsage extends ValidationRule
                 }
 
                 $deprecationReason = $field->deprecationReason;
-                if ($deprecationReason !== null) {
+                if (null !== $deprecationReason) {
                     $parent = $context->getParentType();
                     if (null === $parent) {
                         return;
@@ -76,7 +76,7 @@ class DetectDeprecatedUsage extends ValidationRule
                 }
 
                 $deprecationReason = $value->deprecationReason;
-                if ($deprecationReason !== null) {
+                if (null !== $deprecationReason) {
                     $this->registerDeprecation("{$enum->name}.{$value->name}", $deprecationReason);
                 }
             },
@@ -94,6 +94,6 @@ class DetectDeprecatedUsage extends ValidationRule
             $this->deprecations[$element] = new DeprecatedUsage($reason);
         }
 
-        $this->deprecations[$element]->count++;
+        ++$this->deprecations[$element]->count;
     }
 }

--- a/tests/Unit/Deprecation/DeprecationTest.php
+++ b/tests/Unit/Deprecation/DeprecationTest.php
@@ -49,7 +49,6 @@ final class DeprecationTest extends TestCase
         $this->assertSame(Directive::DEFAULT_DEPRECATION_REASON, $deprecatedUsage->reason);
     }
 
-
     public function testDetectsDeprecatedFieldWithReason(): void
     {
         $this->schema = /** @lang GraphQL */ '


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Replaces `true` with an instance of `DeprecatedUsage` in the array of deprecations given to handlers registered with `DetectDeprecatedUsage::handle()`.

**Breaking changes**

Slightly, but this feature is still experimental.