### PR TITLE
Add the ability to specify the disk the artisan command `lighthouse:print-schema` will write to via the `--disk` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+- Add the ability to specify the disk the schema will print too via the `--disk` option OR the config option `lighthouse.print_schema_disk`
+
 ## v6.6.0
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v6.6.0
+
 ### Fixed
 
 - Correctly exclude all built-in types when calling `lighthouse:ide-helper` with `--omit-built-in` flag https://github.com/nuwave/lighthouse/pull/2376

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 ## Unreleased
 
 ### Added
-- Add the ability to specify the disk the schema will print too via the `--disk` option OR the config option `lighthouse.print_schema_disk`
+
+- Add the ability to specify the disk the artisan command `lighthouse:print-schema` will write to via the `--disk` option
 
 ## v6.6.0
 

--- a/src/Console/PrintSchemaCommand.php
+++ b/src/Console/PrintSchemaCommand.php
@@ -55,6 +55,7 @@ SIGNATURE;
         }
 
         if ($this->option('write')) {
+            /** @var string|null $disk */
             $disk = $this->option('disk');
             $filesystemManager->disk($disk)->put($filename, $schemaString);
             $this->info("Wrote schema to disk ({$disk}) as {$filename}.");

--- a/src/Console/PrintSchemaCommand.php
+++ b/src/Console/PrintSchemaCommand.php
@@ -55,7 +55,7 @@ SIGNATURE;
         }
 
         if ($this->option('write')) {
-            $disk = $this->option('disk') ?: config('lighthouse.print_schema_disk');
+            $disk = $this->option('disk');
             $filesystemManager->disk($disk)->put($filename, $schemaString);
             $this->info("Wrote schema to disk ({$disk}) as {$filename}.");
         } else {

--- a/src/Console/PrintSchemaCommand.php
+++ b/src/Console/PrintSchemaCommand.php
@@ -55,8 +55,13 @@ SIGNATURE;
         }
 
         if ($this->option('write')) {
-            /** @var string|null $disk */
             $disk = $this->option('disk');
+
+            if(is_array($disk) || is_bool($disk)){
+                $this->error('Invalid disk option. The disk must be a string or null.');
+                return;
+            }
+
             $filesystemManager->disk($disk)->put($filename, $schemaString);
             $this->info("Wrote schema to disk ({$disk}) as {$filename}.");
         } else {

--- a/src/Console/PrintSchemaCommand.php
+++ b/src/Console/PrintSchemaCommand.php
@@ -56,9 +56,9 @@ SIGNATURE;
 
         if ($this->option('write')) {
             $disk = $this->option('disk');
-
-            if(is_array($disk) || is_bool($disk)){
-                $this->error('Invalid disk option. The disk must be a string or null.');
+            if (! is_string($disk) && ! is_null($disk)) {
+                $diskType = gettype($disk);
+                $this->error("Expected option disk to be string or null, got: {$diskType}.");
                 return;
             }
 

--- a/src/Console/PrintSchemaCommand.php
+++ b/src/Console/PrintSchemaCommand.php
@@ -6,6 +6,8 @@ use GraphQL\Type\Introspection;
 use GraphQL\Utils\SchemaPrinter;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemManager;
+use Illuminate\Support\Facades\Storage;
 use Nuwave\Lighthouse\Federation\FederationPrinter;
 use Nuwave\Lighthouse\Schema\AST\ASTCache;
 use Nuwave\Lighthouse\Schema\SchemaBuilder;
@@ -21,13 +23,14 @@ class PrintSchemaCommand extends Command
     protected $signature = <<<'SIGNATURE'
 lighthouse:print-schema
 {--W|write : Write the output to a file}
+{--D|disk= : The disk to write the file to}
 {--json : Output JSON instead of GraphQL SDL}
 {--federation : Include federation directives and exclude federation spec additions, like _service.sdl}
 SIGNATURE;
 
     protected $description = 'Compile the GraphQL schema and print the result.';
 
-    public function handle(ASTCache $cache, Filesystem $storage, SchemaBuilder $schemaBuilder): void
+    public function handle(ASTCache $cache, FilesystemManager $filesystemManager, SchemaBuilder $schemaBuilder): void
     {
         // Clear the cache so this always gets the current schema
         $cache->clear();
@@ -52,8 +55,9 @@ SIGNATURE;
         }
 
         if ($this->option('write')) {
-            $storage->put($filename, $schemaString);
-            $this->info("Wrote schema to the default file storage (usually storage/app) as {$filename}.");
+            $disk = $this->option('disk') ?: config('lighthouse.print_schema_disk');
+            $filesystemManager->disk($disk)->put($filename, $schemaString);
+            $this->info("Wrote schema to disk ({$disk}) as {$filename}.");
         } else {
             $this->info($schemaString);
         }

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -449,4 +449,14 @@ return [
          */
         'entities_resolver_namespace' => 'App\\GraphQL\\Entities',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Print Schema Disk
+    |--------------------------------------------------------------------------
+    |
+    | Define what disk should be used when printing the schema to file.
+    |
+    */
+    'print_schema_disk' => env('LIGHTHOUSE_PRINT_SCHEMA_DISK', 'local'),
 ];

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -449,14 +449,4 @@ return [
          */
         'entities_resolver_namespace' => 'App\\GraphQL\\Entities',
     ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Print Schema Disk
-    |--------------------------------------------------------------------------
-    |
-    | Define what disk should be used when printing the schema to file.
-    |
-    */
-    'print_schema_disk' => env('LIGHTHOUSE_PRINT_SCHEMA_DISK', 'local'),
 ];


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

- Add the ability to specify the disk the schema will print to via the `--disk` option OR the config option `lighthouse.print_schema_disk`

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
