### PR TITLE
Add middleware `EnsureXHR` by default

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -17,6 +17,13 @@ Keep in mind they only work when your test class extends `Illuminate\Foundation\
 - Just remove calls to `Nuwave\Lighthouse\Testing\RefreshesSchemaCache::bootRefreshesSchemaCache()`.
 - Replace calls to `Nuwave\Lighthouse\Testing\MakesGraphQLRequests::setUpSubscriptionEnvironment()` with ` use Nuwave\Lighthouse\Testing\TestsSubscriptions`.
 
+### `EnsureXHR` is enabled in the default configuration
+
+The middleware `Nuwave\Lighthouse\Http\Middleware\EnsureXHR` is enabled in the default configuration.
+It will prevent the following type of HTTP requests:
+- `GET` requests
+- `POST` requests that can be created using HTML forms
+
 ## v5 to v6
 
 ### `messages` on `@rules` and `@rulesForArray`

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -29,7 +29,7 @@ return [
          */
         'middleware' => [
             // Ensures the request is not vulnerable to cross-site request forgery.
-            Nuwave\Lighthouse\Http\Middleware\EnsureXHR::class,
+            // Nuwave\Lighthouse\Http\Middleware\EnsureXHR::class,
 
             // Always set the `Accept: application/json` header.
             Nuwave\Lighthouse\Http\Middleware\AcceptJson::class,

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -28,6 +28,9 @@ return [
          * make sure to return spec-compliant responses in case an error is thrown.
          */
         'middleware' => [
+            // Ensures the request is not vulnerable to cross-site request forgery.
+            Nuwave\Lighthouse\Http\Middleware\EnsureXHR::class,
+
             // Always set the `Accept: application/json` header.
             Nuwave\Lighthouse\Http\Middleware\AcceptJson::class,
 

--- a/tests/Utils/Models/User.php
+++ b/tests/Utils/Models/User.php
@@ -180,7 +180,7 @@ final class User extends Authenticatable
             && $this
                 ->posts
                 ->first()
-                ->relationLoaded('comments');
+                ?->relationLoaded('comments');
     }
 
     public function tasksAndPostsCommentsLoaded(): bool
@@ -195,7 +195,7 @@ final class User extends Authenticatable
             && $this
                 ->posts
                 ->first()
-                ->relationLoaded('task');
+                ?->relationLoaded('task');
     }
 
     public function postTasksAndPostsCommentsLoaded(): bool


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Adds the middleware `Nuwave\Lighthouse\Http\Middleware\EnsureXHR` to the default configuration commented.
This makes it easier to add it.

**Breaking changes**

No, but planned for v7. HTTP `GET` and simple `POST` requests stop working when the middleware is added.