### PR TITLE
Fix empty classnames in definitionExceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Return proper error for unknown types in variable definitions
 - Ensure `_entities` maintains order of representations in result https://github.com/nuwave/lighthouse/pull/2286
 - Allow combining `@can` with non-default `@guard` https://github.com/nuwave/lighthouse/pull/2276
-- When a definition for a className cannot be found, instead of an empty classname being present in the exceptionMessage, the classname is now present.
+- Fix error message when failing to find class in namespace https://github.com/nuwave/lighthouse/pull/2342
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Return proper error for unknown types in variable definitions
 - Ensure `_entities` maintains order of representations in result https://github.com/nuwave/lighthouse/pull/2286
 - Allow combining `@can` with non-default `@guard` https://github.com/nuwave/lighthouse/pull/2276
+- When a definition for a className cannot be found, instead of an empty classname being present in the exceptionMessage, the classname is now present.
 
 ### Added
 

--- a/src/Schema/TypeRegistry.php
+++ b/src/Schema/TypeRegistry.php
@@ -348,12 +348,12 @@ class TypeRegistry
 
         $namespacesToTry = (array) config('lighthouse.namespaces.scalars');
 
-        $className = Utils::namespaceClassname(
+        $classNameFQN = Utils::namespaceClassname(
             $className,
             $namespacesToTry,
             static fn (string $className): bool => is_subclass_of($className, ScalarType::class)
         );
-        assert(is_null($className) || is_subclass_of($className, ScalarType::class));
+        assert(is_null($classNameFQN) || is_subclass_of($classNameFQN, ScalarType::class));
 
         if (null === $className) {
             $scalarClass = ScalarType::class;
@@ -361,7 +361,7 @@ class TypeRegistry
             throw new DefinitionException("Failed to find class {$className} extends {$scalarClass} in namespaces [{$consideredNamespaces}] for the scalar {$scalarName}.");
         }
 
-        return new $className([
+        return new $classNameFQN([
             'name' => $scalarName,
             'description' => $scalarDefinition->description->value ?? null,
             'astNode' => $scalarDefinition,

--- a/src/Schema/TypeRegistry.php
+++ b/src/Schema/TypeRegistry.php
@@ -355,7 +355,7 @@ class TypeRegistry
         );
         assert(is_null($namespacedClassName) || is_subclass_of($namespacedClassName, ScalarType::class));
 
-        if (null === $className) {
+        if (null === $namespacedClassName) {
             $scalarClass = ScalarType::class;
             $consideredNamespaces = implode(', ', $namespacesToTry);
             throw new DefinitionException("Failed to find class {$className} extends {$scalarClass} in namespaces [{$consideredNamespaces}] for the scalar {$scalarName}.");

--- a/src/Schema/TypeRegistry.php
+++ b/src/Schema/TypeRegistry.php
@@ -348,12 +348,12 @@ class TypeRegistry
 
         $namespacesToTry = (array) config('lighthouse.namespaces.scalars');
 
-        $classNameFQN = Utils::namespaceClassname(
+        $namespacedClassName = Utils::namespaceClassname(
             $className,
             $namespacesToTry,
             static fn (string $className): bool => is_subclass_of($className, ScalarType::class)
         );
-        assert(is_null($classNameFQN) || is_subclass_of($classNameFQN, ScalarType::class));
+        assert(is_null($namespacedClassName) || is_subclass_of($namespacedClassName, ScalarType::class));
 
         if (null === $className) {
             $scalarClass = ScalarType::class;
@@ -361,7 +361,7 @@ class TypeRegistry
             throw new DefinitionException("Failed to find class {$className} extends {$scalarClass} in namespaces [{$consideredNamespaces}] for the scalar {$scalarName}.");
         }
 
-        return new $classNameFQN([
+        return new $namespacedClassName([
             'name' => $scalarName,
             'description' => $scalarDefinition->description->value ?? null,
             'astNode' => $scalarDefinition,

--- a/src/Subscriptions/SubscriptionResolverProvider.php
+++ b/src/Subscriptions/SubscriptionResolverProvider.php
@@ -48,9 +48,7 @@ class SubscriptionResolverProvider implements ProvidesSubscriptionResolver
         if (null === $namespacedClassName) {
             $subscriptionClass = GraphQLSubscription::class;
             $consideredNamespaces = implode(', ', $namespacesToTry);
-            throw new DefinitionException(
-                "Failed to find class {$className} extends {$subscriptionClass} in namespaces [{$consideredNamespaces}] for the subscription field {$fieldName}"
-            );
+            throw new DefinitionException("Failed to find class {$className} extends {$subscriptionClass} in namespaces [{$consideredNamespaces}] for the subscription field {$fieldName}");
         }
 
         assert(is_subclass_of($namespacedClassName, GraphQLSubscription::class));

--- a/src/Subscriptions/SubscriptionResolverProvider.php
+++ b/src/Subscriptions/SubscriptionResolverProvider.php
@@ -39,13 +39,13 @@ class SubscriptionResolverProvider implements ProvidesSubscriptionResolver
         }
 
         $namespacesToTry = RootType::defaultNamespaces($fieldValue->getParentName());
-        $classNameFQN = Utils::namespaceClassname(
+        $namespacedClassName = Utils::namespaceClassname(
             $className,
             $namespacesToTry,
             static fn (string $class): bool => is_subclass_of($class, GraphQLSubscription::class)
         );
 
-        if (null === $classNameFQN) {
+        if (null === $namespacedClassName) {
             $subscriptionClass = GraphQLSubscription::class;
             $consideredNamespaces = implode(', ', $namespacesToTry);
             throw new DefinitionException(
@@ -53,9 +53,9 @@ class SubscriptionResolverProvider implements ProvidesSubscriptionResolver
             );
         }
 
-        assert(is_subclass_of($classNameFQN, GraphQLSubscription::class));
+        assert(is_subclass_of($namespacedClassName, GraphQLSubscription::class));
 
-        $subscription = Container::getInstance()->make($classNameFQN);
+        $subscription = Container::getInstance()->make($namespacedClassName);
         // Subscriptions can only be placed on a single field on the root
         // query, so there is no need to consider the field path
         $this->subscriptionRegistry->register(

--- a/src/Subscriptions/SubscriptionResolverProvider.php
+++ b/src/Subscriptions/SubscriptionResolverProvider.php
@@ -39,13 +39,13 @@ class SubscriptionResolverProvider implements ProvidesSubscriptionResolver
         }
 
         $namespacesToTry = RootType::defaultNamespaces($fieldValue->getParentName());
-        $className = Utils::namespaceClassname(
+        $classNameFQN = Utils::namespaceClassname(
             $className,
             $namespacesToTry,
             static fn (string $class): bool => is_subclass_of($class, GraphQLSubscription::class)
         );
 
-        if (null === $className) {
+        if (null === $classNameFQN) {
             $subscriptionClass = GraphQLSubscription::class;
             $consideredNamespaces = implode(', ', $namespacesToTry);
             throw new DefinitionException(
@@ -53,9 +53,9 @@ class SubscriptionResolverProvider implements ProvidesSubscriptionResolver
             );
         }
 
-        assert(is_subclass_of($className, GraphQLSubscription::class));
+        assert(is_subclass_of($classNameFQN, GraphQLSubscription::class));
 
-        $subscription = Container::getInstance()->make($className);
+        $subscription = Container::getInstance()->make($classNameFQN);
         // Subscriptions can only be placed on a single field on the root
         // query, so there is no need to consider the field path
         $this->subscriptionRegistry->register(

--- a/src/Subscriptions/SubscriptionResolverProvider.php
+++ b/src/Subscriptions/SubscriptionResolverProvider.php
@@ -48,7 +48,7 @@ class SubscriptionResolverProvider implements ProvidesSubscriptionResolver
         if (null === $namespacedClassName) {
             $subscriptionClass = GraphQLSubscription::class;
             $consideredNamespaces = implode(', ', $namespacesToTry);
-            throw new DefinitionException("Failed to find class {$className} extends {$subscriptionClass} in namespaces [{$consideredNamespaces}] for the subscription field {$fieldName}");
+            throw new DefinitionException("Failed to find class {$className} extends {$subscriptionClass} in namespaces [{$consideredNamespaces}] for the subscription field {$fieldName}.");
         }
 
         assert(is_subclass_of($namespacedClassName, GraphQLSubscription::class));


### PR DESCRIPTION
- [ ] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Because the $className variable is overwritten in the TypeRegistry and SubscriptionResolverProvider, using it in an exception when the className could not be found results in it being null. ```Failed to find class  extends....``` This PR fixes that by assigning the resulting FQN to a new variable.

**Breaking changes**

None
