### PR TITLE
Prevent regression to simple paginator type on fields using `@cache` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find and compare releases at the [GitHub release page](https://github.com/nuwave/lighthouse/releases).
 
 ## Unreleased
-
+- Fix the bug https://github.com/nuwave/lighthouse/issues/2354
 ### Changed
 
 - Use the strongest possible native types over PHPDocs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find and compare releases at the [GitHub release page](https://github.com/nuwave/lighthouse/releases).
 
 ## Unreleased
-- Prevent automatically paginator type change if cache directive exists (https://github.com/nuwave/lighthouse/issues/2354).
+- Prevent automatic paginator type change if cache directive exists (https://github.com/nuwave/lighthouse/issues/2354).
 ### Changed
 
 - Use the strongest possible native types over PHPDocs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find and compare releases at the [GitHub release page](https://github.com/nuwave/lighthouse/releases).
 
 ## Unreleased
-- Fix the bug https://github.com/nuwave/lighthouse/issues/2354
+- Prevent automatically paginator type change if cache directive exists (https://github.com/nuwave/lighthouse/issues/2354).
 ### Changed
 
 - Use the strongest possible native types over PHPDocs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find and compare releases at the [GitHub release page](https://github.com/nuwave/lighthouse/releases).
 
 ## Unreleased
-- Prevent automatic paginator type change if cache directive exists (https://github.com/nuwave/lighthouse/issues/2354).
+
 ### Changed
 
 - Use the strongest possible native types over PHPDocs
@@ -48,6 +48,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Ensure `_entities` maintains order of representations in result https://github.com/nuwave/lighthouse/pull/2286
 - Allow combining `@can` with non-default `@guard` https://github.com/nuwave/lighthouse/pull/2276
 - Fix error message when failing to find class in namespace https://github.com/nuwave/lighthouse/pull/2342
+- Prevent regression to simple paginator type on fields using `@cache` directive https://github.com/nuwave/lighthouse/issues/2354
 
 ### Added
 

--- a/src/Pagination/PaginateDirective.php
+++ b/src/Pagination/PaginateDirective.php
@@ -183,8 +183,8 @@ GRAPHQL;
             return $type;
         }
 
-        // The result will be cached with simple paginator type, however the schema allowed other pagination types.
-        // If pagination data queried in the next request, the cache does not contain the data and throws an exception.
+        // The result will be cached with a simple paginator type, however, the schema allowed other pagination types.
+        // If pagination data is queried in the next request, the cache does not contain the data and throws an exception.
         $hasCacheDirective = $resolveInfo->argumentSet->directives->contains(static fn ($value): bool => $value instanceof CacheDirective);
 
         // If the page info is not requested, we can save a database query by using

--- a/src/Pagination/PaginateDirective.php
+++ b/src/Pagination/PaginateDirective.php
@@ -16,6 +16,7 @@ use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\ComplexityResolverDirective;
+use Nuwave\Lighthouse\Support\Contracts\Directive;
 use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
 use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
@@ -178,18 +179,24 @@ GRAPHQL;
     {
         $type = $this->paginationType();
 
-        // Already the optimal type
+        // Already the most optimal type.
         if ($type->isSimple()) {
             return $type;
         }
 
-        // The result will be cached with a simple paginator type, however, the schema allowed other pagination types.
-        // If pagination data is queried in the next request, the cache does not contain the data and throws an exception.
-        $hasCacheDirective = $resolveInfo->argumentSet->directives->contains(static fn ($value): bool => $value instanceof CacheDirective);
+        // If the result may be used in a cache, we always want to retrieve and store the full pagination data.
+        // Even though the query that initially creates the cache may not need additional information such as
+        // the total counts, following queries may need them - and use the same cached value.
+        $hasCacheDirective = $resolveInfo->argumentSet
+            ->directives
+            ->contains(static fn (Directive $directive): bool => $directive instanceof CacheDirective);
+        if ($hasCacheDirective) {
+            return $type;
+        }
 
-        // If the page info is not requested, we can save a database query by using
-        // the simple paginator - it does not query total counts.
-        if (! $hasCacheDirective && ! isset($resolveInfo->getFieldSelection()[$type->infoFieldName()])) {
+        // If the page info is not requested, we can save a database query by using the simple paginator.
+        // In contrast to the full pagination, it does not query total counts.
+        if (! isset($resolveInfo->getFieldSelection()[$type->infoFieldName()])) {
             return new PaginationType(PaginationType::SIMPLE);
         }
 

--- a/src/Pagination/PaginateDirective.php
+++ b/src/Pagination/PaginateDirective.php
@@ -184,13 +184,11 @@ GRAPHQL;
         }
 
         // If it cached do not manipulate the paginator type.
-        $hasCacheDirective = $resolveInfo->argumentSet->directives->contains(function ($value) {
-            return $value instanceof CacheDirective;
-        });
+        $hasCacheDirective = $resolveInfo->argumentSet->directives->contains(static fn ($value): bool => $value instanceof CacheDirective);
 
         // If the page info is not requested, we can save a database query by using
         // the simple paginator - it does not query total counts.
-        if (!$hasCacheDirective && ! isset($resolveInfo->getFieldSelection()[$type->infoFieldName()])) {
+        if (! $hasCacheDirective && ! isset($resolveInfo->getFieldSelection()[$type->infoFieldName()])) {
             return new PaginationType(PaginationType::SIMPLE);
         }
 

--- a/src/Pagination/PaginateDirective.php
+++ b/src/Pagination/PaginateDirective.php
@@ -183,7 +183,8 @@ GRAPHQL;
             return $type;
         }
 
-        // If it cached do not manipulate the paginator type.
+        // The result will be cached with simple paginator type, however the schema allowed other pagination types.
+        // If pagination data queried in the next request, the cache does not contain the data and throws an exception.
         $hasCacheDirective = $resolveInfo->argumentSet->directives->contains(static fn ($value): bool => $value instanceof CacheDirective);
 
         // If the page info is not requested, we can save a database query by using

--- a/src/Subscriptions/SubscriptionRegistry.php
+++ b/src/Subscriptions/SubscriptionRegistry.php
@@ -141,7 +141,7 @@ class SubscriptionRegistry
         }
 
         return new ExtensionsResponse('lighthouse_subscriptions', [
-            'channel' => $channel
+            'channel' => $channel,
         ]);
     }
 

--- a/tests/Integration/Pagination/PaginateDirectiveDBTest.php
+++ b/tests/Integration/Pagination/PaginateDirectiveDBTest.php
@@ -917,4 +917,45 @@ GRAPHQL;
             ],
         ]);
     }
+
+    public function testPaginateWithCacheDirective(): void
+    {
+        $this->expectNotToPerformAssertions();
+        factory(User::class, 3)->create();
+
+        $this->schema = /** @lang GraphQL */ '
+        type User {
+            id: ID!
+        }
+
+        type Query {
+            users: [User!]! @paginate @cache
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            users(first: 2) {
+                data {
+                    id
+                }
+            }
+        }
+        ');
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            users(first: 2) {
+                paginatorInfo {
+                    count
+                    total
+                    currentPage
+                }
+                data {
+                    id
+                }
+            }
+        }
+        ');
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Fix #2354 

**Changes**

If a cache directive exists, do not manipulate the paginator type.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
