### PR TITLE
Feat: Add support for global id in entity resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 ### Added
 
 - Add method `TypeRegistry::search()` that maybe finds a type with a given name
+- Decode fields with directive `@globalId` in federation model entity resolver
 
 ### Removed
 

--- a/benchmarks/ASTUnserializationBench.php
+++ b/benchmarks/ASTUnserializationBench.php
@@ -54,6 +54,7 @@ GRAPHQL;
 
     /**
      * @Revs(100)
+     *
      * @Iterations(10)
      */
     public function benchUnserializeDocumentNode(): void
@@ -63,6 +64,7 @@ GRAPHQL;
 
     /**
      * @Revs(100)
+     *
      * @Iterations(10)
      */
     public function benchUnserializeDocumentAST(): void

--- a/benchmarks/HugeResponseBench.php
+++ b/benchmarks/HugeResponseBench.php
@@ -51,6 +51,7 @@ GRAPHQL;
 
     /**
      * @Iterations(10)
+     *
      * @OutputTimeUnit("seconds", precision=3)
      */
     public function benchmark1(): void
@@ -66,6 +67,7 @@ GRAPHQL;
 
     /**
      * @Iterations(10)
+     *
      * @OutputTimeUnit("seconds", precision=3)
      */
     public function benchmark100(): void
@@ -83,6 +85,7 @@ GRAPHQL;
 
     /**
      * @Iterations(10)
+     *
      * @OutputTimeUnit("seconds", precision=3)
      */
     public function benchmark10k(): void

--- a/src/Federation/EntityResolverProvider.php
+++ b/src/Federation/EntityResolverProvider.php
@@ -283,6 +283,7 @@ class EntityResolverProvider
         if (! $field) {
             return false;
         }
+
         return ASTHelper::hasDirective($field, $directiveName);
     }
 

--- a/src/GlobalId/GlobalIdDirective.php
+++ b/src/GlobalId/GlobalIdDirective.php
@@ -12,6 +12,8 @@ use Nuwave\Lighthouse\Support\Contracts\GlobalId;
 
 class GlobalIdDirective extends BaseDirective implements FieldMiddleware, ArgSanitizerDirective, ArgDirective
 {
+    public const NAME = 'globalId';
+
     /**
      * @var \Nuwave\Lighthouse\Support\Contracts\GlobalId
      */

--- a/src/Schema/TypeRegistry.php
+++ b/src/Schema/TypeRegistry.php
@@ -421,7 +421,7 @@ class TypeRegistry
      *
      * @param  \GraphQL\Language\AST\ObjectTypeDefinitionNode|\GraphQL\Language\AST\InterfaceTypeDefinitionNode  $typeDefinition
      *
-     * @return \Closure(): array<string, Closure(): array<string, mixed>>
+     * @return \Closure(): array<string, \Closure(): array<string, mixed>>
      */
     protected function makeFieldsLoader($typeDefinition): \Closure
     {

--- a/tests/Integration/Federation/FederationEntitiesModelTest.php
+++ b/tests/Integration/Federation/FederationEntitiesModelTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Integration\Federation;
+
+use GraphQL\Error\Error;
+use GraphQL\Utils\Utils;
+use Nuwave\Lighthouse\Federation\EntityResolverProvider;
+use Nuwave\Lighthouse\Federation\FederationServiceProvider;
+use Nuwave\Lighthouse\Federation\Types\Any;
+use Nuwave\Lighthouse\Support\Contracts\GlobalId;
+use Tests\DBTestCase;
+use Tests\TestCase;
+use Tests\Utils\Models\User;
+
+final class FederationEntitiesModelTest extends DBTestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return array_merge(
+            parent::getPackageProviders($app),
+            [FederationServiceProvider::class]
+        );
+    }
+
+    public function testCallsEntityResolverModel(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type User @model @key(fields: "id") {
+          id: ID! @external
+        }
+        ';
+
+        $user = factory(User::class)->create();
+
+        $userRepresentation = [
+            '__typename' => 'User',
+            'id' => (string) $user->getKey(),
+        ];
+
+        $this->graphQL(/** @lang GraphQL */ '
+        query ($representations: [_Any!]!) {
+            _entities(representations: $representations) {
+                __typename
+                ... on User {
+                    id
+                }
+            }
+        }
+        ', [
+            'representations' => [
+                $userRepresentation,
+            ],
+        ])->assertExactJson([
+            'data' => [
+                '_entities' => [
+                    $userRepresentation
+                ]
+            ]
+        ]);
+    }
+
+    public function testCallsEntityResolverModelWithGlobalId(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type User @model @key(fields: "id") {
+          id: ID! @external @globalId
+        }
+        ';
+
+        $user = factory(User::class)->create();
+
+        $userRepresentation = [
+            '__typename' => 'User',
+            'id' => $this->app->get(GlobalId::class)->encode('User', $user->getKey()),
+        ];
+
+        $this->graphQL(/** @lang GraphQL */ '
+        query ($representations: [_Any!]!) {
+            _entities(representations: $representations) {
+                __typename
+                ... on User {
+                    id
+                }
+            }
+        }
+        ', [
+            'representations' => [
+                $userRepresentation,
+            ],
+        ])->assertExactJson([
+            'data' => [
+                '_entities' => [
+                    $userRepresentation
+                ]
+            ]
+        ]);
+    }
+}

--- a/tests/Integration/Federation/FederationEntitiesModelTest.php
+++ b/tests/Integration/Federation/FederationEntitiesModelTest.php
@@ -2,14 +2,9 @@
 
 namespace Tests\Integration\Federation;
 
-use GraphQL\Error\Error;
-use GraphQL\Utils\Utils;
-use Nuwave\Lighthouse\Federation\EntityResolverProvider;
 use Nuwave\Lighthouse\Federation\FederationServiceProvider;
-use Nuwave\Lighthouse\Federation\Types\Any;
 use Nuwave\Lighthouse\Support\Contracts\GlobalId;
 use Tests\DBTestCase;
-use Tests\TestCase;
 use Tests\Utils\Models\User;
 
 final class FederationEntitiesModelTest extends DBTestCase
@@ -53,9 +48,9 @@ final class FederationEntitiesModelTest extends DBTestCase
         ])->assertExactJson([
             'data' => [
                 '_entities' => [
-                    $userRepresentation
-                ]
-            ]
+                    $userRepresentation,
+                ],
+            ],
         ]);
     }
 
@@ -90,9 +85,9 @@ final class FederationEntitiesModelTest extends DBTestCase
         ])->assertExactJson([
             'data' => [
                 '_entities' => [
-                    $userRepresentation
-                ]
-            ]
+                    $userRepresentation,
+                ],
+            ],
         ]);
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Adds decoding of the global id when using the model entity resolver

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

This will break everyone who used the global id directive and expecting to be able to use database id's when using `_entities`. I would however argue that it is almost a bug :) 
