### PR TITLE
Handle missing models in `@can` with option `resolved`

### DIFF
--- a/src/Auth/CanDirective.php
+++ b/src/Auth/CanDirective.php
@@ -135,7 +135,7 @@ GRAPHQL;
                             ? $modelLike->items()
                             : $modelLike;
 
-                        Utils::applyEach(function (Model $model) use ($gate, $ability, $checkArguments): void {
+                        Utils::applyEach(function (?Model $model) use ($gate, $ability, $checkArguments): void {
                             $this->authorize($gate, $ability, $model, $checkArguments);
                         }, $modelOrModels);
 

--- a/src/Auth/CanDirective.php
+++ b/src/Auth/CanDirective.php
@@ -228,7 +228,7 @@ GRAPHQL;
 
     /**
      * @param  string|array<string>  $ability
-     * @param  string|\Illuminate\Database\Eloquent\Model  $model
+     * @param  string|null|\Illuminate\Database\Eloquent\Model  $model
      * @param  array<int, mixed>  $arguments
      *
      * @throws \Nuwave\Lighthouse\Exceptions\AuthorizationException

--- a/tests/Integration/Auth/CanDirectiveDBTest.php
+++ b/tests/Integration/Auth/CanDirectiveDBTest.php
@@ -4,6 +4,7 @@ namespace Tests\Integration\Auth;
 
 use Nuwave\Lighthouse\Auth\CanDirective;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
+use Nuwave\Lighthouse\Support\AppVersion;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Company;
 use Tests\Utils\Models\Post;
@@ -576,7 +577,13 @@ final class CanDirectiveDBTest extends DBTestCase
             ],
             'errors' => [
                 [
-                    'message' => 'This action is unauthorized.',
+                    // NOTE: The error message differs because
+                    // CanDirective::authorize has differing implementations
+                    // depending on Laravel version. If laravel<6.0 support is
+                    // removed, so can this ternary statement.
+                    'message' => AppVersion::atLeast(6.0)
+                        ? 'This action is unauthorized.'
+                        : 'You are not authorized to access user',
                 ],
             ],
         ]);


### PR DESCRIPTION
This patch addresses an issue where a non-existing instance is queried while a @can directive exists on the field that is resolved. This will result in a type error since PHP expects the first argument of the closure in question to be a Model. The following error is generated

```
Nuwave\\Lighthouse\\Auth\\CanDirective::Nuwave\\Lighthouse\\Auth\\{closure}(): Argument #1 ($model) must be of type Illuminate\\Database\\Eloquent\\Model, null given, called in /***/vendor/nuwave/lighthouse/src/Support/Utils.php on line 117"
```

- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

The fix is to modify the type of the argument into a nullable type. The
operator is available since PHP 7.1, which means this should be a
backwards-compatible fix.

**Breaking changes**

No breaking changes expected.