### PR TITLE
Fix cursor pagination always returning the first page when no fields from the `pageInfo` are requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Fix cursor pagination always returning the first page when no fields from the `pageInfo` are requested https://github.com/nuwave/lighthouse/pull/2190
+
 ## v5.57.2
 
 ### Fixed

--- a/src/Pagination/PaginateDirective.php
+++ b/src/Pagination/PaginateDirective.php
@@ -127,8 +127,11 @@ GRAPHQL;
                     $this->directiveArgValue('scopes') ?? []
                 );
 
-            return PaginationArgs::extractArgs($args, $this->optimalPaginationType($resolveInfo), $this->paginateMaxCount())
-                ->applyToBuilder($query);
+            $paginationArgs = PaginationArgs::extractArgs($args, $this->paginationType(), $this->paginateMaxCount());
+
+            $paginationArgs->type = $this->optimalPaginationType($resolveInfo);
+
+            return $paginationArgs->applyToBuilder($query);
         });
 
         return $fieldValue;

--- a/tests/Integration/Pagination/PaginateDirectiveDBTest.php
+++ b/tests/Integration/Pagination/PaginateDirectiveDBTest.php
@@ -610,12 +610,10 @@ GRAPHQL;
         }
         ';
 
-        $cursor = Cursor::encode(2);
-
-        $this->assertQueryCountMatches(2, function () use ($users, $cursor): void {
-            $this->graphQL(/** @lang GraphQL */ "
-            {
-                users(first: 2, after: \"{$cursor}\") {
+        $this->assertQueryCountMatches(2, function () use ($users): void {
+            $this->graphQL(/** @lang GraphQL */ '
+            query ($after: String!) {
+                users(first: 2, after: $after) {
                     pageInfo {
                       hasNextPage
                       hasPreviousPage
@@ -633,7 +631,9 @@ GRAPHQL;
                     }
                 }
             }
-            ")->assertJson([
+            ', [
+                'after' => Cursor::encode(2),
+            ])->assertJson([
                 'data' => [
                     'users' => [
                         'pageInfo' => [
@@ -676,9 +676,9 @@ GRAPHQL;
         $cursor = Cursor::encode(2);
 
         $this->assertQueryCountMatches(1, function () use ($users, $cursor): void {
-            $this->graphQL(/** @lang GraphQL */ "
-            {
-                users(first: 2, after: \"{$cursor}\") {
+            $this->graphQL(/** @lang GraphQL */ '
+            query ($after: String!) {
+                users(first: 2, after: $after) {
                     edges {
                         node {
                             id
@@ -686,7 +686,9 @@ GRAPHQL;
                     }
                 }
             }
-            ")->assertJson([
+            ', [
+                'after' => Cursor::encode(2),
+            ])->assertJson([
                 'data' => [
                     'users' => [
                         'edges' => [

--- a/tests/Integration/Pagination/PaginateDirectiveDBTest.php
+++ b/tests/Integration/Pagination/PaginateDirectiveDBTest.php
@@ -675,7 +675,7 @@ GRAPHQL;
 
         $cursor = Cursor::encode(2);
 
-        $this->assertQueryCountMatches(1, function () use ($users, $cursor): void {
+        $this->assertQueryCountMatches(1, function () use ($users): void {
             $this->graphQL(/** @lang GraphQL */ '
             query ($after: String!) {
                 users(first: 2, after: $after) {

--- a/tests/Integration/Pagination/PaginateDirectiveDBTest.php
+++ b/tests/Integration/Pagination/PaginateDirectiveDBTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Laravel\Scout\Builder as ScoutBuilder;
 use Mockery;
+use Nuwave\Lighthouse\Pagination\Cursor;
 use Tests\DBTestCase;
 use Tests\TestsScoutEngine;
 use Tests\Utils\Models\Comment;
@@ -586,6 +587,112 @@ GRAPHQL;
                             [
                                 'node' => [
                                     'id' => $user->id,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ])->assertJsonCount(1, 'data.users.edges');
+        });
+    }
+
+    public function testQueriesConnectionPageOffset(): void
+    {
+        $users = factory(User::class, 3)->create();
+
+        $this->schema = /** @lang GraphQL */ '
+        type User {
+            id: ID!
+        }
+
+        type Query {
+            users: [User!]! @paginate(type: CONNECTION)
+        }
+        ';
+
+        $cursor = Cursor::encode(2);
+
+        $this->assertQueryCountMatches(2, function () use ($users, $cursor): void {
+            $this->graphQL(/** @lang GraphQL */ "
+            {
+                users(first: 2, after: \"{$cursor}\") {
+                    pageInfo {
+                      hasNextPage
+                      hasPreviousPage
+                      startCursor
+                      endCursor
+                      total
+                      count
+                      currentPage
+                      lastPage
+                    }
+                    edges {
+                        node {
+                            id
+                        }
+                    }
+                }
+            }
+            ")->assertJson([
+                'data' => [
+                    'users' => [
+                        'pageInfo' => [
+                            'hasNextPage' => false,
+                            'hasPreviousPage' => true,
+                            'startCursor' => 'Mw==',
+                            'endCursor' => 'Mw==',
+                            'total' => 3,
+                            'count' => 1,
+                            'currentPage' => 2,
+                            'lastPage' => 2,
+                        ],
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'id' => $users[2]->id,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ])->assertJsonCount(1, 'data.users.edges');
+        });
+    }
+
+    public function testQueriesConnectionPageOffsetWithoutPageInfo(): void
+    {
+        $users = factory(User::class, 3)->create();
+
+        $this->schema = /** @lang GraphQL */ '
+        type User {
+            id: ID!
+        }
+
+        type Query {
+            users: [User!]! @paginate(type: CONNECTION)
+        }
+        ';
+
+        $cursor = Cursor::encode(2);
+
+        $this->assertQueryCountMatches(1, function () use ($users, $cursor): void {
+            $this->graphQL(/** @lang GraphQL */ "
+            {
+                users(first: 2, after: \"{$cursor}\") {
+                    edges {
+                        node {
+                            id
+                        }
+                    }
+                }
+            }
+            ")->assertJson([
+                'data' => [
+                    'users' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'id' => $users[2]->id,
                                 ],
                             ],
                         ],


### PR DESCRIPTION
- [x] Added or updated tests
- [x] ~Documented user facing changes~
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

Fixes #2189

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

We calculate an optimal pagination strategy when the paginator info is not requested. But since cursor based pagination needs some special handling to correctly calculate the correct page to retrieve the `PaginationArgs::extractArgs` needs to get the original pagination type instead of the optimal type. We can change the type to the optimal one when applying it to the builder keeping the benefits but fixing the bug :)

Thanks @pyrou for finding and reporting the bug and creating the failing tests!

**Breaking changes**

None.
