### PR TITLE
Consider `@rename` when picking the value of a key in `@cache`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Allow `@cacheKey` with `@rename` https://github.com/nuwave/lighthouse/pull/2155
+- Consider `@rename` when picking the value of a key in `@cache` https://github.com/nuwave/lighthouse/pull/2155
 
 ## v5.51.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Allow `@cacheKey` with `@rename` https://github.com/nuwave/lighthouse/pull/2155
+
 ## v5.51.0
 
 ### Added

--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -412,4 +412,13 @@ class ASTHelper
 
         return null;
     }
+
+    public static function getFieldName(FieldDefinitionNode $field): string
+    {
+        $renameDirectiveNode = static::directiveDefinition($field, 'rename');
+
+        return $renameDirectiveNode
+            ? static::directiveArgValue($renameDirectiveNode, 'attribute')
+            : $field->name->value;
+    }
 }

--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -413,7 +413,7 @@ class ASTHelper
         return null;
     }
 
-    public static function getFieldName(FieldDefinitionNode $field): string
+    public static function internalFieldName(FieldDefinitionNode $field): string
     {
         $renameDirectiveNode = static::directiveDefinition($field, 'rename');
 

--- a/src/Schema/Values/TypeValue.php
+++ b/src/Schema/Values/TypeValue.php
@@ -73,9 +73,9 @@ class TypeValue
                 if (ASTHelper::hasDirective($field, CacheKeyDirective::NAME)) {
                     $renameDirectiveNode = ASTHelper::directiveDefinition($field, 'rename');
 
-                    return $renameDirectiveNode
-                        ? $this->cacheKey = ASTHelper::directiveArgValue($renameDirectiveNode, 'attribute')
-                        : $this->cacheKey = $field->name->value;
+                    return $this->cacheKey = $renameDirectiveNode
+                        ? ASTHelper::directiveArgValue($renameDirectiveNode, 'attribute')
+                        : $field->name->value;
                 }
             }
 
@@ -88,7 +88,11 @@ class TypeValue
                     && $fieldType->type instanceof NamedTypeNode
                     && 'ID' === $fieldType->type->name->value
                 ) {
-                    return $this->cacheKey = $field->name->value;
+                    $renameDirectiveNode = ASTHelper::directiveDefinition($field, 'rename');
+
+                    return $this->cacheKey = $renameDirectiveNode
+                        ? ASTHelper::directiveArgValue($renameDirectiveNode, 'attribute')
+                        : $field->name->value;
                 }
             }
 

--- a/src/Schema/Values/TypeValue.php
+++ b/src/Schema/Values/TypeValue.php
@@ -71,11 +71,7 @@ class TypeValue
             // First priority: Look for a field with the @cacheKey directive
             foreach ($fieldDefinitions as $field) {
                 if (ASTHelper::hasDirective($field, CacheKeyDirective::NAME)) {
-                    $renameDirectiveNode = ASTHelper::directiveDefinition($field, 'rename');
-
-                    return $this->cacheKey = $renameDirectiveNode
-                        ? ASTHelper::directiveArgValue($renameDirectiveNode, 'attribute')
-                        : $field->name->value;
+                    return ASTHelper::getFieldName($field);
                 }
             }
 
@@ -88,11 +84,7 @@ class TypeValue
                     && $fieldType->type instanceof NamedTypeNode
                     && 'ID' === $fieldType->type->name->value
                 ) {
-                    $renameDirectiveNode = ASTHelper::directiveDefinition($field, 'rename');
-
-                    return $this->cacheKey = $renameDirectiveNode
-                        ? ASTHelper::directiveArgValue($renameDirectiveNode, 'attribute')
-                        : $field->name->value;
+                    return ASTHelper::getFieldName($field);
                 }
             }
 

--- a/src/Schema/Values/TypeValue.php
+++ b/src/Schema/Values/TypeValue.php
@@ -71,7 +71,7 @@ class TypeValue
             // First priority: Look for a field with the @cacheKey directive
             foreach ($fieldDefinitions as $field) {
                 if (ASTHelper::hasDirective($field, CacheKeyDirective::NAME)) {
-                    return ASTHelper::getFieldName($field);
+                    return $this->cacheKey = ASTHelper::internalFieldName($field);
                 }
             }
 
@@ -84,7 +84,7 @@ class TypeValue
                     && $fieldType->type instanceof NamedTypeNode
                     && 'ID' === $fieldType->type->name->value
                 ) {
-                    return ASTHelper::getFieldName($field);
+                    return $this->cacheKey = ASTHelper::internalFieldName($field);
                 }
             }
 

--- a/src/Schema/Values/TypeValue.php
+++ b/src/Schema/Values/TypeValue.php
@@ -48,6 +48,10 @@ class TypeValue
         return $this->typeDefinition;
     }
 
+    /**
+     * @throws DefinitionException
+     * @throws \Exception
+     */
     public function cacheKey(): ?string
     {
         if (! isset($this->cacheKey)) {
@@ -71,7 +75,11 @@ class TypeValue
             // First priority: Look for a field with the @cacheKey directive
             foreach ($fieldDefinitions as $field) {
                 if (ASTHelper::hasDirective($field, CacheKeyDirective::NAME)) {
-                    return $this->cacheKey = $field->name->value;
+                    $renameDirectiveNode = ASTHelper::directiveDefinition($field, 'rename');
+
+                    return $renameDirectiveNode
+                        ? $this->cacheKey = ASTHelper::directiveArgValue($renameDirectiveNode, 'attribute')
+                        : $this->cacheKey = $field->name->value;
                 }
             }
 

--- a/src/Schema/Values/TypeValue.php
+++ b/src/Schema/Values/TypeValue.php
@@ -48,10 +48,6 @@ class TypeValue
         return $this->typeDefinition;
     }
 
-    /**
-     * @throws DefinitionException
-     * @throws \Exception
-     */
     public function cacheKey(): ?string
     {
         if (! isset($this->cacheKey)) {


### PR DESCRIPTION
- [X] Added or updated tests
- [x] Documented user facing changes
- [X] Updated CHANGELOG.md

Resolves #2152 

**Changes**

If `@rename` exist use the attribute value as the cacheKey.

**Breaking changes**

no.
