### PR TITLE
Fix batch loading a paginated BelongsToMany relation with duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v5.70.1
+
+### Fixed
+
+- Fix batch loading a paginated BelongsToMany relation with duplicates https://github.com/nuwave/lighthouse/pull/2277
+
 ## v5.70.0
 
 ### Added

--- a/src/Execution/ModelsLoader/PaginatedModelsLoader.php
+++ b/src/Execution/ModelsLoader/PaginatedModelsLoader.php
@@ -99,7 +99,11 @@ class PaginatedModelsLoader implements ModelsLoader
         $relatedModels = $mergedRelationQuery->get();
         assert($relatedModels instanceof EloquentCollection);
 
-        return $relatedModels->unique();
+        return $relatedModels->unique(function (Model $relatedModel): string {
+            // Compare all attributes because there might not be a unique primary key
+            // or there could be differing pivot attributes.
+            return $relatedModel->toJson();
+        });
     }
 
     /**

--- a/tests/Integration/Schema/Directives/BelongsToManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/BelongsToManyDirectiveTest.php
@@ -433,7 +433,9 @@ final class BelongsToManyDirectiveTest extends DBTestCase
                     ->map(function (User $user) use ($roleIDs): array {
                         return [
                             'id' => (string) $user->id,
-                            'roles' => $roleIDs,
+                            'roles' => [
+                                'data' => $roleIDs
+                            ],
                         ];
                     })
                     ->all(),

--- a/tests/Integration/Schema/Directives/BelongsToManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/BelongsToManyDirectiveTest.php
@@ -436,7 +436,7 @@ final class BelongsToManyDirectiveTest extends DBTestCase
                             'roles' => $roleIDs,
                         ];
                     })
-                    ->all()
+                    ->all(),
             ],
         ]);
     }

--- a/tests/Integration/Schema/Directives/BelongsToManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/BelongsToManyDirectiveTest.php
@@ -385,6 +385,62 @@ final class BelongsToManyDirectiveTest extends DBTestCase
         ])->assertJsonCount(2, 'data.user.roles.edges');
     }
 
+    public function testQueryPaginatedBelongsToManyWithDuplicates(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            users: [User]! @all
+        }
+
+        type User {
+            id: ID!
+            roles: [Role!]! @belongsToMany(type: SIMPLE)
+        }
+
+        type Role {
+            id: ID!
+        }
+        ';
+
+        $roles = factory(Role::class, 2)->create();
+
+        $users = factory(User::class, 2)->create();
+        foreach ($users as $user) {
+            assert($user instanceof User);
+            $user->roles()->attach($roles);
+        }
+
+        $roleIDs = $roles
+            ->map(function (Role $role): array {
+                return ['id' => (string) $role->id];
+            })
+            ->all();
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            users {
+                id
+                roles(first: 2) {
+                    data {
+                        id
+                    }
+                }
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'users' => $users
+                    ->map(function (User $user) use ($roleIDs): array {
+                        return [
+                            'id' => (string) $user->id,
+                            'roles' => $roleIDs,
+                        ];
+                    })
+                    ->all()
+            ],
+        ]);
+    }
+
     public function testQueryBelongsToManyNestedRelationships(): void
     {
         $this->schema = /** @lang GraphQL */ '

--- a/tests/Integration/Schema/Directives/BelongsToManyDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/BelongsToManyDirectiveTest.php
@@ -434,7 +434,7 @@ final class BelongsToManyDirectiveTest extends DBTestCase
                         return [
                             'id' => (string) $user->id,
                             'roles' => [
-                                'data' => $roleIDs
+                                'data' => $roleIDs,
                             ],
                         ];
                     })


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves https://github.com/nuwave/lighthouse/issues/2264  
Supersedes https://github.com/nuwave/lighthouse/pull/2275  
Supersedes https://github.com/nuwave/lighthouse/pull/2273  
Supersedes https://github.com/nuwave/lighthouse/pull/2278  

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
