### PR TITLE
Fix TestResponse macros recognition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.55.1
+
+### Fixed
+
+- Always register `TestingServiceProvider` in order to ensure macros are recognized by Larastan
+
 ## v5.55.0
 
 ### Changed

--- a/src/LighthouseServiceProvider.php
+++ b/src/LighthouseServiceProvider.php
@@ -130,9 +130,8 @@ class LighthouseServiceProvider extends ServiceProvider
 
         $this->commands(self::COMMANDS);
 
-        if ($this->app->runningUnitTests()) {
-            $this->app->register(TestingServiceProvider::class);
-        }
+        // Always registered in order to ensure macros are recognized by Larastan
+        $this->app->register(TestingServiceProvider::class);
     }
 
     public function boot(ConfigRepository $configRepository): void


### PR DESCRIPTION
Larastan requires macros to actually be registered for semi-static analysis. Otherwise, PHPStan fails with errors such as:

```
Call to an undefined method Illuminate\Testing\TestResponse::assertGraphQLErrorMessage()
```