### PR TITLE
fix: keep order of arguments after renaming

### DIFF
--- a/src/Schema/Directives/RenameArgsDirective.php
+++ b/src/Schema/Directives/RenameArgsDirective.php
@@ -27,6 +27,9 @@ GRAPHQL;
 
     protected function rename(ArgumentSet &$argumentSet): ArgumentSet
     {
+        /** @var array<int, string> */
+        $keys = [];
+
         foreach ($argumentSet->arguments as $name => $argument) {
             // Recursively apply the renaming to nested inputs.
             // We look for further ArgumentSet instances, they
@@ -43,10 +46,17 @@ GRAPHQL;
             $maybeRenameDirective = $argument->directives->first(static fn (Directive $directive): bool => $directive instanceof RenameDirective);
 
             if ($maybeRenameDirective instanceof RenameDirective) {
-                $argumentSet->arguments[$maybeRenameDirective->attributeArgValue()] = $argument;
+                $newName = $maybeRenameDirective->attributeArgValue();
+                $argumentSet->arguments[$newName] = $argument;
                 unset($argumentSet->arguments[$name]);
+                $keys[] = $newName;
+            } else {
+                $keys[] = $name;
             }
         }
+
+        // Keep order of arguments
+        $argumentSet->arguments = array_replace(array_flip($keys), $argumentSet->arguments);
 
         return $argumentSet;
     }


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Currently, using the `@rename` directive reorders the arguments because a new key is set and that one will be appended. Thus, you cannot rely anymore on the order of arguments in the array. This fix will remember the order of keys and later reorder the argument set.

**Breaking changes**

It could potentially break existing applications but only if they for some reason rely on an invalid order of arguments.
