### PR TITLE
Cast storage_ttl from env to int

### DIFF
--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -42,7 +42,7 @@ class RedisStorageManager implements StoresSubscriptions
         if ($ttl) {
             $ttl = (int) $ttl;
         }
-        $this->ttl = (int) $ttl;
+        $this->ttl = $ttl;
     }
 
     public function subscriberByChannel(string $channel): ?Subscriber

--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -38,7 +38,11 @@ class RedisStorageManager implements StoresSubscriptions
         $this->connection = $redis->connection(
             $config->get('lighthouse.subscriptions.broadcasters.echo.connection') ?? 'default'
         );
-        $this->ttl = $config->get('lighthouse.subscriptions.storage_ttl');
+        $ttl = $config->get('lighthouse.subscriptions.storage_ttl');
+        if ($ttl) {
+            $ttl = (int) $ttl;
+        }
+        $this->ttl = (int) $ttl;
     }
 
     public function subscriberByChannel(string $channel): ?Subscriber
@@ -68,7 +72,7 @@ class RedisStorageManager implements StoresSubscriptions
         // This is like using multiple get calls (getSubscriber uses the get command).
         $subscribers = $this->connection->command('mget', [$subscriberIds]);
 
-        return (new Collection($subscribers))
+        return ( new Collection($subscribers) )
             ->filter()
             ->map(static function (?string $subscriber): ?Subscriber {
                 // Some entries may be expired

--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Illuminate\Redis\Connections\Connection as RedisConnection;
 use Illuminate\Support\Collection;
+use Mockery\Exception;
 use Nuwave\Lighthouse\Subscriptions\Contracts\StoresSubscriptions;
 use Nuwave\Lighthouse\Subscriptions\Subscriber;
 
@@ -39,10 +40,13 @@ class RedisStorageManager implements StoresSubscriptions
             $config->get('lighthouse.subscriptions.broadcasters.echo.connection') ?? 'default'
         );
         $ttl = $config->get('lighthouse.subscriptions.storage_ttl');
-        if (is_string($ttl)) {
-            $ttl = (int) $ttl;
+        if (is_int($ttl)) {
+            $this->ttl = $ttl;
+        } elseif (is_string($ttl) && is_numeric($ttl)) {
+            $this->ttl = (int) $ttl;
+        } else {
+            throw new Exception('ttl is not an integer');
         }
-        $this->ttl = $ttl;
     }
 
     public function subscriberByChannel(string $channel): ?Subscriber

--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Subscriptions\Storage;
 
+use GraphQL\Utils\Utils;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Illuminate\Redis\Connections\Connection as RedisConnection;
@@ -76,7 +77,7 @@ class RedisStorageManager implements StoresSubscriptions
         // This is like using multiple get calls (getSubscriber uses the get command).
         $subscribers = $this->connection->command('mget', [$subscriberIds]);
 
-        return ( new Collection($subscribers) )
+        return (new Collection($subscribers))
             ->filter()
             ->map(static function (?string $subscriber): ?Subscriber {
                 // Some entries may be expired

--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -46,7 +46,7 @@ class RedisStorageManager implements StoresSubscriptions
             $this->ttl = (int) $ttl;
         } else {
             $notIntOrNumericString = Utils::printSafe($ttl);
-            throw new \Exception("Expected config option lighthouse.subscriptions.storage_ttl to be an int or a numeric string, got: {$notIntOrNumericString}.");
+            throw new \Exception("Expected config option lighthouse.subscriptions.storage_ttl to be an int, null or a numeric string, got: {$notIntOrNumericString}.");
         }
     }
 

--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Illuminate\Redis\Connections\Connection as RedisConnection;
 use Illuminate\Support\Collection;
-use Mockery\Exception;
 use Nuwave\Lighthouse\Subscriptions\Contracts\StoresSubscriptions;
 use Nuwave\Lighthouse\Subscriptions\Subscriber;
 
@@ -45,7 +44,7 @@ class RedisStorageManager implements StoresSubscriptions
         } elseif (is_string($ttl) && is_numeric($ttl)) {
             $this->ttl = (int) $ttl;
         } else {
-            throw new Exception('ttl is not an integer');
+            throw new \ErrorException('ttl is not an integer');
         }
     }
 

--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -44,7 +44,8 @@ class RedisStorageManager implements StoresSubscriptions
         } elseif (is_string($ttl) && is_numeric($ttl)) {
             $this->ttl = (int) $ttl;
         } else {
-            throw new \ErrorException('ttl is not an integer');
+            $notIntOrNumericString = Utils::printSafe($ttl);
+            throw new \Exception("Expected config option lighthouse.subscriptions.storage_ttl to be an int or a numeric string, got: {$notIntOrNumericString}.");
         }
     }
 

--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -39,7 +39,7 @@ class RedisStorageManager implements StoresSubscriptions
             $config->get('lighthouse.subscriptions.broadcasters.echo.connection') ?? 'default'
         );
         $ttl = $config->get('lighthouse.subscriptions.storage_ttl');
-        if ($ttl) {
+        if (is_string($ttl)) {
             $ttl = (int) $ttl;
         }
         $this->ttl = $ttl;

--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -39,7 +39,7 @@ class RedisStorageManager implements StoresSubscriptions
             $config->get('lighthouse.subscriptions.broadcasters.echo.connection') ?? 'default'
         );
         $ttl = $config->get('lighthouse.subscriptions.storage_ttl');
-        if (is_int($ttl)) {
+        if (is_int($ttl) || is_null($ttl)) {
             $this->ttl = $ttl;
         } elseif (is_string($ttl) && is_numeric($ttl)) {
             $this->ttl = (int) $ttl;

--- a/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
+++ b/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
@@ -66,7 +66,7 @@ final class RedisStorageManagerTest extends TestCase
         $redisConnection = $this->createMock(RedisConnection::class);
         $redisFactory = $this->getRedisFactory($redisConnection);
 
-        $ttl = "1000";
+        $ttl = '1000';
         $config->method('get')->willReturn($ttl);
 
         $channel = 'private-lighthouse-foo';

--- a/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
+++ b/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
@@ -66,7 +66,7 @@ final class RedisStorageManagerTest extends TestCase
         $redisConnection = $this->createMock(RedisConnection::class);
         $redisFactory = $this->getRedisFactory($redisConnection);
 
-        $ttl = 1000;
+        $ttl = "1000";
         $config->method('get')->willReturn($ttl);
 
         $channel = 'private-lighthouse-foo';


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

After you have set env

```env
LIGHTHOUSE_SUBSCRIPTION_STORAGE_TTL=3600
```

And run this:

```bash
php artisan lighthouse:ide-helper
```

you get:

```
  Cannot assign string to property Nuwave\Lighthouse\Subscriptions\Storage\RedisStorageManager::$ttl of type ?int
```

That's because env() function of laravel returns string even if you have a number in your env, it can't understand that's an integer that's why this pull request fixes that bug, any where else in your codebase that you've done the same thing the same error might appear.


**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

A little cast to fix a little bug.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->

No