### PR TITLE
Include field that produced a `RateLimitException` in its message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Changed
+
+- Include the path of the query that produced a RateLimitException in its message https://github.com/nuwave/lighthouse/pull/2149
+
 ## v5.51.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Changed
 
-- Include the path of the query that produced a RateLimitException in its message https://github.com/nuwave/lighthouse/pull/2149
+- Include field that produced a `RateLimitException` in its message https://github.com/nuwave/lighthouse/pull/2149
 
 ## v5.51.0
 

--- a/src/Exceptions/RateLimitException.php
+++ b/src/Exceptions/RateLimitException.php
@@ -10,12 +10,11 @@ use RuntimeException;
  */
 class RateLimitException extends RuntimeException implements ClientAware
 {
-    public const MESSAGE = 'Rate limit for %s exceeded. Try again later.';
     public const CATEGORY = 'rate-limit';
 
-    public function __construct(string $queryPath)
+    public function __construct(string $fieldName)
     {
-        parent::__construct(self::buildErrorMessage($queryPath));
+        parent::__construct(self::buildErrorMessage($fieldName));
     }
 
     public function isClientSafe(): bool
@@ -28,8 +27,8 @@ class RateLimitException extends RuntimeException implements ClientAware
         return self::CATEGORY;
     }
 
-    public static function buildErrorMessage(string $queryPath): string
+    public static function buildErrorMessage(string $fieldName): string
     {
-        return sprintf(self::MESSAGE, $queryPath);
+        return "Rate limit for $fieldName exceeded. Try again later.";
     }
 }

--- a/src/Exceptions/RateLimitException.php
+++ b/src/Exceptions/RateLimitException.php
@@ -12,9 +12,9 @@ class RateLimitException extends RuntimeException implements ClientAware
 {
     public const CATEGORY = 'rate-limit';
 
-    public function __construct(string $fieldName)
+    public function __construct(string $fieldReference)
     {
-        parent::__construct(self::buildErrorMessage($fieldName));
+        parent::__construct("Rate limit for {$fieldReference} exceeded. Try again later.");
     }
 
     public function isClientSafe(): bool
@@ -25,10 +25,5 @@ class RateLimitException extends RuntimeException implements ClientAware
     public function getCategory(): string
     {
         return self::CATEGORY;
-    }
-
-    public static function buildErrorMessage(string $fieldName): string
-    {
-        return "Rate limit for $fieldName exceeded. Try again later.";
     }
 }

--- a/src/Exceptions/RateLimitException.php
+++ b/src/Exceptions/RateLimitException.php
@@ -10,12 +10,12 @@ use RuntimeException;
  */
 class RateLimitException extends RuntimeException implements ClientAware
 {
-    public const MESSAGE = 'Rate limit exceeded. Please try later.';
+    public const MESSAGE = 'Rate limit for %s exceeded. Try again later.';
     public const CATEGORY = 'rate-limit';
 
-    public function __construct()
+    public function __construct(string $queryPath)
     {
-        parent::__construct(self::MESSAGE);
+        parent::__construct(self::buildErrorMessage($queryPath));
     }
 
     public function isClientSafe(): bool
@@ -26,5 +26,10 @@ class RateLimitException extends RuntimeException implements ClientAware
     public function getCategory(): string
     {
         return self::CATEGORY;
+    }
+
+    public static function buildErrorMessage(string $queryPath): string
+    {
+        return sprintf(self::MESSAGE, $queryPath);
     }
 }

--- a/src/Schema/Directives/ThrottleDirective.php
+++ b/src/Schema/Directives/ThrottleDirective.php
@@ -113,7 +113,8 @@ GRAPHQL;
                 $this->handleLimit(
                     $limit['key'],
                     $limit['maxAttempts'],
-                    $limit['decayMinutes']
+                    $limit['decayMinutes'],
+                    implode('.', $resolveInfo->path)
                 );
             }
 
@@ -143,10 +144,10 @@ GRAPHQL;
     /**
      * Checks throttling limit.
      */
-    protected function handleLimit(string $key, int $maxAttempts, float $decayMinutes): void
+    protected function handleLimit(string $key, int $maxAttempts, float $decayMinutes, string $queryPath): void
     {
         if ($this->limiter->tooManyAttempts($key, $maxAttempts)) {
-            throw new RateLimitException();
+            throw new RateLimitException($queryPath);
         }
 
         $this->limiter->hit($key, (int) ($decayMinutes * 60));

--- a/src/Schema/Directives/ThrottleDirective.php
+++ b/src/Schema/Directives/ThrottleDirective.php
@@ -142,12 +142,12 @@ GRAPHQL;
     }
 
     /**
-     * Checks throttling limit.
+     * Checks throttling limit and records this attempt.
      */
-    protected function handleLimit(string $key, int $maxAttempts, float $decayMinutes, string $fieldName): void
+    protected function handleLimit(string $key, int $maxAttempts, float $decayMinutes, string $fieldReference): void
     {
         if ($this->limiter->tooManyAttempts($key, $maxAttempts)) {
-            throw new RateLimitException($fieldName);
+            throw new RateLimitException($fieldReference);
         }
 
         $this->limiter->hit($key, (int) ($decayMinutes * 60));

--- a/src/Schema/Directives/ThrottleDirective.php
+++ b/src/Schema/Directives/ThrottleDirective.php
@@ -114,7 +114,7 @@ GRAPHQL;
                     $limit['key'],
                     $limit['maxAttempts'],
                     $limit['decayMinutes'],
-                    "$resolveInfo->parentType.$resolveInfo->fieldName"
+                    "{$resolveInfo->parentType}.{$resolveInfo->fieldName}"
                 );
             }
 

--- a/src/Schema/Directives/ThrottleDirective.php
+++ b/src/Schema/Directives/ThrottleDirective.php
@@ -114,7 +114,7 @@ GRAPHQL;
                     $limit['key'],
                     $limit['maxAttempts'],
                     $limit['decayMinutes'],
-                    implode('.', $resolveInfo->path)
+                    "$resolveInfo->parentType.$resolveInfo->fieldName"
                 );
             }
 
@@ -144,10 +144,10 @@ GRAPHQL;
     /**
      * Checks throttling limit.
      */
-    protected function handleLimit(string $key, int $maxAttempts, float $decayMinutes, string $queryPath): void
+    protected function handleLimit(string $key, int $maxAttempts, float $decayMinutes, string $fieldName): void
     {
         if ($this->limiter->tooManyAttempts($key, $maxAttempts)) {
-            throw new RateLimitException($queryPath);
+            throw new RateLimitException($fieldName);
         }
 
         $this->limiter->hit($key, (int) ($decayMinutes * 60));

--- a/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
@@ -97,7 +97,7 @@ final class ThrottleDirectiveTest extends TestCase
         {
             foo
         }
-        ')->assertGraphQLErrorMessage(RateLimitException::buildErrorMessage('foo'));
+        ')->assertGraphQLErrorMessage(RateLimitException::buildErrorMessage('Query.foo'));
     }
 
     public function testInlineLimiter(): void
@@ -122,44 +122,6 @@ final class ThrottleDirectiveTest extends TestCase
         {
             foo
         }
-        ')->assertGraphQLErrorMessage(RateLimitException::buildErrorMessage('foo'));
-    }
-
-    public function testExceptionMessageForNestedField(): void
-    {
-        $this->mockResolver([
-            'bar' => Foo::THE_ANSWER,
-        ]);
-
-        $this->schema = /** @lang GraphQL */ '
-        type Foo {
-            bar: Int @throttle(maxAttempts: 1)
-        }
-        type Query {
-            foo: Foo @mock
-        }
-        ';
-
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            foo {
-                bar
-            }
-        }
-        ')->assertJson([
-            'data' => [
-                'foo' => [
-                    'bar' => Foo::THE_ANSWER,
-                ],
-            ],
-        ]);
-
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            foo {
-                bar
-            }
-        }
-        ')->assertGraphQLErrorMessage(RateLimitException::buildErrorMessage('foo.bar'));
+        ')->assertGraphQLErrorMessage(RateLimitException::buildErrorMessage('Query.foo'));
     }
 }

--- a/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
@@ -97,7 +97,9 @@ final class ThrottleDirectiveTest extends TestCase
         {
             foo
         }
-        ')->assertGraphQLErrorMessage(RateLimitException::buildErrorMessage('Query.foo'));
+        ')->assertGraphQLError(
+            new RateLimitException('Query.foo')
+        );
     }
 
     public function testInlineLimiter(): void
@@ -122,6 +124,8 @@ final class ThrottleDirectiveTest extends TestCase
         {
             foo
         }
-        ')->assertGraphQLErrorMessage(RateLimitException::buildErrorMessage('Query.foo'));
+        ')->assertGraphQLError(
+            new RateLimitException('Query.foo')
+        );
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
Resolves #2145 

**Changes**

As discussed in #2145, this PR adds the query path to the `RateLimitException` message.

**Breaking changes**

Only the already mentioned message of the exception changes. 😉 
