### PR TITLE
Change `revert` typo to be `reverse`

### DIFF
--- a/docs/master/testing/extensions.md
+++ b/docs/master/testing/extensions.md
@@ -60,9 +60,9 @@ In this example, we will be testing this fictional custom directive:
 
 ```graphql
 """
-Reverts a string, e.g. 'foo' => 'oof'.
+Reverses a string, e.g. 'foo' => 'oof'.
 """
-directive @revert on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @reverse on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
 The simplest way to mock a resolver is to have it return static data:


### PR DESCRIPTION
- [ ] Added or updated tests  (Not applicable)
- [ ] Documented user facing changes (Not applicable)
- [ ] Updated CHANGELOG.md  (Not applicable)

No related issues.

**Changes**

Simply fix a typo where the word "revert" should have been "reverse" in 2 places of the https://lighthouse-php.com/master/testing/extensions.html#mock-resolvers documentation.

**Breaking changes**

No code changes
