### PR TITLE
Allow checking policies against resolved models in `@can`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.57.0
+
+### Added
+
+- Allow checking policies against resolved models in `@can` https://github.com/nuwave/lighthouse/pull/2159
+
 ## v5.56.0
 
 ### Added

--- a/docs/5/api-reference/directives.md
+++ b/docs/5/api-reference/directives.md
@@ -591,17 +591,12 @@ directive @can(
   ability: String!
 
   """
-  Query for specific model instances to check the policy against, using arguments
-  with directives that add constraints to the query builder, such as `@eq`.
+  Check the policy against the model instances returned by the field resolver.
+  Only use this if the field does not mutate data, it is run before checking.
 
-  Mutually exclusive with `find`.
+  Mutually exclusive with `query` and `find`.
   """
-  query: Boolean = false
-
-  """
-  Apply scopes to the underlying query.
-  """
-  scopes: [String!]
+  resolved: Boolean! = false
 
   """
   Specify the class name of the model to use.
@@ -612,7 +607,7 @@ directive @can(
   """
   Pass along the client given input data as arguments to `Gate::check`.
   """
-  injectArgs: Boolean = false
+  injectArgs: Boolean! = false
 
   """
   Statically defined arguments that are passed to `Gate::check`.
@@ -623,12 +618,25 @@ directive @can(
   args: CanArgs
 
   """
+  Query for specific model instances to check the policy against, using arguments
+  with directives that add constraints to the query builder, such as `@eq`.
+
+  Mutually exclusive with `resolved` and `find`.
+  """
+  query: Boolean! = false
+
+  """
+  Apply scopes to the underlying query.
+  """
+  scopes: [String!]
+
+  """
   If your policy checks against specific model instances, specify
   the name of the field argument that contains its primary key(s).
 
   You may pass the string in dot notation to use nested inputs.
 
-  Mutually exclusive with `search`.
+  Mutually exclusive with `resolved` and `query`.
   """
   find: String
 ) repeatable on FIELD_DEFINITION
@@ -649,12 +657,12 @@ type Mutation {
 }
 ```
 
-Query for specific model instances to check the policy against with the `query` argument:
+Check the policy against the resolved model instances with the `resolved` argument:
 
 ```graphql
 type Query {
   fetchUserByEmail(email: String! @eq): User
-    @can(ability: "view", query: true)
+    @can(ability: "view", resolved: true)
     @find
 }
 ```

--- a/docs/5/security/authorization.md
+++ b/docs/5/security/authorization.md
@@ -89,12 +89,17 @@ class PostPolicy
 ### Protect specific model instances
 
 For some models, you may want to restrict access for specific instances of a model.
-Set the `query` argument to `true` to have Lighthouse fetch the queried model(s)
-before checking permissions against them:
+Set the `resolved` argument to `true` to have Lighthouse check permissions against
+the resolved model instances.
+
+> This will actually run the field before checking permissions, do not use in mutations.
 
 ```graphql
 type Query {
-  post(id: ID! @eq): Post @can(ability: "view", query: true) @find @softDeletes
+  post(id: ID! @eq): Post
+    @can(ability: "view", resolved: true)
+    @find
+    @softDeletes
 }
 ```
 
@@ -107,9 +112,6 @@ class PostPolicy
     }
 }
 ```
-
-Arguments with directives such as `@eq` will constrain the query builder.
-Additional constraints for [soft deleting](../eloquent/soft-deleting.md) also apply.
 
 ### Passing additional arguments
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -591,17 +591,12 @@ directive @can(
   ability: String!
 
   """
-  Query for specific model instances to check the policy against, using arguments
-  with directives that add constraints to the query builder, such as `@eq`.
+  Check the policy against the model instances returned by the field resolver.
+  Only use this if the field does not mutate data, it is run before checking.
 
-  Mutually exclusive with `find`.
+  Mutually exclusive with `query` and `find`.
   """
-  query: Boolean = false
-
-  """
-  Apply scopes to the underlying query.
-  """
-  scopes: [String!]
+  resolved: Boolean! = false
 
   """
   Specify the class name of the model to use.
@@ -612,7 +607,7 @@ directive @can(
   """
   Pass along the client given input data as arguments to `Gate::check`.
   """
-  injectArgs: Boolean = false
+  injectArgs: Boolean! = false
 
   """
   Statically defined arguments that are passed to `Gate::check`.
@@ -623,12 +618,25 @@ directive @can(
   args: CanArgs
 
   """
+  Query for specific model instances to check the policy against, using arguments
+  with directives that add constraints to the query builder, such as `@eq`.
+
+  Mutually exclusive with `resolved` and `find`.
+  """
+  query: Boolean! = false
+
+  """
+  Apply scopes to the underlying query.
+  """
+  scopes: [String!]
+
+  """
   If your policy checks against specific model instances, specify
   the name of the field argument that contains its primary key(s).
 
   You may pass the string in dot notation to use nested inputs.
 
-  Mutually exclusive with `search`.
+  Mutually exclusive with `resolved` and `query`.
   """
   find: String
 ) repeatable on FIELD_DEFINITION
@@ -649,12 +657,12 @@ type Mutation {
 }
 ```
 
-Query for specific model instances to check the policy against with the `query` argument:
+Check the policy against the resolved model instances with the `resolved` argument:
 
 ```graphql
 type Query {
   fetchUserByEmail(email: String! @eq): User
-    @can(ability: "view", query: true)
+    @can(ability: "view", resolved: true)
     @find
 }
 ```

--- a/docs/master/security/authorization.md
+++ b/docs/master/security/authorization.md
@@ -89,12 +89,14 @@ class PostPolicy
 ### Protect specific model instances
 
 For some models, you may want to restrict access for specific instances of a model.
-Set the `query` argument to `true` to have Lighthouse fetch the queried model(s)
-before checking permissions against them:
+Set the `resolved` argument to `true` to have Lighthouse check permissions against
+the resolved model instances.
+
+> This will actually run the field before checking permissions, do not use in mutations.
 
 ```graphql
 type Query {
-  post(id: ID! @eq): Post @can(ability: "view", query: true) @find @softDeletes
+  post(id: ID! @eq): Post @can(ability: "view", resolved: true) @find @softDeletes
 }
 ```
 
@@ -107,9 +109,6 @@ class PostPolicy
     }
 }
 ```
-
-Arguments with directives such as `@eq` will constrain the query builder.
-Additional constraints for [soft deleting](../eloquent/soft-deleting.md) also apply.
 
 ### Passing additional arguments
 

--- a/docs/master/security/authorization.md
+++ b/docs/master/security/authorization.md
@@ -96,7 +96,10 @@ the resolved model instances.
 
 ```graphql
 type Query {
-  post(id: ID! @eq): Post @can(ability: "view", resolved: true) @find @softDeletes
+  post(id: ID! @eq): Post
+    @can(ability: "view", resolved: true)
+    @find
+    @softDeletes
 }
 ```
 

--- a/src/Auth/CanDirective.php
+++ b/src/Auth/CanDirective.php
@@ -8,7 +8,6 @@ use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Contracts\Auth\Access\Gate;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -113,7 +113,7 @@ class GraphQL
             new StartOperationOrOperations($operationOrOperations)
         );
 
-        $resultOrResults = LighthouseUtils::applyEach(
+        $resultOrResults = LighthouseUtils::mapEach(
             /**
              * @return array<string, mixed>
              */

--- a/src/Schema/Directives/ArgTraversalDirective.php
+++ b/src/Schema/Directives/ArgTraversalDirective.php
@@ -46,7 +46,7 @@ abstract class ArgTraversalDirective extends BaseDirective implements FieldMiddl
                 Utils::instanceofMatcher(ArgDirective::class)
             );
 
-            $argument->value = Utils::applyEach(
+            $argument->value = Utils::mapEach(
                 function ($value) use ($directivesForArgument) {
                     if ($value instanceof ArgumentSet) {
                         $value = $this->transform($value, $directivesForArgument);

--- a/src/Schema/Directives/ConvertEmptyStringsToNullDirective.php
+++ b/src/Schema/Directives/ConvertEmptyStringsToNullDirective.php
@@ -27,7 +27,7 @@ GRAPHQL;
 
     public function sanitize($argumentValue)
     {
-        return Utils::applyEach(
+        return Utils::mapEach(
             function ($value) {
                 return $value instanceof ArgumentSet
                     ? $this->transformArgumentSet($value)

--- a/src/Schema/Directives/MutationExecutorDirective.php
+++ b/src/Schema/Directives/MutationExecutorDirective.php
@@ -77,7 +77,7 @@ abstract class MutationExecutorDirective extends BaseDirective implements FieldR
     {
         $update = new ResolveNested($this->makeExecutionFunction($parentRelation));
 
-        return Utils::applyEach(
+        return Utils::mapEach(
             static function (ArgumentSet $argumentSet) use ($update, $model) {
                 return $update($model->newInstance(), $argumentSet);
             },

--- a/src/Schema/Directives/NestDirective.php
+++ b/src/Schema/Directives/NestDirective.php
@@ -30,7 +30,7 @@ GRAPHQL;
     {
         $resolveNested = new ResolveNested();
 
-        return Utils::applyEach(
+        return Utils::mapEach(
             static function (ArgumentSet $argumentSet) use ($resolveNested, $root) {
                 return $resolveNested($root, $argumentSet);
             },

--- a/src/Schema/Directives/SpreadDirective.php
+++ b/src/Schema/Directives/SpreadDirective.php
@@ -53,7 +53,7 @@ GRAPHQL;
 
         foreach ($original->arguments as $name => $argument) {
             // Recurse down first, as that resolves the more deeply nested spreads first
-            $argument->value = Utils::applyEach(
+            $argument->value = Utils::mapEach(
                 function ($value) {
                     if ($value instanceof ArgumentSet) {
                         return $this->spread($value);

--- a/src/Schema/Directives/TrimDirective.php
+++ b/src/Schema/Directives/TrimDirective.php
@@ -33,7 +33,7 @@ GRAPHQL;
      */
     public function sanitize($argumentValue)
     {
-        return Utils::applyEach(
+        return Utils::mapEach(
             function ($value) {
                 return $value instanceof ArgumentSet
                     ? $this->transformArgumentSet($value)

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -84,19 +84,36 @@ class Utils
     }
 
     /**
-     * Apply a callback to a value or each value in an array.
+     * Map a value or each value in an array.
      *
      * @param  mixed|array<mixed>  $valueOrValues
      *
      * @return mixed|array<mixed>
      */
-    public static function applyEach(Closure $callback, $valueOrValues)
+    public static function mapEach(Closure $callback, $valueOrValues)
     {
         if (is_array($valueOrValues)) {
             return array_map($callback, $valueOrValues);
         }
 
         return $callback($valueOrValues);
+    }
+
+    /**
+     * Apply a callback to a value or each value in an iterable.
+     *
+     * @param  mixed|iterable<mixed>  $valueOrValues
+     */
+    public static function applyEach(Closure $callback, $valueOrValues): void
+    {
+        if (is_iterable($valueOrValues)) {
+            foreach ($valueOrValues as $value) {
+                $callback($value);
+            }
+            return;
+        }
+
+        $callback($valueOrValues);
     }
 
     /**

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -110,6 +110,7 @@ class Utils
             foreach ($valueOrValues as $value) {
                 $callback($value);
             }
+
             return;
         }
 

--- a/tests/Integration/Auth/CanDirectiveDBTest.php
+++ b/tests/Integration/Auth/CanDirectiveDBTest.php
@@ -115,7 +115,7 @@ final class CanDirectiveDBTest extends DBTestCase
                 name
             }
         }
-        ')->assertGraphQLErrorMessage(CanDirective::missingKeyToFindModel('some.path'));
+        ')->assertGraphQLError(CanDirective::missingKeyToFindModel('some.path'));
     }
 
     public function testFindUsingNestedInputWithDotNotation(): void
@@ -197,7 +197,7 @@ final class CanDirectiveDBTest extends DBTestCase
         }
         ', [
             'foo' => $post->id,
-        ])->assertGraphQLErrorCategory(AuthorizationException::CATEGORY);
+        ])->assertGraphQLError(new AuthorizationException('This action is unauthorized.'));
     }
 
     public function testHandleMultipleModels(): void

--- a/tests/Integration/Auth/CanDirectiveDBTest.php
+++ b/tests/Integration/Auth/CanDirectiveDBTest.php
@@ -197,7 +197,7 @@ final class CanDirectiveDBTest extends DBTestCase
         }
         ', [
             'foo' => $post->id,
-        ])->assertGraphQLError(new AuthorizationException('This action is unauthorized.'));
+        ])->assertGraphQLErrorCategory(AuthorizationException::CATEGORY);
     }
 
     public function testHandleMultipleModels(): void

--- a/tests/Integration/Auth/CanDirectiveDBTest.php
+++ b/tests/Integration/Auth/CanDirectiveDBTest.php
@@ -18,8 +18,8 @@ final class CanDirectiveDBTest extends DBTestCase
         $admin->name = UserPolicy::ADMIN;
         $this->be($admin);
 
-        /** @var \Tests\Utils\Models\User $user */
         $user = factory(User::class)->create();
+        assert($user instanceof User);
 
         $this->schema = /** @lang GraphQL */ '
         type Query {
@@ -119,8 +119,8 @@ final class CanDirectiveDBTest extends DBTestCase
 
     public function testFindUsingNestedInputWithDotNotation(): void
     {
-        /** @var \Tests\Utils\Models\User $user */
         $user = factory(User::class)->create();
+        assert($user instanceof User);
         $this->be($user);
 
         $this->schema = /** @lang GraphQL */ '
@@ -164,11 +164,11 @@ final class CanDirectiveDBTest extends DBTestCase
         $admin->name = UserPolicy::ADMIN;
         $this->be($admin);
 
-        /** @var \Tests\Utils\Models\User $author */
         $author = factory(User::class)->create();
+        assert($author instanceof User);
 
-        /** @var \Tests\Utils\Models\Post $post */
         $post = factory(Post::class)->make();
+        assert($post instanceof Post);
         $post->user()->associate($author);
         $post->save();
 
@@ -205,13 +205,13 @@ final class CanDirectiveDBTest extends DBTestCase
         $admin->name = UserPolicy::ADMIN;
         $this->be($admin);
 
-        /** @var \Tests\Utils\Models\Post $postA */
         $postA = factory(Post::class)->make();
+        assert($postA instanceof Post);
         $postA->user()->associate($admin);
         $postA->save();
 
-        /** @var \Tests\Utils\Models\Post $postB */
         $postB = factory(Post::class)->make();
+        assert($postB instanceof Post);
         $postB->user()->associate($admin);
         $postB->save();
 
@@ -255,8 +255,8 @@ final class CanDirectiveDBTest extends DBTestCase
         $admin->name = UserPolicy::ADMIN;
         $this->be($admin);
 
-        /** @var \Tests\Utils\Models\Task $task */
         $task = factory(Task::class)->create();
+        assert($task instanceof Task);
         $task->delete();
 
         $this->schema = /** @lang GraphQL */ '
@@ -295,8 +295,8 @@ final class CanDirectiveDBTest extends DBTestCase
         $admin->name = UserPolicy::ADMIN;
         $this->be($admin);
 
-        /** @var \Tests\Utils\Models\User $user */
         $user = factory(User::class)->create();
+        assert($user instanceof User);
 
         $this->schema = /** @lang GraphQL */ '
         type Query {
@@ -368,13 +368,13 @@ final class CanDirectiveDBTest extends DBTestCase
         $admin->name = UserPolicy::ADMIN;
         $this->be($admin);
 
-        /** @var \Tests\Utils\Models\Post $postA */
         $postA = factory(Post::class)->make();
+        assert($postA instanceof Post);
         $postA->user()->associate($admin);
         $postA->save();
 
-        /** @var \Tests\Utils\Models\Post $postB */
         $postB = factory(Post::class)->make();
+        assert($postB instanceof Post);
         $postB->user()->associate($admin);
         $postB->save();
 
@@ -418,8 +418,8 @@ final class CanDirectiveDBTest extends DBTestCase
         $admin->name = UserPolicy::ADMIN;
         $this->be($admin);
 
-        /** @var \Tests\Utils\Models\Task $task */
         $task = factory(Task::class)->create();
+        assert($task instanceof Task);
         $task->delete();
 
         $this->schema = /** @lang GraphQL */ '

--- a/tests/Integration/Auth/CanDirectiveDBTest.php
+++ b/tests/Integration/Auth/CanDirectiveDBTest.php
@@ -494,7 +494,6 @@ final class CanDirectiveDBTest extends DBTestCase
         ]);
     }
 
-
     public function testChecksAgainstRelation(): void
     {
         $user = new User();

--- a/tests/Integration/Auth/CanDirectiveDBTest.php
+++ b/tests/Integration/Auth/CanDirectiveDBTest.php
@@ -5,6 +5,7 @@ namespace Tests\Integration\Auth;
 use Nuwave\Lighthouse\Auth\CanDirective;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Tests\DBTestCase;
+use Tests\Utils\Models\Company;
 use Tests\Utils\Models\Post;
 use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
@@ -447,6 +448,98 @@ final class CanDirectiveDBTest extends DBTestCase
             'data' => [
                 'task' => [
                     'name' => $task->name,
+                ],
+            ],
+        ]);
+    }
+
+    public function testChecksAgainstResolvedModelsFromPaginator(): void
+    {
+        $user = new User();
+        $user->name = UserPolicy::ADMIN;
+        $this->be($user);
+
+        $user = factory(User::class)->create();
+
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            users: [User!]!
+                @can(ability: "view", resolved: true)
+                @paginate
+        }
+
+        type User {
+            name: String
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            users(first: 2) {
+                data {
+                    name
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'users' => [
+                    'data' => [
+                        [
+                            'name' => $user->name,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+
+    public function testChecksAgainstRelation(): void
+    {
+        $user = new User();
+        $user->name = UserPolicy::ADMIN;
+        $this->be($user);
+
+        $company = factory(Company::class)->create();
+
+        $user = factory(User::class)->make();
+        assert($user instanceof User);
+        $user->company()->associate($company);
+        $user->save();
+
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            company: Company @first
+        }
+
+        type Company {
+            users: [User!]!
+                @can(ability: "view", resolved: true)
+                @hasMany
+        }
+
+        type User {
+            name: String
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            company {
+                users {
+                    name
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'company' => [
+                    'users' => [
+                        [
+                            'name' => $user->name,
+                        ],
+                    ],
                 ],
             ],
         ]);

--- a/tests/Unit/Tests/Unit/Auth/CanDirectiveTest.php
+++ b/tests/Unit/Tests/Unit/Auth/CanDirectiveTest.php
@@ -367,7 +367,7 @@ final class CanDirectiveTest extends TestCase
         }
 
 GRAPHQL
-);
+        );
     }
 
     /**


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves https://github.com/nuwave/lighthouse/issues/2158

Resolves https://github.com/nuwave/lighthouse/issues/1989

**Changes**

Adds the option `resolved` to `@can` as an alternative to `find` and `query`.
Instead of fetching models to check against before calling the resolver, it will instead use the result of
resolving the field and check against that.

**Breaking changes**

None.