### PR TITLE
Add `PaginatorInfo`, `SimplePaginatorInfo`, `PageInfo` only when required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Add `PaginatorInfo`, `SimplePaginatorInfo`, `PageInfo` only as soon as they're required
+- Add `PaginatorInfo`, `SimplePaginatorInfo`, `PageInfo` only when required
 
 ## v6.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Add `PaginatorInfo`, `SimplePaginatorInfo`, `PageInfo` only as soon as they're required
+
 ## v6.11.0
 
 ### Added

--- a/src/Pagination/PaginationManipulator.php
+++ b/src/Pagination/PaginationManipulator.php
@@ -72,6 +72,10 @@ class PaginationManipulator
         int $maxCount = null,
         ObjectTypeDefinitionNode $edgeType = null,
     ): void {
+        if (! isset($this->documentAST->types[self::pageInfo()->getName()->value])) {
+            $this->documentAST->setTypeDefinition(self::pageInfo());
+        }
+
         $fieldTypeName = ASTHelper::getUnderlyingTypeName($fieldDefinition);
 
         if ($edgeType !== null) {
@@ -158,6 +162,10 @@ GRAPHQL
         int $defaultCount = null,
         int $maxCount = null,
     ): void {
+        if (! isset($this->documentAST->types[self::paginatorInfo()->getName()->value])) {
+            $this->documentAST->setTypeDefinition(self::paginatorInfo());
+        }
+
         $fieldTypeName = ASTHelper::getUnderlyingTypeName($fieldDefinition);
         $paginatorTypeName = "{$fieldTypeName}Paginator";
         $paginatorFieldClassName = addslashes(PaginatorField::class);
@@ -193,6 +201,10 @@ GRAPHQL
         int $defaultCount = null,
         int $maxCount = null,
     ): void {
+        if (! isset($this->documentAST->types[self::simplePaginatorInfo()->getName()->value])) {
+            $this->documentAST->setTypeDefinition(self::simplePaginatorInfo());
+        }
+
         $fieldTypeName = ASTHelper::getUnderlyingTypeName($fieldDefinition);
         $paginatorTypeName = "{$fieldTypeName}SimplePaginator";
         $paginatorFieldClassName = addslashes(SimplePaginatorField::class);
@@ -248,5 +260,95 @@ GRAPHQL
         );
 
         return $typeNode;
+    }
+
+    protected static function paginatorInfo(): ObjectTypeDefinitionNode
+    {
+        return Parser::objectTypeDefinition(/** @lang GraphQL */ '
+            "Information about pagination using a fully featured paginator."
+            type PaginatorInfo {
+              "Number of items in the current page."
+              count: Int!
+
+              "Index of the current page."
+              currentPage: Int!
+
+              "Index of the first item in the current page."
+              firstItem: Int
+
+              "Are there more pages after this one?"
+              hasMorePages: Boolean!
+
+              "Index of the last item in the current page."
+              lastItem: Int
+
+              "Index of the last available page."
+              lastPage: Int!
+
+              "Number of items per page."
+              perPage: Int!
+
+              "Number of total available items."
+              total: Int!
+            }
+        ');
+    }
+
+    protected static function simplePaginatorInfo(): ObjectTypeDefinitionNode
+    {
+        return Parser::objectTypeDefinition(/** @lang GraphQL */ '
+            "Information about pagination using a simple paginator."
+            type SimplePaginatorInfo {
+              "Number of items in the current page."
+              count: Int!
+
+              "Index of the current page."
+              currentPage: Int!
+
+              "Index of the first item in the current page."
+              firstItem: Int
+
+              "Index of the last item in the current page."
+              lastItem: Int
+
+              "Number of items per page."
+              perPage: Int!
+
+              "Are there more pages after this one?"
+              hasMorePages: Boolean!
+            }
+        ');
+    }
+
+    protected static function pageInfo(): ObjectTypeDefinitionNode
+    {
+        return Parser::objectTypeDefinition(/** @lang GraphQL */ '
+            "Information about pagination using a Relay style cursor connection."
+            type PageInfo {
+              "When paginating forwards, are there more items?"
+              hasNextPage: Boolean!
+
+              "When paginating backwards, are there more items?"
+              hasPreviousPage: Boolean!
+
+              "The cursor to continue paginating backwards."
+              startCursor: String
+
+              "The cursor to continue paginating forwards."
+              endCursor: String
+
+              "Total number of nodes in the paginated connection."
+              total: Int!
+
+              "Number of nodes in the current page."
+              count: Int!
+
+              "Index of the current page."
+              currentPage: Int!
+
+              "Index of the last available page."
+              lastPage: Int!
+            }
+        ');
     }
 }

--- a/src/Pagination/PaginationManipulator.php
+++ b/src/Pagination/PaginationManipulator.php
@@ -72,8 +72,9 @@ class PaginationManipulator
         int $maxCount = null,
         ObjectTypeDefinitionNode $edgeType = null,
     ): void {
-        if (! isset($this->documentAST->types[self::pageInfo()->getName()->value])) {
-            $this->documentAST->setTypeDefinition(self::pageInfo());
+        $pageInfoNode = self::pageInfo();
+        if (! isset($this->documentAST->types[$pageInfoNode->getName()->value])) {
+            $this->documentAST->setTypeDefinition($pageInfoNode);
         }
 
         $fieldTypeName = ASTHelper::getUnderlyingTypeName($fieldDefinition);
@@ -162,8 +163,9 @@ GRAPHQL
         int $defaultCount = null,
         int $maxCount = null,
     ): void {
-        if (! isset($this->documentAST->types[self::paginatorInfo()->getName()->value])) {
-            $this->documentAST->setTypeDefinition(self::paginatorInfo());
+        $paginatorInfoNode = self::paginatorInfo();
+        if (! isset($this->documentAST->types[$paginatorInfoNode->getName()->value])) {
+            $this->documentAST->setTypeDefinition($paginatorInfoNode);
         }
 
         $fieldTypeName = ASTHelper::getUnderlyingTypeName($fieldDefinition);
@@ -201,8 +203,9 @@ GRAPHQL
         int $defaultCount = null,
         int $maxCount = null,
     ): void {
-        if (! isset($this->documentAST->types[self::simplePaginatorInfo()->getName()->value])) {
-            $this->documentAST->setTypeDefinition(self::simplePaginatorInfo());
+        $simplePaginatorInfoNode = self::simplePaginatorInfo();
+        if (! isset($this->documentAST->types[$simplePaginatorInfoNode->getName()->value])) {
+            $this->documentAST->setTypeDefinition($simplePaginatorInfoNode);
         }
 
         $fieldTypeName = ASTHelper::getUnderlyingTypeName($fieldDefinition);

--- a/src/Pagination/PaginationServiceProvider.php
+++ b/src/Pagination/PaginationServiceProvider.php
@@ -2,11 +2,8 @@
 
 namespace Nuwave\Lighthouse\Pagination;
 
-use GraphQL\Language\AST\ObjectTypeDefinitionNode;
-use GraphQL\Language\Parser;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\ServiceProvider;
-use Nuwave\Lighthouse\Events\ManipulateAST;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 
 class PaginationServiceProvider extends ServiceProvider
@@ -14,101 +11,5 @@ class PaginationServiceProvider extends ServiceProvider
     public function boot(Dispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
-        $dispatcher->listen(ManipulateAST::class, static function (ManipulateAST $manipulateAST): void {
-            $documentAST = $manipulateAST->documentAST;
-            $documentAST->setTypeDefinition(self::paginatorInfo());
-            $documentAST->setTypeDefinition(self::simplePaginatorInfo());
-            $documentAST->setTypeDefinition(self::pageInfo());
-        });
-    }
-
-    protected static function paginatorInfo(): ObjectTypeDefinitionNode
-    {
-        return Parser::objectTypeDefinition(/** @lang GraphQL */ '
-            "Information about pagination using a fully featured paginator."
-            type PaginatorInfo {
-              "Number of items in the current page."
-              count: Int!
-
-              "Index of the current page."
-              currentPage: Int!
-
-              "Index of the first item in the current page."
-              firstItem: Int
-
-              "Are there more pages after this one?"
-              hasMorePages: Boolean!
-
-              "Index of the last item in the current page."
-              lastItem: Int
-
-              "Index of the last available page."
-              lastPage: Int!
-
-              "Number of items per page."
-              perPage: Int!
-
-              "Number of total available items."
-              total: Int!
-            }
-        ');
-    }
-
-    protected static function simplePaginatorInfo(): ObjectTypeDefinitionNode
-    {
-        return Parser::objectTypeDefinition(/** @lang GraphQL */ '
-            "Information about pagination using a simple paginator."
-            type SimplePaginatorInfo {
-              "Number of items in the current page."
-              count: Int!
-
-              "Index of the current page."
-              currentPage: Int!
-
-              "Index of the first item in the current page."
-              firstItem: Int
-
-              "Index of the last item in the current page."
-              lastItem: Int
-
-              "Number of items per page."
-              perPage: Int!
-
-              "Are there more pages after this one?"
-              hasMorePages: Boolean!
-            }
-        ');
-    }
-
-    protected static function pageInfo(): ObjectTypeDefinitionNode
-    {
-        return Parser::objectTypeDefinition(/** @lang GraphQL */ '
-            "Information about pagination using a Relay style cursor connection."
-            type PageInfo {
-              "When paginating forwards, are there more items?"
-              hasNextPage: Boolean!
-
-              "When paginating backwards, are there more items?"
-              hasPreviousPage: Boolean!
-
-              "The cursor to continue paginating backwards."
-              startCursor: String
-
-              "The cursor to continue paginating forwards."
-              endCursor: String
-
-              "Total number of nodes in the paginated connection."
-              total: Int!
-
-              "Number of nodes in the current page."
-              count: Int!
-
-              "Index of the current page."
-              currentPage: Int!
-
-              "Index of the last available page."
-              lastPage: Int!
-            }
-        ');
     }
 }

--- a/tests/Unit/Pagination/PaginateDirectiveTest.php
+++ b/tests/Unit/Pagination/PaginateDirectiveTest.php
@@ -17,9 +17,106 @@ use Tests\TestCase;
 
 final class PaginateDirectiveTest extends TestCase
 {
-    public function testIncludesPaginationInfoObjectsInSchema(): void
+    public function testIncludesPaginatorInfoTypeInSchema(): void
     {
-        $schema = $this->buildSchemaWithPlaceholderQuery('');
+        $schema = $this->buildSchemaWithPlaceholderQuery(/** @lang GraphQL */ '
+        type User {
+            id: ID!
+            name: String!
+        }
+
+        extend type Query {
+            users: [User!]! @paginate
+        }
+        ');
+        $schemaString = SchemaPrinter::doPrint($schema);
+
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<'GRAPHQL'
+"Information about pagination using a fully featured paginator."
+type PaginatorInfo {
+  "Number of items in the current page."
+  count: Int!
+
+  "Index of the current page."
+  currentPage: Int!
+
+  "Index of the first item in the current page."
+  firstItem: Int
+
+  "Are there more pages after this one?"
+  hasMorePages: Boolean!
+
+  "Index of the last item in the current page."
+  lastItem: Int
+
+  "Index of the last available page."
+  lastPage: Int!
+
+  "Number of items per page."
+  perPage: Int!
+
+  "Number of total available items."
+  total: Int!
+}
+GRAPHQL
+            ,
+            $schemaString,
+        );
+    }
+
+    public function testIncludesSimplePaginatorInfoTypeInSchema(): void
+    {
+        $schema = $this->buildSchemaWithPlaceholderQuery(/** @lang GraphQL */ '
+        type User {
+            id: ID!
+            name: String!
+        }
+
+        extend type Query {
+            users: [User!]! @paginate(type: SIMPLE)
+        }
+        ');
+        $schemaString = SchemaPrinter::doPrint($schema);
+
+        $this->assertStringContainsString(/** @lang GraphQL */ <<<'GRAPHQL'
+"Information about pagination using a simple paginator."
+type SimplePaginatorInfo {
+  "Number of items in the current page."
+  count: Int!
+
+  "Index of the current page."
+  currentPage: Int!
+
+  "Index of the first item in the current page."
+  firstItem: Int
+
+  "Index of the last item in the current page."
+  lastItem: Int
+
+  "Number of items per page."
+  perPage: Int!
+
+  "Are there more pages after this one?"
+  hasMorePages: Boolean!
+}
+GRAPHQL
+            ,
+            $schemaString,
+        );
+    }
+
+    public function testIncludesPageInfoTypeInSchema(): void
+    {
+        $schema = $this->buildSchemaWithPlaceholderQuery(/** @lang GraphQL */ '
+        type User {
+            id: ID!
+            name: String!
+        }
+
+        extend type Query {
+            users: [User!]! @paginate(type: CONNECTION)
+        }
+        ');
         $schemaString = SchemaPrinter::doPrint($schema);
 
         $this->assertStringContainsString(/** @lang GraphQL */ <<<'GRAPHQL'
@@ -53,64 +150,16 @@ GRAPHQL
             ,
             $schemaString,
         );
+    }
 
-        $this->assertStringContainsString(/** @lang GraphQL */ <<<'GRAPHQL'
-"Information about pagination using a fully featured paginator."
-type PaginatorInfo {
-  "Number of items in the current page."
-  count: Int!
+    public function testDoesntIncludePaginationInfoObjectsInSchemaIfNotNeeded(): void
+    {
+        $schema = $this->buildSchemaWithPlaceholderQuery('');
+        $typeMap = $schema->getTypeMap();
 
-  "Index of the current page."
-  currentPage: Int!
-
-  "Index of the first item in the current page."
-  firstItem: Int
-
-  "Are there more pages after this one?"
-  hasMorePages: Boolean!
-
-  "Index of the last item in the current page."
-  lastItem: Int
-
-  "Index of the last available page."
-  lastPage: Int!
-
-  "Number of items per page."
-  perPage: Int!
-
-  "Number of total available items."
-  total: Int!
-}
-GRAPHQL
-            ,
-            $schemaString,
-        );
-
-        $this->assertStringContainsString(/** @lang GraphQL */ <<<'GRAPHQL'
-"Information about pagination using a simple paginator."
-type SimplePaginatorInfo {
-  "Number of items in the current page."
-  count: Int!
-
-  "Index of the current page."
-  currentPage: Int!
-
-  "Index of the first item in the current page."
-  firstItem: Int
-
-  "Index of the last item in the current page."
-  lastItem: Int
-
-  "Number of items per page."
-  perPage: Int!
-
-  "Are there more pages after this one?"
-  hasMorePages: Boolean!
-}
-GRAPHQL
-            ,
-            $schemaString,
-        );
+        $this->assertArrayNotHasKey('PageInfo', $typeMap);
+        $this->assertArrayNotHasKey('SimplePaginatorInfo', $typeMap);
+        $this->assertArrayNotHasKey('PaginatorInfo', $typeMap);
     }
 
     public function testManipulatesPaginator(): void


### PR DESCRIPTION
Resolves #2388
 
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Currently pagination-related types are registered in the document ast even if they're never used. After this PR, these types will only be registered if they're actually needed.

**Breaking changes**

None as far as I can tell.
