### PR TITLE
Require filter directives such as `@whereKey` in `@delete`, `@forceDelete` and `@restore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Expected resolver arguments in `ResolveInfo::enhanceBuilder()`
 - Pass the path array to `CacheKeyAndTags::key()` https://github.com/nuwave/lighthouse/pull/2176
 - Require implementations of `BatchedEntityResolver` to maintain the keys given in `array $representations` https://github.com/nuwave/lighthouse/pull/2286
+- Require filter directives such as `@eq` in `@delete`, `@forceDelete` and `@restore`
 
 ### Fixed
 
@@ -40,6 +41,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Remove trait `ClearsSchemaCache`
 - Remove config option `lighthouse.unbox_bensampo_enum_enum_instances`
 - Remove `ArgumentSet::enhanceBuilder()`, use `ResolveInfo::enhanceBuilder()`
+- Remove the `globalId` argument from `@delete`, `@forceDelete` and `@restore`
 
 ## v5.70.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Expected resolver arguments in `ResolveInfo::enhanceBuilder()`
 - Pass the path array to `CacheKeyAndTags::key()` https://github.com/nuwave/lighthouse/pull/2176
 - Require implementations of `BatchedEntityResolver` to maintain the keys given in `array $representations` https://github.com/nuwave/lighthouse/pull/2286
-- Require filter directives such as `@eq` in `@delete`, `@forceDelete` and `@restore`
+- Require filter directives such as `@whereKey` in `@delete`, `@forceDelete` and `@restore`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Expected resolver arguments in `ResolveInfo::enhanceBuilder()`
 - Pass the path array to `CacheKeyAndTags::key()` https://github.com/nuwave/lighthouse/pull/2176
 - Require implementations of `BatchedEntityResolver` to maintain the keys given in `array $representations` https://github.com/nuwave/lighthouse/pull/2286
-- Require filter directives such as `@whereKey` in `@delete`, `@forceDelete` and `@restore`
+- Require filter directives such as `@whereKey` in `@delete`, `@forceDelete` and `@restore` https://github.com/nuwave/lighthouse/pull/2289
 
 ### Fixed
 
@@ -27,6 +27,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Add method `TypeRegistry::search()` that maybe finds a type with a given name
 - Decode fields with directive `@globalId` in federation model entity resolver
 - Support Laravel 10 https://github.com/nuwave/lighthouse/pull/2287
+- Add directive `@whereKey` to filter Models by their primary key https://github.com/nuwave/lighthouse/pull/2289
 
 ### Removed
 
@@ -41,7 +42,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Remove trait `ClearsSchemaCache`
 - Remove config option `lighthouse.unbox_bensampo_enum_enum_instances`
 - Remove `ArgumentSet::enhanceBuilder()`, use `ResolveInfo::enhanceBuilder()`
-- Remove the `globalId` argument from `@delete`, `@forceDelete` and `@restore`
+- Remove the `globalId` argument from `@delete`, `@forceDelete` and `@restore` https://github.com/nuwave/lighthouse/pull/2289
 
 ## v5.70.3
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -30,6 +30,28 @@ within the directive definition and leads to static validation errors.
 )
 ```
 
+### Use filters in `@delete`, `@forceDelete` and `@restore`
+
+Whereas previously, those directives enforced the usage of a single argument and assumed that
+to be the ID or list of IDs of the models to modify, they now leverage filter directives such as `@eq`.
+This brings them in line with other directives such as `@find` and `@all`.
+
+```diff
+type Mutation {
+-   deleteUser(id: ID!): User! @delete
++   deleteUser(id: ID! @eq): User! @delete
+}
+```
+
+If your argument is named differently from your primary key, you will need to pass that explicitly.
+
+```diff
+type Mutation {
+-   deleteUsers(userIDs: [ID!]!): [User!]! @delete
++   deleteUsers(userIDs: [ID!]! @in(key: "id")): [User!]! @delete
+}
+```
+
 ### Use `@globalId` over `@delete(globalId: true)`
 
 The `@delete`, `@forceDelete`, `@restore` and `@upsert` directives no longer offer the

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -33,22 +33,17 @@ within the directive definition and leads to static validation errors.
 ### Use filters in `@delete`, `@forceDelete` and `@restore`
 
 Whereas previously, those directives enforced the usage of a single argument and assumed that
-to be the ID or list of IDs of the models to modify, they now leverage filter directives such as `@eq`.
+to be the ID or list of IDs of the models to modify, they now leverage argument filter directives.
 This brings them in line with other directives such as `@find` and `@all`.
+
+You will need to explicitly add `@whereKey` to the argument that contained the ID or IDs.
 
 ```diff
 type Mutation {
 -   deleteUser(id: ID!): User! @delete
-+   deleteUser(id: ID! @eq): User! @delete
-}
-```
-
-If your argument is named differently from your primary key, you will need to pass that explicitly.
-
-```diff
-type Mutation {
--   deleteUsers(userIDs: [ID!]!): [User!]! @delete
-+   deleteUsers(userIDs: [ID!]! @in(key: "id")): [User!]! @delete
++   deleteUser(id: ID! @whereKey): User! @delete
+-   restoreUsers(userIDs: [ID!]!): [User!]! @restore
++   restoreUsers(userIDs: [ID!]! @whereKey): [User!]! @restore
 }
 ```
 
@@ -60,7 +55,7 @@ The `@delete`, `@forceDelete`, `@restore` and `@upsert` directives no longer off
 ```diff
 type Mutation {
 -   deleteUser(id: ID!): User! @delete(globalId: true)
-+   deleteUser(id: ID! @globalId): User! @delete
++   deleteUser(id: ID! @globalId @whereKey): User! @delete
 }
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -3765,12 +3765,12 @@ Use together with directives that make Eloquent queries such as [@find](#find), 
 
 ```graphql
 type Query {
-    post(id: ID! @whereKey): Post @find
-    posts(ids: [ID!]! @whereKey): [Post!]! @all
+  post(id: ID! @whereKey): Post @find
+  posts(ids: [ID!]! @whereKey): [Post!]! @all
 }
 
 type Mutation {
-    deletePost(id: ID! @whereKey): Post! @delete
+  deletePost(id: ID! @whereKey): Post! @delete
 }
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -956,6 +956,11 @@ directive @delete(
   resolver and if the name of the relation is not the arg name.
   """
   relation: String
+
+  """
+  Apply scopes to the underlying query.
+  """
+  scopes: [String!]
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
@@ -1198,6 +1203,11 @@ directive @forceDelete(
   This is only needed when the default model detection does not work.
   """
   model: String
+
+  """
+  Apply scopes to the underlying query.
+  """
+  scopes: [String!]
 ) on FIELD_DEFINITION
 ```
 
@@ -2889,7 +2899,12 @@ directive @restore(
   Specify the class name of the model to use.
   This is only needed when the default model detection does not work.
   """
-model: String
+  model: String
+
+  """
+  Apply scopes to the underlying query.
+  """
+  scopes: [String!]
 ) on FIELD_DEFINITION
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -941,18 +941,9 @@ This directive can also be used as a [nested arg resolver](../concepts/arg-resol
 
 ```graphql
 """
-Delete one or more models by their ID.
-The field must have a single non-null argument that may be a list.
+Delete one or more models.
 """
 directive @delete(
-  """
-  DEPRECATED use @globalId, will be removed in v6
-
-  Set to `true` to use global ids for finding the model.
-  If set to `false`, regular non-global ids are used.
-  """
-  globalId: Boolean = false
-
   """
   Specify the class name of the model to use.
   This is only needed when the default model detection does not work.
@@ -1199,18 +1190,9 @@ type Query {
 
 ```graphql
 """
-Permanently remove one or more soft deleted models by their ID.
-The field must have a single non-null argument that may be a list.
+Permanently remove one or more soft deleted models.
 """
 directive @forceDelete(
-  """
-  DEPRECATED use @globalId, will be removed in v6
-
-  Set to `true` to use global ids for finding the model.
-  If set to `false`, regular non-global ids are used.
-  """
-  globalId: Boolean = false
-
   """
   Specify the class name of the model to use.
   This is only needed when the default model detection does not work.
@@ -2900,23 +2882,14 @@ input UserInput {
 
 ```graphql
 """
-Un-delete one or more soft deleted models by their ID.
-The field must have a single non-null argument that may be a list.
+Un-delete one or more soft deleted models.
 """
 directive @restore(
-  """
-  DEPRECATED use @globalId, will be removed in v6
-
-  Set to `true` to use global ids for finding the model.
-  If set to `false`, regular non-global ids are used.
-  """
-  globalId: Boolean = false
-
   """
   Specify the class name of the model to use.
   This is only needed when the default model detection does not work.
   """
-  model: String
+model: String
 ) on FIELD_DEFINITION
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -973,7 +973,7 @@ It will return an instance of the Model so you can show its data one last time.
 
 ```graphql
 type Mutation {
-  deletePost(id: ID! @eq): Post! @delete
+  deletePost(id: ID! @whereKey): Post! @delete
 }
 ```
 
@@ -984,7 +984,7 @@ _In contrast to Laravel mass updates, this does trigger model events._
 
 ```graphql
 type Mutation {
-  deletePosts(ids: [ID!] @in(key: "id"), title: String @eq): [Post!]! @delete
+  deletePosts(ids: [ID!] @whereKey, title: String @eq): [Post!]! @delete
 }
 ```
 
@@ -993,7 +993,7 @@ or is located in a non-default namespace, set it with the `model` argument.
 
 ```graphql
 type Mutation {
-  deletePost(id: ID!): Post @delete(model: "Bar\\Baz\\MyPost")
+  deletePost(id: ID! @whereKey): Post @delete(model: "Bar\\Baz\\MyPost")
 }
 ```
 
@@ -1223,7 +1223,7 @@ Use it on a root mutation field that returns an instance of the Model.
 
 ```graphql
 type Mutation {
-  forceDeletePost(id: ID!): Post @forceDelete
+  forceDeletePost(id: ID! @whereKey): Post @forceDelete
 }
 ```
 
@@ -2924,7 +2924,7 @@ Use it on a root mutation field that returns an instance of the Model.
 
 ```graphql
 type Mutation {
-  restorePost(id: ID!): Post @restore
+  restorePost(id: ID! @whereKey): Post @restore
 }
 ```
 
@@ -3738,6 +3738,39 @@ You may use the `key` argument to look into the JSON content:
 ```graphql
 type Query {
   posts(tags: [String]! @whereJsonContains(key: "tags->recent")): [Post!]! @all
+}
+```
+
+## @whereKey
+
+```graphql
+"""
+Add a where clause on the primary key to the Eloquent Model query.
+"""
+directive @whereKey(
+  """
+  Provide a value to compare against.
+  Only required when this directive is used on a field.
+  """
+  value: WhereKeyValue
+) repeatable on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+
+"""
+Any constant literal value: https://graphql.github.io/graphql-spec/draft/#sec-Input-Values
+"""
+scalar WhereKeyValue
+```
+
+Use together with directives that make Eloquent queries such as [@find](#find), [@all](#all) or [@delete](#delete).
+
+```graphql
+type Query {
+    post(id: ID! @whereKey): Post @find
+    posts(ids: [ID!]! @whereKey): [Post!]! @all
+}
+
+type Mutation {
+    deletePost(id: ID! @whereKey): Post! @delete
 }
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -968,33 +968,23 @@ directive @delete(
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 ```
 
-Use it on a root mutation field that returns an instance of the Model.
+Use this on root mutation fields.
+It will return an instance of the Model so you can show its data one last time.
 
 ```graphql
 type Mutation {
-  deletePost(id: ID!): Post @delete
+  deletePost(id: ID! @eq): Post! @delete
 }
 ```
 
-In the upcoming `v6`, the `@delete`, `@forceDelete` and `@restore` directives no longer offer the
-`globalId` argument. Use `@globalId` on the argument instead.
-
-```diff
-type Mutation {
--   deleteUser(id: ID!): User! @delete(globalId: true)
-+   deleteUser(id: ID! @globalId): User! @delete
-}
-```
-
-You can also delete multiple models at once.
-Define a field that takes a list of IDs and returns a collection of the
-deleted models.
+You can also delete multiple models at once, for example by a list of IDs or a filter.
+Be careful with the filters you offer to avoid accidental mass deletion.
 
 _In contrast to Laravel mass updates, this does trigger model events._
 
 ```graphql
 type Mutation {
-  deletePosts(id: [ID!]!): [Post!]! @delete
+  deletePosts(ids: [ID!] @in(key: "id"), title: String @eq): [Post!]! @delete
 }
 ```
 
@@ -1011,7 +1001,7 @@ This directive can also be used as a [nested arg resolver](../concepts/arg-resol
 
 ```graphql
 type Mutation {
-  updateUser(id: Int, deleteTasks: [Int!]! @delete(relation: "tasks")): User
+  updateUser(id: ID!, deleteTasks: [ID!]! @delete(relation: "tasks")): User!
     @update
 }
 ```
@@ -1022,7 +1012,7 @@ possible model that can be deleted.
 
 ```graphql
 type Mutation {
-  updateTask(id: Int, deleteUser: Boolean @delete(relation: "user")): Task
+  updateTask(id: ID!, deleteUser: Boolean @delete(relation: "user")): Task!
     @update
 }
 ```

--- a/docs/master/eloquent/getting-started.md
+++ b/docs/master/eloquent/getting-started.md
@@ -285,7 +285,7 @@ Deleting models is a breeze using the [@delete](../api-reference/directives.md#d
 
 ```graphql
 type Mutation {
-  deleteUser(id: ID!): User @delete
+  deleteUser(id: ID! @whereKey): User @delete
 }
 ```
 

--- a/docs/master/eloquent/soft-deleting.md
+++ b/docs/master/eloquent/soft-deleting.md
@@ -50,7 +50,7 @@ you can restore your model using the [@restore](../api-reference/directives.md#r
 
 ```graphql
 type Mutation {
-  restoreFlight(id: ID!): Flight @restore
+  restoreFlight(id: ID! @whereKey): Flight @restore
 }
 ```
 
@@ -74,7 +74,7 @@ Your model must use the `Illuminate\Database\Eloquent\SoftDeletes` trait.
 
 ```graphql
 type Mutation {
-  forceDeleteFlight(id: ID!): Flight @forceDelete
+  forceDeleteFlight(id: ID! @whereKey): Flight @forceDelete
 }
 ```
 

--- a/src/Schema/Directives/DeleteDirective.php
+++ b/src/Schema/Directives/DeleteDirective.php
@@ -80,6 +80,7 @@ GRAPHQL;
             // Deleting when `false` is given seems wrong.
             if ($idOrIds) {
                 if ($relationIsBelongsToLike) {
+                    /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo $relation TODO remove with newer PHPStan */
                     $relation->dissociate();
                     $relation->getParent()->save();
                 }

--- a/src/Schema/Directives/DeleteDirective.php
+++ b/src/Schema/Directives/DeleteDirective.php
@@ -37,6 +37,11 @@ directive @delete(
   resolver and if the name of the relation is not the arg name.
   """
   relation: String
+
+  """
+  Apply scopes to the underlying query.
+  """
+  scopes: [String!]
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 GRAPHQL;
     }

--- a/src/Schema/Directives/DeleteDirective.php
+++ b/src/Schema/Directives/DeleteDirective.php
@@ -5,6 +5,7 @@ namespace Nuwave\Lighthouse\Schema\Directives;
 use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\InputValueDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -21,18 +22,9 @@ class DeleteDirective extends ModifyModelExistenceDirective implements ArgResolv
     {
         return /** @lang GraphQL */ <<<'GRAPHQL'
 """
-Delete one or more models by their ID.
-The field must have a single non-null argument that may be a list.
+Delete one or more models.
 """
 directive @delete(
-  """
-  DEPRECATED use @globalId, will be removed in v6
-
-  Set to `true` to use global ids for finding the model.
-  If set to `false`, regular non-global ids are used.
-  """
-  globalId: Boolean = false
-
   """
   Specify the class name of the model to use.
   This is only needed when the default model detection does not work.
@@ -49,9 +41,9 @@ directive @delete(
 GRAPHQL;
     }
 
-    protected function find(string $modelClass, $idOrIds)
+    protected function enhanceBuilder(EloquentBuilder $builder): EloquentBuilder
     {
-        return $modelClass::find($idOrIds);
+        return $builder;
     }
 
     protected function modifyExistence(Model $model): bool
@@ -88,7 +80,6 @@ GRAPHQL;
             // Deleting when `false` is given seems wrong.
             if ($idOrIds) {
                 if ($relationIsBelongsToLike) {
-                    /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo $relation TODO remove with newer PHPStan */
                     $relation->dissociate();
                     $relation->getParent()->save();
                 }
@@ -111,9 +102,7 @@ GRAPHQL;
         ObjectTypeDefinitionNode &$parentType
     ) {
         if (! $this->directiveArgValue('relation')) {
-            throw new DefinitionException(
-                'The @delete directive requires the "relation" to be set when used as an argument resolver.'
-            );
+            throw new DefinitionException('The @delete directive requires "relation" to be set when used as an argument resolver.');
         }
     }
 }

--- a/src/Schema/Directives/DeleteDirective.php
+++ b/src/Schema/Directives/DeleteDirective.php
@@ -80,7 +80,7 @@ GRAPHQL;
             // Deleting when `false` is given seems wrong.
             if ($idOrIds) {
                 if ($relationIsBelongsToLike) {
-                    /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo $relation TODO remove with newer PHPStan */
+                    /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo $relation TODO remove with newer PHPStan that comes with Laravel 9 */
                     $relation->dissociate();
                     $relation->getParent()->save();
                 }

--- a/src/Schema/Directives/ModifyModelExistenceDirective.php
+++ b/src/Schema/Directives/ModifyModelExistenceDirective.php
@@ -4,6 +4,8 @@ namespace Nuwave\Lighthouse\Schema\Directives;
 
 use GraphQL\Error\Error;
 use GraphQL\Language\AST\ListTypeNode;
+use GraphQL\Language\AST\NonNullTypeNode;
+use GraphQL\Language\AST\TypeNode;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Nuwave\Lighthouse\Execution\ErrorPool;
@@ -47,7 +49,7 @@ abstract class ModifyModelExistenceDirective extends BaseDirective implements Fi
 
     public function resolveField(FieldValue $fieldValue): FieldValue
     {
-        $expectsList = $fieldValue->getField()->type instanceof ListTypeNode;
+        $expectsList = $this->expectsList($fieldValue->getField()->type);
 
         $fieldValue->setResolver(function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($expectsList) {
             $builder = $resolveInfo->enhanceBuilder(
@@ -79,6 +81,15 @@ abstract class ModifyModelExistenceDirective extends BaseDirective implements Fi
         });
 
         return $fieldValue;
+    }
+
+    private function expectsList(TypeNode $typeNode): bool
+    {
+        if ($typeNode instanceof NonNullTypeNode) {
+            return $this->expectsList($typeNode->type);
+        }
+
+        return $typeNode instanceof ListTypeNode;
     }
 
     /**

--- a/src/Schema/Directives/ModifyModelExistenceDirective.php
+++ b/src/Schema/Directives/ModifyModelExistenceDirective.php
@@ -3,22 +3,18 @@
 namespace Nuwave\Lighthouse\Schema\Directives;
 
 use GraphQL\Error\Error;
-use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\ListTypeNode;
-use GraphQL\Language\AST\NonNullTypeNode;
-use GraphQL\Language\AST\ObjectTypeDefinitionNode;
-use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Execution\ErrorPool;
+use Nuwave\Lighthouse\Execution\ResolveInfo;
 use Nuwave\Lighthouse\Execution\TransactionalMutations;
-use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
-use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
 use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 use Nuwave\Lighthouse\Support\Contracts\GlobalId;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
-abstract class ModifyModelExistenceDirective extends BaseDirective implements FieldResolver, FieldManipulator
+abstract class ModifyModelExistenceDirective extends BaseDirective implements FieldResolver
 {
     /**
      * @var \Nuwave\Lighthouse\Support\Contracts\GlobalId
@@ -51,116 +47,44 @@ abstract class ModifyModelExistenceDirective extends BaseDirective implements Fi
 
     public function resolveField(FieldValue $fieldValue): FieldValue
     {
-        $fieldValue->setResolver(function ($root, array $args) {
-            /** @var string|int|array<string>|array<int> $idOrIds */
-            $idOrIds = reset($args);
+        $expectsList = $fieldValue->getField()->type instanceof ListTypeNode;
 
-            // TODO remove in v6
-            if ($this->directiveArgValue('globalId')) {
-                // @phpstan-ignore-next-line We know that global ids must be strings
-                $idOrIds = $this->decodeIdOrIds($idOrIds);
-            }
-
-            $modelOrModels = $this->find(
-                $this->getModelClass(),
-                $idOrIds
+        $fieldValue->setResolver(function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($expectsList) {
+            $builder = $resolveInfo->enhanceBuilder(
+                $this->getModelClass()::query(),
+                $this->directiveArgValue('scopes', []),
+                $root,
+                $args,
+                $context,
+                $resolveInfo
             );
+            assert($builder instanceof EloquentBuilder);
 
-            $modifyModelExistence = function (Model $model): void {
+            $modelOrModels = $this->enhanceBuilder($builder)->get();
+
+            foreach ($modelOrModels as $model) {
                 $success = $this->transactionalMutations->execute(
-                    function () use ($model): bool {
-                        return $this->modifyExistence($model);
-                    },
+                    fn (): bool => $this->modifyExistence($model),
                     $model->getConnectionName()
                 );
 
                 if (! $success) {
                     $this->errorPool->record(self::couldNotModify($model));
                 }
-            };
-
-            if ($modelOrModels instanceof Model) {
-                $modifyModelExistence($modelOrModels);
-            } elseif ($modelOrModels instanceof EloquentCollection) {
-                foreach ($modelOrModels as $model) {
-                    $modifyModelExistence($model);
-                }
             }
 
-            return $modelOrModels;
+            return $expectsList
+                ? $modelOrModels
+                : $modelOrModels->first();
         });
 
         return $fieldValue;
     }
 
     /**
-     * Get the type of the id argument.
-     *
-     * Not using an actual type hint, as the manipulateFieldDefinition function
-     * validates the type during schema build time.
-     *
-     * @return mixed but should be a \GraphQL\Language\AST\NonNullTypeNode
+     * Enhance the builder used to resolve the models.
      */
-    protected function idArgument()
-    {
-        $fieldNode = $this->definitionNode;
-        assert($fieldNode instanceof FieldDefinitionNode);
-
-        return $fieldNode->arguments[0]->type;
-    }
-
-    public function manipulateFieldDefinition(
-        DocumentAST &$documentAST,
-        FieldDefinitionNode &$fieldDefinition,
-        ObjectTypeDefinitionNode &$parentType
-    ): void {
-        // Ensure there is only a single argument defined on the field.
-        if (1 !== count($fieldDefinition->arguments)) {
-            throw new DefinitionException(
-                'The @' . $this->name() . " directive requires the field {$this->nodeName()} to only contain a single argument."
-            );
-        }
-
-        if (! $this->idArgument() instanceof NonNullTypeNode) {
-            throw new DefinitionException(
-                'The @' . $this->name() . " directive requires the field {$this->nodeName()} to have a NonNull argument. Mark it with !"
-            );
-        }
-    }
-
-    /**
-     * @param  string|array<string>  $idOrIds
-     *
-     * @return string|array<string>
-     */
-    protected function decodeIdOrIds($idOrIds)
-    {
-        // At this point we know the type is at least wrapped in a NonNull type, so we go one deeper
-        if ($this->idArgument()->type instanceof ListTypeNode) {
-            assert(is_array($idOrIds));
-
-            return array_map(
-                function (string $id): string {
-                    return $this->globalId->decodeID($id);
-                },
-                $idOrIds
-            );
-        } else {
-            assert(is_string($idOrIds));
-
-            return $this->globalId->decodeID($idOrIds);
-        }
-    }
-
-    /**
-     * Find one or more models by id.
-     *
-     * @param  class-string<\Illuminate\Database\Eloquent\Model>  $modelClass
-     * @param  string|int|array<string>|array<int>  $idOrIds
-     *
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model>|null
-     */
-    abstract protected function find(string $modelClass, $idOrIds);
+    abstract protected function enhanceBuilder(EloquentBuilder $builder): EloquentBuilder;
 
     /**
      * Bring a model in or out of existence.

--- a/src/Schema/Directives/WhereKeyDirective.php
+++ b/src/Schema/Directives/WhereKeyDirective.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Nuwave\Lighthouse\Schema\Directives;
+
+use GraphQL\Language\AST\FieldDefinitionNode;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+use Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective;
+use Nuwave\Lighthouse\Support\Contracts\FieldBuilderDirective;
+use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+
+class WhereKeyDirective extends BaseDirective implements ArgBuilderDirective, FieldBuilderDirective, FieldManipulator
+{
+    public static function definition(): string
+    {
+        return /** @lang GraphQL */ <<<'GRAPHQL'
+"""
+Add a where clause on the primary key to the Eloquent Model query.
+"""
+directive @whereKey(
+  """
+  Provide a value to compare against.
+  Only required when this directive is used on a field.
+  """
+  value: WhereKeyValue
+) repeatable on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+
+"""
+Any constant literal value: https://graphql.github.io/graphql-spec/draft/#sec-Input-Values
+"""
+scalar WhereKeyValue
+GRAPHQL;
+    }
+
+    public function handleBuilder($builder, $value): object
+    {
+        if (! $builder instanceof EloquentBuilder) {
+            $notEloquentBuilder = get_class($builder);
+            throw new DefinitionException("The {$this->name()} directive only works with queries that use an Eloquent builder, got: {$notEloquentBuilder}.");
+        }
+
+        return $builder->whereKey($value);
+    }
+
+    public function manipulateFieldDefinition(DocumentAST &$documentAST, FieldDefinitionNode &$fieldDefinition, ObjectTypeDefinitionNode &$parentType)
+    {
+        if (! $this->directiveHasArgument('value')) {
+            throw new DefinitionException("Must provide the argument `value` when using {$this->name()} on field `{$parentType->name->value}.{$fieldDefinition->name->value}`.");
+        }
+    }
+
+    public function handleFieldBuilder(object $builder, $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo): object
+    {
+        return $this->handleBuilder(
+            $builder,
+            $this->directiveArgValue('value')
+        );
+    }
+}

--- a/src/SoftDeletes/ForceDeleteDirective.php
+++ b/src/SoftDeletes/ForceDeleteDirective.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\SoftDeletes;
 
 use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Directives\ModifyModelExistenceDirective;
@@ -16,18 +17,9 @@ class ForceDeleteDirective extends ModifyModelExistenceDirective
     {
         return /** @lang GraphQL */ <<<'GRAPHQL'
 """
-Permanently remove one or more soft deleted models by their ID.
-The field must have a single non-null argument that may be a list.
+Permanently remove one or more soft deleted models.
 """
 directive @forceDelete(
-  """
-  DEPRECATED use @globalId, will be removed in v6
-
-  Set to `true` to use global ids for finding the model.
-  If set to `false`, regular non-global ids are used.
-  """
-  globalId: Boolean = false
-
   """
   Specify the class name of the model to use.
   This is only needed when the default model detection does not work.
@@ -37,11 +29,11 @@ directive @forceDelete(
 GRAPHQL;
     }
 
-    protected function find(string $modelClass, $idOrIds)
+    protected function enhanceBuilder(EloquentBuilder $builder): EloquentBuilder
     {
         /** @see \Illuminate\Database\Eloquent\SoftDeletes */
         // @phpstan-ignore-next-line because it involves mixins
-        return $modelClass::withTrashed()->find($idOrIds);
+        return $builder->withTrashed();
     }
 
     protected function modifyExistence(Model $model): bool

--- a/src/SoftDeletes/ForceDeleteDirective.php
+++ b/src/SoftDeletes/ForceDeleteDirective.php
@@ -26,6 +26,11 @@ directive @forceDelete(
   This is only needed when the default model detection does not work.
   """
   model: String
+
+  """
+  Apply scopes to the underlying query.
+  """
+  scopes: [String!]
 ) on FIELD_DEFINITION
 GRAPHQL;
     }

--- a/src/SoftDeletes/ForceDeleteDirective.php
+++ b/src/SoftDeletes/ForceDeleteDirective.php
@@ -8,8 +8,9 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Directives\ModifyModelExistenceDirective;
+use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
 
-class ForceDeleteDirective extends ModifyModelExistenceDirective
+class ForceDeleteDirective extends ModifyModelExistenceDirective implements FieldManipulator
 {
     public const MODEL_NOT_USING_SOFT_DELETES = 'Use the @forceDelete directive only for Model classes that use the SoftDeletes trait.';
 
@@ -43,16 +44,11 @@ GRAPHQL;
         return (bool) $model->forceDelete();
     }
 
-    /**
-     * Manipulate the AST based on a field definition.
-     */
     public function manipulateFieldDefinition(
         DocumentAST &$documentAST,
         FieldDefinitionNode &$fieldDefinition,
         ObjectTypeDefinitionNode &$parentType
     ): void {
-        parent::manipulateFieldDefinition($documentAST, $fieldDefinition, $parentType);
-
         SoftDeletesServiceProvider::assertModelUsesSoftDeletes(
             $this->getModelClass(),
             self::MODEL_NOT_USING_SOFT_DELETES

--- a/src/SoftDeletes/RestoreDirective.php
+++ b/src/SoftDeletes/RestoreDirective.php
@@ -44,16 +44,11 @@ GRAPHQL;
         return (bool) $model->restore();
     }
 
-    /**
-     * Manipulate the AST based on a field definition.
-     */
     public function manipulateFieldDefinition(
         DocumentAST &$documentAST,
         FieldDefinitionNode &$fieldDefinition,
         ObjectTypeDefinitionNode &$parentType
     ): void {
-        parent::manipulateFieldDefinition($documentAST, $fieldDefinition, $parentType);
-
         SoftDeletesServiceProvider::assertModelUsesSoftDeletes(
             $this->getModelClass(),
             self::MODEL_NOT_USING_SOFT_DELETES

--- a/src/SoftDeletes/RestoreDirective.php
+++ b/src/SoftDeletes/RestoreDirective.php
@@ -4,6 +4,7 @@ namespace Nuwave\Lighthouse\SoftDeletes;
 
 use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Directives\ModifyModelExistenceDirective;
@@ -17,18 +18,9 @@ class RestoreDirective extends ModifyModelExistenceDirective implements FieldMan
     {
         return /** @lang GraphQL */ <<<'GRAPHQL'
 """
-Un-delete one or more soft deleted models by their ID.
-The field must have a single non-null argument that may be a list.
+Un-delete one or more soft deleted models.
 """
 directive @restore(
-  """
-  DEPRECATED use @globalId, will be removed in v6
-
-  Set to `true` to use global ids for finding the model.
-  If set to `false`, regular non-global ids are used.
-  """
-  globalId: Boolean = false
-
   """
   Specify the class name of the model to use.
   This is only needed when the default model detection does not work.
@@ -38,11 +30,11 @@ directive @restore(
 GRAPHQL;
     }
 
-    protected function find(string $modelClass, $idOrIds)
+    protected function enhanceBuilder(EloquentBuilder $builder): EloquentBuilder
     {
         /** @see \Illuminate\Database\Eloquent\SoftDeletes */
         // @phpstan-ignore-next-line because it involves mixins
-        return $modelClass::withTrashed()->find($idOrIds);
+        return $builder->withTrashed();
     }
 
     protected function modifyExistence(Model $model): bool

--- a/src/SoftDeletes/RestoreDirective.php
+++ b/src/SoftDeletes/RestoreDirective.php
@@ -26,6 +26,11 @@ directive @restore(
   This is only needed when the default model detection does not work.
   """
   model: String
+
+  """
+  Apply scopes to the underlying query.
+  """
+  scopes: [String!]
 ) on FIELD_DEFINITION
 GRAPHQL;
     }

--- a/tests/Integration/Auth/CanDirectiveDBTest.php
+++ b/tests/Integration/Auth/CanDirectiveDBTest.php
@@ -219,7 +219,7 @@ final class CanDirectiveDBTest extends DBTestCase
 
         $this->schema = /** @lang GraphQL */ '
         type Mutation {
-            deletePosts(ids: [ID!]! @in(key: "id")): [Post!]!
+            deletePosts(ids: [ID!]! @whereKey): [Post!]!
                 @can(ability: "delete", find: "ids")
                 @delete
         }
@@ -382,7 +382,7 @@ final class CanDirectiveDBTest extends DBTestCase
 
         $this->schema = /** @lang GraphQL */ '
         type Mutation {
-            deletePosts(ids: [ID!]! @in(key: "id")): [Post!]!
+            deletePosts(ids: [ID!]! @whereKey): [Post!]!
                 @can(ability: "delete", query: true)
                 @delete
         }

--- a/tests/Integration/Auth/CanDirectiveDBTest.php
+++ b/tests/Integration/Auth/CanDirectiveDBTest.php
@@ -219,7 +219,7 @@ final class CanDirectiveDBTest extends DBTestCase
 
         $this->schema = /** @lang GraphQL */ '
         type Mutation {
-            deletePosts(ids: [ID!]!): [Post!]!
+            deletePosts(ids: [ID!]! @in(key: "id")): [Post!]!
                 @can(ability: "delete", find: "ids")
                 @delete
         }
@@ -382,7 +382,7 @@ final class CanDirectiveDBTest extends DBTestCase
 
         $this->schema = /** @lang GraphQL */ '
         type Mutation {
-            deletePosts(ids: [ID!]!): [Post!]!
+            deletePosts(ids: [ID!]! @in(key: "id")): [Post!]!
                 @can(ability: "delete", query: true)
                 @delete
         }

--- a/tests/Integration/Schema/Directives/DeleteDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/DeleteDirectiveTest.php
@@ -23,7 +23,7 @@ final class DeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            deleteUser(id: ID!): User @delete
+            deleteUser(id: ID! @eq): User @delete
         }
         ';
 
@@ -54,7 +54,7 @@ final class DeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            deleteUser(id: ID!): User @delete
+            deleteUser(id: ID! @eq): User @delete
         }
         ';
 
@@ -82,7 +82,7 @@ final class DeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            deleteUsers(ids: [ID!]!): [User!]! @delete
+            deleteUsers(ids: [ID!]! @in(key: "id")): [User!]! @delete
         }
         ';
 
@@ -107,7 +107,7 @@ final class DeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            deleteUsers(ids: [ID!]!): [User!]! @delete
+            deleteUsers(ids: [ID!]! @in(key: "id")): [User!]! @delete
         }
         ';
 
@@ -132,7 +132,7 @@ final class DeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            deleteUsers(ids: [ID!]!): [User!]! @delete
+            deleteUsers(ids: [ID!]! @in(key: "id")): [User!]! @delete
         }
         ';
 
@@ -147,52 +147,6 @@ final class DeleteDirectiveTest extends DBTestCase
                 'deleteUsers' => [],
             ],
         ]);
-    }
-
-    public function testRejectsDefinitionWithNullableArgument(): void
-    {
-        $this->expectException(DefinitionException::class);
-
-        $this->buildSchema(/** @lang GraphQL */ '
-        type User {
-            id: ID!
-            name: String
-        }
-
-        type Mutation {
-            deleteUser(id: ID): User @delete
-        }
-        ' . self::PLACEHOLDER_QUERY);
-    }
-
-    public function testRejectsDefinitionWithNoArgument(): void
-    {
-        $this->expectException(DefinitionException::class);
-
-        $this->buildSchema(/** @lang GraphQL */ '
-        type User {
-            id: ID!
-        }
-
-        type Mutation {
-            deleteUser: User @delete
-        }
-        ' . self::PLACEHOLDER_QUERY);
-    }
-
-    public function testRejectsDefinitionWithMultipleArguments(): void
-    {
-        $this->expectException(DefinitionException::class);
-
-        $this->buildSchema(/** @lang GraphQL */ '
-        type User {
-            id: ID!
-        }
-
-        type Mutation {
-            deleteUser(foo: String, bar: Int): User @delete
-        }
-        ' . self::PLACEHOLDER_QUERY);
     }
 
     public function testRequiresRelationWhenUsingAsArgResolver(): void
@@ -405,7 +359,7 @@ final class DeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            deleteUser(id: ID!): User @delete
+            deleteUser(id: ID! @eq): User @delete
         }
         ';
 

--- a/tests/Integration/Schema/Directives/DeleteDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/DeleteDirectiveTest.php
@@ -23,7 +23,7 @@ final class DeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            deleteUser(id: ID! @eq): User @delete
+            deleteUser(id: ID! @whereKey): User @delete
         }
         ';
 
@@ -54,7 +54,7 @@ final class DeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            deleteUser(id: ID! @eq): User @delete
+            deleteUser(id: ID! @whereKey): User @delete
         }
         ';
 
@@ -82,7 +82,7 @@ final class DeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            deleteUsers(ids: [ID!]! @in(key: "id")): [User!]! @delete
+            deleteUsers(ids: [ID!]! @whereKey): [User!]! @delete
         }
         ';
 
@@ -107,7 +107,7 @@ final class DeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            deleteUsers(ids: [ID!]! @in(key: "id")): [User!]! @delete
+            deleteUsers(ids: [ID!]! @whereKey): [User!]! @delete
         }
         ';
 
@@ -132,7 +132,7 @@ final class DeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            deleteUsers(ids: [ID!]! @in(key: "id")): [User!]! @delete
+            deleteUsers(ids: [ID!]! @whereKey): [User!]! @delete
         }
         ';
 
@@ -359,7 +359,7 @@ final class DeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            deleteUser(id: ID! @eq): User @delete
+            deleteUser(id: ID! @whereKey): User @delete
         }
         ';
 

--- a/tests/Integration/Schema/Directives/DeleteDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/DeleteDirectiveTest.php
@@ -134,9 +134,9 @@ final class DeleteDirectiveTest extends DBTestCase
                 'deleteUsers' => [
                     [
                         'id' => $foo->id,
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ]);
 
         $this->assertCount(1, User::all());

--- a/tests/Integration/SoftDeletes/ForceDeleteDirectiveTest.php
+++ b/tests/Integration/SoftDeletes/ForceDeleteDirectiveTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Integration\SoftDeletes;
 
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\SoftDeletes\ForceDeleteDirective;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Task;
@@ -21,7 +20,7 @@ final class ForceDeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            forceDeleteTask(id: ID!): Task @forceDelete
+            forceDeleteTask(id: ID! @whereKey): Task @forceDelete
         }
         ';
 
@@ -53,7 +52,7 @@ final class ForceDeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            forceDeleteTask(id: ID!): Task @forceDelete
+            forceDeleteTask(id: ID! @whereKey): Task @forceDelete
         }
         ';
 
@@ -85,7 +84,7 @@ final class ForceDeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            forceDeleteTasks(id: [ID!]!): [Task!]! @forceDelete
+            forceDeleteTasks(id: [ID!]! @whereKey): [Task!]! @forceDelete
         }
         ';
 
@@ -118,7 +117,7 @@ final class ForceDeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            forceDeleteTasks(id: ID! @eq): Task!
+            forceDeleteTasks(id: ID! @whereKey): Task!
                 @can(ability: "delete", query: true)
                 @forceDelete
         }
@@ -153,7 +152,7 @@ final class ForceDeleteDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            forceDeleteTasks(id: ID! @eq): Task!
+            forceDeleteTasks(id: ID! @whereKey): Task!
                 @can(ability: "delete", query: true)
                 @forceDelete
                 # The order has to be like this, otherwise @forceDelete will throw
@@ -172,52 +171,7 @@ final class ForceDeleteDirectiveTest extends DBTestCase
         $this->assertCount(0, Task::withTrashed()->get());
     }
 
-    public function testRejectsDefinitionWithNullableArgument(): void
-    {
-        $this->expectException(DefinitionException::class);
-
-        $this->buildSchema(/** @lang GraphQL */ '
-        type Task {
-            id: ID!
-        }
-
-        type Query {
-            deleteTask(id: ID): Task @forceDelete
-        }
-        ');
-    }
-
-    public function testRejectsDefinitionWithNoArgument(): void
-    {
-        $this->expectException(DefinitionException::class);
-
-        $this->buildSchema(/** @lang GraphQL */ '
-        type Task {
-            id: ID!
-        }
-
-        type Query {
-            deleteTask: Task @forceDelete
-        }
-        ');
-    }
-
-    public function testRejectsDefinitionWithMultipleArguments(): void
-    {
-        $this->expectException(DefinitionException::class);
-
-        $this->buildSchema(/** @lang GraphQL */ '
-        type Task {
-            id: ID!
-        }
-
-        type Query {
-            deleteTask(foo: String, bar: Int): Task @forceDelete
-        }
-        ');
-    }
-
-    public function testRejectsUsingDirectiveWithNoSoftDeleteModels(): void
+    public function testRejectsUsingDirectiveWithNonSoftDeleteModels(): void
     {
         $this->expectExceptionMessage(ForceDeleteDirective::MODEL_NOT_USING_SOFT_DELETES);
         $this->buildSchema(/** @lang GraphQL */ '
@@ -226,7 +180,7 @@ final class ForceDeleteDirectiveTest extends DBTestCase
         }
 
         type Query {
-            deleteUser(id: ID!): User @forceDelete
+            deleteUser(id: ID! @whereKey): User @forceDelete
         }
         ');
     }

--- a/tests/Integration/SoftDeletes/RestoreDirectiveTest.php
+++ b/tests/Integration/SoftDeletes/RestoreDirectiveTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Integration\SoftDeletes;
 
-use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\SoftDeletes\RestoreDirective;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Task;
@@ -25,7 +24,7 @@ final class RestoreDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            restoreTask(id: ID!): Task @restore
+            restoreTask(id: ID! @whereKey): Task @restore
         }
         ';
 
@@ -63,7 +62,7 @@ final class RestoreDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            restoreTasks(id: [ID!]!): [Task!]! @restore
+            restoreTasks(id: [ID!]! @whereKey): [Task!]! @restore
         }
         ';
 
@@ -98,7 +97,7 @@ final class RestoreDirectiveTest extends DBTestCase
         }
 
         type Mutation {
-            restoreTasks(id: ID! @eq): Task!
+            restoreTasks(id: ID! @whereKey): Task!
                 @can(ability: "delete", query: true)
                 @restore
         }
@@ -121,52 +120,7 @@ final class RestoreDirectiveTest extends DBTestCase
         $this->assertCount(1, Task::withoutTrashed()->get());
     }
 
-    public function testRejectsDefinitionWithNullableArgument(): void
-    {
-        $this->expectException(DefinitionException::class);
-
-        $this->buildSchema(/** @lang GraphQL */ '
-        type Task {
-            id: ID!
-        }
-
-        type Query {
-            restoreTask(id: ID): Task @restore
-        }
-        ');
-    }
-
-    public function testRejectsDefinitionWithNoArgument(): void
-    {
-        $this->expectException(DefinitionException::class);
-
-        $this->buildSchema(/** @lang GraphQL */ '
-        type Task {
-            id: ID!
-        }
-
-        type Query {
-            restoreTask: Task @restore
-        }
-        ');
-    }
-
-    public function testRejectsDefinitionWithMultipleArguments(): void
-    {
-        $this->expectException(DefinitionException::class);
-
-        $this->buildSchema(/** @lang GraphQL */ '
-        type Task {
-            id: ID!
-        }
-
-        type Query {
-            restoreTask(foo: String, bar: Int): Task @restore
-        }
-        ');
-    }
-
-    public function testRejectsUsingDirectiveWithNoSoftDeleteModels(): void
+    public function testRejectsUsingDirectiveWithNonSoftDeleteModels(): void
     {
         $this->expectExceptionMessage(RestoreDirective::MODEL_NOT_USING_SOFT_DELETES);
 
@@ -176,7 +130,7 @@ final class RestoreDirectiveTest extends DBTestCase
         }
 
         type Query {
-            restoreUser(id: ID!): User @restore
+            restoreUser(id: ID! @whereKey): User @restore
         }
         ');
     }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves https://github.com/nuwave/lighthouse/issues/2288

**Changes**

Prior to this PR, `@delete`, `@forceDelete` and `@restore` relied upon the field they were used upon just defining a single
argument to use as the ID/IDs to find the models to modify.

Now, they will leverage the same mechanisms as other directives like `@all` or `@find` do to find the models:
- scopes
- argument filter directives such as `@eq`
- any other way of influencing the query builder

A new directive `@whereKey` has been added to support the most common use case of finding by primary key.
In addition, this change opens up many new possibilities to leverage those directives, e.g. deleting all models that match
a set of conditions.

TODO: determine if the same change can be made to `@update` and `@upsert`, see https://github.com/nuwave/lighthouse/issues/1145.

**Breaking changes**

- Remove the `globalId` argument from `@delete`, `@forceDelete` and `@restore`
- Require filter directives such as `@whereKey` in `@delete`, `@forceDelete` and `@restore`