### PR TITLE
Add validation support for pagination resolver mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Changed
 
+- Add validation support to `Paginator` with `resolver` mode
 - Pass resolver arguments to `FieldBuilderDirective::handleFieldBuilder()` https://github.com/nuwave/lighthouse/pull/2234
 - Expected resolver arguments in `ResolveInfo::enhanceBuilder()`
 - Pass the path array to `CacheKeyAndTags::key()` https://github.com/nuwave/lighthouse/pull/2176

--- a/src/Pagination/PaginateDirective.php
+++ b/src/Pagination/PaginateDirective.php
@@ -128,6 +128,9 @@ GRAPHQL;
     {
         $fieldValue->setResolver(function ($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo): Paginator {
             if ($this->directiveHasArgument('resolver')) {
+                // This is done only for validation
+                PaginationArgs::extractArgs($args, $this->paginationType(), $this->paginateMaxCount());
+                
                 $paginator = $this->getResolverFromArgument('resolver')($root, $args, $context, $resolveInfo);
 
                 assert(

--- a/src/Pagination/PaginateDirective.php
+++ b/src/Pagination/PaginateDirective.php
@@ -130,7 +130,7 @@ GRAPHQL;
             if ($this->directiveHasArgument('resolver')) {
                 // This is done only for validation
                 PaginationArgs::extractArgs($args, $this->paginationType(), $this->paginateMaxCount());
-                
+
                 $paginator = $this->getResolverFromArgument('resolver')($root, $args, $context, $resolveInfo);
 
                 assert(

--- a/tests/Unit/Pagination/PaginateDirectiveTest.php
+++ b/tests/Unit/Pagination/PaginateDirectiveTest.php
@@ -504,7 +504,7 @@ GRAPHQL
 
         $result = $this->graphQL(/** @lang GraphQL */ '
         {
-            users1(first: 10) {
+            users(first: 10) {
                 data {
                     id
                     name

--- a/tests/Unit/Pagination/PaginateDirectiveTest.php
+++ b/tests/Unit/Pagination/PaginateDirectiveTest.php
@@ -498,8 +498,7 @@ GRAPHQL
         }
 
         type Query {
-            users1: [User!]! @paginate(maxCount: 6, resolver: "' . $this->qualifyTestResolver('returnPaginatedDataInsteadOfBuilder') . '")
-            users2: [User!]! @paginate(maxCount: 10)
+            users: [User!]! @paginate(maxCount: 6, resolver: "' . $this->qualifyTestResolver('returnPaginatedDataInsteadOfBuilder') . '")
         }
         ';
 

--- a/tests/Unit/Pagination/PaginateDirectiveTest.php
+++ b/tests/Unit/Pagination/PaginateDirectiveTest.php
@@ -487,6 +487,39 @@ GRAPHQL
         );
     }
 
+    public function testIsLimitedByMaxCountFromDirectiveWithResolver(): void
+    {
+        config(['lighthouse.pagination.max_count' => 5]);
+
+        $this->schema = /** @lang GraphQL */ '
+        type User {
+            id: ID!
+            name: String!
+        }
+
+        type Query {
+            users1: [User!]! @paginate(maxCount: 6, resolver: "' . $this->qualifyTestResolver('returnPaginatedDataInsteadOfBuilder') . '")
+            users2: [User!]! @paginate(maxCount: 10)
+        }
+        ';
+
+        $result = $this->graphQL(/** @lang GraphQL */ '
+        {
+            users1(first: 10) {
+                data {
+                    id
+                    name
+                }
+            }
+        }
+        ');
+
+        $this->assertSame(
+            PaginationArgs::requestedTooManyItems(6, 10),
+            $result->json('errors.0.message')
+        );
+    }
+
     public function testIsLimitedToMaxCountFromConfig(): void
     {
         config(['lighthouse.pagination.max_count' => 5]);


### PR DESCRIPTION
- [x] Added or updated tests (No tests were found about maxCount limit on pagination anyways)
- [ ] Documented user facing changes (This was really like a bug fix so the users expected this to work out of the box but it didn't)
- [X] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
This is an update on https://github.com/nuwave/lighthouse/pull/2232

**Changes**

When using maxCount the validation wasn't applied now it is so you can get errors like:

```
"Maximum number of 20 requested items exceeded, got 30. Fetch smaller chunks."
```

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

Nothing.

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
