### PR TITLE
Fixed resolving composite object `@key` in default model entity resolver for federation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v6.2.1
+
+### Fixed
+
+- Fixed resolving composite object `@key` in default model entity resolver for federation
+
 ## v6.2.0
 
 ### Changed

--- a/src/Federation/EntityResolverProvider.php
+++ b/src/Federation/EntityResolverProvider.php
@@ -229,7 +229,7 @@ class EntityResolverProvider
                 return;
             }
 
-            $this->applySatisfiedSelection($builder, $subSelection, $representation, $definition);
+            $this->applySatisfiedSelection($builder, $subSelection, $value, $definition);
         }
     }
 


### PR DESCRIPTION
See https://github.com/apollographql/apollo-federation-subgraph-compatibility/pull/352