### PR TITLE
Fix `--omit-built-in` option on `ide-helper` command not excluding default scalars and introspection types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Correctly exclude all built-in types when calling `lighthouse:ide-helper` with `--omit-built-in` flag https://github.com/nuwave/lighthouse/pull/2376
+
 ## v6.5.0
 
 ### Added

--- a/docs/4/subscriptions/client-implementations.md
+++ b/docs/4/subscriptions/client-implementations.md
@@ -25,9 +25,8 @@ class PusherLink extends ApolloLink {
     });
 
     // Capture the super method
-    const prevSubscribe = subscribeObservable.subscribe.bind(
-      subscribeObservable
-    );
+    const prevSubscribe =
+      subscribeObservable.subscribe.bind(subscribeObservable);
 
     // Override subscribe to return an `unsubscribe` object, see
     // https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/client.ts#L182-L212

--- a/docs/5/subscriptions/client-implementations.md
+++ b/docs/5/subscriptions/client-implementations.md
@@ -25,9 +25,8 @@ class PusherLink extends ApolloLink {
     });
 
     // Capture the super method
-    const prevSubscribe = subscribeObservable.subscribe.bind(
-      subscribeObservable
-    );
+    const prevSubscribe =
+      subscribeObservable.subscribe.bind(subscribeObservable);
 
     // Override subscribe to return an `unsubscribe` object, see
     // https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/client.ts#L182-L212

--- a/docs/6/subscriptions/client-implementations.md
+++ b/docs/6/subscriptions/client-implementations.md
@@ -25,9 +25,8 @@ class PusherLink extends ApolloLink {
     });
 
     // Capture the super method
-    const prevSubscribe = subscribeObservable.subscribe.bind(
-      subscribeObservable
-    );
+    const prevSubscribe =
+      subscribeObservable.subscribe.bind(subscribeObservable);
 
     // Override subscribe to return an `unsubscribe` object, see
     // https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/client.ts#L182-L212

--- a/docs/master/subscriptions/client-implementations.md
+++ b/docs/master/subscriptions/client-implementations.md
@@ -25,9 +25,8 @@ class PusherLink extends ApolloLink {
     });
 
     // Capture the super method
-    const prevSubscribe = subscribeObservable.subscribe.bind(
-      subscribeObservable
-    );
+    const prevSubscribe =
+      subscribeObservable.subscribe.bind(subscribeObservable);
 
     // Override subscribe to return an `unsubscribe` object, see
     // https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/client.ts#L182-L212

--- a/src/Console/IdeHelperCommand.php
+++ b/src/Console/IdeHelperCommand.php
@@ -2,11 +2,11 @@
 
 namespace Nuwave\Lighthouse\Console;
 
-use GraphQL\Type\Introspection;
 use GraphQL\Language\AST\TypeDefinitionNode;
 use GraphQL\Language\Parser;
 use GraphQL\Type\Definition\Directive as DirectiveDefinition;
 use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Introspection;
 use GraphQL\Utils\SchemaPrinter;
 use HaydenPierce\ClassFinder\ClassFinder;
 use Illuminate\Console\Command;

--- a/src/Console/IdeHelperCommand.php
+++ b/src/Console/IdeHelperCommand.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Console;
 
+use GraphQL\Type\Introspection;
 use GraphQL\Language\AST\TypeDefinitionNode;
 use GraphQL\Language\Parser;
 use GraphQL\Type\Definition\Directive as DirectiveDefinition;
@@ -39,7 +40,7 @@ GRAPHQL;
     protected function getOptions(): array
     {
         return [
-            ['omit-built-in', null, InputOption::VALUE_OPTIONAL, 'Do not include built-in definitions.'],
+            ['omit-built-in', null, InputOption::VALUE_NONE, 'Do not include built-in definitions.'],
         ];
     }
 
@@ -172,6 +173,10 @@ GRAPHQL;
         $astCache->clear();
 
         $allTypes = $schemaBuilder->schema()->getTypeMap();
+
+        if ($this->option('omit-built-in')) {
+            $sourceTypes = array_merge($sourceTypes, Type::getStandardTypes(), Introspection::getTypes());
+        }
 
         $programmaticTypes = array_diff_key($allTypes, $sourceTypes);
 


### PR DESCRIPTION
#2099 requested a way to not clash with built-in types of IDE's (mainly the Jetbrains GraphQL plugin) and #2362 partially solved that. However default scalars and introspection types were still outputted to programatic-types.graphql, this solves that.

This also fixes the `--omit-built-in` accepting a value which it probably shouldn't have since it's a boolean flag (there or not there).