### PR TITLE
Allow pagination types for `@morphToMany`

### DIFF
--- a/src/Schema/Directives/MorphToManyDirective.php
+++ b/src/Schema/Directives/MorphToManyDirective.php
@@ -2,9 +2,9 @@
 
 namespace Nuwave\Lighthouse\Schema\Directives;
 
-use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
+use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
 
-class MorphToManyDirective extends RelationDirective implements FieldResolver
+class MorphToManyDirective extends RelationDirective implements FieldManipulator
 {
     public static function definition(): string
     {
@@ -23,7 +23,51 @@ directive @morphToMany(
   Apply scopes to the underlying query.
   """
   scopes: [String!]
+
+  """
+  Allows to resolve the relation as a paginated list.
+  """
+  type: MorphToManyType
+
+  """
+  Allow clients to query paginated lists without specifying the amount of items.
+  Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  """
+  defaultCount: Int
+
+  """
+  Limit the maximum amount of items that clients can request from paginated lists.
+  Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  """
+  maxCount: Int
+
+  """
+  Specify a custom type that implements the Edge interface
+  to extend edge object.
+  Only applies when using Relay style "connection" pagination.
+  """
+  edgeType: String
 ) on FIELD_DEFINITION
+
+"""
+Options for the `type` argument of `@morphToMany`.
+"""
+enum MorphToManyType {
+    """
+    Offset-based pagination, similar to the Laravel default.
+    """
+    PAGINATOR
+
+    """
+    Offset-based pagination like the Laravel "Simple Pagination", which does not count the total number of records.
+    """
+    SIMPLE
+
+    """
+    Cursor-based pagination, compatible with the Relay specification.
+    """
+    CONNECTION
+}
 GRAPHQL;
     }
 }

--- a/tests/Integration/Schema/Directives/MorphToManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/MorphToManyDirectiveTest.php
@@ -137,7 +137,7 @@ final class MorphToManyDirectiveTest extends DBTestCase
                                 'node' => [
                                     'id' => $tag->id,
                                     'name' => $tag->name,
-                                ]
+                                ],
                             ];
                         })->toArray(),
                     ],


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

Resolves #2153

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
`MorphToManyDirective` now implements `FieldManipulator` instead of `FieldResolver`.
