### PR TITLE
Handle explicit `null` in `@in` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v6.18.1
+
+### Fixed
+
+- Handle explicit `null` in `@in` directive
+
 ## v6.18.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Handle explicit `null` in `@in` directive
+- Handle explicit `null` in `@in` directive https://github.com/nuwave/lighthouse/pull/2445
 
 ## v6.18.0
 

--- a/src/Schema/Directives/InDirective.php
+++ b/src/Schema/Directives/InDirective.php
@@ -27,6 +27,10 @@ GRAPHQL;
 
     public function handleBuilder(QueryBuilder|EloquentBuilder|Relation $builder, $value): QueryBuilder|EloquentBuilder|Relation
     {
+        if ($value === null) {
+            return $builder;
+        }
+
         return $builder->whereIn(
             $this->directiveArgValue('key', $this->nodeName()),
             $value,

--- a/tests/Integration/Schema/Directives/InDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/InDirectiveTest.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types=1);
+
+namespace Schema\Directives;
+
+use Tests\DBTestCase;
+use Tests\Utils\Models\User;
+
+final class InDirectiveTest extends DBTestCase
+{
+    public function testInIDs(): void
+    {
+        $user1 = factory(User::class)->create();
+        assert($user1 instanceof User);
+
+        factory(User::class)->create();
+
+        $this->schema = /** @lang GraphQL */ '
+        type User {
+            id: ID!
+        }
+
+        type Query {
+            users(ids: [ID!] @in(key: "id")): [User!]! @all
+        }
+        ';
+
+        $user1ID = (string) $user1->id;
+
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            query ($ids: [ID!]) {
+                users(ids: $ids) {
+                    id
+                }
+            }
+            ', [
+                'ids' => [$user1ID],
+            ])
+            ->assertJson([
+                'data' => [
+                    'users' => [
+                        [
+                            'id' => $user1ID,
+                        ]
+                    ]
+                ]
+            ]);
+    }
+
+    public function testExplicitNull(): void
+    {
+        $users = factory(User::class, 2)->create();
+
+        $this->schema = /** @lang GraphQL */ '
+        type User {
+            id: ID!
+        }
+
+        type Query {
+            users(ids: [ID!] @in(key: "id")): [User!]! @all
+        }
+        ';
+
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            query ($ids: [ID!]) {
+                users(ids: $ids) {
+                    id
+                }
+            }
+            ', [
+                'ids' => null,
+            ])
+            ->assertJsonCount($users->count(), 'data.users');
+    }
+
+    public function testExplicitNullInArray(): void
+    {
+        factory(User::class, 2)->create();
+
+        $this->schema = /** @lang GraphQL */ '
+        type User {
+            id: ID!
+        }
+
+        type Query {
+            users(ids: [ID] @in(key: "id")): [User!]! @all
+        }
+        ';
+
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            query ($ids: [ID]) {
+                users(ids: $ids) {
+                    id
+                }
+            }
+            ', [
+                'ids' => [null],
+            ])
+            ->assertJsonCount(0, 'data.users');
+    }
+
+    public function testEmptyArray(): void
+    {
+        factory(User::class, 2)->create();
+
+        $this->schema = /** @lang GraphQL */ '
+        type User {
+            id: ID!
+        }
+
+        type Query {
+            users(ids: [ID!] @in(key: "id")): [User!]! @all
+        }
+        ';
+
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            query ($ids: [ID!]) {
+                users(ids: $ids) {
+                    id
+                }
+            }
+            ', [
+                'ids' => [],
+            ])
+            ->assertJsonCount(0, 'data.users');
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/nuwave/lighthouse/issues/2444
 
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Do not apply `@in` when `null` is passed.

**Breaking changes**

None.
