### PR TITLE
`ScoutEnhancer::enhanceBuilder()` improvements to be more similar to …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
-### Added
+### Changed
 
-- `ScoutEnhancer::enhanceBuilder()` will process all `ScoutBuilderDirective` attached to argument (only first was processed previously)
-- `ResolveInfo::enhanceBuilder()` will pass `$directiveFilter` into `ScoutEnhancer::enhanceBuilder()`
+- `ScoutEnhancer::enhanceBuilder()` will process not only the first but all `ScoutBuilderDirective` attached to argument https://github.com/nuwave/lighthouse/pull/2429
+- `ResolveInfo::enhanceBuilder()` will pass `$directiveFilter` into `ScoutEnhancer::enhanceBuilder()` https://github.com/nuwave/lighthouse/pull/2429
 
 ## v6.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- `ScoutEnhancer::enhanceBuilder()` will process all `ScoutBuilderDirective` attached to argument (only first was processed previously)
+- `ResolveInfo::enhanceBuilder()` will pass `$directiveFilter` into `ScoutEnhancer::enhanceBuilder()`
+
 ## v6.15.0
 
 ### Added

--- a/src/Execution/ResolveInfo.php
+++ b/src/Execution/ResolveInfo.php
@@ -94,19 +94,17 @@ class ResolveInfo extends BaseResolveInfo
         foreach ($argumentSet->arguments as $argument) {
             $value = $argument->toPlain();
 
-            $filteredDirectives = $argument
-                ->directives
-                ->filter(Utils::instanceofMatcher(ArgBuilderDirective::class));
+            foreach ($argument->directives as $directive) {
+                if (! ($directive instanceof ArgBuilderDirective)) {
+                    continue;
+                }
 
-            if ($directiveFilter !== null) {
-                // @phpstan-ignore-next-line PHPStan does not get this list is filtered for ArgBuilderDirective
-                $filteredDirectives = $filteredDirectives->filter($directiveFilter);
+                if ($directiveFilter !== null && ! $directiveFilter($directive)) {
+                    continue;
+                }
+
+                $builder = $directive->handleBuilder($builder, $value);
             }
-
-            // @phpstan-ignore-next-line PHPStan does not get this list is filtered for ArgBuilderDirective
-            $filteredDirectives->each(static function (ArgBuilderDirective $argBuilderDirective) use (&$builder, $value): void {
-                $builder = $argBuilderDirective->handleBuilder($builder, $value);
-            });
 
             Utils::applyEach(
                 static function ($value) use (&$builder, $directiveFilter): void {

--- a/src/Execution/ResolveInfo.php
+++ b/src/Execution/ResolveInfo.php
@@ -42,7 +42,7 @@ class ResolveInfo extends BaseResolveInfo
      * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<TModel>|\Illuminate\Database\Eloquent\Relations\Relation<TModel>|\Laravel\Scout\Builder  $builder
      * @param  array<string>  $scopes
      * @param  array<string, mixed>  $args
-     * @param  (callable(\Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective): bool)|null  $directiveFilter
+     * @param  (callable(\Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective|\Nuwave\Lighthouse\Scout\ScoutBuilderDirective): bool)|null  $directiveFilter
      *
      * @return \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<TModel>|\Illuminate\Database\Eloquent\Relations\Relation<TModel>|\Laravel\Scout\Builder
      */
@@ -52,7 +52,7 @@ class ResolveInfo extends BaseResolveInfo
 
         $scoutEnhancer = new ScoutEnhancer($argumentSet, $builder);
         if ($scoutEnhancer->canEnhanceBuilder()) {
-            return $scoutEnhancer->enhanceBuilder();
+            return $scoutEnhancer->enhanceBuilder($directiveFilter);
         }
 
         self::applyArgBuilderDirectives($argumentSet, $builder, $directiveFilter);

--- a/src/Scout/ScoutEnhancer.php
+++ b/src/Scout/ScoutEnhancer.php
@@ -64,9 +64,7 @@ class ScoutEnhancer
         return $this->hasSearchArguments();
     }
 
-    /**
-     * @param (callable(\Nuwave\Lighthouse\Scout\ScoutBuilderDirective): bool)|null $directiveFilter
-     */
+    /** @param (callable(\Nuwave\Lighthouse\Scout\ScoutBuilderDirective): bool)|null $directiveFilter */
     public function enhanceBuilder(callable $directiveFilter = null): ScoutBuilder
     {
         $scoutBuilder = $this->builder instanceof ScoutBuilder
@@ -75,11 +73,11 @@ class ScoutEnhancer
 
         foreach ($this->argumentsWithScoutBuilderDirectives as $argument) {
             foreach ($argument->directives as $directive) {
-                if (!($directive instanceof ScoutBuilderDirective)) {
+                if (! ($directive instanceof ScoutBuilderDirective)) {
                     continue;
                 }
 
-                if ($directiveFilter !== null && !$directiveFilter($directive)) {
+                if ($directiveFilter !== null && ! $directiveFilter($directive)) {
                     continue;
                 }
 

--- a/src/Scout/ScoutEnhancer.php
+++ b/src/Scout/ScoutEnhancer.php
@@ -64,19 +64,27 @@ class ScoutEnhancer
         return $this->hasSearchArguments();
     }
 
-    public function enhanceBuilder(): ScoutBuilder
+    /**
+     * @param (callable(\Nuwave\Lighthouse\Scout\ScoutBuilderDirective): bool)|null $directiveFilter
+     */
+    public function enhanceBuilder(callable $directiveFilter = null): ScoutBuilder
     {
         $scoutBuilder = $this->builder instanceof ScoutBuilder
             ? $this->builder
             : $this->enhanceEloquentBuilder();
 
         foreach ($this->argumentsWithScoutBuilderDirectives as $argument) {
-            $scoutBuilderDirective = $argument
-                ->directives
-                ->first(Utils::instanceofMatcher(ScoutBuilderDirective::class));
-            assert($scoutBuilderDirective instanceof ScoutBuilderDirective);
+            foreach ($argument->directives as $directive) {
+                if (!($directive instanceof ScoutBuilderDirective)) {
+                    continue;
+                }
 
-            $scoutBuilderDirective->handleScoutBuilder($scoutBuilder, $argument->toPlain());
+                if ($directiveFilter !== null && !$directiveFilter($directive)) {
+                    continue;
+                }
+
+                $directive->handleScoutBuilder($scoutBuilder, $argument->toPlain());
+            }
         }
 
         return $scoutBuilder;

--- a/tests/Unit/Execution/ResolveInfoTest.php
+++ b/tests/Unit/Execution/ResolveInfoTest.php
@@ -1,0 +1,148 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Execution;
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Nuwave\Lighthouse\Execution\Arguments\Argument;
+use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
+use Nuwave\Lighthouse\Execution\ResolveInfo;
+use Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective;
+use Nuwave\Lighthouse\Support\Contracts\Directive;
+use Tests\TestCase;
+use Tests\Utils\Models\User;
+
+final class ResolveInfoTest extends TestCase
+{
+    public function testApplyArgBuilderDirectives(): void
+    {
+        $directiveOne = new class() implements Directive, ArgBuilderDirective {
+            public static function definition(): string
+            {
+                return '';
+            }
+
+            public function handleBuilder(QueryBuilder|EloquentBuilder|Relation $builder, mixed $value): QueryBuilder|EloquentBuilder|Relation
+            {
+                return $builder->where('one', $value);
+            }
+        };
+        $directiveTwo = new class() implements Directive, ArgBuilderDirective {
+            public static function definition(): string
+            {
+                return '';
+            }
+
+            public function handleBuilder(QueryBuilder|EloquentBuilder|Relation $builder, mixed $value): QueryBuilder|EloquentBuilder|Relation
+            {
+                return $builder->where('two', $value);
+            }
+        };
+        $directiveNested = new class() implements Directive, ArgBuilderDirective {
+            public static function definition(): string
+            {
+                return '';
+            }
+
+            public function handleBuilder(QueryBuilder|EloquentBuilder|Relation $builder, mixed $value): QueryBuilder|EloquentBuilder|Relation
+            {
+                return $builder->where('nested', $value);
+            }
+        };
+        $directiveIgnored = new class() implements Directive, ArgBuilderDirective {
+            public static function definition(): string
+            {
+                return '';
+            }
+
+            public function handleBuilder(QueryBuilder|EloquentBuilder|Relation $builder, mixed $value): QueryBuilder|EloquentBuilder|Relation
+            {
+                return $builder->where('ignored', $value);
+            }
+        };
+        $directiveWithoutInterface = new class() implements Directive {
+            public static function definition(): string
+            {
+                return '';
+            }
+        };
+
+        $value = 'value';
+        $nested = 'nested value';
+        $argumentSet = new ArgumentSet();
+
+        $argumentA = new Argument();
+        $argumentA->value = $value;
+        $argumentA->directives->push(
+            $directiveWithoutInterface,
+            $directiveIgnored,
+            $directiveTwo,
+            $directiveOne,
+        );
+        $argumentSet->arguments['a'] = $argumentA;
+
+        $nestedArgument = new Argument();
+        $nestedArgument->value = $nested;
+        $nestedArgument->directives->push(
+            $directiveNested,
+        );
+        $nestedArgumentSet = new ArgumentSet();
+        $nestedArgumentSet->arguments['nested'] = $nestedArgument;
+
+        $argumentB = new Argument();
+        $argumentB->value = $nestedArgumentSet;
+        $argumentSet->arguments['b'] = $argumentB;
+
+        $builder = User::query();
+        $resolveInfo = new class() extends ResolveInfo {
+            /** @phpstan-ignore-next-line no need to call parent `__construct` */
+            public function __construct()
+            {
+                // empty
+            }
+
+            public static function applyArgBuilderDirectives(ArgumentSet $argumentSet, Relation|EloquentBuilder|QueryBuilder &$builder, callable $directiveFilter = null): void
+            {
+                parent::applyArgBuilderDirectives(
+                    $argumentSet,
+                    $builder,
+                    $directiveFilter,
+                );
+            }
+        };
+
+        $resolveInfo::applyArgBuilderDirectives(
+            $argumentSet,
+            $builder,
+            static fn (ArgBuilderDirective $directive): bool => $directive !== $directiveIgnored,
+        );
+
+        self::assertSame(
+            [
+                [
+                    'type' => 'Basic',
+                    'column' => 'two',
+                    'operator' => '=',
+                    'value' => $value,
+                    'boolean' => 'and',
+                ],
+                [
+                    'type' => 'Basic',
+                    'column' => 'one',
+                    'operator' => '=',
+                    'value' => $value,
+                    'boolean' => 'and',
+                ],
+                [
+                    'type' => 'Basic',
+                    'column' => 'nested',
+                    'operator' => '=',
+                    'value' => $nested,
+                    'boolean' => 'and',
+                ],
+            ],
+            $builder->toBase()->wheres,
+        );
+    }
+}

--- a/tests/Unit/Scout/ScoutEnhancerTest.php
+++ b/tests/Unit/Scout/ScoutEnhancerTest.php
@@ -11,7 +11,7 @@ use Nuwave\Lighthouse\Support\Contracts\Directive;
 use Tests\TestCase;
 use Tests\Utils\Models\User;
 
-class ScoutEnhancerTest extends TestCase
+final class ScoutEnhancerTest extends TestCase
 {
     public function testEnhanceBuilder(): void
     {
@@ -67,15 +67,12 @@ class ScoutEnhancerTest extends TestCase
         $argumentSet->arguments['argument'] = $argument;
         $builder = new ScoutBuilder(new User(), '*');
         $enhancer = new ScoutEnhancer($argumentSet, $builder);
+        $builder = $enhancer->enhanceBuilder(static fn (ScoutBuilderDirective $directive): bool => $directive !== $directiveIgnored);
 
-        $builder = $enhancer->enhanceBuilder(static function (ScoutBuilderDirective $directive) use ($directiveIgnored): bool {
-            return $directive !== $directiveIgnored;
-        });
-
-        self::assertEquals(
+        self::assertSame(
             [
-                'one' => $value,
                 'two' => $value,
+                'one' => $value,
             ],
             $builder->wheres,
         );

--- a/tests/Unit/Scout/ScoutEnhancerTest.php
+++ b/tests/Unit/Scout/ScoutEnhancerTest.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Scout;
+
+use Laravel\Scout\Builder as ScoutBuilder;
+use Nuwave\Lighthouse\Execution\Arguments\Argument;
+use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
+use Nuwave\Lighthouse\Scout\ScoutBuilderDirective;
+use Nuwave\Lighthouse\Scout\ScoutEnhancer;
+use Nuwave\Lighthouse\Support\Contracts\Directive;
+use Tests\TestCase;
+use Tests\Utils\Models\User;
+
+class ScoutEnhancerTest extends TestCase
+{
+    public function testEnhanceBuilder(): void
+    {
+        $directiveOne = new class() implements Directive, ScoutBuilderDirective {
+            public static function definition(): string
+            {
+                return '';
+            }
+
+            public function handleScoutBuilder(ScoutBuilder $builder, mixed $value): ScoutBuilder
+            {
+                return $builder->where('one', $value);
+            }
+        };
+        $directiveTwo = new class() implements Directive, ScoutBuilderDirective {
+            public static function definition(): string
+            {
+                return '';
+            }
+
+            public function handleScoutBuilder(ScoutBuilder $builder, mixed $value): ScoutBuilder
+            {
+                return $builder->where('two', $value);
+            }
+        };
+        $directiveIgnored = new class() implements Directive, ScoutBuilderDirective {
+            public static function definition(): string
+            {
+                return '';
+            }
+
+            public function handleScoutBuilder(ScoutBuilder $builder, mixed $value): ScoutBuilder
+            {
+                return $builder->where('ignored', $value);
+            }
+        };
+        $directiveWithoutInterface = new class() implements Directive {
+            public static function definition(): string
+            {
+                return '';
+            }
+        };
+        $value = 'value';
+        $argument = new Argument();
+        $argument->value = $value;
+        $argument->directives->push(
+            $directiveWithoutInterface,
+            $directiveIgnored,
+            $directiveTwo,
+            $directiveOne,
+        );
+        $argumentSet = new ArgumentSet();
+        $argumentSet->arguments['argument'] = $argument;
+        $builder = new ScoutBuilder(new User(), '*');
+        $enhancer = new ScoutEnhancer($argumentSet, $builder);
+
+        $builder = $enhancer->enhanceBuilder(static function (ScoutBuilderDirective $directive) use ($directiveIgnored): bool {
+            return $directive !== $directiveIgnored;
+        });
+
+        self::assertEquals(
+            [
+                'one' => $value,
+                'two' => $value,
+            ],
+            $builder->wheres,
+        );
+    }
+}


### PR DESCRIPTION
…`ArgBuilderDirective`: process all `ScoutBuilderDirective` directives and directives filter support.

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
 
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Not sure why, but `ScoutEnhancer::enhanceBuilder()` use only first directive 

https://github.com/nuwave/lighthouse/blob/0f46c721f5d1a1f181e4bae2c6c6b00cd1930bf5/src/Scout/ScoutEnhancer.php#L73-L76

This is contrary to how `ArgBuilderDirective`/`FieldBuilderDirective` directives works: `ResolveInfo::enhanceBuilder()` process all of them. So the PR makes `ScoutEnhancer::enhanceBuilder()` to process all `ScoutBuilderDirective` directives.

The PR also fix directives filter - the filter will be applied to `ScoutBuilderDirective` too.

**Breaking changes**

If someone passes `$directiveFilter` into `ResolveInfo::enhanceBuilder()` it may be need to update its declaration to accept `\Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective|\Nuwave\Lighthouse\Scout\ScoutBuilderDirective`.
