### PR TITLE
Do not cache schema when runing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Do not cache schema when running tests https://github.com/nuwave/lighthouse/pull/2259
+
 ## v5.69.1
 
 ### Fixed

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -87,7 +87,10 @@ return [
         /*
          * Setting to true enables schema caching.
          */
-        'enable' => env('LIGHTHOUSE_CACHE_ENABLE', 'local' !== env('APP_ENV')),
+        'enable' => env(
+            'LIGHTHOUSE_CACHE_ENABLE',
+            !in_array(env('APP_ENV'), ['local', 'testing'], true)
+        ),
 
         /*
          * Allowed values:


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

Lighthouse config file disables schema caching **only** if `APP_ENV` is set to `local`

Out of the box, `APP_ENV`  is set to `testing` when running PHPUnit tests (as defined in phpunit.xml).

This means that when running tests using `php artisan test` or `sail test` the schema gets cached.
Any further changes to schema require the file ./bootstrap/cache/lighthouse-schema.php to be deleted for the tests to pickup the schema changes, which I don't think is the intended behavior.

This PR fixes that behavior by disabling cache for both `local` and `testing` application environments.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
