### PR TITLE
Allow unlimited pagination from directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Changed
+
+- Setting explicitly `maxCount: null` or `defaultCount: null` in schema now behaves same as in configuration `lighthouse.pagination`
+
 ## v5.57.3
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Changed
 
-- Setting explicitly `maxCount: null` or `defaultCount: null` in schema now behaves same as in configuration `lighthouse.pagination`
+- Respect explicit `maxCount: null` or `defaultCount: null` in pagination directives over config `lighthouse.pagination`
 
 ## v5.57.3
 

--- a/docs/5/api-reference/directives.md
+++ b/docs/5/api-reference/directives.md
@@ -249,12 +249,14 @@ directive @belongsToMany(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 
@@ -1496,12 +1498,14 @@ directive @hasMany(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 
@@ -1586,12 +1590,14 @@ directive @hasManyThrough(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 
@@ -1967,12 +1973,14 @@ directive @morphMany(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 
@@ -2103,12 +2111,14 @@ directive @morphToMany(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 
@@ -2430,12 +2440,14 @@ directive @paginate(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 ) on FIELD_DEFINITION

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -249,12 +249,14 @@ directive @belongsToMany(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 
@@ -1496,12 +1498,14 @@ directive @hasMany(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 
@@ -1586,12 +1590,14 @@ directive @hasManyThrough(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 
@@ -1967,12 +1973,14 @@ directive @morphMany(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 
@@ -2103,12 +2111,14 @@ directive @morphToMany(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 
@@ -2430,12 +2440,14 @@ directive @paginate(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 ) on FIELD_DEFINITION

--- a/src/Auth/AuthDirective.php
+++ b/src/Auth/AuthDirective.php
@@ -39,8 +39,7 @@ GRAPHQL;
     public function resolveField(FieldValue $fieldValue): FieldValue
     {
         $fieldValue->setResolver(function (): ?Authenticatable {
-            $guard = $this->directiveArgValue('guard')
-                ?? AuthServiceProvider::guard();
+            $guard = $this->directiveArgValue('guard', AuthServiceProvider::guard());
             assert(is_string($guard) || is_null($guard));
 
             // @phpstan-ignore-next-line phpstan does not know about App\User, which implements Authenticatable

--- a/src/Auth/CanDirective.php
+++ b/src/Auth/CanDirective.php
@@ -167,7 +167,7 @@ GRAPHQL;
             return $argumentSet
                 ->enhanceBuilder(
                     $this->getModelClass()::query(),
-                    $this->directiveArgValue('scopes') ?? []
+                    $this->directiveArgValue('scopes', [])
                 )
                 ->get();
         }
@@ -201,7 +201,7 @@ GRAPHQL;
             try {
                 $enhancedBuilder = $argumentSet->enhanceBuilder(
                     $queryBuilder,
-                    $this->directiveArgValue('scopes') ?? [],
+                    $this->directiveArgValue('scopes', []),
                     Utils::instanceofMatcher(TrashedDirective::class)
                 );
                 assert($enhancedBuilder instanceof Builder);

--- a/src/Auth/GuardDirective.php
+++ b/src/Auth/GuardDirective.php
@@ -60,8 +60,7 @@ GRAPHQL;
         $fieldValue->setResolver(function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($previousResolver) {
             // TODO remove cast in v6
             $with = (array) (
-                $this->directiveArgValue('with')
-                ?? [AuthServiceProvider::guard()]
+                $this->directiveArgValue('with', AuthServiceProvider::guard())
             );
 
             $this->authenticate($with);

--- a/src/Auth/GuardDirective.php
+++ b/src/Auth/GuardDirective.php
@@ -59,9 +59,9 @@ GRAPHQL;
 
         $fieldValue->setResolver(function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($previousResolver) {
             // TODO remove cast in v6
-            $with = (array) (
+            $with = (array)
                 $this->directiveArgValue('with', AuthServiceProvider::guard())
-            );
+            ;
 
             $this->authenticate($with);
 

--- a/src/Auth/WhereAuthDirective.php
+++ b/src/Auth/WhereAuthDirective.php
@@ -50,8 +50,7 @@ GRAPHQL;
             function (object $query): void {
                 assert($query instanceof EloquentBuilder);
 
-                $guard = $this->directiveArgValue('guard')
-                    ?? AuthServiceProvider::guard();
+                $guard = $this->directiveArgValue('guard',  AuthServiceProvider::guard());
 
                 $userId = $this
                     ->authFactory

--- a/src/Auth/WhereAuthDirective.php
+++ b/src/Auth/WhereAuthDirective.php
@@ -50,7 +50,7 @@ GRAPHQL;
             function (object $query): void {
                 assert($query instanceof EloquentBuilder);
 
-                $guard = $this->directiveArgValue('guard',  AuthServiceProvider::guard());
+                $guard = $this->directiveArgValue('guard', AuthServiceProvider::guard());
 
                 $userId = $this
                     ->authFactory

--- a/src/Cache/CacheDirective.php
+++ b/src/Cache/CacheDirective.php
@@ -62,7 +62,7 @@ GRAPHQL;
         $shouldUseTags = $this->shouldUseTags();
         $resolver = $fieldValue->getResolver();
         $maxAge = $this->directiveArgValue('maxAge');
-        $isPrivate = $this->directiveArgValue('private') ?? false;
+        $isPrivate = $this->directiveArgValue('private', false);
 
         $fieldValue->setResolver(
             function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($rootCacheKey, $shouldUseTags, $resolver, $maxAge, $isPrivate) {

--- a/src/GlobalId/GlobalIdDirective.php
+++ b/src/GlobalId/GlobalIdDirective.php
@@ -100,9 +100,7 @@ GRAPHQL;
                 case 'ARRAY':
                     return $this->globalId->decode($argumentValue);
                 default:
-                    throw new DefinitionException(
-                        "The decode argument of the @{$this->name()} directive can only be TYPE, ARRAY or ID, got {$decode}"
-                    );
+                    throw new DefinitionException("The decode argument of the @{$this->name()} directive can only be TYPE, ARRAY or ID, got {$decode}.");
             }
         }
 

--- a/src/OrderBy/OrderByDirective.php
+++ b/src/OrderBy/OrderByDirective.php
@@ -260,7 +260,7 @@ GRAPHQL;
     {
         return $builder->orderBy(
             $this->directiveArgValue('column'),
-            $this->directiveArgValue('direction') ?? 'ASC'
+            $this->directiveArgValue('direction', 'ASC')
         );
     }
 

--- a/src/Pagination/PaginateDirective.php
+++ b/src/Pagination/PaginateDirective.php
@@ -126,7 +126,7 @@ GRAPHQL;
                 ->argumentSet
                 ->enhanceBuilder(
                     $query,
-                    $this->directiveArgValue('scopes') ?? []
+                    $this->directiveArgValue('scopes', [])
                 );
 
             $paginationArgs = PaginationArgs::extractArgs($args, $this->paginationType(), $this->paginateMaxCount());
@@ -160,7 +160,7 @@ GRAPHQL;
     protected function paginationType(): PaginationType
     {
         return new PaginationType(
-            $this->directiveArgValue('type') ?? PaginationType::PAGINATOR
+            $this->directiveArgValue('type', PaginationType::PAGINATOR)
         );
     }
 

--- a/src/Pagination/PaginateDirective.php
+++ b/src/Pagination/PaginateDirective.php
@@ -164,13 +164,11 @@ GRAPHQL;
 
     protected function defaultCount(): ?int
     {
-        return $this->directiveArgValue('defaultCount')
-            ?? config('lighthouse.pagination.default_count');
+        return $this->directiveArgValue('defaultCount', config('lighthouse.pagination.default_count'));
     }
 
     protected function paginateMaxCount(): ?int
     {
-        return $this->directiveArgValue('maxCount')
-            ?? config('lighthouse.pagination.max_count');
+        return $this->directiveArgValue('maxCount', config('lighthouse.pagination.max_count'));
     }
 }

--- a/src/Pagination/PaginateDirective.php
+++ b/src/Pagination/PaginateDirective.php
@@ -51,12 +51,14 @@ directive @paginate(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 ) on FIELD_DEFINITION

--- a/src/Schema/Directives/AllDirective.php
+++ b/src/Schema/Directives/AllDirective.php
@@ -60,7 +60,7 @@ GRAPHQL;
                 ->argumentSet
                 ->enhanceBuilder(
                     $query,
-                    $this->directiveArgValue('scopes') ?? []
+                    $this->directiveArgValue('scopes', [])
                 )
                 ->get();
         });

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -148,8 +148,7 @@ abstract class BaseDirective implements Directive
      */
     protected function getModelClass(string $argumentName = 'model'): string
     {
-        $model = $this->directiveArgValue($argumentName)
-            ?? ASTHelper::modelName($this->definitionNode);
+        $model = $this->directiveArgValue($argumentName, ASTHelper::modelName($this->definitionNode));
 
         if (! $model) {
             throw new DefinitionException(

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -114,9 +114,9 @@ abstract class BaseDirective implements Directive
     /**
      * Get the value of an argument on the directive.
      *
-     * @param  mixed|null  $default
+     * @param  mixed  $default Use this over `??` to preserve explicit `null`
      *
-     * @return mixed|null
+     * @return mixed The argument value or the default
      */
     protected function directiveArgValue(string $name, $default = null)
     {

--- a/src/Schema/Directives/BelongsToManyDirective.php
+++ b/src/Schema/Directives/BelongsToManyDirective.php
@@ -32,12 +32,14 @@ directive @belongsToMany(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 

--- a/src/Schema/Directives/CountDirective.php
+++ b/src/Schema/Directives/CountDirective.php
@@ -64,7 +64,7 @@ GRAPHQL;
 
                 $this->makeBuilderDecorator($resolveInfo)($query);
 
-                if ($this->directiveArgValue('distinct') ?? false) {
+                if ($this->directiveArgValue('distinct')) {
                     $query->distinct();
                 }
 

--- a/src/Schema/Directives/DeleteDirective.php
+++ b/src/Schema/Directives/DeleteDirective.php
@@ -66,9 +66,11 @@ GRAPHQL;
      */
     public function __invoke($parent, $idOrIds): void
     {
-        $relationName = $this->directiveArgValue('relation')
+        $relationName = $this->directiveArgValue(
+            'relation',
             // Use the name of the argument if no explicit relation name is given
-            ?? $this->nodeName();
+            $this->nodeName()
+        );
         /** @var \Illuminate\Database\Eloquent\Relations\Relation $relation */
         $relation = $parent->{$relationName}();
 

--- a/src/Schema/Directives/EqDirective.php
+++ b/src/Schema/Directives/EqDirective.php
@@ -46,7 +46,7 @@ GRAPHQL;
     public function handleBuilder($builder, $value): object
     {
         return $builder->where(
-            $this->directiveArgValue('key') ?? $this->nodeName(),
+            $this->directiveArgValue('key', $this->nodeName()),
             $value
         );
     }
@@ -54,7 +54,7 @@ GRAPHQL;
     public function handleScoutBuilder(ScoutBuilder $builder, $value): ScoutBuilder
     {
         return $builder->where(
-            $this->directiveArgValue('key') ?? $this->nodeName(),
+            $this->directiveArgValue('key', $this->nodeName()),
             $value
         );
     }

--- a/src/Schema/Directives/FindDirective.php
+++ b/src/Schema/Directives/FindDirective.php
@@ -39,7 +39,7 @@ GRAPHQL;
                 ->argumentSet
                 ->enhanceBuilder(
                     $this->getModelClass()::query(),
-                    $this->directiveArgValue('scopes') ?? []
+                    $this->directiveArgValue('scopes', [])
                 )
                 ->get();
 

--- a/src/Schema/Directives/FirstDirective.php
+++ b/src/Schema/Directives/FirstDirective.php
@@ -38,7 +38,7 @@ GRAPHQL;
                 ->argumentSet
                 ->enhanceBuilder(
                     $this->getModelClass()::query(),
-                    $this->directiveArgValue('scopes') ?? []
+                    $this->directiveArgValue('scopes', [])
                 )
                 ->first();
         });

--- a/src/Schema/Directives/HasManyDirective.php
+++ b/src/Schema/Directives/HasManyDirective.php
@@ -33,12 +33,14 @@ directive @hasMany(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 

--- a/src/Schema/Directives/InDirective.php
+++ b/src/Schema/Directives/InDirective.php
@@ -25,7 +25,7 @@ GRAPHQL;
     public function handleBuilder($builder, $value): object
     {
         return $builder->whereIn(
-            $this->directiveArgValue('key') ?? $this->nodeName(),
+            $this->directiveArgValue('key', $this->nodeName()),
             $value
         );
     }

--- a/src/Schema/Directives/LikeDirective.php
+++ b/src/Schema/Directives/LikeDirective.php
@@ -59,7 +59,7 @@ GRAPHQL;
         }
 
         return $builder->where(
-            $this->directiveArgValue('key') ?? $this->nodeName(),
+            $this->directiveArgValue('key', $this->nodeName()),
             'LIKE',
             $value
         );

--- a/src/Schema/Directives/MethodDirective.php
+++ b/src/Schema/Directives/MethodDirective.php
@@ -32,8 +32,7 @@ GRAPHQL;
     public function resolveField(FieldValue $fieldValue): FieldValue
     {
         $fieldValue->setResolver(function ($root, array $args) {
-            $method = $this->directiveArgValue('name')
-                ?? $this->nodeName();
+            $method = $this->directiveArgValue('name', $this->nodeName());
             assert(is_string($method));
 
             $orderedArgs = [];

--- a/src/Schema/Directives/MorphManyDirective.php
+++ b/src/Schema/Directives/MorphManyDirective.php
@@ -32,12 +32,14 @@ directive @morphMany(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 

--- a/src/Schema/Directives/MorphToManyDirective.php
+++ b/src/Schema/Directives/MorphToManyDirective.php
@@ -32,12 +32,14 @@ directive @morphToMany(
   """
   Allow clients to query paginated lists without specifying the amount of items.
   Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  Setting this to `null` means clients have to explicitly ask for the count.
   """
   defaultCount: Int
 
   """
   Limit the maximum amount of items that clients can request from paginated lists.
   Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  Setting this to `null` means the count is unrestricted.
   """
   maxCount: Int
 

--- a/src/Schema/Directives/MutationExecutorDirective.php
+++ b/src/Schema/Directives/MutationExecutorDirective.php
@@ -54,9 +54,11 @@ abstract class MutationExecutorDirective extends BaseDirective implements FieldR
      */
     public function __invoke($parent, $args)
     {
-        $relationName = $this->directiveArgValue('relation')
+        $relationName = $this->directiveArgValue(
+            'relation',
             // Use the name of the argument if no explicit relation name is given
-            ?? $this->nodeName();
+            $this->nodeName()
+        );
 
         $relation = $parent->{$relationName}();
         assert($relation instanceof Relation);

--- a/src/Schema/Directives/NeqDirective.php
+++ b/src/Schema/Directives/NeqDirective.php
@@ -25,7 +25,7 @@ GRAPHQL;
     public function handleBuilder($builder, $value): object
     {
         return $builder->where(
-            $this->directiveArgValue('key') ?? $this->nodeName(),
+            $this->directiveArgValue('key', $this->nodeName()),
             '<>',
             $value
         );

--- a/src/Schema/Directives/NotInDirective.php
+++ b/src/Schema/Directives/NotInDirective.php
@@ -25,7 +25,7 @@ GRAPHQL;
     public function handleBuilder($builder, $value): object
     {
         return $builder->whereNotIn(
-            $this->directiveArgValue('key') ?? $this->nodeName(),
+            $this->directiveArgValue('key', $this->nodeName()),
             $value
         );
     }

--- a/src/Schema/Directives/RelationDirective.php
+++ b/src/Schema/Directives/RelationDirective.php
@@ -181,14 +181,12 @@ abstract class RelationDirective extends BaseDirective implements FieldResolver
 
     protected function paginationMaxCount(): ?int
     {
-        return $this->directiveArgValue('maxCount')
-            ?? $this->lighthouseConfig['pagination']['max_count'];
+        return $this->directiveArgValue('maxCount', $this->lighthouseConfig['pagination']['max_count']);
     }
 
     protected function paginationDefaultCount(): ?int
     {
-        return $this->directiveArgValue('defaultCount')
-            ?? $this->lighthouseConfig['pagination']['default_count'];
+        return $this->directiveArgValue('defaultCount', $this->lighthouseConfig['pagination']['default_count']);
     }
 
     protected function isSameConnection(Relation $relation): bool

--- a/src/Schema/Directives/RelationDirectiveHelpers.php
+++ b/src/Schema/Directives/RelationDirectiveHelpers.php
@@ -18,14 +18,12 @@ trait RelationDirectiveHelpers
      */
     protected function scopes(): array
     {
-        return $this->directiveArgValue('scopes')
-            ?? [];
+        return $this->directiveArgValue('scopes', []);
     }
 
     protected function relation(): string
     {
-        return $this->directiveArgValue('relation')
-            ?? $this->nodeName();
+        return $this->directiveArgValue('relation', $this->nodeName());
     }
 
     /**

--- a/src/Schema/Directives/ScopeDirective.php
+++ b/src/Schema/Directives/ScopeDirective.php
@@ -31,8 +31,7 @@ GRAPHQL;
      */
     public function handleBuilder($builder, $value): object
     {
-        $scope = $this->directiveArgValue('name')
-            ?? $this->nodeName();
+        $scope = $this->directiveArgValue('name', $this->nodeName());
 
         try {
             return $builder->{$scope}($value);

--- a/src/Schema/Directives/ThrottleDirective.php
+++ b/src/Schema/Directives/ThrottleDirective.php
@@ -101,8 +101,8 @@ GRAPHQL;
         } else {
             $limits[] = [
                 'key' => sha1($this->directiveArgValue('prefix') . $this->request->ip()),
-                'maxAttempts' => $this->directiveArgValue('maxAttempts') ?? 60,
-                'decayMinutes' => $this->directiveArgValue('decayMinutes') ?? 1.0,
+                'maxAttempts' => $this->directiveArgValue('maxAttempts', 60),
+                'decayMinutes' => $this->directiveArgValue('decayMinutes', 1.0),
             ];
         }
 

--- a/src/Schema/Directives/WhereBetweenDirective.php
+++ b/src/Schema/Directives/WhereBetweenDirective.php
@@ -28,7 +28,7 @@ GRAPHQL;
     public function handleBuilder($builder, $value): object
     {
         return $builder->whereBetween(
-            $this->directiveArgValue('key') ?? $this->nodeName(),
+            $this->directiveArgValue('key', $this->nodeName()),
             $value
         );
     }

--- a/src/Schema/Directives/WhereDirective.php
+++ b/src/Schema/Directives/WhereDirective.php
@@ -36,7 +36,7 @@ GRAPHQL;
     public function handleBuilder($builder, $value): object
     {
         // Allow users to overwrite the default "where" clause, e.g. "whereYear"
-        $clause = $this->directiveArgValue('clause',  'where');
+        $clause = $this->directiveArgValue('clause', 'where');
 
         return $builder->{$clause}(
             $this->directiveArgValue('key', $this->nodeName()),

--- a/src/Schema/Directives/WhereDirective.php
+++ b/src/Schema/Directives/WhereDirective.php
@@ -36,11 +36,11 @@ GRAPHQL;
     public function handleBuilder($builder, $value): object
     {
         // Allow users to overwrite the default "where" clause, e.g. "whereYear"
-        $clause = $this->directiveArgValue('clause') ?? 'where';
+        $clause = $this->directiveArgValue('clause',  'where');
 
         return $builder->{$clause}(
-            $this->directiveArgValue('key') ?? $this->nodeName(),
-            $this->directiveArgValue('operator') ?? '=',
+            $this->directiveArgValue('key', $this->nodeName()),
+            $this->directiveArgValue('operator', '='),
             $value
         );
     }

--- a/src/Schema/Directives/WhereJsonContainsDirective.php
+++ b/src/Schema/Directives/WhereJsonContainsDirective.php
@@ -25,7 +25,7 @@ GRAPHQL;
     public function handleBuilder($builder, $value): object
     {
         return $builder->whereJsonContains(
-            $this->directiveArgValue('key',  $this->nodeName()),
+            $this->directiveArgValue('key', $this->nodeName()),
             $value
         );
     }

--- a/src/Schema/Directives/WhereJsonContainsDirective.php
+++ b/src/Schema/Directives/WhereJsonContainsDirective.php
@@ -25,7 +25,7 @@ GRAPHQL;
     public function handleBuilder($builder, $value): object
     {
         return $builder->whereJsonContains(
-            $this->directiveArgValue('key') ?? $this->nodeName(),
+            $this->directiveArgValue('key',  $this->nodeName()),
             $value
         );
     }

--- a/src/Schema/Directives/WhereNotBetweenDirective.php
+++ b/src/Schema/Directives/WhereNotBetweenDirective.php
@@ -28,7 +28,7 @@ GRAPHQL;
     public function handleBuilder($builder, $value): object
     {
         return $builder->whereNotBetween(
-            $this->directiveArgValue('key') ?? $this->nodeName(),
+            $this->directiveArgValue('key', $this->nodeName()),
             $value
         );
     }

--- a/src/Support/Traits/GeneratesColumnsEnum.php
+++ b/src/Support/Traits/GeneratesColumnsEnum.php
@@ -48,7 +48,6 @@ trait GeneratesColumnsEnum
         ObjectTypeDefinitionNode &$parentType
     ): string {
         $columnsEnum = $this->directiveArgValue('columnsEnum');
-
         if (! is_null($columnsEnum)) {
             return $columnsEnum;
         }

--- a/src/Testing/MockDirective.php
+++ b/src/Testing/MockDirective.php
@@ -39,7 +39,7 @@ GRAPHQL;
     public function resolveField(FieldValue $fieldValue): FieldValue
     {
         $fieldValue->setResolver(function () {
-            $key = $this->directiveArgValue('key') ?? 'default';
+            $key = $this->directiveArgValue('key', 'default');
             $resolver = $this->mockResolverService->get($key);
 
             return $resolver(...func_get_args());

--- a/src/Validation/ValidatorDirective.php
+++ b/src/Validation/ValidatorDirective.php
@@ -86,13 +86,10 @@ GRAPHQL;
             );
         }
 
-        if ($this->directiveHasArgument('class')) {
-            $classCandidate = $this->directiveArgValue('class');
-        } else {
-            $classCandidate = $typeDefinition->name->value . 'Validator';
-        }
-
-        $this->setFullClassnameOnDirective($typeDefinition, $classCandidate);
+        $this->setFullClassnameOnDirective(
+            $typeDefinition,
+            $this->directiveArgValue('class', "{$typeDefinition->name->value}Validator")
+        );
     }
 
     public function manipulateFieldDefinition(
@@ -100,16 +97,16 @@ GRAPHQL;
         FieldDefinitionNode &$fieldDefinition,
         ObjectTypeDefinitionNode &$parentType
     ) {
-        if ($this->directiveHasArgument('class')) {
-            $classCandidate = $this->directiveArgValue('class');
-        } else {
-            $classCandidate = $parentType->name->value
-                . '\\'
-                . ucfirst($fieldDefinition->name->value)
-                . 'Validator';
-        }
-
-        $this->setFullClassnameOnDirective($fieldDefinition, $classCandidate);
+        $this->setFullClassnameOnDirective(
+            $fieldDefinition,
+            $this->directiveArgValue(
+                'class',
+                $parentType->name->value
+                    . '\\'
+                    . ucfirst($fieldDefinition->name->value)
+                    . 'Validator'
+            )
+        );
     }
 
     /**

--- a/tests/Integration/Pagination/PaginateDirectiveDBTest.php
+++ b/tests/Integration/Pagination/PaginateDirectiveDBTest.php
@@ -796,6 +796,35 @@ GRAPHQL;
         ')->assertJsonCount($defaultCount, 'data.users.data');
     }
 
+    public function testIsUnlimitedByMaxCountFromDirective(): void
+    {
+        config(['lighthouse.pagination.max_count' => 5]);
+
+        $this->schema = /** @lang GraphQL */ '
+        type User {
+            id: ID!
+            name: String!
+        }
+
+        type Query {
+            users: [User!]! @paginate(maxCount: null)
+        }
+        ';
+
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            {
+                users(first: 10) {
+                    data {
+                        id
+                        name
+                    }
+                }
+            }
+            ')
+            ->assertGraphQLErrorFree();
+    }
+
     public function testQueriesSimplePagination(): void
     {
         config(['lighthouse.pagination.default_count' => 10]);

--- a/tests/Integration/Schema/Directives/MorphManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/MorphManyDirectiveTest.php
@@ -306,6 +306,46 @@ final class MorphManyDirectiveTest extends DBTestCase
         );
     }
 
+    public function testPaginatorTypeIsUnlimitedByMaxCountFromDirective(): void
+    {
+        config(['lighthouse.pagination.max_count' => 1]);
+
+        $this->schema = /** @lang GraphQL */ '
+        type Post {
+            id: ID!
+            title: String!
+            images: [Image!] @morphMany(type: PAGINATOR, maxCount: null)
+        }
+
+        type Image {
+            id: ID!
+        }
+
+        type Query {
+            post (
+                id: ID! @eq
+            ): Post @find
+        }
+        ';
+
+        $this
+            ->graphQL(/** @lang GraphQL */ "
+            {
+                post(id: {$this->post->id}) {
+                    id
+                    title
+                    images(first: 10) {
+                        data {
+                            id
+                        }
+                    }
+                }
+            }
+            ")
+            ->assertGraphQLErrorFree();
+
+    }
+
     public function testHandlesPaginationWithCountZero(): void
     {
         $this->schema = /** @lang GraphQL */ '

--- a/tests/Integration/Schema/Directives/MorphManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/MorphManyDirectiveTest.php
@@ -343,7 +343,6 @@ final class MorphManyDirectiveTest extends DBTestCase
             }
             ")
             ->assertGraphQLErrorFree();
-
     }
 
     public function testHandlesPaginationWithCountZero(): void

--- a/tests/Unit/Pagination/PaginateDirectiveTest.php
+++ b/tests/Unit/Pagination/PaginateDirectiveTest.php
@@ -554,6 +554,34 @@ GRAPHQL
         );
     }
 
+    public function testCountExplicitlyRequiredFromDirective(): void
+    {
+        config(['lighthouse.pagination.default_count' => 2]);
+
+        $this->schema = /** @lang GraphQL */ '
+        type User {
+            id: ID!
+            name: String!
+        }
+
+        type Query {
+            users: [User!] @paginate(defaultCount: null)
+        }
+        ';
+
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            {
+                users {
+                    data {
+                        id
+                    }
+                }
+            }
+            ')
+            ->assertGraphQLErrorMessage('Field "users" argument "first" of type "Int!" is required but not provided.');
+    }
+
     /**
      * @dataProvider nonNullPaginationResults
      */

--- a/tests/Unit/Pagination/PaginateDirectiveTest.php
+++ b/tests/Unit/Pagination/PaginateDirectiveTest.php
@@ -486,35 +486,6 @@ GRAPHQL
         );
     }
 
-    public function testIsUnlimitedByMaxCountFromDirective(): void
-    {
-        config(['lighthouse.pagination.max_count' => 5]);
-
-        $this->schema = /** @lang GraphQL */ '
-        type User {
-            id: ID!
-            name: String!
-        }
-
-        type Query {
-            users: [User!]! @paginate(maxCount: null)
-        }
-        ';
-
-        $this
-            ->graphQL(/** @lang GraphQL */ '
-            {
-                users(first: 10) {
-                    data {
-                        id
-                        name
-                    }
-                }
-            }
-            ')
-            ->assertGraphQLErrorFree();
-    }
-
     public function testIsLimitedToMaxCountFromConfig(): void
     {
         config(['lighthouse.pagination.max_count' => 5]);

--- a/tests/Unit/Pagination/PaginateDirectiveTest.php
+++ b/tests/Unit/Pagination/PaginateDirectiveTest.php
@@ -486,6 +486,35 @@ GRAPHQL
         );
     }
 
+    public function testIsUnlimitedByMaxCountFromDirective(): void
+    {
+        config(['lighthouse.pagination.max_count' => 5]);
+
+        $this->schema = /** @lang GraphQL */ '
+        type User {
+            id: ID!
+            name: String!
+        }
+
+        type Query {
+            users: [User!]! @paginate(maxCount: null)
+        }
+        ';
+
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            {
+                users(first: 10) {
+                    data {
+                        id
+                        name
+                    }
+                }
+            }
+            ')
+            ->assertGraphQLErrorFree();
+    }
+
     public function testIsLimitedToMaxCountFromConfig(): void
     {
         config(['lighthouse.pagination.max_count' => 5]);


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

In configuration file `lighthouse.pagination` the key `defaultCount` and `maxCount` are used as a default value when not specified in schema.   Also, specific behaviors [are documented](https://github.com/nuwave/lighthouse/blob/master/src/lighthouse.php#L210) in  for these key for the `null` values. 

```php
    'pagination' => [
        /*
         * Allow clients to query paginated lists without specifying the amount of items.
         * Setting this to `null` means clients have to explicitly ask for the count.
         */
        'default_count' => null,

        /*
         * Limit the maximum amount of items that clients can request from paginated lists.
         * Setting this to `null` means the count is unrestricted.
         */
        'max_count' => null,
    ],
```
  
  While it is authorized currently to override these default value in schema, by setting value higher or lower than the configuration value; It is not currently supported to explicitly set `null` in schema exceptionally, for a specified field to unrestrict pagination (maxCount: null) OR to make clients have to explicitly ask for the count (defaultCount: null)
  
    This PR solves this little inconsistency between schema and configuration behavior.
  
**Breaking changes**

Even if this might be very unusual, people using explicitly `maxCount: null` or `defaultCount: null` in their schema, are  currently falling back to configuration value if any.     With this PR, `maxCount: null` will unrestrict pagination limitation, while `defaultCount: null` will require clients to explicitly ask for the count. 

People not specifying maxCount or defaultCount in schema and relying on configuration fallback remains backward compatible.

