### PR TITLE
Fix `@convertEmptyStringsToNull` on fields and matrices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Fix `@convertEmptyStringsToNull` on fields and matrices https://github.com/nuwave/lighthouse/pull/2142
+
 ## v5.49.0
 
 ### Added

--- a/src/Schema/Directives/ConvertEmptyStringsToNullDirective.php
+++ b/src/Schema/Directives/ConvertEmptyStringsToNullDirective.php
@@ -59,11 +59,13 @@ GRAPHQL;
     {
         foreach ($argumentSet->arguments as $argument) {
             $namedType = $argument->namedType();
-            if (null !== $namedType && ScalarType::STRING === $namedType->name) {
-                continue;
+            if (
+                null !== $namedType
+                && ScalarType::STRING === $namedType->name
+                && !$namedType->nonNull
+            ) {
+                $argument->value = $this->sanitize($argument->value);
             }
-
-            $argument->value = $this->sanitize($argument->value);
         }
 
         return $argumentSet;

--- a/src/Schema/Directives/ConvertEmptyStringsToNullDirective.php
+++ b/src/Schema/Directives/ConvertEmptyStringsToNullDirective.php
@@ -27,7 +27,7 @@ GRAPHQL;
 
     public function sanitize($argumentValue)
     {
-        return Utils::mapEach(
+        return Utils::mapEachRecursive(
             function ($value) {
                 return $value instanceof ArgumentSet
                     ? $this->transformArgumentSet($value)

--- a/src/Schema/Directives/ConvertEmptyStringsToNullDirective.php
+++ b/src/Schema/Directives/ConvertEmptyStringsToNullDirective.php
@@ -62,7 +62,7 @@ GRAPHQL;
             if (
                 null !== $namedType
                 && ScalarType::STRING === $namedType->name
-                && !$namedType->nonNull
+                && ! $namedType->nonNull
             ) {
                 $argument->value = $this->sanitize($argument->value);
             }

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -100,6 +100,24 @@ class Utils
     }
 
     /**
+     * Map a value or each value in an array.
+     *
+     * @param  mixed|array<mixed>  $valueOrValues
+     *
+     * @return mixed|array<mixed>
+     */
+    public static function mapEachRecursive(Closure $callback, $valueOrValues)
+    {
+        if (is_array($valueOrValues)) {
+            return array_map(function ($value) use ($callback) {
+                return static::mapEachRecursive($callback, $value);
+            }, $valueOrValues);
+        }
+
+        return $callback($valueOrValues);
+    }
+
+    /**
      * Apply a callback to a value or each value in an iterable.
      *
      * @param  mixed|iterable<mixed>  $valueOrValues

--- a/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
@@ -22,7 +22,7 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
         {
             foo(bar: "")
         }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'foo' => null,
             ],
@@ -45,7 +45,7 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
         {
             foo(bar: [[["", null, "baz"]]])
         }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'foo' => [[[null, null, 'baz']]],
             ],
@@ -69,7 +69,8 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
             foo(
                 foo: String
                 bar: [String]!
-                baz: Int!
+                baz: [[[String]]]!
+                qux: Int!
             ): Foo! @convertEmptyStringsToNull @mock
         }
         ';
@@ -79,6 +80,7 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
             foo(
                 foo: ""
                 bar: [""]
+                baz: [[[""]]]
                 baz: 3
             ) {
                 foo
@@ -86,12 +88,13 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
                 baz
             }
         }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'foo' => [
                     'foo' => null,
                     'bar' => [null],
-                    'baz' => 3,
+                    'baz' => [[[null]]],
+                    'qux' => 3,
                 ],
             ],
         ]);
@@ -131,7 +134,7 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
                 baz
             }
         }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'foo' => [
                     'foo' => '',
@@ -158,7 +161,7 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
         {
             foo(bar: "")
         }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'foo' => null,
             ],

--- a/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
@@ -62,7 +62,8 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
         type Foo {
             foo: String
             bar: [String]!
-            baz: Int!
+            baz: [[[String]]]!
+            qux: Int!
         }
 
         type Query {
@@ -81,11 +82,12 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
                 foo: ""
                 bar: [""]
                 baz: [[[""]]]
-                baz: 3
+                qux: 3
             ) {
                 foo
                 bar
                 baz
+                qux
             }
         }
         ')->assertExactJson([


### PR DESCRIPTION
#2130 (comment)

- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Fix `@convertEmptyStringsToNull` on fields and matrices.

**Breaking changes**

None.