### PR TITLE
Add `@feature` directive to conditionally add a field based on a feature state (using Laravel Pennant)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -56,8 +56,7 @@ jobs:
       - name: "Remove conflicting dependencies that are not needed here"
         run: composer remove --dev --no-update phpbench/phpbench rector/rector
 
-      - name: "Remove dependencies that only work on PHP 8.2 or higher"
-        if: matrix.php-version == '8.0' || matrix.php-version == '8.1'
+      - if: matrix.laravel-version != '^10'
         run: composer remove --dev --no-update laravel/pennant
 
       - run: >
@@ -128,8 +127,7 @@ jobs:
       - name: "Remove conflicting dependencies that are not needed here"
         run: composer remove --dev --no-update nunomaduro/larastan phpstan/phpstan-mockery phpbench/phpbench rector/rector
 
-      - name: "Remove dependencies that only work on PHP 8.2 or higher"
-        if: matrix.php-version == '8.0' || matrix.php-version == '8.1'
+      - if: matrix.laravel-version != '^10'
         run: composer remove --dev --no-update laravel/pennant
 
       - run: >

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -56,6 +56,10 @@ jobs:
       - name: "Remove conflicting dependencies that are not needed here"
         run: composer remove --dev --no-update phpbench/phpbench rector/rector
 
+      - name: "Remove dependencies that only work on PHP 8.2 or higher"
+        if: matrix.php-version == "8.0" || matrix.php-version == "8.1"
+        run: composer remove --dev --no-update laravel/pennant
+
       - run: >
           composer require
           illuminate/contracts:${{ matrix.laravel-version }}
@@ -123,6 +127,10 @@ jobs:
 
       - name: "Remove conflicting dependencies that are not needed here"
         run: composer remove --dev --no-update nunomaduro/larastan phpstan/phpstan-mockery phpbench/phpbench rector/rector
+
+      - name: "Remove dependencies that only work on PHP 8.2 or higher"
+        if: matrix.php-version == "8.0" || matrix.php-version == "8.1"
+        run: composer remove --dev --no-update laravel/pennant
 
       - run: >
           composer require

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -147,9 +147,9 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 8.2
+          - "8.2"
         laravel-version:
-          - ^9
+          - "^10"
 
     services:
       mysql:
@@ -196,9 +196,9 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 8.2
+          - "8.2"
         laravel-version:
-          - ^10
+          - "^10"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -200,7 +200,7 @@ jobs:
         php-version:
           - 8.2
         laravel-version:
-          - ^9
+          - ^10
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -57,7 +57,7 @@ jobs:
         run: composer remove --dev --no-update phpbench/phpbench rector/rector
 
       - name: "Remove dependencies that only work on PHP 8.2 or higher"
-        if: matrix.php-version == "8.0" || matrix.php-version == "8.1"
+        if: matrix.php-version == '8.0' || matrix.php-version == '8.1'
         run: composer remove --dev --no-update laravel/pennant
 
       - run: >
@@ -129,7 +129,7 @@ jobs:
         run: composer remove --dev --no-update nunomaduro/larastan phpstan/phpstan-mockery phpbench/phpbench rector/rector
 
       - name: "Remove dependencies that only work on PHP 8.2 or higher"
-        if: matrix.php-version == "8.0" || matrix.php-version == "8.1"
+        if: matrix.php-version == '8.0' || matrix.php-version == '8.1'
         run: composer remove --dev --no-update laravel/pennant
 
       - run: >

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- Add directive `@feature` to conditionally add annotated elements based on the state of a feature using [Laravel Pennant](https://github.com/laravel/pennant) https://github.com/nuwave/lighthouse/pull/2442 
+
 ## v6.17.0
 
 ### Added

--- a/benchmarks/QueryBench.php
+++ b/benchmarks/QueryBench.php
@@ -13,6 +13,11 @@ abstract class QueryBench extends TestCase
     /** Cached graphQL endpoint. */
     protected string $graphQLEndpoint;
 
+    public function __construct()
+    {
+        parent::__construct(static::class);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "laravel/framework": "^9 || ^10",
         "laravel/legacy-factories": "^1.1.1",
         "laravel/lumen-framework": "^9 || ^10 || dev-master",
+        "laravel/pennant": "^1.0",
         "laravel/scout": "^8 || ^9 || ^10",
         "mattiasgeniar/phpunit-query-count-assertions": "^1.1",
         "mll-lab/graphql-php-scalars": "^6",
@@ -72,6 +73,7 @@
     },
     "suggest": {
         "bensampo/laravel-enum": "Convenient enum definitions that can easily be registered in your Schema",
+        "laravel/pennant": "Required for the @feature directive",
         "laravel/scout": "Required for the @search directive",
         "mll-lab/graphql-php-scalars": "Useful scalar types, required for @whereConditions",
         "mll-lab/laravel-graphiql": "A graphical interactive in-browser GraphQL IDE - integrated with Laravel",

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "laravel/framework": "^9 || ^10",
         "laravel/legacy-factories": "^1.1.1",
         "laravel/lumen-framework": "^9 || ^10 || dev-master",
-        "laravel/pennant": "^1.0",
+        "laravel/pennant": "^1",
         "laravel/scout": "^8 || ^9 || ^10",
         "mattiasgeniar/phpunit-query-count-assertions": "^1.1",
         "mll-lab/graphql-php-scalars": "^6",

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -1078,7 +1078,7 @@ type Mutation {
 
 ```graphql
 """
-Include or exclude the annotated element in or from the schema depending of the state of a feature using Laravel Pennant.
+Conditionally add the annotated element to schema depending of the state of a feature using Laravel Pennant.
 """
 directive @feature(
     """

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -1078,18 +1078,18 @@ type Mutation {
 
 ```graphql
 """
-Conditionally add the annotated element to schema depending of the state of a feature using Laravel Pennant.
+Include the annotated element in the schema depending on a Laravel Pennant feature.
 """
 directive @feature(
     """
     The name of the feature to be checked (can be a string or class name).
     """
-    name: String
-    
+    name: String!
+
     """
-    Specify what the state of the feature should be for the field to be applied.
+    Specify what the state of the feature should be for the field to be included.
     """
-    when: FeatureState = ACTIVE
+    when: FeatureState! = ACTIVE
 ) on FIELD_DEFINITION | OBJECT
 
 """
@@ -1100,7 +1100,7 @@ enum FeatureState {
     Indicates an active feature.
     """
     ACTIVE
-    
+
     """
     Indicates an inactive feature.
     """

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -1074,6 +1074,49 @@ type Mutation {
 }
 ```
 
+## @feature
+
+```graphql
+"""
+Include or exclude the annotated element in or from the schema depending of the state of a feature using Laravel Pennant.
+"""
+directive @feature(
+    """
+    The name of the feature to be checked (can be a string or class name).
+    """
+    name: String
+    
+    """
+    Specify what the state of the feature should be for the field to be applied.
+    """
+    when: FeatureState = ACTIVE
+) on FIELD_DEFINITION | OBJECT
+
+"""
+Options for the `when` argument of `@feature`.
+"""
+enum FeatureState {
+    """
+    Indicates an active feature.
+    """
+    ACTIVE
+    
+    """
+    Indicates an inactive feature.
+    """
+    INACTIVE
+}
+```
+
+Requires the installation of [Laravel Pennant](https://laravel.com/docs/pennant)
+and manual registration of the service provider in `config/app.php`:
+
+```php
+'providers' => [
+    \Nuwave\Lighthouse\Pennant\PennantServiceProvider::class,
+],
+```
+
 ## @field
 
 ```graphql

--- a/docs/master/digging-deeper/feature-toggles.md
+++ b/docs/master/digging-deeper/feature-toggles.md
@@ -25,9 +25,46 @@ type Query {
 }
 ```
 
+## @feature
+
+The [@feature](../api-reference/directives.md#feature) directive allows to include fields in the schema depending
+on a [Laravel Pennant](https://laravel.com/docs/pennant) feature.
+
+For example, you might want a new experimental field only to be available when the according feature is active:
+
+```graphql
+type Query {
+  experimentalField: String! @feature(name: "new-api")
+}
+```
+
+In this case, `experimentalField` will only be included when the `new-api` feature is active. 
+
+Another example would be to only include a field when the feature is inactive:
+
+```graphql
+type Query {
+  deprecatedField: String! @feature(name: "new-api", when: "INACTIVE")
+}
+```
+
+When using [class based features](https://laravel.com/docs/pennant#class-based-features), 
+the classname should be used as value for the `name` argument:
+
+```graphql
+type Query {
+  experimentalField: String! @feature(name: "App\\Features\\NewApi")
+}
+```
+
 ## Interaction With Schema Cache
 
 [@show](../api-reference/directives.md#show) and [@hide](../api-reference/directives.md#hide) work by manipulating the schema.
 This means that when using their `env` option, the inclusion or exclusion of elements depends on the value
 of `app()->environment()` at the time the schema is built and not update on later environment changes.
 If you are pre-generating your schema cache, make sure to match the environment to your deployment target.
+
+The same goes for [@feature](../api-reference/directives.md#feature). Whether a field is included in the schema will be
+based on the state of a feature at the time the schema is built. In addition, if you are pre-generating your schema cache, 
+you will only be able to use features that support [nullable scopes](https://laravel.com/docs/pennant#nullable-scope), 
+as there won't be an authenticated user to check the feature against.

--- a/docs/master/digging-deeper/feature-toggles.md
+++ b/docs/master/digging-deeper/feature-toggles.md
@@ -49,7 +49,7 @@ type Query {
 ```
 
 When using [class based features](https://laravel.com/docs/pennant#class-based-features), 
-the classname should be used as value for the `name` argument:
+the fully qualified class name must be used as the value for the `name` argument:
 
 ```graphql
 type Query {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,6 +15,9 @@ parameters:
   excludePaths:
   - tests/Utils/Models/WithoutRelationClassImport.php # Intentionally wrong
   - tests/LaravelPhpdocAlignmentFixer.php # Copied from laravel/pint
+  # laravel/pennant requires Laravel 10
+  - src/Pennant
+  - tests/Integration/Pennant
   ignoreErrors:
   # PHPStan does not get it
   - '#Parameter \#1 \$callback of static method Closure::fromCallable\(\) expects callable\(\): mixed, array{object, .*} given\.#'
@@ -23,6 +26,7 @@ parameters:
   - '#Parameter \#1 \$response of static method Nuwave\\Lighthouse\\Testing\\TestResponseUtils::extractValidationErrors\(\) expects Illuminate\\Testing\\TestResponse, \$this\(Nuwave\\Lighthouse\\Testing\\TestResponseMixin\) given\.#'
   - path: tests/database/factories/*
     message: '#Variable \$factory might not be defined#'
+
 
   # Mixins are magical
   - path: src/Testing/TestResponseMixin.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,11 +3,11 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
-  <source>
+  <coverage>K
     <include>
       <directory>src</directory>
     </include>
-  </source>
+  </coverage>
   <testsuites>
     <testsuite name="Unit">
       <directory>tests/Unit</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,11 +3,11 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
-  <coverage>K
+  <source>
     <include>
       <directory>src</directory>
     </include>
-  </coverage>
+  </source>
   <testsuites>
     <testsuite name="Unit">
       <directory>tests/Unit</directory>

--- a/src/Pennant/FeatureDirective.php
+++ b/src/Pennant/FeatureDirective.php
@@ -29,7 +29,7 @@ directive @feature(
     """
     Specify what the state of the feature should be for the field to be applied.
     """
-    when: FeatureState = ACTIVE
+    when: FeatureState! = ACTIVE
 ) on FIELD_DEFINITION | OBJECT
 
 """

--- a/src/Pennant/FeatureDirective.php
+++ b/src/Pennant/FeatureDirective.php
@@ -18,7 +18,7 @@ final class FeatureDirective extends HideDirective
     {
         return /** @lang GraphQL */ <<<'GRAPHQL'
 """
-Include or exclude the annotated element in or from the schema depending of the state of a feature using Laravel Pennant.
+Conditionally add the annotated element to schema depending of the state of a feature using Laravel Pennant.
 """
 directive @feature(
     """

--- a/src/Pennant/FeatureDirective.php
+++ b/src/Pennant/FeatureDirective.php
@@ -57,7 +57,7 @@ GRAPHQL;
         return match ($requiredFeatureState) {
             'ACTIVE' => $this->features->inactive($feature),
             'INACTIVE' => $this->features->active($feature),
-            default => throw new DefinitionException("Found invalid feature state: {$requiredFeatureState}"),
+            default => throw new DefinitionException("Expected FeatureState `ACTIVE` or `INACTIVE` for argument `when` of @{$this->name()} on {$this->nodeName()}, got `{$requiredFeatureState}`."),
         };
     }
 }

--- a/src/Pennant/FeatureDirective.php
+++ b/src/Pennant/FeatureDirective.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Pennant;
+
+use Laravel\Pennant\FeatureManager;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Schema\Directives\HideDirective;
+
+final class FeatureDirective extends HideDirective
+{
+    public function __construct(
+        private FeatureManager $features,
+    ) {
+        parent::__construct();
+    }
+
+    public static function definition(): string
+    {
+        return /** @lang GraphQL */ <<<'GRAPHQL'
+"""
+Include or exclude the annotated element in or from the schema depending of the state of a feature using Laravel Pennant.
+"""
+directive @feature(
+    """
+    The name of the feature to be checked (can be a string or class name).
+    """
+    name: String
+    
+    """
+    Specify what the state of the feature should be for the field to be applied.
+    """
+    when: FeatureState = ACTIVE
+) on FIELD_DEFINITION | OBJECT
+
+"""
+Options for the `when` argument of `@feature`.
+"""
+enum FeatureState {
+    """
+    Indicates an active feature.
+    """
+    ACTIVE
+    
+    """
+    Indicates an inactive feature.
+    """
+    INACTIVE
+}
+GRAPHQL;
+    }
+
+    protected function shouldHide(): bool
+    {
+        $feature = $this->directiveArgValue('name');
+        $requiredFeatureState = $this->directiveArgValue('when', 'ACTIVE');
+
+        return match ($requiredFeatureState) {
+            'ACTIVE' => $this->features->inactive($feature),
+            'INACTIVE' => $this->features->active($feature),
+            default => throw new DefinitionException("Found invalid feature state: {$requiredFeatureState}"),
+        };
+    }
+}

--- a/src/Pennant/FeatureDirective.php
+++ b/src/Pennant/FeatureDirective.php
@@ -18,7 +18,7 @@ final class FeatureDirective extends HideDirective
     {
         return /** @lang GraphQL */ <<<'GRAPHQL'
 """
-Conditionally add the annotated element to schema depending of the state of a feature using Laravel Pennant.
+Include the annotated element in the schema depending on a Laravel Pennant feature.
 """
 directive @feature(
     """

--- a/src/Pennant/FeatureDirective.php
+++ b/src/Pennant/FeatureDirective.php
@@ -24,7 +24,7 @@ directive @feature(
     """
     The name of the feature to be checked (can be a string or class name).
     """
-    name: String
+    name: String!
     
     """
     Specify what the state of the feature should be for the field to be applied.

--- a/src/Pennant/FeatureDirective.php
+++ b/src/Pennant/FeatureDirective.php
@@ -27,7 +27,7 @@ directive @feature(
     name: String!
     
     """
-    Specify what the state of the feature should be for the field to be applied.
+    Specify what the state of the feature should be for the field to be included.
     """
     when: FeatureState! = ACTIVE
 ) on FIELD_DEFINITION | OBJECT

--- a/src/Pennant/PennantServiceProvider.php
+++ b/src/Pennant/PennantServiceProvider.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Pennant;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\ServiceProvider;
+use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
+
+final class PennantServiceProvider extends ServiceProvider
+{
+    public function boot(Dispatcher $dispatcher): void
+    {
+        $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
+    }
+}

--- a/tests/Integration/Pennant/FeatureDirectiveTest.php
+++ b/tests/Integration/Pennant/FeatureDirectiveTest.php
@@ -24,7 +24,7 @@ final class FeatureDirectiveTest extends TestCase
             GRAPHQL;
 
         $response = $this->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
-            query {
+            {
                 fieldWhenActive
             }
             GRAPHQL,
@@ -44,7 +44,7 @@ final class FeatureDirectiveTest extends TestCase
             GRAPHQL;
 
         $response = $this->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
-            query {
+            {
                 fieldWhenActive
             }
             GRAPHQL,
@@ -65,7 +65,7 @@ final class FeatureDirectiveTest extends TestCase
             GRAPHQL;
 
         $response = $this->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
-            query {
+            {
                 fieldWhenInactive
             }
             GRAPHQL,
@@ -87,7 +87,7 @@ final class FeatureDirectiveTest extends TestCase
             GRAPHQL;
 
         $response = $this->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
-            query {
+            {
                 fieldWhenActive
             }
             GRAPHQL,
@@ -114,7 +114,7 @@ final class FeatureDirectiveTest extends TestCase
             GRAPHQL;
 
         $response = $this->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
-            query {
+            {
                 fieldWhenActive
             }
             GRAPHQL,
@@ -140,7 +140,7 @@ final class FeatureDirectiveTest extends TestCase
             GRAPHQL;
 
         $response = $this->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
-            query {
+            {
                 fieldWhenInactive
             }
             GRAPHQL,

--- a/tests/Integration/Pennant/FeatureDirectiveTest.php
+++ b/tests/Integration/Pennant/FeatureDirectiveTest.php
@@ -55,7 +55,7 @@ final class FeatureDirectiveTest extends TestCase
 
     public function testUnavailableWhenFeatureIsActive(): void
     {
-        Feature::define('new-api', fn () => true);
+        Feature::define('new-api', fn (): bool => true);
         $this->schema = /* @lang GraphQL */ <<<'GRAPHQL'
             type Query {
                 fieldWhenInactive: String!
@@ -76,8 +76,9 @@ final class FeatureDirectiveTest extends TestCase
 
     public function testAvailableWhenFeatureIsActive(): void
     {
-        Feature::define('new-api', fn () => true);
-        $this->mockResolver(fn (): string => 'active');
+        Feature::define('new-api', fn (): bool => true);
+        $fieldValue = 'active';
+        $this->mockResolver(fn (): string => $fieldValue);
         $this->schema = /* @lang GraphQL */ <<<'GRAPHQL'
             type Query {
                 fieldWhenActive: String!
@@ -96,15 +97,16 @@ final class FeatureDirectiveTest extends TestCase
         $response->assertGraphQLErrorFree();
         $response->assertJson([
             'data' => [
-                'fieldWhenActive' => 'active',
+                'fieldWhenActive' => $fieldValue,
             ],
         ]);
     }
 
     public function testAvailableWhenFeatureIsActiveWithDefaultFeatureState(): void
     {
-        Feature::define('new-api', fn () => true);
-        $this->mockResolver(fn (): string => 'active');
+        Feature::define('new-api', fn (): bool => true);
+        $fieldValue = 'active';
+        $this->mockResolver(fn (): string => $fieldValue);
         $this->schema = /* @lang GraphQL */ <<<'GRAPHQL'
             type Query {
                 fieldWhenActive: String!
@@ -123,14 +125,15 @@ final class FeatureDirectiveTest extends TestCase
         $response->assertGraphQLErrorFree();
         $response->assertJson([
             'data' => [
-                'fieldWhenActive' => 'active',
+                'fieldWhenActive' => $fieldValue,
             ],
         ]);
     }
 
     public function testAvailableWhenFeatureIsInactive(): void
     {
-        $this->mockResolver(fn (): string => 'inactive');
+        $fieldValue = 'inactive';
+        $this->mockResolver(fn (): string => $fieldValue);
         $this->schema = /* @lang GraphQL */ <<<'GRAPHQL'
             type Query {
                 fieldWhenInactive: String!
@@ -149,15 +152,13 @@ final class FeatureDirectiveTest extends TestCase
         $response->assertGraphQLErrorFree();
         $response->assertJson([
             'data' => [
-                'fieldWhenInactive' => 'inactive',
+                'fieldWhenInactive' => $fieldValue,
             ],
         ]);
     }
 
     private function assertCannotQueryFieldErrorMessage(TestResponse $response, string $expected): void
     {
-        $response->assertGraphQLErrorMessage(
-            "Cannot query field \"{$expected}\" on type \"Query\".",
-        );
+        $response->assertGraphQLErrorMessage("Cannot query field \"{$expected}\" on type \"Query\".");
     }
 }

--- a/tests/Integration/Pennant/FeatureDirectiveTest.php
+++ b/tests/Integration/Pennant/FeatureDirectiveTest.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Integration\Pennant;
+
+use Illuminate\Testing\TestResponse;
+use Laravel\Pennant\Feature;
+use Nuwave\Lighthouse\Testing\MocksResolvers;
+use Nuwave\Lighthouse\Testing\UsesTestSchema;
+use Tests\TestCase;
+
+final class FeatureDirectiveTest extends TestCase
+{
+    use UsesTestSchema;
+    use MocksResolvers;
+
+    /** @before */
+    public function setUpSchema(): void
+    {
+        $this->schema = /* @lang GraphQL */ <<<'GRAPHQL'
+type Query {
+    fieldWhenFeatureInactive: String! 
+        @feature(name: "foo", when: INACTIVE)
+        @mock
+    fieldWhenFeatureActive: String!
+        @feature(name: "foo", when: ACTIVE)
+        @mock
+    fieldWhenFeatureActiveByDefault: String!
+        @feature(name: "foo")
+        @mock 
+}
+GRAPHQL;
+    }
+
+    /** @after */
+    public function unsetSchema(): void
+    {
+        unset($this->schema);
+    }
+
+    public function testUnavailableWhenFeatureIsInactive(): void
+    {
+        $response = $this->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
+            query {
+                fieldWhenFeatureActive
+                fieldWhenFeatureActiveByDefault
+            }
+            GRAPHQL,
+        );
+
+        $this->assertCannotQueryFieldErrorMessage($response, 'fieldWhenFeatureActive', 'fieldWhenFeatureInactive');
+        $this->assertCannotQueryFieldErrorMessage(
+            $response,
+            'fieldWhenFeatureActiveByDefault',
+            'fieldWhenFeatureInactive',
+        );
+    }
+
+    public function testUnavailableWhenFeatureIsActive(): void
+    {
+        Feature::define('foo', fn () => true);
+
+        $response = $this->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
+            query {
+                fieldWhenFeatureInactive
+            }
+            GRAPHQL,
+        );
+
+        $this->assertCannotQueryFieldErrorMessage($response, 'fieldWhenFeatureInactive', 'fieldWhenFeatureActive');
+    }
+
+    public function testAvailableWhenFeatureIsActive(): void
+    {
+        Feature::define('foo', fn () => true);
+        $this->mockResolver(fn (): string => 'active');
+
+        $response = $this->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
+            query {
+                fieldWhenFeatureActive
+                fieldWhenFeatureActiveByDefault
+            }
+            GRAPHQL,
+        );
+
+        $response->assertGraphQLErrorFree();
+        $response->assertJson([
+            'data' => [
+                'fieldWhenFeatureActive' => 'active',
+                'fieldWhenFeatureActiveByDefault' => 'active',
+            ],
+        ]);
+    }
+
+    public function testAvailableWhenFeatureIsInactive(): void
+    {
+        $this->mockResolver(fn (): string => 'inactive');
+
+        $response = $this->graphQL(/* @lang GraphQL */ <<<'GRAPHQL'
+            query {
+                fieldWhenFeatureInactive
+            }
+            GRAPHQL,
+        );
+
+        $response->assertGraphQLErrorFree();
+        $response->assertJson([
+            'data' => [
+                'fieldWhenFeatureInactive' => 'inactive',
+            ],
+        ]);
+    }
+
+    private function assertCannotQueryFieldErrorMessage(
+        TestResponse $response,
+        string $expected,
+        string $suggested,
+    ): void {
+        $response->assertGraphQLErrorMessage(
+            "Cannot query field \"{$expected}\" on type \"Query\". Did you mean \"{$suggested}\"?",
+        );
+    }
+}

--- a/tests/Integration/Pennant/FeatureDirectiveTest.php
+++ b/tests/Integration/Pennant/FeatureDirectiveTest.php
@@ -27,6 +27,10 @@ final class FeatureDirectiveTest extends TestCase
 
     protected function getPackageProviders($app): array
     {
+        if (AppVersion::below(10)) {
+            return parent::getPackageProviders($app);
+        }
+
         return array_merge(
             parent::getPackageProviders($app),
             [

--- a/tests/Integration/Pennant/FeatureDirectiveTest.php
+++ b/tests/Integration/Pennant/FeatureDirectiveTest.php
@@ -6,6 +6,7 @@ use Illuminate\Testing\TestResponse;
 use Laravel\Pennant\Feature;
 use Laravel\Pennant\PennantServiceProvider as LaravelPennantServiceProvider;
 use Nuwave\Lighthouse\Pennant\PennantServiceProvider as LighthousePennantServiceProvider;
+use Nuwave\Lighthouse\Support\AppVersion;
 use Nuwave\Lighthouse\Testing\MocksResolvers;
 use Nuwave\Lighthouse\Testing\UsesTestSchema;
 use Tests\TestCase;
@@ -19,8 +20,8 @@ final class FeatureDirectiveTest extends TestCase
     {
         parent::setUp();
 
-        if (version_compare(PHP_VERSION, '8.2.0', '<')) {
-            $this->markTestSkipped('Requires laravel/pennant, which requires PHP 8.2');
+        if (AppVersion::below(10)) {
+            $this->markTestSkipped('Requires laravel/pennant, which requires Laravel 10');
         }
     }
 

--- a/tests/Integration/Pennant/FeatureDirectiveTest.php
+++ b/tests/Integration/Pennant/FeatureDirectiveTest.php
@@ -4,6 +4,8 @@ namespace Tests\Integration\Pennant;
 
 use Illuminate\Testing\TestResponse;
 use Laravel\Pennant\Feature;
+use Laravel\Pennant\PennantServiceProvider as LaravelPennantServiceProvider;
+use Nuwave\Lighthouse\Pennant\PennantServiceProvider as LighthousePennantServiceProvider;
 use Nuwave\Lighthouse\Testing\MocksResolvers;
 use Nuwave\Lighthouse\Testing\UsesTestSchema;
 use Tests\TestCase;
@@ -20,6 +22,17 @@ final class FeatureDirectiveTest extends TestCase
         if (version_compare(PHP_VERSION, '8.2.0', '<')) {
             $this->markTestSkipped('Requires laravel/pennant, which requires PHP 8.2');
         }
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return array_merge(
+            parent::getPackageProviders($app),
+            [
+                LaravelPennantServiceProvider::class,
+                LighthousePennantServiceProvider::class,
+            ],
+        );
     }
 
     public function testUnavailableWhenFeatureIsInactive(): void

--- a/tests/Integration/Pennant/FeatureDirectiveTest.php
+++ b/tests/Integration/Pennant/FeatureDirectiveTest.php
@@ -13,6 +13,15 @@ final class FeatureDirectiveTest extends TestCase
     use UsesTestSchema;
     use MocksResolvers;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (version_compare(PHP_VERSION, '8.2.0', '<')) {
+            $this->markTestSkipped('Requires laravel/pennant, which requires PHP 8.2');
+        }
+    }
+
     public function testUnavailableWhenFeatureIsInactive(): void
     {
         $this->schema = /* @lang GraphQL */ <<<'GRAPHQL'

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,6 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Redis\RedisServiceProvider;
-use Laravel\Pennant\PennantServiceProvider as LaravelPennantServiceProvider;
 use Laravel\Scout\ScoutServiceProvider as LaravelScoutServiceProvider;
 use Nuwave\Lighthouse\Auth\AuthServiceProvider as LighthouseAuthServiceProvider;
 use Nuwave\Lighthouse\Cache\CacheServiceProvider;
@@ -76,7 +75,6 @@ GRAPHQL;
         return [
             AuthServiceProvider::class,
             LaravelScoutServiceProvider::class,
-            LaravelPennantServiceProvider::class,
             RedisServiceProvider::class,
 
             // Lighthouse's own
@@ -85,7 +83,6 @@ GRAPHQL;
             CacheServiceProvider::class,
             CacheControlServiceProvider::class,
             GlobalIdServiceProvider::class,
-            LighthousePennantServiceProvider::class,
             LighthouseScoutServiceProvider::class,
             OrderByServiceProvider::class,
             PaginationServiceProvider::class,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,7 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Redis\RedisServiceProvider;
+use Laravel\Pennant\PennantServiceProvider as LaravelPennantServiceProvider;
 use Laravel\Scout\ScoutServiceProvider as LaravelScoutServiceProvider;
 use Nuwave\Lighthouse\Auth\AuthServiceProvider as LighthouseAuthServiceProvider;
 use Nuwave\Lighthouse\Cache\CacheServiceProvider;
@@ -18,6 +19,7 @@ use Nuwave\Lighthouse\GlobalId\GlobalIdServiceProvider;
 use Nuwave\Lighthouse\LighthouseServiceProvider;
 use Nuwave\Lighthouse\OrderBy\OrderByServiceProvider;
 use Nuwave\Lighthouse\Pagination\PaginationServiceProvider;
+use Nuwave\Lighthouse\Pennant\PennantServiceProvider as LighthousePennantServiceProvider;
 use Nuwave\Lighthouse\Schema\SchemaBuilder;
 use Nuwave\Lighthouse\Scout\ScoutServiceProvider as LighthouseScoutServiceProvider;
 use Nuwave\Lighthouse\SoftDeletes\SoftDeletesServiceProvider;
@@ -74,6 +76,7 @@ GRAPHQL;
         return [
             AuthServiceProvider::class,
             LaravelScoutServiceProvider::class,
+            LaravelPennantServiceProvider::class,
             RedisServiceProvider::class,
 
             // Lighthouse's own
@@ -82,6 +85,7 @@ GRAPHQL;
             CacheServiceProvider::class,
             CacheControlServiceProvider::class,
             GlobalIdServiceProvider::class,
+            LighthousePennantServiceProvider::class,
             LighthouseScoutServiceProvider::class,
             OrderByServiceProvider::class,
             PaginationServiceProvider::class,
@@ -168,6 +172,8 @@ GRAPHQL;
         $config->set('database.redis.options', [
             'prefix' => 'lighthouse-test-',
         ]);
+
+        $config->set('pennant.default', 'array');
 
         // Defaults to "algolia", which is not needed in our test setup
         $config->set('scout.driver', null);


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

This PR introduces a new `@feature` directive, which can be used to conditionally add a field to the schema based on the state of a feature flag:

```graphql
query {
  fieldWhenFeatureInactive: String! 
    @feature(name: "new-api", when: INACTIVE)

  fieldWhenFeatureActive: String!
    @feature(name: "new-api")
}
```

The `fieldWhenFeatureInactive` will only be available if the feature called `new-api` is inactive, whereas fieldWhenFeatureActive will only be available when the feature is active.

I've been using this in a codebase for a client, and thought it might be useful in other projects as well. Let me know if you guys like this ;)

**Breaking changes**

There are no breaking changes.
