### PR TITLE
Remove schema cache v1

### DIFF
--- a/docs/master/performance/schema-caching.md
+++ b/docs/master/performance/schema-caching.md
@@ -13,8 +13,8 @@ using the [cache](../api-reference/commands.md#cache) artisan command:
     php artisan lighthouse:cache
 
 The structure of the serialized schema can change between Lighthouse releases.
-In order to prevent errors, use cache version 2 and a deployment method that
-atomically updates both the cache file and the dependencies, e.g. K8s.
+In order to prevent errors, use a deployment method that atomically updates
+both the cache file and the dependencies, e.g. K8s.
 
 ## Development
 
@@ -25,16 +25,3 @@ In order to speed up responses during development, change this setting to be alw
     'enable' => env('LIGHTHOUSE_SCHEMA_CACHE_ENABLE', true),
 ],
 ```
-
-## Leverage OPcache
-
-If you use [OPcache](https://www.php.net/manual/en/book.opcache.php), set cache version to `2` in `config/lighthouse.php`.
-
-```php
-'schema_cache' => [
-    'enable' => env('LIGHTHOUSE_SCHEMA_CACHE_ENABLE', true),
-    'version' => env('LIGHTHOUSE_SCHEMA_CACHE_VERSION', 2),
-],
-```
-
-This will store the compiled schema as a PHP file on your disk, allowing OPcache to pick it up.

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -89,33 +89,7 @@ return [
         'enable' => env('LIGHTHOUSE_SCHEMA_CACHE_ENABLE', 'local' !== env('APP_ENV')),
 
         /*
-         * Allowed values:
-         * - 1: uses the store, key and ttl config values to store the schema as a string in the given cache store.
-         * - 2: uses the path config value to store the schema in a PHP file allowing OPcache to pick it up.
-         */
-        'version' => env('LIGHTHOUSE_SCHEMA_CACHE_VERSION', 1),
-
-        /*
-         * Allows using a specific cache store, uses the app's default if set to null.
-         * Only relevant if version is set to 1.
-         */
-        'store' => env('LIGHTHOUSE_SCHEMA_CACHE_STORE', null),
-
-        /*
-         * The name of the cache item for the schema cache.
-         * Only relevant if version is set to 1.
-         */
-        'key' => env('LIGHTHOUSE_SCHEMA_CACHE_KEY', 'lighthouse-schema'),
-
-        /*
-         * Duration in seconds the schema should remain cached, null means forever.
-         * Only relevant if version is set to 1.
-         */
-        'ttl' => env('LIGHTHOUSE_SCHEMA_CACHE_TTL', null),
-
-        /*
          * File path to store the lighthouse schema.
-         * Only relevant if version is set to 2.
          */
         'path' => env('LIGHTHOUSE_SCHEMA_CACHE_PATH', base_path('bootstrap/cache/lighthouse-schema.php')),
     ],

--- a/tests/Console/CacheCommandTest.php
+++ b/tests/Console/CacheCommandTest.php
@@ -14,19 +14,13 @@ use Tests\TestsSerialization;
 
 final class CacheCommandTest extends TestCase
 {
-    use TestsSerialization;
     use TestsSchemaCache;
-
-    protected ConfigRepository $config;
 
     public function setUp(): void
     {
         parent::setUp();
 
-        $this->config = $this->app->make(ConfigRepository::class);
-
         $this->setUpSchemaCache();
-        $this->useSerializingArrayStore();
     }
 
     protected function tearDown(): void
@@ -36,27 +30,8 @@ final class CacheCommandTest extends TestCase
         parent::tearDown();
     }
 
-    public function testCacheVersion1(): void
+    public function testCache(): void
     {
-        $this->config->set('lighthouse.schema_cache.version', 1);
-        $this->config->set('lighthouse.schema_cache.ttl', 60);
-        $this->config->set('lighthouse.schema_cache.store', 'array');
-
-        $key = $this->config->get('lighthouse.schema_cache.key');
-
-        $cache = $this->app->make(CacheRepository::class);
-        $this->assertFalse($cache->has($key));
-
-        $this->commandTester(new CacheCommand())->execute([]);
-
-        $this->assertTrue($cache->has($key));
-        $this->assertInstanceOf(DocumentAST::class, $cache->get($key));
-    }
-
-    public function testCacheVersion2(): void
-    {
-        $this->config->set('lighthouse.schema_cache.version', 2);
-
         $filesystem = $this->app->make(Filesystem::class);
         $path = $this->schemaCachePath();
         $this->assertFalse($filesystem->exists($path));
@@ -65,15 +40,5 @@ final class CacheCommandTest extends TestCase
 
         $this->assertTrue($filesystem->exists($path));
         DocumentAST::fromArray(require $path);
-    }
-
-    public function testCacheVersionUnknown(): void
-    {
-        $this->config->set('lighthouse.schema_cache.version', 3);
-
-        $commandTester = $this->commandTester(new CacheCommand());
-
-        $this->expectException(UnknownCacheVersionException::class);
-        $commandTester->execute([]);
     }
 }

--- a/tests/Console/ClearCacheCommandTest.php
+++ b/tests/Console/ClearCacheCommandTest.php
@@ -14,16 +14,10 @@ final class ClearCacheCommandTest extends TestCase
 {
     use TestsSchemaCache;
 
-    /**
-     * @var \Illuminate\Contracts\Config\Repository
-     */
-    protected $config;
-
     public function setUp(): void
     {
         parent::setUp();
 
-        $this->config = $this->app->make(ConfigRepository::class);
         $this->setUpSchemaCache();
     }
 
@@ -34,26 +28,8 @@ final class ClearCacheCommandTest extends TestCase
         parent::tearDown();
     }
 
-    public function testClearsCacheVersion1(): void
+    public function testClearsCache(): void
     {
-        $this->config->set('lighthouse.schema_cache.version', 1);
-        $this->config->set('lighthouse.schema_cache.ttl', 60);
-
-        $key = $this->config->get('lighthouse.schema_cache.key');
-
-        $cache = $this->app->make(CacheRepository::class);
-
-        $cache->put($key, 'foo', 60);
-        $this->assertTrue($cache->has($key));
-
-        $this->commandTester(new ClearCacheCommand())->execute([]);
-        $this->assertFalse($cache->has($key));
-    }
-
-    public function testClearsCacheVersion2(): void
-    {
-        $this->config->set('lighthouse.schema_cache.version', 2);
-
         $filesystem = $this->app->make(Filesystem::class);
         $path = $this->schemaCachePath();
         $filesystem->put($path, 'foo');
@@ -61,13 +37,5 @@ final class ClearCacheCommandTest extends TestCase
 
         $this->commandTester(new ClearCacheCommand())->execute([]);
         $this->assertFalse($filesystem->exists($path));
-    }
-
-    public function testCacheVersionUnknown(): void
-    {
-        $this->config->set('lighthouse.schema_cache.version', 3);
-
-        $this->expectException(UnknownCacheVersionException::class);
-        $this->commandTester(new ClearCacheCommand())->execute([]);
     }
 }

--- a/tests/Integration/SchemaCachingTest.php
+++ b/tests/Integration/SchemaCachingTest.php
@@ -31,14 +31,8 @@ final class SchemaCachingTest extends TestCase
         parent::tearDown();
     }
 
-    /**
-     * @dataProvider cacheVersions
-     */
-    public function testSchemaCachingWithUnionType(int $cacheVersion): void
+    public function testSchemaCachingWithUnionType(): void
     {
-        $config = $this->app->make(ConfigRepository::class);
-        $config->set('lighthouse.schema_cache.version', $cacheVersion);
-
         $this->schema = /** @lang GraphQL */ '
         type Query {
             foo: Foo @mock
@@ -80,7 +74,6 @@ final class SchemaCachingTest extends TestCase
     public function testInvalidSchemaCacheContents(): void
     {
         $config = $this->app->make(ConfigRepository::class);
-        $config->set('lighthouse.schema_cache.version', 2);
 
         $filesystem = $this->app->make(Filesystem::class);
         $path = $config->get('lighthouse.schema_cache.path');

--- a/tests/TestsSchemaCache.php
+++ b/tests/TestsSchemaCache.php
@@ -24,17 +24,4 @@ trait TestsSchemaCache
         $filesystem = $this->app->make(Filesystem::class);
         $filesystem->delete($this->schemaCachePath());
     }
-
-    /**
-     * Data provider for the different cache versions.
-     *
-     * @return array<int, array{int}>
-     */
-    public static function cacheVersions(): array
-    {
-        return [
-            [1],
-            [2],
-        ];
-    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

Schema cache v1 is dead, long live schema cache v2.

**Breaking changes**

Shouldn't really break things, but it could for some people who have a hard dependency of the schema appearing in their configured cache storage.
