### PR TITLE
Complex where conditions custom column names fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.62.0
+
+### Changed
+
+- Extract uploaded file name calculation to method in `@upload` directive https://github.com/nuwave/lighthouse/pull/2215
+
 ## v5.61.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1868,4 +1868,3 @@ You can find and compare releases at the [GitHub release page](https://github.co
 We just started maintaining a changelog starting from v3.
 
 If someone wants to make one for previous versions, pull requests are welcome.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+- Fixed GraphQL enum names generation from column names containing symbols 
+
 ## v5.62.0
 
 ### Changed
@@ -1866,3 +1868,4 @@ You can find and compare releases at the [GitHub release page](https://github.co
 We just started maintaining a changelog starting from v3.
 
 If someone wants to make one for previous versions, pull requests are welcome.
+

--- a/src/Support/Traits/GeneratesColumnsEnum.php
+++ b/src/Support/Traits/GeneratesColumnsEnum.php
@@ -2,7 +2,6 @@
 
 namespace Nuwave\Lighthouse\Support\Traits;
 
-use Illuminate\Support\Str;
 use GraphQL\Language\Parser;
 use Nuwave\Lighthouse\Support\Utils;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;

--- a/src/Support/Traits/GeneratesColumnsEnum.php
+++ b/src/Support/Traits/GeneratesColumnsEnum.php
@@ -2,15 +2,16 @@
 
 namespace Nuwave\Lighthouse\Support\Traits;
 
-use GraphQL\Language\AST\EnumTypeDefinitionNode;
+use Illuminate\Support\Str;
+use GraphQL\Language\Parser;
+use Nuwave\Lighthouse\Support\Utils;
+use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use GraphQL\Language\AST\FieldDefinitionNode;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+use GraphQL\Language\AST\EnumTypeDefinitionNode;
 use GraphQL\Language\AST\InputValueDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
-use GraphQL\Language\Parser;
-use Illuminate\Support\Str;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
-use Nuwave\Lighthouse\Schema\AST\ASTHelper;
-use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 
 /**
  * Directives may want to constrain database columns to an enum.
@@ -83,9 +84,7 @@ trait GeneratesColumnsEnum
         $enumValues = array_map(
             function (string $columnName): string {
                 return
-                    strtoupper(
-                        Str::snake($columnName)
-                    )
+                    Utils::columnNameToGraphQLName($columnName)
                     . ' @enum(value: "' . $columnName . '")';
             },
             $allowedColumns

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -3,9 +3,10 @@
 namespace Nuwave\Lighthouse\Support;
 
 use Closure;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use ReflectionClass;
 use ReflectionException;
+use Illuminate\Support\Str;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
 
 class Utils
 {
@@ -160,5 +161,26 @@ class Utils
         return function ($object) use ($classLike): bool {
             return $object instanceof $classLike;
         };
+    }
+
+    /**
+     * Return valid uppercased GraphQL columns enum name for a given column name.
+     *
+     * @param  string  $columnName
+     * 
+     * @return string
+     */
+    public static function columnNameToGraphQLName(string $columnName): string
+    {
+        // preserve separator on specific characters like $ for MariaDB and . for MongoDB
+        $separatedColumnName = str_replace(str_split('\$\.'), '_', Str::snake($columnName));
+
+        // valid graphql name can only start with a letter or underscore
+        // https://spec.graphql.org/draft/#sec-Names
+        $prepend = preg_match('/^[a-zA-Z_]/', $separatedColumnName) ? '' : '_';
+
+        return strtoupper(
+            $prepend . Str::slug($separatedColumnName, "_")
+        );
     }
 }

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -7,6 +7,7 @@ use ReflectionClass;
 use ReflectionException;
 use Illuminate\Support\Str;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use function Safe\preg_match;
 
 class Utils
 {

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -165,10 +165,6 @@ class Utils
 
     /**
      * Return valid uppercased GraphQL columns enum name for a given column name.
-     *
-     * @param  string  $columnName
-     * 
-     * @return string
      */
     public static function columnNameToGraphQLName(string $columnName): string
     {

--- a/tests/Integration/Execution/ArgBuilderDirectiveTest.php
+++ b/tests/Integration/Execution/ArgBuilderDirectiveTest.php
@@ -209,7 +209,7 @@ final class ArgBuilderDirectiveTest extends DBTestCase
         ', [
             'between' => [
                 now()->subDay()->startOfDay()->format('Y-m-d H:i:s'),
-                now()->subDay()->endOfDay()->format('Y-m-d H:i:s')
+                now()->subDay()->endOfDay()->format('Y-m-d H:i:s'),
             ],
         ])->assertJsonCount(1, 'data.users');
     }
@@ -282,7 +282,7 @@ final class ArgBuilderDirectiveTest extends DBTestCase
             'between' => [
                 now()->subDay()->startOfDay()->format('Y-m-d H:i:s'),
                 now()->subDay()->endOfDay()->format('Y-m-d H:i:s'),
-            ]
+            ],
         ])->assertJsonCount(2, 'data.users');
     }
 
@@ -312,7 +312,7 @@ final class ArgBuilderDirectiveTest extends DBTestCase
             }
         }
         ', [
-            'created_at' => $oneYearAgo->format('Y')
+            'created_at' => $oneYearAgo->format('Y'),
         ])->assertJsonCount(1, 'data.users');
     }
 

--- a/tests/Unit/Support/UtilsTest.php
+++ b/tests/Unit/Support/UtilsTest.php
@@ -7,14 +7,7 @@ use Nuwave\Lighthouse\Support\Utils;
 
 final class UtilsTest extends TestCase
 {
-    /**
-     * A basic unit test example.
-     *
-     * @return void
-     * @group utils
-     */
-
-    public function testUsualColumnNameGeneratorHelper(): void
+    public function testColumnNameToGraphQLName(): void
     {
         $this->assertSame(
             'COLUMN_NAME',
@@ -25,17 +18,7 @@ final class UtilsTest extends TestCase
             'COLUMN_NAME',
             Utils::columnNameToGraphQLName('columnName')
         );
-    }
 
-    /**
-     * A basic unit test example.
-     *
-     * @return void
-     * @group utils
-     */
-
-    public function testUnusualColumnNameGeneratorHelper(): void
-    {
         $this->assertSame(
             'SOME_NESTED_COLUMN_NAME',
             Utils::columnNameToGraphQLName('some.nested.column_name')

--- a/tests/Unit/Support/UtilsTest.php
+++ b/tests/Unit/Support/UtilsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit\Support\Http\Middleware;
+
+use Tests\TestCase;
+use Nuwave\Lighthouse\Support\Utils;
+
+final class UtilsTest extends TestCase
+{
+    /**
+     * A basic unit test example.
+     *
+     * @return void
+     * @group utils
+     */
+
+    public function testUsualColumnNameGeneratorHelper(): void
+    {
+        $this->assertSame(
+            'COLUMN_NAME',
+            Utils::columnNameToGraphQLName('column_name')
+        );
+
+        $this->assertSame(
+            'COLUMN_NAME',
+            Utils::columnNameToGraphQLName('columnName')
+        );
+    }
+
+    /**
+     * A basic unit test example.
+     *
+     * @return void
+     * @group utils
+     */
+
+    public function testUnusualColumnNameGeneratorHelper(): void
+    {
+        $this->assertSame(
+            'SOME_NESTED_COLUMN_NAME',
+            Utils::columnNameToGraphQLName('some.nested.column_name')
+        );
+
+        $this->assertSame(
+            'COLUMN_NAME',
+            Utils::columnNameToGraphQLName('$columnName')
+        );
+
+        $this->assertSame(
+            '_123_COLUMN_NAME',
+            Utils::columnNameToGraphQLName('123_column_name')
+        );
+
+        $this->assertSame(
+            '_123_COLUMN_NAME',
+            Utils::columnNameToGraphQLName('123Column$Name')
+        );
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Updated CHANGELOG.md

Resolves #2216

**Changes**

GeneratesColumnsEnum trait now uses static method columnNameToGraphQLName added to Utils. This should prevent the generation of invalid GraphQL names from column names.

