### PR TITLE
Auto setup RefreshSchemaCache testing trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Changed
+
+- Automatically setup `RefreshSchemaCache` trait.
+
 ## v6.1.0
 
 ### Added

--- a/src/Testing/RefreshesSchemaCache.php
+++ b/src/Testing/RefreshesSchemaCache.php
@@ -47,4 +47,9 @@ trait RefreshesSchemaCache
             self::$schemaCacheWasRefreshed = true;
         }
     }
+
+    protected function setUpRefreshesSchemaCache(): void
+    {
+        $this->bootRefreshesSchemaCache();
+    }
 }


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Laravel `Illuminate\Foundation\Testing\TestCase` automatically calls the `setUp<TraitName>` method on test setUp if it exists.

This PR adds the `setUpRefreshesSchemaCache` method to the `RefreshSchemaCache` trait to automatically setup the trait and not require the user to manually call the `bootRefreshesSchemaCache` method
