### PR TITLE
Add option `findOrFail` to `@can` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v6.11.0
+
 ### Added
 
 - Add option `findOrFail` to `@can` directive https://github.com/nuwave/lighthouse/pull/2416

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- Add option `findOrFail` to `@can` directive https://github.com/nuwave/lighthouse/pull/2416
+
 ## v6.10.1
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ setup: build docs/node_modules vendor ## Setup the local environment
 
 .PHONY: build
 build: ## Build the local Docker containers
-	docker-compose build --pull --build-arg USER_ID=$(shell id -u) --build-arg GROUP_ID=$(shell id -g)
+	docker-compose build --pull --build-arg USER_ID=$(shell id --user) --build-arg GROUP_ID=$(shell id --group)
 
 .PHONY: up
 up: ## Bring up the docker-compose stack

--- a/docs/6/api-reference/directives.md
+++ b/docs/6/api-reference/directives.md
@@ -666,6 +666,11 @@ directive @can(
   Mutually exclusive with `resolved` and `query`.
   """
   find: String
+
+  """
+  Should the query fail when the models of `find` were not found?
+  """
+  findOrFail: Boolean! = true
 ) repeatable on FIELD_DEFINITION
 
 """

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -666,6 +666,11 @@ directive @can(
   Mutually exclusive with `resolved` and `query`.
   """
   find: String
+
+  """
+  Should the query fail when the models of `find` were not found?
+  """
+  findOrFail: Boolean! = true
 ) repeatable on FIELD_DEFINITION
 
 """

--- a/src/Auth/CanDirective.php
+++ b/src/Auth/CanDirective.php
@@ -12,7 +12,6 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Execution\Resolved;
@@ -212,7 +211,15 @@ GRAPHQL;
                 throw new Error($modelNotFoundException->getMessage());
             }
 
-            return Collection::wrap($modelOrModels);
+            if ($modelOrModels instanceof Model) {
+                return [$modelOrModels];
+            }
+
+            if ($modelOrModels === null) {
+                return [];
+            }
+
+            return $modelOrModels;
         }
 
         return [$this->getModelClass()];

--- a/tests/Integration/Auth/CanDirectiveDBTest.php
+++ b/tests/Integration/Auth/CanDirectiveDBTest.php
@@ -91,6 +91,39 @@ final class CanDirectiveDBTest extends DBTestCase
         ]);
     }
 
+    public function testFailsToFindSpecificModelWithFindOrFailFalse(): void
+    {
+        $user = new User();
+        $user->name = UserPolicy::ADMIN;
+        $this->be($user);
+
+        $this->mockResolver(null);
+
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            user(id: ID @eq): User
+                @can(ability: "view", find: "id", findOrFail: false)
+                @mock
+        }
+
+        type User {
+            name: String!
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            user(id: "not-present") {
+                name
+            }
+        }
+        ')->assertExactJson([
+            'data' => [
+                'user' => null,
+            ],
+        ]);
+    }
+
     public function testThrowsIfFindValueIsNotGiven(): void
     {
         $user = new User();


### PR DESCRIPTION
Resolves https://github.com/nuwave/lighthouse/issues/1642
 
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Allow `@can` with `find` to not throw.

**Breaking changes**

None.