### PR TITLE
Allow configuring `security.disable_introspection` through the env variable `LIGHTHOUSE_SECURITY_DISABLE_INTROSPECTION`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
-- Allow configuring the `disable_introspection setting` via the `.env` file https://github.com/nuwave/lighthouse/pull/2205
+### Added
+
+- Allow configuring `security.disable_introspection` through the env variable `LIGHTHOUSE_SECURITY_DISABLE_INTROSPECTION` https://github.com/nuwave/lighthouse/pull/2205
 
 ## v5.58.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+- Allow configuring the `disable_introspection setting` via the `.env` file https://github.com/nuwave/lighthouse/pull/2205
+
 ## v5.58.2
 
 ### Fixed

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -193,7 +193,9 @@ return [
     'security' => [
         'max_query_complexity' => \GraphQL\Validator\Rules\QueryComplexity::DISABLED,
         'max_query_depth' => \GraphQL\Validator\Rules\QueryDepth::DISABLED,
-        'disable_introspection' => \GraphQL\Validator\Rules\DisableIntrospection::DISABLED,
+        'disable_introspection' => (bool) env('LIGHTHOUSE_DISABLE_INTROSPECTION', false)
+            ? \GraphQL\Validator\Rules\DisableIntrospection::ENABLED
+            : \GraphQL\Validator\Rules\DisableIntrospection::DISABLED,
     ],
 
     /*

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -193,7 +193,7 @@ return [
     'security' => [
         'max_query_complexity' => \GraphQL\Validator\Rules\QueryComplexity::DISABLED,
         'max_query_depth' => \GraphQL\Validator\Rules\QueryDepth::DISABLED,
-        'disable_introspection' => (bool) env('LIGHTHOUSE_DISABLE_INTROSPECTION', false)
+        'disable_introspection' => (bool) env('LIGHTHOUSE_SECURITY_DISABLE_INTROSPECTION', false)
             ? \GraphQL\Validator\Rules\DisableIntrospection::ENABLED
             : \GraphQL\Validator\Rules\DisableIntrospection::DISABLED,
     ],


### PR DESCRIPTION
- [ ] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Allow configuring the disable_introspection setting via the .env file.

I find this feature useful because i like using introspection on local environments only.
On testing/production I disable introspection, so having the ability to configure introspection from the  ```.env``` file might be useful.

**Breaking changes**
none

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
