### PR TITLE
Open EnsureXHR middleware for extension

### DIFF
--- a/src/Support/Http/Middleware/EnsureXHR.php
+++ b/src/Support/Http/Middleware/EnsureXHR.php
@@ -48,7 +48,7 @@ class EnsureXHR
             throw new BadRequestHttpException('Content-Type header must be set');
         }
 
-        if (Str::startsWith($contentType, self::FORM_CONTENT_TYPES)) {
+        if (Str::startsWith($contentType, static::FORM_CONTENT_TYPES)) {
             throw new BadRequestHttpException("Content-Type $contentType is forbidden");
         }
 


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

This PR makes the ```handle``` method of the ```EnsureXHR``` class to inherit ```FORM_CONTENT_TYPES``` const (when EnsureXHR class is extended).

Use case:
By extending the ```EnsureXHR``` class, one can exclude any content-type (like multipart/form-data) without the need to override the middleware's handle method. 

<details>
  <summary>See example code</summary>

```
...

class EnsureXHR extends \Nuwave\Lighthouse\Support\Http\Middleware\EnsureXHR
{
    public const FORM_CONTENT_TYPES = [
        'application/x-www-form-urlencoded',
        'text/plain',
    ];

    public function handle(Request $request, Closure $next)
    {
        return parent::handle($request, $next);
    }
}

```
</details>

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
