### PR TITLE
Optimize paginator query when no page info is requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Changed
+
+- `@paginate` directive will use a simple pagination strategy when the paginator info is not requested https://github.com/nuwave/lighthouse/pull/2170
+
 ## v5.54.0
 
 ### Changed

--- a/src/Pagination/ConnectionField.php
+++ b/src/Pagination/ConnectionField.php
@@ -41,7 +41,6 @@ class ConnectionField
     /**
      * Resolve edges for connection.
      *
-     * @param  \Illuminate\Pagination\AbstractPaginator  $paginator
      * @param  array<string, mixed>  $args
      */
     public function edgeResolver(AbstractPaginator $paginator, array $args, GraphQLContext $context, ResolveInfo $resolveInfo): Collection

--- a/src/Pagination/ConnectionField.php
+++ b/src/Pagination/ConnectionField.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\Pagination;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
@@ -40,10 +41,10 @@ class ConnectionField
     /**
      * Resolve edges for connection.
      *
-     * @param  \Illuminate\Pagination\LengthAwarePaginator<mixed>  $paginator
+     * @param  \Illuminate\Pagination\AbstractPaginator  $paginator
      * @param  array<string, mixed>  $args
      */
-    public function edgeResolver(LengthAwarePaginator $paginator, array $args, GraphQLContext $context, ResolveInfo $resolveInfo): Collection
+    public function edgeResolver(AbstractPaginator $paginator, array $args, GraphQLContext $context, ResolveInfo $resolveInfo): Collection
     {
         // We know those types because we manipulated them during PaginationManipulator
         /** @var \GraphQL\Type\Definition\NonNull $nonNullList */

--- a/src/Pagination/PaginateDirective.php
+++ b/src/Pagination/PaginateDirective.php
@@ -143,12 +143,8 @@ GRAPHQL;
             return $type;
         }
 
-        $pageInfoFieldName = $type->isPaginator()
-            ? 'paginatorInfo'
-            : 'pageInfo';
-
         // If the page info is not requested we can optimize by using a simple paginator that doesn't query total counts
-        if (! isset($resolveInfo->getFieldSelection()[$pageInfoFieldName])) {
+        if (! isset($resolveInfo->getFieldSelection()[$type->getInfoFieldName()])) {
             return new PaginationType(PaginationType::SIMPLE);
         }
 

--- a/src/Pagination/PaginationArgs.php
+++ b/src/Pagination/PaginationArgs.php
@@ -100,7 +100,7 @@ class PaginationArgs
             : 'paginate';
 
         if ($builder instanceof ScoutBuilder) {
-            // Fallback to `paginate` when `simplePaginate` is not available, it was introduced in v8.6.0
+            // TODO remove fallback when requiring Laravel 8.6.0+
             if ($this->type->isSimple() && ! method_exists($builder, 'simplePaginate')) {
                 $methodName = 'paginate';
             }

--- a/src/Pagination/PaginationArgs.php
+++ b/src/Pagination/PaginationArgs.php
@@ -100,6 +100,11 @@ class PaginationArgs
             : 'paginate';
 
         if ($builder instanceof ScoutBuilder) {
+            // Fallback to `paginate` when `simplePaginate` is not available, it was introduced in v8.6.0
+            if ($this->type->isSimple() && ! method_exists($builder, 'simplePaginate')) {
+                $methodName = 'paginate';
+            }
+
             return $builder->{$methodName}($this->first, 'page', $this->page);
         }
 

--- a/src/Pagination/PaginationManipulator.php
+++ b/src/Pagination/PaginationManipulator.php
@@ -97,7 +97,7 @@ class PaginationManipulator
             "A paginated list of {$fieldTypeName} edges."
             type {$connectionTypeName} {
                 "Pagination information about the list of edges."
-                {$paginationType->getInfoFieldName()}: PageInfo! @field(resolver: "{$connectionFieldName}@pageInfoResolver")
+                {$paginationType->infoFieldName()}: PageInfo! @field(resolver: "{$connectionFieldName}@pageInfoResolver")
 
                 "A list of {$fieldTypeName} edges."
                 edges: [{$connectionEdgeName}!]! @field(resolver: "{$connectionFieldName}@edgeResolver")
@@ -175,7 +175,7 @@ GRAPHQL
             "A paginated list of {$fieldTypeName} items."
             type {$paginatorTypeName} {
                 "Pagination information about the list of items."
-                {$paginationType->getInfoFieldName()}: PaginatorInfo! @field(resolver: "{$paginatorFieldClassName}@paginatorInfoResolver")
+                {$paginationType->infoFieldName()}: PaginatorInfo! @field(resolver: "{$paginatorFieldClassName}@paginatorInfoResolver")
 
                 "A list of {$fieldTypeName} items."
                 data: [{$fieldTypeName}!]! @field(resolver: "{$paginatorFieldClassName}@dataResolver")
@@ -212,7 +212,7 @@ GRAPHQL
             "A paginated list of {$fieldTypeName} items."
             type {$paginatorTypeName} {
                 "Pagination information about the list of items."
-                {$paginationType->getInfoFieldName()}: SimplePaginatorInfo! @field(resolver: "{$paginatorFieldClassName}@paginatorInfoResolver")
+                {$paginationType->infoFieldName()}: SimplePaginatorInfo! @field(resolver: "{$paginatorFieldClassName}@paginatorInfoResolver")
 
                 "A list of {$fieldTypeName} items."
                 data: [{$fieldTypeName}!]! @field(resolver: "{$paginatorFieldClassName}@dataResolver")

--- a/src/Pagination/PaginationManipulator.php
+++ b/src/Pagination/PaginationManipulator.php
@@ -65,17 +65,18 @@ class PaginationManipulator
         ?ObjectTypeDefinitionNode $edgeType = null
     ): void {
         if ($paginationType->isConnection()) {
-            $this->registerConnection($fieldDefinition, $parentType, $defaultCount, $maxCount, $edgeType);
+            $this->registerConnection($fieldDefinition, $parentType, $paginationType, $defaultCount, $maxCount, $edgeType);
         } elseif ($paginationType->isSimple()) {
-            $this->registerSimplePaginator($fieldDefinition, $parentType, $defaultCount, $maxCount);
+            $this->registerSimplePaginator($fieldDefinition, $parentType, $paginationType, $defaultCount, $maxCount);
         } else {
-            $this->registerPaginator($fieldDefinition, $parentType, $defaultCount, $maxCount);
+            $this->registerPaginator($fieldDefinition, $parentType, $paginationType, $defaultCount, $maxCount);
         }
     }
 
     protected function registerConnection(
         FieldDefinitionNode &$fieldDefinition,
         ObjectTypeDefinitionNode &$parentType,
+        PaginationType $paginationType,
         ?int $defaultCount = null,
         ?int $maxCount = null,
         ?ObjectTypeDefinitionNode $edgeType = null
@@ -96,7 +97,7 @@ class PaginationManipulator
             "A paginated list of {$fieldTypeName} edges."
             type {$connectionTypeName} {
                 "Pagination information about the list of edges."
-                pageInfo: PageInfo! @field(resolver: "{$connectionFieldName}@pageInfoResolver")
+                {$paginationType->getInfoFieldName()}: PageInfo! @field(resolver: "{$connectionFieldName}@pageInfoResolver")
 
                 "A list of {$fieldTypeName} edges."
                 edges: [{$connectionEdgeName}!]! @field(resolver: "{$connectionFieldName}@edgeResolver")
@@ -162,6 +163,7 @@ GRAPHQL
     protected function registerPaginator(
         FieldDefinitionNode &$fieldDefinition,
         ObjectTypeDefinitionNode &$parentType,
+        PaginationType $paginationType,
         ?int $defaultCount = null,
         ?int $maxCount = null
     ): void {
@@ -173,7 +175,7 @@ GRAPHQL
             "A paginated list of {$fieldTypeName} items."
             type {$paginatorTypeName} {
                 "Pagination information about the list of items."
-                paginatorInfo: PaginatorInfo! @field(resolver: "{$paginatorFieldClassName}@paginatorInfoResolver")
+                {$paginationType->getInfoFieldName()}: PaginatorInfo! @field(resolver: "{$paginatorFieldClassName}@paginatorInfoResolver")
 
                 "A list of {$fieldTypeName} items."
                 data: [{$fieldTypeName}!]! @field(resolver: "{$paginatorFieldClassName}@dataResolver")
@@ -198,6 +200,7 @@ GRAPHQL
     protected function registerSimplePaginator(
         FieldDefinitionNode &$fieldDefinition,
         ObjectTypeDefinitionNode &$parentType,
+        PaginationType $paginationType,
         ?int $defaultCount = null,
         ?int $maxCount = null
     ): void {
@@ -209,7 +212,7 @@ GRAPHQL
             "A paginated list of {$fieldTypeName} items."
             type {$paginatorTypeName} {
                 "Pagination information about the list of items."
-                paginatorInfo: SimplePaginatorInfo! @field(resolver: "{$paginatorFieldClassName}@paginatorInfoResolver")
+                {$paginationType->getInfoFieldName()}: SimplePaginatorInfo! @field(resolver: "{$paginatorFieldClassName}@paginatorInfoResolver")
 
                 "A list of {$fieldTypeName} items."
                 data: [{$fieldTypeName}!]! @field(resolver: "{$paginatorFieldClassName}@dataResolver")

--- a/src/Pagination/PaginationType.php
+++ b/src/Pagination/PaginationType.php
@@ -57,4 +57,13 @@ class PaginationType
     {
         return self::SIMPLE === $this->type;
     }
+
+    public function getInfoFieldName(): string
+    {
+        if ($this->isConnection()) {
+            return 'pageInfo';
+        }
+
+        return 'paginatorInfo';
+    }
 }

--- a/src/Pagination/PaginationType.php
+++ b/src/Pagination/PaginationType.php
@@ -58,12 +58,15 @@ class PaginationType
         return self::SIMPLE === $this->type;
     }
 
-    public function getInfoFieldName(): string
+    public function infoFieldName(): string
     {
-        if ($this->isConnection()) {
-            return 'pageInfo';
+        switch ($this->type) {
+            case self::PAGINATOR:
+                return 'paginatorInfo';
+            case self::CONNECTION:
+                return 'pageInfo';
+            default:
+                throw new \Exception("infoFieldName is not implemented for pagination type: {$this->type}.");
         }
-
-        return 'paginatorInfo';
     }
 }

--- a/src/Pagination/PaginationType.php
+++ b/src/Pagination/PaginationType.php
@@ -29,17 +29,15 @@ class PaginationType
             case 'paginator':
                 $this->type = self::PAGINATOR;
                 break;
+            case 'simple':
+                $this->type = self::SIMPLE;
+                break;
             case 'connection':
             case 'relay':
                 $this->type = self::CONNECTION;
                 break;
-            case 'simple':
-                $this->type = self::SIMPLE;
-                break;
             default:
-                throw new DefinitionException(
-                    "Found invalid pagination type: {$paginationType}"
-                );
+                throw new DefinitionException("Found invalid pagination type: {$paginationType}");
         }
     }
 
@@ -48,20 +46,21 @@ class PaginationType
         return self::PAGINATOR === $this->type;
     }
 
-    public function isConnection(): bool
-    {
-        return self::CONNECTION === $this->type;
-    }
-
     public function isSimple(): bool
     {
         return self::SIMPLE === $this->type;
+    }
+
+    public function isConnection(): bool
+    {
+        return self::CONNECTION === $this->type;
     }
 
     public function infoFieldName(): string
     {
         switch ($this->type) {
             case self::PAGINATOR:
+            case self::SIMPLE:
                 return 'paginatorInfo';
             case self::CONNECTION:
                 return 'pageInfo';

--- a/src/Pagination/PaginatorField.php
+++ b/src/Pagination/PaginatorField.php
@@ -3,6 +3,7 @@
 namespace Nuwave\Lighthouse\Pagination;
 
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Support\Collection;
 
 class PaginatorField
@@ -31,11 +32,11 @@ class PaginatorField
     /**
      * Resolve data for connection.
      *
-     * @param  \Illuminate\Pagination\LengthAwarePaginator<mixed>  $root
+     * @param  \Illuminate\Pagination\AbstractPaginator  $root
      *
      * @return \Illuminate\Support\Collection<mixed>
      */
-    public function dataResolver(LengthAwarePaginator $root): Collection
+    public function dataResolver(AbstractPaginator $root): Collection
     {
         // @phpstan-ignore-next-line static refers to the wrong class because it is a proxied method call
         return $root->values();

--- a/src/Pagination/PaginatorField.php
+++ b/src/Pagination/PaginatorField.php
@@ -32,8 +32,6 @@ class PaginatorField
     /**
      * Resolve data for connection.
      *
-     * @param  \Illuminate\Pagination\AbstractPaginator  $root
-     *
      * @return \Illuminate\Support\Collection<mixed>
      */
     public function dataResolver(AbstractPaginator $root): Collection

--- a/tests/AssertsQueryCounts.php
+++ b/tests/AssertsQueryCounts.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests;
+
+use Closure;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * This trait was taken from a package that has less Laravel version support than we require.
+ *
+ * @see https://github.com/mattiasgeniar/phpunit-query-count-assertions
+ */
+trait AssertsQueryCounts
+{
+    public function assertNoQueriesExecuted(Closure $closure = null): void
+    {
+        if ($closure) {
+            self::trackQueries();
+
+            $closure();
+        }
+
+        $this->assertQueryCountMatches(0);
+
+        if ($closure) {
+            DB::flushQueryLog();
+        }
+    }
+
+    public function assertQueryCountMatches(int $count, Closure $closure = null): void
+    {
+        if ($closure) {
+            self::trackQueries();
+
+            $closure();
+        }
+
+        $this->assertEquals($count, self::getQueryCount());
+
+        if ($closure) {
+            DB::flushQueryLog();
+        }
+    }
+
+    public function assertQueryCountLessThan(int $count, Closure $closure = null): void
+    {
+        if ($closure) {
+            self::trackQueries();
+
+            $closure();
+        }
+
+        $this->assertLessThan($count, self::getQueryCount());
+
+        if ($closure) {
+            DB::flushQueryLog();
+        }
+    }
+
+    public function assertQueryCountGreaterThan(int $count, Closure $closure = null): void
+    {
+        if ($closure) {
+            self::trackQueries();
+
+            $closure();
+        }
+
+        $this->assertGreaterThan($count, self::getQueryCount());
+
+        if ($closure) {
+            DB::flushQueryLog();
+        }
+    }
+
+    public static function trackQueries(): void
+    {
+        DB::enableQueryLog();
+    }
+
+    /** @return array<array{query: string, bindings: array<int, mixed>, time: ?float}> */
+    public static function getQueriesExecuted(): array
+    {
+        return DB::getQueryLog();
+    }
+
+    public static function getQueryCount(): int
+    {
+        return count(self::getQueriesExecuted());
+    }
+}

--- a/tests/AssertsQueryCounts.php
+++ b/tests/AssertsQueryCounts.php
@@ -6,13 +6,21 @@ use Closure;
 use Illuminate\Support\Facades\DB;
 
 /**
- * This trait was taken from a package that has less Laravel version support than we require.
+ * This trait was taken from a package that supports fewer Laravel versions than us.
  *
  * @see https://github.com/mattiasgeniar/phpunit-query-count-assertions
+ * @mixin \PHPUnit\Framework\TestCase
  */
 trait AssertsQueryCounts
 {
-    public function assertNoQueriesExecuted(Closure $closure = null): void
+    protected function countQueries(?int &$count): void
+    {
+        DB::listen(function () use (&$count): void {
+            ++$count;
+        });
+    }
+
+    protected function assertNoQueriesExecuted(Closure $closure = null): void
     {
         if ($closure) {
             self::trackQueries();
@@ -27,7 +35,7 @@ trait AssertsQueryCounts
         }
     }
 
-    public function assertQueryCountMatches(int $count, Closure $closure = null): void
+    protected function assertQueryCountMatches(int $count, Closure $closure = null): void
     {
         if ($closure) {
             self::trackQueries();
@@ -42,7 +50,7 @@ trait AssertsQueryCounts
         }
     }
 
-    public function assertQueryCountLessThan(int $count, Closure $closure = null): void
+    protected function assertQueryCountLessThan(int $count, Closure $closure = null): void
     {
         if ($closure) {
             self::trackQueries();
@@ -57,7 +65,7 @@ trait AssertsQueryCounts
         }
     }
 
-    public function assertQueryCountGreaterThan(int $count, Closure $closure = null): void
+    protected function assertQueryCountGreaterThan(int $count, Closure $closure = null): void
     {
         if ($closure) {
             self::trackQueries();
@@ -72,18 +80,18 @@ trait AssertsQueryCounts
         }
     }
 
-    public static function trackQueries(): void
+    protected static function trackQueries(): void
     {
         DB::enableQueryLog();
     }
 
     /** @return array<array{query: string, bindings: array<int, mixed>, time: ?float}> */
-    public static function getQueriesExecuted(): array
+    protected static function getQueriesExecuted(): array
     {
         return DB::getQueryLog();
     }
 
-    public static function getQueryCount(): int
+    protected static function getQueryCount(): int
     {
         return count(self::getQueriesExecuted());
     }

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Facades\DB;
 
 abstract class DBTestCase extends TestCase
 {
+    use AssertsQueryCounts;
+
     public const DEFAULT_CONNECTION = 'mysql';
     public const ALTERNATE_CONNECTION = 'alternate';
 

--- a/tests/Integration/Cache/CacheDirectiveTest.php
+++ b/tests/Integration/Cache/CacheDirectiveTest.php
@@ -322,6 +322,9 @@ final class CacheDirectiveTest extends DBTestCase
         $this->graphQL(/** @lang GraphQL */ '
         {
             users(first: 5) {
+                paginatorInfo {
+                    total
+                }
                 data {
                     id
                     name

--- a/tests/Integration/Defer/DeferDBTest.php
+++ b/tests/Integration/Defer/DeferDBTest.php
@@ -29,7 +29,7 @@ final class DeferDBTest extends DBTestCase
         $user->company()->associate($company);
         $user->save();
 
-        $user->unsetRelations();
+        $user->setRelations([]);
 
         $this->mockResolver($user);
 
@@ -87,7 +87,7 @@ final class DeferDBTest extends DBTestCase
 
         $user = $users[0];
         assert($user instanceof User);
-        $user->unsetRelations();
+        $user->setRelations([]);
 
         $this->mockResolver($user);
 

--- a/tests/Integration/Defer/DeferDBTest.php
+++ b/tests/Integration/Defer/DeferDBTest.php
@@ -4,7 +4,6 @@ namespace Tests\Integration\Defer;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
-use Illuminate\Support\Facades\DB;
 use Nuwave\Lighthouse\Defer\DeferServiceProvider;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Company;
@@ -23,9 +22,14 @@ final class DeferDBTest extends DBTestCase
     public function testDeferBelongsToFields(): void
     {
         $company = factory(Company::class)->create();
-        $user = factory(User::class)->create([
-            'company_id' => $company->getKey(),
-        ]);
+        assert($company instanceof Company);
+
+        $user = factory(User::class)->make();
+        assert($user instanceof User);
+        $user->company()->associate($company);
+        $user->save();
+
+        $user->unsetRelations();
 
         $this->mockResolver($user);
 
@@ -44,10 +48,7 @@ final class DeferDBTest extends DBTestCase
         }
         ';
 
-        $queries = 0;
-        DB::listen(function () use (&$queries): void {
-            ++$queries;
-        });
+        $this->countQueries($queryCount);
 
         $chunks = $this->streamGraphQL(/** @lang GraphQL */ '
         {
@@ -60,7 +61,7 @@ final class DeferDBTest extends DBTestCase
         }
         ');
 
-        $this->assertSame(1, $queries);
+        $this->assertSame(1, $queryCount);
         $this->assertCount(2, $chunks);
 
         $deferredUser = $chunks[0];
@@ -75,10 +76,18 @@ final class DeferDBTest extends DBTestCase
     public function testDeferNestedRelationshipFields(): void
     {
         $company = factory(Company::class)->create();
-        $users = factory(User::class, 5)->create([
-            'company_id' => $company->getKey(),
-        ]);
+        assert($company instanceof Company);
+
+        $users = factory(User::class, 5)->make();
+        foreach ($users as $user) {
+            assert($user instanceof User);
+            $user->company()->associate($company);
+            $user->save();
+        }
+
         $user = $users[0];
+        assert($user instanceof User);
+        $user->unsetRelations();
 
         $this->mockResolver($user);
 
@@ -98,10 +107,7 @@ final class DeferDBTest extends DBTestCase
         }
         ';
 
-        $queries = 0;
-        DB::listen(function () use (&$queries): void {
-            ++$queries;
-        });
+        $this->countQueries($queryCount);
 
         $chunks = $this->streamGraphQL(/** @lang GraphQL */ '
         {
@@ -117,7 +123,7 @@ final class DeferDBTest extends DBTestCase
         }
         ');
 
-        $this->assertSame(2, $queries);
+        $this->assertSame(2, $queryCount);
         $this->assertCount(3, $chunks);
 
         $deferredUser = $chunks[0];
@@ -172,10 +178,7 @@ final class DeferDBTest extends DBTestCase
         }
         ';
 
-        $queries = 0;
-        DB::listen(function () use (&$queries): void {
-            ++$queries;
-        });
+        $this->countQueries($queryCount);
 
         $chunks = $this->streamGraphQL(/** @lang GraphQL */ '
         {
@@ -191,7 +194,7 @@ final class DeferDBTest extends DBTestCase
         }
         ');
 
-        $this->assertSame(2, $queries);
+        $this->assertSame(2, $queryCount);
         $this->assertCount(3, $chunks);
 
         $deferredCompanies = $chunks[0];

--- a/tests/Integration/Execution/DataLoader/RelationBatchLoaderTest.php
+++ b/tests/Integration/Execution/DataLoader/RelationBatchLoaderTest.php
@@ -145,21 +145,23 @@ final class RelationBatchLoaderTest extends DBTestCase
                 );
             });
 
-        $this->assertQueryCountMatches(3, function () use ($userCount, $alternateConnectionsPerUser): void {
-            $this
-                ->graphQL(/** @lang GraphQL */ '
-                {
-                    users {
-                        alternateConnections {
-                            id
-                        }
+        $this->countQueries($queryCount);
+
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            {
+                users {
+                    alternateConnections {
+                        id
                     }
                 }
-                ')
-                ->assertJsonCount($userCount, 'data.users')
-                ->assertJsonCount($alternateConnectionsPerUser, 'data.users.0.alternateConnections')
-                ->assertJsonCount($alternateConnectionsPerUser, 'data.users.1.alternateConnections');
-        });
+            }
+            ')
+            ->assertJsonCount($userCount, 'data.users')
+            ->assertJsonCount($alternateConnectionsPerUser, 'data.users.0.alternateConnections')
+            ->assertJsonCount($alternateConnectionsPerUser, 'data.users.1.alternateConnections');
+
+        $this->assertSame(3, $queryCount);
     }
 
     public function testDoesNotBatchloadRelationsWithNullDatabaseConnections(): void

--- a/tests/Integration/Pagination/PaginateDirectiveDBTest.php
+++ b/tests/Integration/Pagination/PaginateDirectiveDBTest.php
@@ -4,7 +4,7 @@ namespace Tests\Integration\Pagination;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Facades\DB;
+use Tests\AssertsQueryCounts;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Comment;
 use Tests\Utils\Models\Post;
@@ -12,11 +12,14 @@ use Tests\Utils\Models\User;
 
 final class PaginateDirectiveDBTest extends DBTestCase
 {
+    use AssertsQueryCounts;
+
     public function testPaginate(): void
     {
         factory(User::class, 3)->create();
 
-        $this->schema = /** @lang GraphQL */ '
+        $this->schema /** @lang GraphQL */
+            = '
         type User {
             id: ID!
         }
@@ -57,7 +60,8 @@ final class PaginateDirectiveDBTest extends DBTestCase
     {
         factory(User::class, 2)->create();
 
-        $this->schema = /** @lang GraphQL */ '
+        $this->schema /** @lang GraphQL */
+            = '
         type User {
             id: ID!
         }
@@ -97,7 +101,8 @@ final class PaginateDirectiveDBTest extends DBTestCase
         $posts = factory(Post::class, 2)->create();
         $user->posts()->saveMany($posts);
 
-        $this->schema = /** @lang GraphQL */ '
+        $this->schema /** @lang GraphQL */
+            = '
         type Post {
             id: ID!
         }
@@ -152,7 +157,8 @@ final class PaginateDirectiveDBTest extends DBTestCase
             'name' => null,
         ]);
 
-        $this->schema = /** @lang GraphQL */ '
+        $this->schema /** @lang GraphQL */
+            = '
         type User {
             id: String!
         }
@@ -213,7 +219,8 @@ final class PaginateDirectiveDBTest extends DBTestCase
             'post_id' => $posts->first()->id,
         ]);
 
-        $this->schema = /** @lang GraphQL */ '
+        $this->schema /** @lang GraphQL */
+            = '
         type User {
             posts: [Post!]! @paginate
         }
@@ -292,7 +299,8 @@ final class PaginateDirectiveDBTest extends DBTestCase
     {
         factory(User::class, 3)->create();
 
-        $this->schema = /** @lang GraphQL */ '
+        $this->schema /** @lang GraphQL */
+            = '
         type User {
             id: ID!
         }
@@ -328,7 +336,8 @@ final class PaginateDirectiveDBTest extends DBTestCase
 
     public function testQueriesConnectionWithNoData(): void
     {
-        $this->schema = /** @lang GraphQL */ '
+        $this->schema /** @lang GraphQL */
+            = '
         type User {
             id: ID!
         }
@@ -378,7 +387,8 @@ final class PaginateDirectiveDBTest extends DBTestCase
 
     public function testQueriesPaginationWithNoData(): void
     {
-        $this->schema = /** @lang GraphQL */ '
+        $this->schema /** @lang GraphQL */
+            = '
         type User {
             id: ID!
         }
@@ -439,32 +449,27 @@ final class PaginateDirectiveDBTest extends DBTestCase
         }
         ';
 
-        DB::enableQueryLog();
-
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            users(first: 1) {
-                data {
-                    id
+        $this->assertQueryCountMatches(1, function () use ($user) {
+            $this->graphQL(/** @lang GraphQL */ '
+            {
+                users(first: 1) {
+                    data {
+                        id
+                    }
                 }
             }
-        }
-        ')->assertJson([
-            'data' => [
-                'users' => [
-                    'data' => [
-                        [
-                            'id' => $user->id,
+            ')->assertJson([
+                'data' => [
+                    'users' => [
+                        'data' => [
+                            [
+                                'id' => $user->id,
+                            ],
                         ],
                     ],
                 ],
-            ],
-        ])->assertJsonCount(1, 'data.users.data');
-
-        DB::disableQueryLog();
-
-        $this->assertCount(1, DB::getQueryLog());
-        DB::flushQueryLog();
+            ])->assertJsonCount(1, 'data.users.data');
+        });
     }
 
     public function testQueriesConnectionWithoutPageInfo(): void
@@ -482,43 +487,39 @@ final class PaginateDirectiveDBTest extends DBTestCase
         }
         ';
 
-        DB::enableQueryLog();
-
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            users(first: 1) {
-                edges {
-                    node {
-                        id
+        $this->assertQueryCountMatches(1, function () use ($user) {
+            $this->graphQL(/** @lang GraphQL */ '
+            {
+                users(first: 1) {
+                    edges {
+                        node {
+                            id
+                        }
                     }
                 }
             }
-        }
-        ')->assertJson([
-            'data' => [
-                'users' => [
-                    'edges' => [
-                        [
-                            'node' => [
-                                'id' => $user->id,
+            ')->assertJson([
+                'data' => [
+                    'users' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'id' => $user->id,
+                                ],
                             ],
                         ],
                     ],
                 ],
-            ],
-        ])->assertJsonCount(1, 'data.users.edges');
-
-        DB::disableQueryLog();
-
-        $this->assertCount(1, DB::getQueryLog());
-        DB::flushQueryLog();
+            ])->assertJsonCount(1, 'data.users.edges');
+        });
     }
 
     public function testPaginatesWhenDefinedInTypeExtension(): void
     {
         factory(User::class, 2)->create();
 
-        $this->schema .= /** @lang GraphQL */ '
+        $this->schema /** @lang GraphQL */
+            .= '
         type User {
             id: ID!
         }
@@ -543,7 +544,8 @@ final class PaginateDirectiveDBTest extends DBTestCase
     {
         factory(User::class, 3)->create();
 
-        $this->schema = /** @lang GraphQL */ '
+        $this->schema /** @lang GraphQL */
+            = '
         type User {
             id: ID!
         }
@@ -584,7 +586,8 @@ final class PaginateDirectiveDBTest extends DBTestCase
         $defaultCount = 2;
         config(['lighthouse.pagination.default_count' => $defaultCount]);
 
-        $this->schema = /** @lang GraphQL */ '
+        $this->schema /** @lang GraphQL */
+            = '
         type User {
             id: ID!
             name: String!
@@ -611,8 +614,8 @@ final class PaginateDirectiveDBTest extends DBTestCase
         config(['lighthouse.pagination.default_count' => 10]);
         factory(User::class, 3)->create();
 
-        DB::enableQueryLog();
-        $this->schema = /** @lang GraphQL */ '
+        $this->schema /** @lang GraphQL */
+            = '
         type User {
             id: ID!
             name: String!
@@ -624,34 +627,34 @@ final class PaginateDirectiveDBTest extends DBTestCase
         }
         ';
 
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            usersPaginated {
-                paginatorInfo {
-                    total
-                }
-                data {
-                    id
-                }
-            }
-        }
-        ')->assertJsonCount(3, 'data.usersPaginated.data');
         // "paginate" fires 2 queries: One for data, one for counting.
-        $this->assertCount(2, DB::getQueryLog());
-        DB::flushQueryLog();
-
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            usersSimplePaginated {
-                data {
-                    id
+        $this->assertQueryCountMatches(2, function () {
+            $this->graphQL(/** @lang GraphQL */ '
+            {
+                usersPaginated {
+                    paginatorInfo {
+                        total
+                    }
+                    data {
+                        id
+                    }
                 }
             }
-        }
-        ')->assertJsonCount(3, 'data.usersSimplePaginated.data');
-        // "simplePaginate" only fires one query.
-        $this->assertCount(1, DB::getQueryLog());
-        DB::disableQueryLog();
+            ')->assertJsonCount(3, 'data.usersPaginated.data');
+        });
+
+        // "simplePaginate" only fires one query for the data.
+        $this->assertQueryCountMatches(1, function () {
+            $this->graphQL(/** @lang GraphQL */ '
+            {
+                usersSimplePaginated {
+                    data {
+                        id
+                    }
+                }
+            }
+            ')->assertJsonCount(3, 'data.usersSimplePaginated.data');
+        });
     }
 
     public function testGetSimplePaginationAttributes(): void
@@ -659,7 +662,8 @@ final class PaginateDirectiveDBTest extends DBTestCase
         config(['lighthouse.pagination.default_count' => 10]);
         factory(User::class, 3)->create();
 
-        $this->schema = /** @lang GraphQL */ '
+        $this->schema /** @lang GraphQL */
+            = '
         type User {
             id: ID!
             name: String!

--- a/tests/Integration/Schema/Directives/AggregateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/AggregateDirectiveTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Integration\Schema\Directives;
 
-use Illuminate\Support\Facades\DB;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Support\AppVersion;
 use Tests\DBTestCase;
@@ -119,34 +118,29 @@ final class AggregateDirectiveTest extends DBTestCase
                 $task->save();
             });
 
-        $queries = 0;
-        DB::listen(static function () use (&$queries): void {
-            ++$queries;
-        });
-
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            users {
-                workload
+        $this->assertQueryCountMatches(2, function (): void {
+            $this->graphQL(/** @lang GraphQL */ '
+            {
+                users {
+                    workload
+                }
             }
-        }
-        ')->assertExactJson([
-            'data' => [
-                'users' => [
-                    [
-                        'workload' => 0,
-                    ],
-                    [
-                        'workload' => 1,
-                    ],
-                    [
-                        'workload' => 2,
+            ')->assertExactJson([
+                'data' => [
+                    'users' => [
+                        [
+                            'workload' => 0,
+                        ],
+                        [
+                            'workload' => 1,
+                        ],
+                        [
+                            'workload' => 2,
+                        ],
                     ],
                 ],
-            ],
-        ]);
-
-        $this->assertSame(2, $queries);
+            ]);
+        });
     }
 
     public function testSumRelationWithScopes(): void

--- a/tests/Integration/Schema/Directives/BelongsToDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/BelongsToDirectiveTest.php
@@ -319,7 +319,7 @@ final class BelongsToDirectiveTest extends DBTestCase
         $user->company()->associate($company);
         $user->save();
 
-        $user->unsetRelations();
+        $user->setRelations([]);
 
         $this->be($user);
 

--- a/tests/Integration/Schema/Directives/BelongsToDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/BelongsToDirectiveTest.php
@@ -15,8 +15,8 @@ final class BelongsToDirectiveTest extends DBTestCase
     {
         $company = factory(Company::class)->create();
 
-        /** @var \Tests\Utils\Models\User $user */
         $user = factory(User::class)->make();
+        assert($user instanceof User);
         $user->company()->associate($company);
         $user->save();
 
@@ -59,8 +59,8 @@ final class BelongsToDirectiveTest extends DBTestCase
     {
         $company = factory(Company::class)->create();
 
-        /** @var \Tests\Utils\Models\User $user */
         $user = factory(User::class)->make();
+        assert($user instanceof User);
         $user->company()->associate($company);
         $user->save();
 
@@ -104,8 +104,8 @@ final class BelongsToDirectiveTest extends DBTestCase
         $company = factory(Company::class)->create();
         $team = factory(Team::class)->create();
 
-        /** @var \Tests\Utils\Models\User $user */
         $user = factory(User::class)->make();
+        assert($user instanceof User);
         $user->company()->associate($company);
         $user->team()->associate($team);
         $user->save();
@@ -319,6 +319,8 @@ final class BelongsToDirectiveTest extends DBTestCase
         $user->company()->associate($company);
         $user->save();
 
+        $user->unsetRelations();
+
         $this->be($user);
 
         $this->schema = /** @lang GraphQL */ '
@@ -335,7 +337,7 @@ final class BelongsToDirectiveTest extends DBTestCase
         }
         ';
 
-        $this->assertQueryCountMatches(2, function () use ($company): void {
+        $this->assertNoQueriesExecuted(function () use ($company): void {
             $this->graphQL(/** @lang GraphQL */ '
             {
                 user {

--- a/tests/Integration/Schema/Directives/CountDirectiveDBTest.php
+++ b/tests/Integration/Schema/Directives/CountDirectiveDBTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Integration\Schema\Directives;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Activity;
@@ -94,34 +93,29 @@ final class CountDirectiveDBTest extends DBTestCase
                 ]);
             });
 
-        $queries = 0;
-        DB::listen(function () use (&$queries): void {
-            ++$queries;
-        });
-
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            users {
-                tasks_count
+        $this->assertQueryCountMatches(2, function (): void {
+            $this->graphQL(/** @lang GraphQL */ '
+            {
+                users {
+                    tasks_count
+                }
             }
-        }
-        ')->assertExactJson([
-            'data' => [
-                'users' => [
-                    [
-                        'tasks_count' => 3,
-                    ],
-                    [
-                        'tasks_count' => 2,
-                    ],
-                    [
-                        'tasks_count' => 1,
+            ')->assertExactJson([
+                'data' => [
+                    'users' => [
+                        [
+                            'tasks_count' => 3,
+                        ],
+                        [
+                            'tasks_count' => 2,
+                        ],
+                        [
+                            'tasks_count' => 1,
+                        ],
                     ],
                 ],
-            ],
-        ]);
-
-        $this->assertEquals(2, $queries);
+            ]);
+        });
     }
 
     public function testCountRelationThatIsNotSuffixedWithCount(): void

--- a/tests/Integration/Schema/Directives/WithCountDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/WithCountDirectiveTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Integration\Schema\Directives;
 
-use Illuminate\Support\Facades\DB;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Task;
@@ -31,34 +30,29 @@ final class WithCountDirectiveTest extends DBTestCase
                 ]);
             });
 
-        $queries = 0;
-        DB::listen(function () use (&$queries): void {
-            ++$queries;
-        });
-
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            users {
-                tasksCountLoaded
+        $this->assertQueryCountMatches(2, function (): void {
+            $this->graphQL(/** @lang GraphQL */ '
+            {
+                users {
+                    tasksCountLoaded
+                }
             }
-        }
-        ')->assertExactJson([
-            'data' => [
-                'users' => [
-                    [
-                        'tasksCountLoaded' => true,
-                    ],
-                    [
-                        'tasksCountLoaded' => true,
-                    ],
-                    [
-                        'tasksCountLoaded' => true,
+            ')->assertExactJson([
+                'data' => [
+                    'users' => [
+                        [
+                            'tasksCountLoaded' => true,
+                        ],
+                        [
+                            'tasksCountLoaded' => true,
+                        ],
+                        [
+                            'tasksCountLoaded' => true,
+                        ],
                     ],
                 ],
-            ],
-        ]);
-
-        $this->assertSame(2, $queries);
+            ]);
+        });
     }
 
     public function testFailsToEagerLoadRelationCountWithoutRelation(): void


### PR DESCRIPTION
- [x] Added or updated tests
- [x] ~Documented user facing changes~
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

When doing a paginated query we use the `LengthAwarePaginator` from Laravel. This makes total sense but we can optimize in case the query doesn't request the paginator info, then we can fallback to a simple paginator saving a `count(*)` query which is always nice :)

This is especially useful when you want to do something like getting the first object from a paginated list to see if it exists or to show a data but don't want yet another attribute, instead you can do something like this without the `count(*)` query penalty:

```graphql
# Pseudo schema
type User {
    auditLogs: [AuditLogEntry!]! @paginate
}

type Query {
    viewer: User @auth
}


# Query
{
    viewer {
        auditLogs(first: 1, page: 1) {
            data {
                id
                createdAt
            }
        }
    }
}
```

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->

I think none... maybe API changes I made that are breaking?
