### PR TITLE
chore: cast `schema_cache.enable` to boolean

### DIFF
--- a/src/Schema/AST/ASTCache.php
+++ b/src/Schema/AST/ASTCache.php
@@ -25,7 +25,7 @@ class ASTCache
     {
         /** @var CacheConfig $cacheConfig */
         $cacheConfig = $config->get('lighthouse.schema_cache');
-        $this->enable = $cacheConfig['enable'];
+        $this->enable = (bool) $cacheConfig['enable'];
         $this->path = $cacheConfig['path'] ?? base_path('bootstrap/cache/lighthouse-schema.php');
     }
 


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

When [setting `LIGHTHOUSE_SCHEMA_CACHE_ENABLE` to `false` in a PHPUnit configuration](https://github.com/nuwave/lighthouse/blob/master/docs/master/performance/query-caching.md#testing-caveats), it seems that this get's parsed as an empty string. This then causes the env to be loaded incorrectly and ends up throwing an error with `Cannot assign string to property Nuwave\\Lighthouse\\Schema\\AST\\ASTCache::$enable of type bool` since the ASTCache was changed to be strictly typed properties.

I'm not sure if this would be considered an issue with PHPUnit (9) not parsing the XML correctly, however this hasn't been an issue until the properties were typed. I guess because before the empty string was treated as `false`. 🤷🏻

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
