### PR TITLE
Reset cached values of arguments in `BaseDirective::hydrate()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Reset cached values of arguments in `BaseDirective::hydrate()`
+
 ## v6.15.0
 
 ### Added

--- a/src/Schema/Directives/BaseDirective.php
+++ b/src/Schema/Directives/BaseDirective.php
@@ -64,6 +64,8 @@ abstract class BaseDirective implements Directive
         $this->directiveNode = $directiveNode;
         $this->definitionNode = $definitionNode;
 
+        unset($this->directiveArgs);
+
         return $this;
     }
 

--- a/tests/Unit/Schema/Directives/BaseDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/BaseDirectiveTest.php
@@ -238,6 +238,30 @@ final class BaseDirectiveTest extends TestCase
         $directive->validateMutuallyExclusiveArguments(['bar', 'baz', 'qux']);
     }
 
+    public function testHydrateShouldResetCachedArgs(): void
+    {
+        $directive = $this->constructFieldDirective('foo: ID @dummy(arg: "value")');
+
+        $this->assertSame(
+            'value',
+            // @phpstan-ignore-next-line protected method is called via wrapper below
+            $directive->directiveArgValue('arg'),
+        );
+
+        $field = Parser::fieldDefinition('foo: ID @dummy(arg: "new value")');
+
+        $directive->hydrate(
+            $field->directives[0],
+            $field,
+        );
+
+        $this->assertSame(
+            'new value',
+            // @phpstan-ignore-next-line protected method is called via wrapper below
+            $directive->directiveArgValue('arg'),
+        );
+    }
+
     protected function constructFieldDirective(string $definition): BaseDirective
     {
         $fieldDefinition = Parser::fieldDefinition($definition);


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
 
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

`BaseDirective::hydrate()` doesn't reset cached args. Not sure when/where it can be critical, just found in my notes....

**Breaking changes**

Nope.
