### PR TITLE
`@where` ignoreNull attribute

### DIFF
--- a/docs/6/api-reference/directives.md
+++ b/docs/6/api-reference/directives.md
@@ -3677,6 +3677,12 @@ directive @where(
   Exclusively required when this directive is used on a field.
   """
   value: WhereValue
+
+  """
+  Wether null values should be ignored.
+  If set to true null values will be treated as if the argument is not present in the request.
+  """
+  ignoreNull: Boolean! = false
 ) repeatable on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 """
@@ -3709,6 +3715,14 @@ When used on a field, you must define `key` and `value`:
 ```graphql
 type Query {
   importantPosts: [Post!]! @all @where(key: "priority", operator: ">", value: 5)
+}
+```
+
+If you want to prevent null values to be passed to the query you can set `ignoreNull` to true:
+
+```graphql
+type Query {
+    posts(before: DateTime @where(operator: "<", ignoreNull: true)): [Post!]! @all
 }
 ```
 

--- a/docs/6/api-reference/directives.md
+++ b/docs/6/api-reference/directives.md
@@ -3677,12 +3677,6 @@ directive @where(
   Exclusively required when this directive is used on a field.
   """
   value: WhereValue
-
-  """
-  Wether null values should be ignored.
-  If set to true null values will be treated as if the argument is not present in the request.
-  """
-  ignoreNull: Boolean! = false
 ) repeatable on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 """
@@ -3715,14 +3709,6 @@ When used on a field, you must define `key` and `value`:
 ```graphql
 type Query {
   importantPosts: [Post!]! @all @where(key: "priority", operator: ">", value: 5)
-}
-```
-
-If you want to prevent null values to be passed to the query you can set `ignoreNull` to true:
-
-```graphql
-type Query {
-    posts(before: DateTime @where(operator: "<", ignoreNull: true)): [Post!]! @all
 }
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -3677,6 +3677,11 @@ directive @where(
   Exclusively required when this directive is used on a field.
   """
   value: WhereValue
+
+  """
+  Treat explicit `null` as if the argument is not present in the request.
+  """
+  ignoreNull: Boolean! = false
 ) repeatable on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 """
@@ -3709,6 +3714,30 @@ When used on a field, you must define `key` and `value`:
 ```graphql
 type Query {
   importantPosts: [Post!]! @all @where(key: "priority", operator: ">", value: 5)
+}
+```
+
+If you want to prevent explicit `null` values to be passed to the query you can use `ignoreNull`:
+
+```graphql
+type Post {
+    id: ID!
+    # There are not null titles
+    title: String!
+}
+
+type Query {
+    posts(title: String @where(ignoreNull: true)): [Post!]! @all
+}
+
+query {
+    posts {
+        # gets all posts
+    }
+
+    posts(title: null) {
+        # same result as above
+    }
 }
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -3679,7 +3679,7 @@ directive @where(
   value: WhereValue
 
   """
-  Treat explicit `null` as if the argument is not present in the request.
+  Treat explicit `null` as if the argument is not present in the request?
   """
   ignoreNull: Boolean! = false
 ) repeatable on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -3722,7 +3722,7 @@ If you want to prevent explicit `null` values to be passed to the query you can 
 ```graphql
 type Post {
     id: ID!
-    # There are not null titles
+    # Never null
     title: String!
 }
 

--- a/src/Schema/Directives/WhereDirective.php
+++ b/src/Schema/Directives/WhereDirective.php
@@ -41,6 +41,12 @@ directive @where(
   Exclusively required when this directive is used on a field.
   """
   value: WhereValue
+
+  """
+  Wether null values should be ignored.
+  If set to true null values will be treated as if the argument is not present in the request.
+  """
+  ignoreNull: Boolean! = false
 ) repeatable on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 """
@@ -52,6 +58,10 @@ GRAPHQL;
 
     public function handleBuilder(QueryBuilder|EloquentBuilder|Relation $builder, $value): QueryBuilder|EloquentBuilder|Relation
     {
+        if ($value === null && $this->directiveArgValue('ignoreNull', false)) {
+            return $builder;
+        }
+
         // Allow users to overwrite the default "where" clause, e.g. "whereYear"
         $clause = $this->directiveArgValue('clause', 'where');
 

--- a/src/Schema/Directives/WhereDirective.php
+++ b/src/Schema/Directives/WhereDirective.php
@@ -62,12 +62,23 @@ GRAPHQL;
             return $builder;
         }
 
+        $operator = $this->directiveArgValue('operator', '=');
+
+        // If the client sends an illegal value to the used operator it would crash the query
+        // we prevent it checking if the combination is acceptable using `prepareValueAndOperator`
+        // and catching the exception, if the combination is illegal we just ignore it
+        try {
+            $builder->prepareValueAndOperator($value, $operator);
+        } catch (\InvalidArgumentException) {
+            return $builder;
+        }
+
         // Allow users to overwrite the default "where" clause, e.g. "whereYear"
         $clause = $this->directiveArgValue('clause', 'where');
 
         return $builder->{$clause}(
             $this->directiveArgValue('key', $this->nodeName()),
-            $this->directiveArgValue('operator', '='),
+            $operator,
             $value
         );
     }

--- a/src/Schema/Directives/WhereDirective.php
+++ b/src/Schema/Directives/WhereDirective.php
@@ -61,23 +61,12 @@ GRAPHQL;
             return $builder;
         }
 
-        $operator = $this->directiveArgValue('operator', '=');
-
-        // If the client sends an illegal value to the used operator it would crash the query
-        // we prevent it checking if the combination is acceptable using `prepareValueAndOperator`
-        // and catching the exception, if the combination is illegal we just ignore it
-        try {
-            $builder->prepareValueAndOperator($value, $operator);
-        } catch (\InvalidArgumentException) {
-            return $builder;
-        }
-
         // Allow users to overwrite the default "where" clause, e.g. "whereYear"
         $clause = $this->directiveArgValue('clause', 'where');
 
         return $builder->{$clause}(
             $this->directiveArgValue('key', $this->nodeName()),
-            $operator,
+            $this->directiveArgValue('operator', '='),
             $value
         );
     }

--- a/src/Schema/Directives/WhereDirective.php
+++ b/src/Schema/Directives/WhereDirective.php
@@ -43,8 +43,7 @@ directive @where(
   value: WhereValue
 
   """
-  Wether null values should be ignored.
-  If set to true null values will be treated as if the argument is not present in the request.
+  Treat explicit `null` as if the argument is not present in the request?
   """
   ignoreNull: Boolean! = false
 ) repeatable on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION

--- a/tests/Integration/Schema/Directives/WhereDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/WhereDirectiveTest.php
@@ -40,35 +40,6 @@ final class WhereDirectiveTest extends DBTestCase
             ->assertJsonCount(1, 'data.usersBeginningWithF');
     }
 
-    public function testInvalidOperatorValueIsIgnored(): void
-    {
-        $users = factory(User::class, 2)->create();
-
-        $this->schema = /** @lang GraphQL */'
-        scalar DateTime @scalar(class: "Nuwave\\\Lighthouse\\\Schema\\\Types\\\Scalars\\\DateTime")
-
-        type User {
-            id: ID!
-            created_at: DateTime!
-        }
-
-        type Query {
-            users(createdAfter: DateTime @where(key: "created_at", operator: ">")): [User!]! @all
-        }
-        ';
-
-        $this
-            ->graphQL(/** @lang GraphQL */'
-            {
-                users(createdAfter: null) {
-                    id
-                }
-            }
-            ')
-            ->assertGraphQLErrorFree()
-            ->assertJsonCount($users->count(), 'data.users');
-    }
-
     public function testIgnoreNull(): void
     {
         $userWithoutEmail = factory(User::class)->create(['email' => null]);

--- a/tests/Integration/Schema/Directives/WhereDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/WhereDirectiveTest.php
@@ -40,18 +40,20 @@ final class WhereDirectiveTest extends DBTestCase
             ->assertJsonCount(1, 'data.usersBeginningWithF');
     }
 
-    public function testIgnoreNull(): void
+    public function testInvalidOperatorValueIsIgnored(): void
     {
         $users = factory(User::class, 2)->create();
 
         $this->schema = /** @lang GraphQL */'
         scalar DateTime @scalar(class: "Nuwave\\\Lighthouse\\\Schema\\\Types\\\Scalars\\\DateTime")
+
         type User {
             id: ID!
             created_at: DateTime!
         }
+
         type Query {
-            users(createdAfter: DateTime @where(key: "created_at", operator: ">", ignoreNull: true)): [User!]! @all
+            users(createdAfter: DateTime @where(key: "created_at", operator: ">")): [User!]! @all
         }
         ';
 
@@ -65,5 +67,48 @@ final class WhereDirectiveTest extends DBTestCase
             ')
             ->assertGraphQLErrorFree()
             ->assertJsonCount($users->count(), 'data.users');
+    }
+
+    public function testIgnoreNull(): void
+    {
+        $userWithoutEmail = factory(User::class)->create(['email' => null]);
+        $userWithEmail = factory(User::class)->create();
+
+        $this->schema = /** @lang GraphQL */'
+        scalar DateTime @scalar(class: "Nuwave\\\Lighthouse\\\Schema\\\Types\\\Scalars\\\DateTime")
+
+        type User {
+            id: ID!
+            email: String
+        }
+
+        type Query {
+            usersIgnoreNull(email: String @where(ignoreNull: true)): [User!]! @all
+            usersExplicitNull(email: String @where): [User!]! @all
+        }
+        ';
+
+        $this
+            ->graphQL(/** @lang GraphQL */'
+            {
+                usersIgnoreNull(email: null) {
+                    id
+                }
+
+                usersExplicitNull(email: null) {
+                    id
+                }
+            }
+            ')
+            ->assertGraphQLErrorFree()
+            ->assertJsonCount(2, 'data.usersIgnoreNull')
+            ->assertJsonPath('data.usersIgnoreNull', [
+                ['id' => (string)$userWithoutEmail->id],
+                ['id' => (string)$userWithEmail->id],
+            ])
+            ->assertJsonCount(1, 'data.usersExplicitNull')
+            ->assertJsonPath('data.usersExplicitNull', [[
+                'id' => (string)$userWithoutEmail->id,
+            ]]);
     }
 }


### PR DESCRIPTION
Treat null values the same as if they're not present, useful to prevent InvalidArgumentException if the operator is not on of `=`, `<>` or `!=`.
 
- [x] Added or updated tests
- [x] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**
Added the optional `ignoreNull` attribute to `@where` directive.

**Breaking changes**
No