### PR TITLE
Fix directive option `model` on schema elements using built-in types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.57.5
+
+### Fixed
+
+- Fix directive option `model` on schema elements using built-in types
+
 ## v5.57.4
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Fix directive option `model` on schema elements using built-in types
+- Fix directive option `model` on schema elements using built-in types https://github.com/nuwave/lighthouse/pull/2196
 
 ## v5.57.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Respect explicit `maxCount: null` or `defaultCount: null` in pagination directives over config `lighthouse.pagination`
+- Respect explicit `maxCount: null` or `defaultCount: null` in pagination directives over config `lighthouse.pagination` https://github.com/nuwave/lighthouse/pull/2193
 
 ## v5.57.3
 

--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -382,15 +382,19 @@ class ASTHelper
     {
         $typeName = static::getUnderlyingTypeName($field);
 
-        /** @var \Nuwave\Lighthouse\Schema\AST\ASTBuilder $astBuilder */
+        $standardTypes = Type::getStandardTypes();
+        if (isset($standardTypes[$typeName])) {
+            return Parser::scalarTypeDefinition("scalar {$typeName}");
+        }
+
         $astBuilder = app(ASTBuilder::class);
+        assert($astBuilder instanceof ASTBuilder);
+
         $documentAST = $astBuilder->documentAST();
 
         $type = $documentAST->types[$typeName] ?? null;
         if (null === $type) {
-            throw new DefinitionException(
-                "Type '$typeName' on '{$field->name->value}' can not be found in the schema.'"
-            );
+            throw new DefinitionException("Type '$typeName' on '{$field->name->value}' can not be found in the schema.'");
         }
 
         return $type;

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -151,9 +151,7 @@ abstract class BaseDirective implements Directive
         $model = $this->directiveArgValue($argumentName, ASTHelper::modelName($this->definitionNode));
 
         if (! $model) {
-            throw new DefinitionException(
-                "Could not determine a model name for the '@{$this->name()}' directive on '{$this->nodeName()}."
-            );
+            throw new DefinitionException("Could not determine a model name for the '@{$this->name()}' directive on '{$this->nodeName()}.");
         }
 
         return $this->namespaceModelClass($model);

--- a/src/Schema/FallbackTypeNodeConverter.php
+++ b/src/Schema/FallbackTypeNodeConverter.php
@@ -32,8 +32,9 @@ class FallbackTypeNodeConverter extends TypeNodeConverter
 
     protected function namedType(string $nodeName): Type
     {
-        if (isset(Type::getStandardTypes()[$nodeName])) {
-            return Type::getStandardTypes()[$nodeName];
+        $standardTypes = Type::getStandardTypes();
+        if (isset($standardTypes[$nodeName])) {
+            return $standardTypes[$nodeName];
         }
 
         if (! $this->typeRegistry->has($nodeName)) {

--- a/tests/Unit/Schema/AST/ASTHelperTest.php
+++ b/tests/Unit/Schema/AST/ASTHelperTest.php
@@ -3,7 +3,10 @@
 namespace Tests\Unit\Schema\AST;
 
 use GraphQL\Language\AST\DirectiveDefinitionNode;
+use GraphQL\Language\AST\FieldDefinitionNode;
+use GraphQL\Language\AST\ScalarTypeDefinitionNode;
 use GraphQL\Language\Parser;
+use GraphQL\Type\Definition\Type;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Tests\TestCase;
@@ -25,8 +28,7 @@ final class ASTHelperTest extends TestCase
         ');
 
         $this->expectException(DefinitionException::class);
-
-        $objectType1->fields = ASTHelper::mergeUniqueNodeList(
+        ASTHelper::mergeUniqueNodeList(
             $objectType1->fields,
             $objectType2->fields
         );
@@ -56,9 +58,9 @@ final class ASTHelperTest extends TestCase
 
         $this->assertCount(3, $objectType1->fields);
 
-        /** @var \GraphQL\Language\AST\FieldDefinitionNode $firstNameField */
         $firstNameField = ASTHelper::firstByName($objectType1->fields, 'first_name');
 
+        assert($firstNameField instanceof FieldDefinitionNode);
         $this->assertCount(1, $firstNameField->directives);
     }
 
@@ -190,7 +192,6 @@ GRAPHQL
     public function testThrowsOnSyntaxError(): void
     {
         $this->expectException(DefinitionException::class);
-
         ASTHelper::extractDirectiveDefinition(/** @lang GraphQL */ <<<'GRAPHQL'
 invalid GraphQL
 GRAPHQL
@@ -200,7 +201,6 @@ GRAPHQL
     public function testThrowsIfMissingDirectiveDefinitions(): void
     {
         $this->expectException(DefinitionException::class);
-
         ASTHelper::extractDirectiveDefinition(/** @lang GraphQL */ <<<'GRAPHQL'
 scalar Foo
 GRAPHQL
@@ -210,11 +210,20 @@ GRAPHQL
     public function testThrowsOnMultipleDirectiveDefinitions(): void
     {
         $this->expectException(DefinitionException::class);
-
         ASTHelper::extractDirectiveDefinition(/** @lang GraphQL */ <<<'GRAPHQL'
 directive @foo on OBJECT
 directive @bar on OBJECT
 GRAPHQL
         );
+    }
+
+    public function testUnderlyingTypeKnowsStandardTypes(): void
+    {
+        $type = ASTHelper::underlyingType(
+            Parser::fieldDefinition('foo: ID')
+        );
+
+        $this->assertInstanceOf(ScalarTypeDefinitionNode::class, $type);
+        $this->assertSame(Type::ID, $type->name->value);
     }
 }

--- a/tests/Unit/Schema/Directives/BaseDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/BaseDirectiveTest.php
@@ -198,7 +198,7 @@ final class BaseDirectiveTest extends TestCase
             }
 
             /**
-             * Allow to call protected methods from the test.
+             * Allows calling protected methods from the test.
              *
              * @param  array<mixed>  $args
              *

--- a/tests/Unit/Schema/Directives/BaseDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/BaseDirectiveTest.php
@@ -77,8 +77,6 @@ final class BaseDirectiveTest extends TestCase
     {
         $directive = $this->constructFieldDirective('foo: String @dummy(model: "Team")');
 
-        $directive->getModelClass();
-
         $this->assertSame(
             Team::class,
             $directive->getModelClass()

--- a/tests/Unit/Schema/Directives/BaseDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/BaseDirectiveTest.php
@@ -73,6 +73,18 @@ final class BaseDirectiveTest extends TestCase
         $directive->getModelClass();
     }
 
+    public function testBuiltInTypeTolerated(): void
+    {
+        $directive = $this->constructFieldDirective('foo: String @dummy(model: "Team")');
+
+        $directive->getModelClass();
+
+        $this->assertSame(
+            Team::class,
+            $directive->getModelClass()
+        );
+    }
+
     public function testThrowsIfTheClassIsNotAModel(): void
     {
         $this->schema .= /** @lang GraphQL */ '


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] ~Documented user facing changes~
- [x] Updated CHANGELOG.md

Resolves https://github.com/nuwave/lighthouse/pull/2195

Resolves https://github.com/nuwave/lighthouse/issues/2194

**Changes**

Adds a fallback to `ASTHelper::getUnderlyingType()` for built-in types.

**Breaking changes**

None.