### PR TITLE
Support multiple default guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Rename configuration option `schema.register` to `schema_path`
 - Restructure cache related configuration options
 - Register all non-user namespaces through `RegisterDirectiveNamespaces` event https://github.com/nuwave/lighthouse/pull/2337
+- Guard default configuration options in `lighthouse.php` supports multiple guards.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Rename configuration option `schema.register` to `schema_path`
 - Restructure cache related configuration options
 - Register all non-user namespaces through `RegisterDirectiveNamespaces` event https://github.com/nuwave/lighthouse/pull/2337
-- Guard default configuration options in `lighthouse.php` supports multiple guards.
+- Guard default configuration options in `lighthouse.php` supports multiple guards https://github.com/nuwave/lighthouse/pull/2345
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Rename configuration option `schema.register` to `schema_path`
 - Restructure cache related configuration options
 - Register all non-user namespaces through `RegisterDirectiveNamespaces` event https://github.com/nuwave/lighthouse/pull/2337
-- Guard default configuration options in `lighthouse.php` supports multiple guards https://github.com/nuwave/lighthouse/pull/2345
+- Guard default configuration options in `lighthouse.php` allows multiple guards https://github.com/nuwave/lighthouse/pull/2345
+- Make `@auth` and `@whereAuth` support multiple guards https://github.com/nuwave/lighthouse/pull/2345
 
 ### Fixed
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -321,7 +321,7 @@ the default Laravel authentication guard will be used (`auth.defaults.guard`).
 
 ### Update `@auth` and `@whereAuth` directives
 
-The `guard` attribute, on `@auth` and `@whereAuth` directives, has been renamed `guards` and expects an array.
+The `guard` argument on `@auth` and `@whereAuth` directives has been renamed to `guards` and now expects a list instead of a single string.
 
 ```diff
 - @auth(guard: "api")

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -319,6 +319,17 @@ The `lighthouse.guard` configuration key was renamed to `lighthouse.guards` and 
 If `lighthouse.guards` configuration is missing,
 the default Laravel authentication guard will be used (`auth.defaults.guard`).
 
+### Update `@auth` and `@whereAuth` directives
+
+The `guard` attribute, on `@auth` and `@whereAuth` directives, has been renamed `guards` and expects an array.
+
+```diff
+- @auth(guard: "api")
++ @auth(guards: ["api"])
+- @whereAuth(guard: "api")
++ @whereAuth(guards: ["api"])
+```
+
 ## v4 to v5
 
 ### Update PHP, Laravel and PHPUnit

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -307,7 +307,7 @@ in your `app/config.php`, it is no longer registered by default.
 ],
 ```
 
-### Update lighthouse.guard configuration
+### Update `lighthouse.guard` configuration
 
 The `lighthouse.guard` configuration key was renamed to `lighthouse.guards` and expects an array.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -307,6 +307,18 @@ in your `app/config.php`, it is no longer registered by default.
 ],
 ```
 
+### Update lighthouse.guard configuration
+
+The `lighthouse.guard` configuration key was renamed to `lighthouse.guards` and expects an array.
+
+```diff
+- 'guard' => 'api',
++ 'guards' => ['api'],
+```
+
+If `lighthouse.guards` configuration is missing,
+the default Laravel authentication guard will be used (`auth.defaults.guard`).
+
 ## v4 to v5
 
 ### Update PHP, Laravel and PHPUnit

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -174,7 +174,7 @@ you can pass the guard name as the `guards` argument.
 
 ```graphql
 type Query {
-    me: User @auth(guards: ["api"])
+  me: User @auth(guards: ["api"])
 }
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -156,10 +156,10 @@ Return the currently authenticated user as the result of a query.
 """
 directive @auth(
   """
-  Specify which guard to use, e.g. "api".
+  Specify which guards to use, e.g. ["api"].
   When not defined, the default from `lighthouse.php` is used.
   """
-  guard: String
+  guards: String
 ) on FIELD_DEFINITION
 ```
 
@@ -170,11 +170,21 @@ type Query {
 ```
 
 If you need to use a guard besides the default to resolve the authenticated user,
-you can pass the guard name as the `guard` argument
+you can pass the guard name as the `guards` argument.
 
 ```graphql
 type Query {
-  me: User @auth(guard: "api")
+    me: User @auth(guards: ["api"])
+}
+```
+
+When multiple guards are passed, the first one that returns a user is used.
+
+```graphql
+union Authenticable = Admin | User
+
+type Query {
+  me: Authenticable @auth(guards: ["api", "admin"])
 }
 ```
 
@@ -3619,10 +3629,10 @@ directive @whereAuth(
   relation: String!
 
   """
-  Specify which guard to use, e.g. "api".
+  Specify which guards to use, e.g. ["api"].
   When not defined, the default from `lighthouse.php` is used.
   """
-  guard: String
+  guards: String
 ) on FIELD_DEFINITION
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -159,7 +159,7 @@ directive @auth(
   Specify which guards to use, e.g. ["api"].
   When not defined, the default from `lighthouse.php` is used.
   """
-  guards: String
+  guards: [String!]
 ) on FIELD_DEFINITION
 ```
 
@@ -3632,7 +3632,7 @@ directive @whereAuth(
   Specify which guards to use, e.g. ["api"].
   When not defined, the default from `lighthouse.php` is used.
   """
-  guards: String
+  guards: [String!]
 ) on FIELD_DEFINITION
 ```
 

--- a/docs/master/security/authentication.md
+++ b/docs/master/security/authentication.md
@@ -35,14 +35,15 @@ operations for guest users, so you will have to handle login outside GraphQL.
 
 ## Configure the guard
 
-You can configure a default guard to use for authenticating GraphQL requests in `lighthouse.php`.
+You can configure default guards to use for authenticating GraphQL requests in `lighthouse.php`.
 
 ```php
-    'guard' => 'api',
+    'guards' => ['api'],
 ```
 
 This setting is used whenever Lighthouse looks for an authenticated user, for example in directives
 such as [@guard](../api-reference/directives.md#guard), or when applying the `AttemptAuthentication` middleware.
+When multiple guards are configured, the first one that is authenticated will be used.
 
 Stateless guards are recommended for most use cases, such as the default `api` guard.
 
@@ -60,7 +61,7 @@ to `sanctum` and register Sanctum's `EnsureFrontendRequestsAreStateful` as the f
             // ... other middleware
         ],
     ],
-    'guard' => 'sanctum',
+    'guards' => ['sanctum'],
 ```
 
 Note that Sanctum requires you to send an CSRF token as [header](https://laravel.com/docs/csrf#csrf-x-csrf-token)

--- a/src/Auth/AuthDirective.php
+++ b/src/Auth/AuthDirective.php
@@ -47,16 +47,14 @@ GRAPHQL;
      */
     protected function authenticatedUser(array $guards): ?Authenticatable
     {
-        $user = null;
-
         foreach ($guards as $guard) {
-            $user = $this->authFactory->guard($guard)->user();
-
-            if (isset($user)) {
-                break;
+            $user = $this->authFactory->guard($guard)
+                ->user();
+            if ($user !== null) {
+                return $user;
             }
         }
 
-        return $user;
+        return null;
     }
 }

--- a/src/Auth/AuthDirective.php
+++ b/src/Auth/AuthDirective.php
@@ -22,10 +22,10 @@ Return the currently authenticated user as the result of a query.
 """
 directive @auth(
   """
-  Specify which guard to use, e.g. "api".
+  Specify which guards to use, e.g. ["api"].
   When not defined, the default from `lighthouse.php` is used.
   """
-  guard: String
+  guards: [String!]
 ) on FIELD_DEFINITION
 GRAPHQL;
     }
@@ -33,13 +33,30 @@ GRAPHQL;
     public function resolveField(FieldValue $fieldValue): callable
     {
         return function (): ?Authenticatable {
-            $guard = $this->directiveArgValue('guard', current(AuthServiceProvider::guards()) ?: null);
-            assert(is_string($guard) || is_null($guard));
+            $guards = $this->directiveArgValue('guards', AuthServiceProvider::guards());
+            assert(is_array($guards));
 
-            return $this
-                ->authFactory
-                ->guard($guard)
-                ->user();
+            return $this->authenticatedUser($guards);
         };
+    }
+
+    /**
+     * Return the first logged-in user to any of the given guards.
+     *
+     * @param  array<string|null>  $guards
+     */
+    protected function authenticatedUser(array $guards): ?Authenticatable
+    {
+        $user = null;
+
+        foreach ($guards as $guard) {
+            $user = $this->authFactory->guard($guard)->user();
+
+            if (isset($user)) {
+                break;
+            }
+        }
+
+        return $user;
     }
 }

--- a/src/Auth/AuthDirective.php
+++ b/src/Auth/AuthDirective.php
@@ -33,7 +33,7 @@ GRAPHQL;
     public function resolveField(FieldValue $fieldValue): callable
     {
         return function (): ?Authenticatable {
-            $guard = $this->directiveArgValue('guard', AuthServiceProvider::guard());
+            $guard = $this->directiveArgValue('guard', current(AuthServiceProvider::guards()) ?: null);
             assert(is_string($guard) || is_null($guard));
 
             return $this

--- a/src/Auth/AuthDirective.php
+++ b/src/Auth/AuthDirective.php
@@ -43,7 +43,7 @@ GRAPHQL;
     /**
      * Return the first logged-in user to any of the given guards.
      *
-     * @param  array<string|null>  $guards
+     * @param  array<string>  $guards
      */
     protected function authenticatedUser(array $guards): ?Authenticatable
     {

--- a/src/Auth/AuthDirective.php
+++ b/src/Auth/AuthDirective.php
@@ -50,7 +50,7 @@ GRAPHQL;
         foreach ($guards as $guard) {
             $user = $this->authFactory->guard($guard)
                 ->user();
-            if ($user !== null) {
+            if (null !== $user) {
                 return $user;
             }
         }

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -23,6 +23,6 @@ class AuthServiceProvider extends ServiceProvider
         $config = Container::getInstance()->make(ConfigRepository::class);
 
         return $config->get('lighthouse.guards')
-            ?? [$config->get('auth.default.guard')];
+            ?? [$config->get('auth.defaults.guard')];
     }
 }

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -21,15 +21,7 @@ class AuthServiceProvider extends ServiceProvider
     public static function guards(): array
     {
         $config = Container::getInstance()->make(ConfigRepository::class);
-        $guards = $config->get('auth.guards');
 
-        $lighthouseGuards = array_filter(
-            (array) $config->get('lighthouse.guards', []),
-            static fn (string $guard): bool => isset($guards[$guard]),
-        );
-
-        return [] !== $lighthouseGuards
-            ? $lighthouseGuards
-            : [$config->get('auth.defaults.guard')];
+        return $config->get('lighthouse.guards') ?: [$config->get('auth.guards')];
     }
 }

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -15,14 +15,21 @@ class AuthServiceProvider extends ServiceProvider
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
     }
 
-    public static function guard(): ?string
+    /**
+     * @return string[]
+     */
+    public static function guards(): array
     {
         $config = Container::getInstance()->make(ConfigRepository::class);
-        $lighthouseGuard = $config->get('lighthouse.guard');
         $guards = $config->get('auth.guards');
 
-        return isset($guards[$lighthouseGuard])
-            ? $lighthouseGuard
-            : $config->get('auth.defaults.guard');
+        $lighthouseGuards = array_filter(
+            (array) $config->get('lighthouse.guards', []),
+            static fn (string $guard): bool => isset($guards[$guard]),
+        );
+
+        return [] !== $lighthouseGuards
+            ? $lighthouseGuards
+            : [$config->get('auth.defaults.guard')];
     }
 }

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -22,6 +22,7 @@ class AuthServiceProvider extends ServiceProvider
     {
         $config = Container::getInstance()->make(ConfigRepository::class);
 
-        return $config->get('lighthouse.guards') ?: [$config->get('auth.guards')];
+        return $config->get('lighthouse.guards')
+            ?? [$config->get('auth.guards')];
     }
 }

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -16,7 +16,7 @@ class AuthServiceProvider extends ServiceProvider
     }
 
     /**
-     * @return string[]
+     * @return array<string>
      */
     public static function guards(): array
     {

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -23,6 +23,6 @@ class AuthServiceProvider extends ServiceProvider
         $config = Container::getInstance()->make(ConfigRepository::class);
 
         return $config->get('lighthouse.guards')
-            ?? [$config->get('auth.guards')];
+            ?? [$config->get('auth.default.guard')];
     }
 }

--- a/src/Auth/GuardDirective.php
+++ b/src/Auth/GuardDirective.php
@@ -23,7 +23,7 @@ use Nuwave\Lighthouse\Support\Contracts\TypeManipulator;
 class GuardDirective extends BaseDirective implements FieldMiddleware, TypeManipulator, TypeExtensionManipulator
 {
     public function __construct(
-        protected AuthFactory $auth
+        protected AuthFactory $authFactory
     ) {}
 
     public static function definition(): string
@@ -50,8 +50,8 @@ GRAPHQL;
     public function handleField(FieldValue $fieldValue): void
     {
         $fieldValue->wrapResolver(fn (callable $resolver): \Closure => function (mixed $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($resolver) {
-            $with = $this->directiveArgValue('with', AuthServiceProvider::guards());
-            $context->setUser($this->authenticate($with));
+            $guards = $this->directiveArgValue('with', AuthServiceProvider::guards());
+            $context->setUser($this->authenticate($guards));
 
             return $resolver($root, $args, $context, $resolveInfo);
         });
@@ -65,11 +65,11 @@ GRAPHQL;
     protected function authenticate(array $guards): Authenticatable
     {
         foreach ($guards as $guard) {
-            $user = $this->auth->guard($guard)->user();
+            $user = $this->authFactory->guard($guard)->user();
 
             if (null !== $user) {
                 // @phpstan-ignore-next-line passing null works fine here
-                $this->auth->shouldUse($guard);
+                $this->authFactory->shouldUse($guard);
 
                 return $user;
             }

--- a/src/Auth/GuardDirective.php
+++ b/src/Auth/GuardDirective.php
@@ -50,7 +50,7 @@ GRAPHQL;
     public function handleField(FieldValue $fieldValue): void
     {
         $fieldValue->wrapResolver(fn (callable $resolver): \Closure => function (mixed $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($resolver) {
-            $with = $this->directiveArgValue('with', (array) AuthServiceProvider::guard());
+            $with = $this->directiveArgValue('with',  AuthServiceProvider::guards());
             $context->setUser($this->authenticate($with));
 
             return $resolver($root, $args, $context, $resolveInfo);

--- a/src/Auth/GuardDirective.php
+++ b/src/Auth/GuardDirective.php
@@ -50,7 +50,7 @@ GRAPHQL;
     public function handleField(FieldValue $fieldValue): void
     {
         $fieldValue->wrapResolver(fn (callable $resolver): \Closure => function (mixed $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($resolver) {
-            $with = $this->directiveArgValue('with',  AuthServiceProvider::guards());
+            $with = $this->directiveArgValue('with', AuthServiceProvider::guards());
             $context->setUser($this->authenticate($with));
 
             return $resolver($root, $args, $context, $resolveInfo);

--- a/src/Auth/WhereAuthDirective.php
+++ b/src/Auth/WhereAuthDirective.php
@@ -47,7 +47,7 @@ GRAPHQL;
             function (object $query): void {
                 assert($query instanceof EloquentBuilder);
 
-                $guard = $this->directiveArgValue('guard', AuthServiceProvider::guard());
+                $guard = $this->directiveArgValue('guard', current(AuthServiceProvider::guards()) ?: null);
 
                 $userId = $this
                     ->authFactory

--- a/src/Auth/WhereAuthDirective.php
+++ b/src/Auth/WhereAuthDirective.php
@@ -56,7 +56,7 @@ GRAPHQL;
     /**
      * Return the ID of the first logged-in user to any of the given guards.
      *
-     * @param  array<string|null>  $guards
+     * @param  array<string>  $guards
      */
     protected function authenticatedUserID(array $guards): int|null|string
     {

--- a/src/Auth/WhereAuthDirective.php
+++ b/src/Auth/WhereAuthDirective.php
@@ -48,28 +48,26 @@ GRAPHQL;
                 assert($query instanceof EloquentBuilder);
 
                 $guards = $this->directiveArgValue('guards', AuthServiceProvider::guards());
-                $query->whereKey($this->authenticatedUserId($guards));
+                $query->whereKey($this->authenticatedUserID($guards));
             },
         );
     }
 
     /**
-     * Return the first logged-in user id to any of the given guards.
+     * Return the ID of the first logged-in user to any of the given guards.
      *
      * @param  array<string|null>  $guards
      */
-    protected function authenticatedUserId(array $guards): int|null|string
+    protected function authenticatedUserID(array $guards): int|null|string
     {
-        $userId = null;
-
         foreach ($guards as $guard) {
-            $userId = $this->authFactory->guard($guard)->id();
-
-            if (isset($userId)) {
-                break;
+            $id = $this->authFactory->guard($guard)
+                ->id();
+            if ($id !== null) {
+                return $id;
             }
         }
 
-        return $userId;
+        return null;
     }
 }

--- a/src/Auth/WhereAuthDirective.php
+++ b/src/Auth/WhereAuthDirective.php
@@ -63,7 +63,7 @@ GRAPHQL;
         foreach ($guards as $guard) {
             $id = $this->authFactory->guard($guard)
                 ->id();
-            if ($id !== null) {
+            if (null !== $id) {
                 return $id;
             }
         }

--- a/src/Schema/Context.php
+++ b/src/Schema/Context.php
@@ -20,7 +20,15 @@ class Context implements GraphQLContext
          */
         public Request $request,
     ) {
-        $this->user = $request->user(AuthServiceProvider::guard());
+        foreach (AuthServiceProvider::guards() as $guard) {
+            $user = $request->user($guard);
+
+            if (null !== $user) {
+                $this->user = $user;
+
+                break;
+            }
+        }
     }
 
     /**

--- a/src/Schema/Context.php
+++ b/src/Schema/Context.php
@@ -12,7 +12,7 @@ class Context implements GraphQLContext
     /**
      * An instance of the currently authenticated user.
      */
-    public ?Authenticatable $user;
+    public ?Authenticatable $user = null;
 
     public function __construct(
         /**

--- a/src/Schema/Context.php
+++ b/src/Schema/Context.php
@@ -12,7 +12,7 @@ class Context implements GraphQLContext
     /**
      * An instance of the currently authenticated user.
      */
-    public ?Authenticatable $user = null;
+    public ?Authenticatable $user;
 
     public function __construct(
         /**
@@ -20,12 +20,12 @@ class Context implements GraphQLContext
          */
         public Request $request,
     ) {
+        $this->user = null;
+
         foreach (AuthServiceProvider::guards() as $guard) {
-            $user = $request->user($guard);
+            $this->user = $request->user($guard);
 
-            if (null !== $user) {
-                $this->user = $user;
-
+            if (isset($this->user)) {
                 break;
             }
         }

--- a/src/Subscriptions/Iterators/AuthenticatingSyncIterator.php
+++ b/src/Subscriptions/Iterators/AuthenticatingSyncIterator.php
@@ -25,10 +25,10 @@ class AuthenticatingSyncIterator implements SubscriptionIterator
         $previousGuardName = $this->configRepository->get('auth.defaults.guard');
 
         // Store the previous default Lighthouse guard name, so we can restore it after we're done
-        $defaultLighthouseGuardName = $this->configRepository->get('lighthouse.guard');
+        $defaultLighthouseGuardName = $this->configRepository->get('lighthouse.guards');
 
         // Set our subscription guard as the default guard for Lighthouse
-        $this->configRepository->set('lighthouse.guard', SubscriptionGuard::GUARD_NAME);
+        $this->configRepository->set('lighthouse.guards', [SubscriptionGuard::GUARD_NAME]);
 
         // Set our subscription guard as the default guard for the application
         $this->authFactory->shouldUse(SubscriptionGuard::GUARD_NAME);
@@ -59,7 +59,7 @@ class AuthenticatingSyncIterator implements SubscriptionIterator
             });
         } finally {
             // Restore the previous default Lighthouse guard name
-            $this->configRepository->set('lighthouse.guard', $defaultLighthouseGuardName);
+            $this->configRepository->set('lighthouse.guards', [$defaultLighthouseGuardName]);
 
             // Restore the previous default guard name
             $this->authFactory->shouldUse($previousGuardName);

--- a/src/Subscriptions/Iterators/AuthenticatingSyncIterator.php
+++ b/src/Subscriptions/Iterators/AuthenticatingSyncIterator.php
@@ -25,7 +25,7 @@ class AuthenticatingSyncIterator implements SubscriptionIterator
         $previousGuardName = $this->configRepository->get('auth.defaults.guard');
 
         // Store the previous default Lighthouse guard name, so we can restore it after we're done
-        $defaultLighthouseGuardName = $this->configRepository->get('lighthouse.guards');
+        $defaultLighthouseGuardNames = $this->configRepository->get('lighthouse.guards');
 
         // Set our subscription guard as the default guard for Lighthouse
         $this->configRepository->set('lighthouse.guards', [SubscriptionGuard::GUARD_NAME]);
@@ -59,7 +59,7 @@ class AuthenticatingSyncIterator implements SubscriptionIterator
             });
         } finally {
             // Restore the previous default Lighthouse guard name
-            $this->configRepository->set('lighthouse.guards', [$defaultLighthouseGuardName]);
+            $this->configRepository->set('lighthouse.guards', $defaultLighthouseGuardNames);
 
             // Restore the previous default guard name
             $this->authFactory->shouldUse($previousGuardName);

--- a/src/Support/Http/Middleware/AttemptAuthentication.php
+++ b/src/Support/Http/Middleware/AttemptAuthentication.php
@@ -28,7 +28,7 @@ class AttemptAuthentication
     protected function attemptAuthentication(array $guards): void
     {
         if ([] === $guards) {
-            $guards = [AuthServiceProvider::guard()];
+            $guards = AuthServiceProvider::guards();
         }
 
         foreach ($guards as $guard) {

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -53,13 +53,11 @@ return [
     |
     | The guards to use for authenticating GraphQL requests, if needed.
     | Used in directives such as `@guard` or the `AttemptAuthentication` middleware.
-    | Falls back to the Laravel default if the defined guards is `null`.
+    | Falls back to the Laravel default if `null`.
     |
     */
 
-    'guards' => [
-        'api',
-    ],
+    'guards' => ['api'],
 
     /*
     |--------------------------------------------------------------------------

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -48,16 +48,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Authentication Guard
+    | Authentication Guards
     |--------------------------------------------------------------------------
     |
-    | The guard to use for authenticating GraphQL requests, if needed.
+    | The guards to use for authenticating GraphQL requests, if needed.
     | Used in directives such as `@guard` or the `AttemptAuthentication` middleware.
-    | Falls back to the Laravel default if the defined guard is either `null` or not found.
+    | Falls back to the Laravel default if the defined guards is `null`.
     |
     */
 
-    'guard' => 'api',
+    'guards' => [
+        'api',
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Integration/Execution/FieldBuilderDirectiveTest.php
+++ b/tests/Integration/Execution/FieldBuilderDirectiveTest.php
@@ -55,7 +55,7 @@ final class FieldBuilderDirectiveTest extends DBTestCase
                 @all
                 @whereAuth(
                     relation: "user"
-                    guard: "web"
+                    guards: ["web"]
                 )
         }
         ';

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -138,7 +138,7 @@ GRAPHQL;
             | DebugFlag::RETHROW_UNSAFE_EXCEPTIONS
         );
 
-        $config->set('lighthouse.guard', null);
+        $config->set('lighthouse.guards', null);
 
         $config->set('lighthouse.subscriptions', [
             'version' => 1,

--- a/tests/Unit/Auth/AuthDirectiveTest.php
+++ b/tests/Unit/Auth/AuthDirectiveTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Auth;
 
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Tests\TestCase;
 use Tests\Utils\Models\User;
 
@@ -39,7 +40,7 @@ final class AuthDirectiveTest extends TestCase
         ]);
     }
 
-    public function testResolveAuthenticatedUserWithGuardArgument(): void
+    public function testResolveAuthenticatedUserWithGuardsArgument(): void
     {
         $user = new User();
         $user->name = 'foo';
@@ -53,7 +54,53 @@ final class AuthDirectiveTest extends TestCase
         }
 
         type Query {
-            user: User! @auth(guard: "web")
+            user: User! @auth(guards: ["web"])
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            user {
+                name
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'user' => [
+                    'name' => $user->name,
+                ],
+            ],
+        ]);
+    }
+
+    public function testResolveAuthenticatedUserWithMultipleGuardsArgument(): void
+    {
+        $config = $this->app->make(ConfigRepository::class);
+
+        $config->set('auth.guards', array_merge($config->get('auth.guards'), [
+            'web' => [
+                'driver' => 'session',
+                'provider' => 'users',
+            ],
+            'api' => [
+                'driver' => 'session',
+                'provider' => 'users',
+            ],
+        ]));
+
+        $user = new User();
+        $user->name = 'foo';
+
+        $authFactory = $this->app->make(AuthFactory::class);
+        $authFactory->guard('api')->setUser($user);
+
+        $this->schema = /** @lang GraphQL */ '
+        type User {
+            name: String!
+        }
+
+        type Query {
+            user: User! @auth(guards: ["web", "api"])
         }
         ';
 

--- a/tests/Unit/Auth/UserContextTest.php
+++ b/tests/Unit/Auth/UserContextTest.php
@@ -9,8 +9,7 @@ use Tests\Utils\Models\User;
 
 final class UserContextTest extends TestCase
 {
-
-    function setUp(): void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -73,7 +72,7 @@ final class UserContextTest extends TestCase
             'web' => [
                 'driver' => 'session',
                 'provider' => 'users',
-                ],
+            ],
             'api' => [
                 'driver' => 'session',
                 'provider' => 'users',

--- a/tests/Unit/Auth/UserContextTest.php
+++ b/tests/Unit/Auth/UserContextTest.php
@@ -23,9 +23,7 @@ final class UserContextTest extends TestCase
         }
         ';
 
-        $this->mockResolver(function ($_, $args, $context) {
-            return $context->user();
-        });
+        $this->mockResolver(static fn ($_, $args, $context) => $context->user());
     }
 
     public function testResolveAuthenticatedUserUsingContext(): void

--- a/tests/Unit/Auth/UserContextTest.php
+++ b/tests/Unit/Auth/UserContextTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Unit\Auth;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 use Tests\TestCase;
 use Tests\Utils\Models\User;
 
@@ -23,7 +25,7 @@ final class UserContextTest extends TestCase
         }
         ';
 
-        $this->mockResolver(static fn ($_, $args, $context) => $context->user());
+        $this->mockResolver(static fn ($_, array $args, GraphQLContext $context): ?Authenticatable => $context->user());
     }
 
     public function testResolveAuthenticatedUserUsingContext(): void

--- a/tests/Unit/Auth/UserContextTest.php
+++ b/tests/Unit/Auth/UserContextTest.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Auth;
+
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Tests\TestCase;
+use Tests\Utils\Models\User;
+
+final class UserContextTest extends TestCase
+{
+
+    function setUp(): void
+    {
+        parent::setUp();
+
+        $this->schema = /** @lang GraphQL */ '
+        type User {
+            name: String!
+        }
+
+        type Query {
+            user: User @mock
+        }
+        ';
+
+        $this->mockResolver(function ($_, $args, $context) {
+            return $context->user();
+        });
+    }
+
+    public function testResolveAuthenticatedUserUsingContext(): void
+    {
+        $user = new User();
+        $user->name = 'foo';
+        $this->be($user);
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            user {
+                name
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'user' => [
+                    'name' => $user->name,
+                ],
+            ],
+        ]);
+    }
+
+    public function testResolveGuestUserUsingContext(): void
+    {
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            user {
+                name
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'user' => null,
+            ],
+        ]);
+    }
+
+    public function testResolveAuthenticatedUserUsingContextWithMultipleGuards(): void
+    {
+        $config = $this->app->make(ConfigRepository::class);
+
+        $config->set('auth.guards', array_merge($config->get('auth.guards'), [
+            'web' => [
+                'driver' => 'session',
+                'provider' => 'users',
+                ],
+            'api' => [
+                'driver' => 'session',
+                'provider' => 'users',
+            ],
+        ]));
+
+        $config->set('lighthouse.guards', ['web', 'api']);
+
+        $user = new User();
+        $user->name = 'foo';
+
+        $authFactory = $this->app->make(AuthFactory::class);
+        $authFactory->guard('api')->setUser($user);
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            user {
+                name
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'user' => [
+                    'name' => $user->name,
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Unit/Support/Http/Middleware/AttemptAuthenticationTest.php
+++ b/tests/Unit/Support/Http/Middleware/AttemptAuthenticationTest.php
@@ -25,7 +25,7 @@ final class AttemptAuthenticationTest extends TestCase
         $config->set('lighthouse.route.middleware', [
             AttemptAuthentication::class,
         ]);
-        $config->set('lighthouse.guard', 'foo');
+        $config->set('lighthouse.guards', ['foo']);
         $config->set('auth.guards.foo', [
             'driver' => 'foo',
             'provider' => 'users',


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md
- [x] Change @auth(guard:) and @whereAuth(guard:) into @auth(guards:) and @whereAuth(guards:)

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

When using a query or mutation without `@guard` directive, to allow guest users, only one single default guard was attempted for $context->user. Specifying multiple guards with `@guard(with:)` allow to attempt multiples guard, but this would disallow guest users.

This PR propose to change the `lighthouse.guard` configuration to support multiple guards.

**Breaking changes**

- `lighthouse.guard` configuration key has been renamed `lighthouse.guards` and expect now an array.
- `@auth(guard: String)` has been changed to `@auth(guards: [String!])`
- `@whereAuth(guard: String)` has been changed to `@whereAuth(guards: [String!])`