### PR TITLE
Improve handling `ModelNotFoundException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
-## v5.6x.0
-
 ### Fixed
 
 - Fix handle model not found thrown inside a custom mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.6x.0
+
+### Fixed
+
+- Fix handle model not found thrown inside a custom mutation.
+
+### Added
+
+- Add a new error handler `ModelNotFoundErrorHandler` to handle models not found correctly, before this had the category internal server error.
+
 ## v5.63.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,9 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
-### Fixed
+### Changed
 
-- Fix handle model not found thrown inside a custom mutation.
-
-### Added
-
-- Add a new error handler `ModelNotFoundErrorHandler` to handle models not found correctly, before this had the category internal server error.
+- Improve handling `ModelNotFoundException` https://github.com/nuwave/lighthouse/pull/2220
 
 ## v5.63.0
 

--- a/src/Auth/CanDirective.php
+++ b/src/Auth/CanDirective.php
@@ -11,7 +11,6 @@ use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
@@ -198,18 +197,14 @@ GRAPHQL;
                 $queryBuilder->onlyTrashed();
             }
 
-            try {
-                $enhancedBuilder = $argumentSet->enhanceBuilder(
-                    $queryBuilder,
-                    $this->directiveArgValue('scopes', []),
-                    Utils::instanceofMatcher(TrashedDirective::class)
-                );
-                assert($enhancedBuilder instanceof Builder);
+            $enhancedBuilder = $argumentSet->enhanceBuilder(
+                $queryBuilder,
+                $this->directiveArgValue('scopes', []),
+                Utils::instanceofMatcher(TrashedDirective::class)
+            );
+            assert($enhancedBuilder instanceof Builder);
 
-                $modelOrModels = $enhancedBuilder->findOrFail($findValue);
-            } catch (ModelNotFoundException $exception) {
-                throw new Error($exception->getMessage());
-            }
+            $modelOrModels = $enhancedBuilder->findOrFail($findValue);
 
             if ($modelOrModels instanceof Model) {
                 $modelOrModels = [$modelOrModels];

--- a/src/Execution/ModelNotFoundErrorHandler.php
+++ b/src/Execution/ModelNotFoundErrorHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Nuwave\Lighthouse\Execution;
+
+use Closure;
+use GraphQL\Error\Error;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+/**
+ * Wrap model not found exceptions.
+ */
+class ModelNotFoundErrorHandler implements ErrorHandler
+{
+    public function __invoke(?Error $error, Closure $next): ?array
+    {
+        if (null === $error) {
+            return $next(null);
+        }
+
+        $previous = $error->getPrevious();
+
+        if ($previous instanceof ModelNotFoundException) {
+            return $next(new Error($previous->getMessage()));
+        }
+
+        return $next($error);
+    }
+}

--- a/src/Execution/ModelNotFoundErrorHandler.php
+++ b/src/Execution/ModelNotFoundErrorHandler.php
@@ -20,7 +20,7 @@ class ModelNotFoundErrorHandler implements ErrorHandler
         $previous = $error->getPrevious();
 
         if ($previous instanceof ModelNotFoundException) {
-            return $next(new Error($previous->getMessage()));
+            return $next(new Error($previous->getMessage(), null, null, [], null, null, ['category' => 'not_found']));
         }
 
         return $next($error);

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -266,6 +266,7 @@ return [
     'error_handlers' => [
         \Nuwave\Lighthouse\Execution\AuthenticationErrorHandler::class,
         \Nuwave\Lighthouse\Execution\AuthorizationErrorHandler::class,
+        \Nuwave\Lighthouse\Execution\ModelNotFoundErrorHandler::class,
         \Nuwave\Lighthouse\Execution\ValidationErrorHandler::class,
         \Nuwave\Lighthouse\Execution\ExtensionErrorHandler::class,
         \Nuwave\Lighthouse\Execution\ReportingErrorHandler::class,

--- a/tests/Integration/ModelNotFound/ModelNotFoundTest.php
+++ b/tests/Integration/ModelNotFound/ModelNotFoundTest.php
@@ -34,6 +34,6 @@ class ModelNotFoundTest extends DBTestCase
         '
         )
             ->assertGraphQLErrorMessage( 'No query results for model [Tests\Utils\Models\Post] -1')
-            ->assertGraphQLErrorCategory('graphql');
+            ->assertGraphQLErrorCategory('not_found');
     }
 }

--- a/tests/Integration/ModelNotFound/ModelNotFoundTest.php
+++ b/tests/Integration/ModelNotFound/ModelNotFoundTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Integration\ModelNotFound;
+
+use Tests\DBTestCase;
+
+/**
+ * This test out the functionality of the error handler `NotFoundErrorHandler`.
+ */
+class ModelNotFoundTest extends DBTestCase
+{
+    protected $schema = /** @lang GraphQL */
+        '
+    type Post {
+        id: ID!
+    }
+
+    type Query {
+            post (
+                id: ID! @eq
+            ): Post @find @can(ability: "view", find: "id")
+        }
+    ';
+
+    public function testModelNotFoundWithCanDirective()
+    {
+        $this->graphQL(
+        /** @lang GraphQL */ '
+        {
+            post(id: -1) {
+                id
+            }
+        }
+        '
+        )
+            ->assertGraphQLErrorMessage( 'No query results for model [Tests\Utils\Models\Post] -1')
+            ->assertGraphQLErrorCategory('graphql');
+    }
+}


### PR DESCRIPTION
- [X] Added or updated tests
- [ ] Documented user facing changes
- [X] Updated CHANGELOG.md (but the numbering still needs to be fixed)

This links to a conversion at [Slack](https://lighthouse-php.slack.com/archives/CB28A070S/p1666092971554689).

**Changes**

This pull request removes the try catch for a model not found.

https://github.com/nuwave/lighthouse/blob/f46b1f4556d29cd7db486c66feef8ce9bebac9ee/src/Auth/CanDirective.php#L201-L212

I have removed the try catch, which means `ModelNotFoundException` thrown from a custom mutation will now also be captured with the new error handler.

While before a custom mutation:

```php
class UpdateArticleContent {
  pubic function __invoke(...) {
    $article = Article::query()->findOrFail();
  }
}
```

Would result in a error response like below:

```json
{
  "errors": [
    {
      "debugMessage": "No query results for model [App\\Article] 500",
      "message": "Internal server error",
      "extensions": {
        "category": "internal"
      }
    }
  ]
}
```

And when debug is disabled, the response was non descriptive and handled as an internal server error:

```json
{
  "errors": [
    {
      "message": "Internal server error",
      "extensions": {
        "category": "internal"
      }
    }
  ],
  "data": {
    "article": null
  }
}
```

With the new changes:

```json
{
  "errors": [
    {
      "message": "No query results for model [App\\Article] -1",
      "extensions": {
        "category": "not_found"
      }
    }
  ],
  "data": {
    "article": null
  }
}
```

Also the category has been changed from "graphql" into "not_found" to make it easier, to detect if content doesn't exist.

**Breaking changes**

Not sure ...
