### PR TITLE
Allow customizing the definition of the root `Query` field `node` added by `@node`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Added
 
-- Allow customizing the definition of the root `Query` field `node` added by `@node`
+- Allow customizing the definition of the root `Query` field `node` added by `@node` https://github.com/nuwave/lighthouse/pull/2449
 
 ## v6.18.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v6.19.0
+
+### Added
+
+- Allow customizing the definition of the root `Query` field `node` added by `@node`
+
 ## v6.18.2
 
 ### Fixed

--- a/docs/6/api-reference/directives.md
+++ b/docs/6/api-reference/directives.md
@@ -2366,7 +2366,7 @@ If you want to customize its description, change the resolver or add middleware,
 ```graphql
 type Query {
     "This description is up to you."
-    node(id: ID! @globalId): Node @field(resolver: "Nuwave\\Lighthouse\GlobalId\\NodeRegistry@resolve")
+    node(id: ID! @globalId): Node @field(resolver: "Nuwave\\Lighthouse\\GlobalId\\NodeRegistry@resolve")
         @someMiddlewareDirective
         @maybeAuthorization
 }

--- a/docs/6/api-reference/directives.md
+++ b/docs/6/api-reference/directives.md
@@ -2360,6 +2360,18 @@ directive @node(
 ) on OBJECT
 ```
 
+When you use `@node` on a type, Lighthouse will add a field `node` to the root Query type.
+If you want to customize its description, change the resolver or add middleware, you can add it yourself like this:
+
+```graphql
+type Query {
+    "This description is up to you."
+    node(id: ID! @globalId): Node @field(resolver: "Nuwave\\Lighthouse\GlobalId\\NodeRegistry@resolve")
+        @someMiddlewareDirective
+        @maybeAuthorization
+}
+```
+
 Lighthouse defaults to resolving types through the underlying model,
 for example by calling `User::find($id)`.
 
@@ -2381,7 +2393,8 @@ The `resolver` argument has to specify a function which will be passed the
 decoded `id` and resolves to a result.
 
 ```php
-public function byId($id): array {
+public function byId($id): array
+{
     return [
         'DE' => ['name' => 'Germany'],
         'MY' => ['name' => 'Malaysia'],
@@ -2391,8 +2404,8 @@ public function byId($id): array {
 
 [Read more](../digging-deeper/relay.md#global-object-identification).
 
-Behind the scenes, Lighthouse will decode the global id sent from the client
-to find the model by it's primary id in the database.
+Behind the scenes, Lighthouse will decode the global ID sent from the client
+to find the model by its primary key in the database.
 
 ## @notIn
 

--- a/docs/6/digging-deeper/relay.md
+++ b/docs/6/digging-deeper/relay.md
@@ -33,11 +33,11 @@ type User {
 You may rebind the `\Nuwave\Lighthouse\Support\Contracts\GlobalId` interface to add your
 own mechanism of encoding/decoding global ids.
 
-[Global Object Identification](https://facebook.github.io/relay/graphql/objectidentification.htm)
+[Global Object Identification](https://relay.dev/graphql/objectidentification.htm)
 
-[@node](../api-reference/directives.md#node)
-
-[@globalId](../api-reference/directives.md#globalid)
+Directives:
+- [@node](../api-reference/directives.md#node)
+- [@globalId](../api-reference/directives.md#globalid)
 
 ## Input Object Mutations
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2366,7 +2366,7 @@ If you want to customize its description, change the resolver or add middleware,
 ```graphql
 type Query {
     "This description is up to you."
-    node(id: ID! @globalId): Node @field(resolver: "Nuwave\\Lighthouse\GlobalId\\NodeRegistry@resolve")
+    node(id: ID! @globalId): Node @field(resolver: "Nuwave\\Lighthouse\\GlobalId\\NodeRegistry@resolve")
         @someMiddlewareDirective
         @maybeAuthorization
 }

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2360,6 +2360,18 @@ directive @node(
 ) on OBJECT
 ```
 
+When you use `@node` on a type, Lighthouse will add a field `node` to the root Query type.
+If you want to customize its description, change the resolver or add middleware, you can add it yourself like this:
+
+```graphql
+type Query {
+    "This description is up to you."
+    node(id: ID! @globalId): Node @field(resolver: "Nuwave\\Lighthouse\GlobalId\\NodeRegistry@resolve")
+        @someMiddlewareDirective
+        @maybeAuthorization
+}
+```
+
 Lighthouse defaults to resolving types through the underlying model,
 for example by calling `User::find($id)`.
 
@@ -2381,7 +2393,8 @@ The `resolver` argument has to specify a function which will be passed the
 decoded `id` and resolves to a result.
 
 ```php
-public function byId($id): array {
+public function byId($id): array
+{
     return [
         'DE' => ['name' => 'Germany'],
         'MY' => ['name' => 'Malaysia'],
@@ -2391,8 +2404,8 @@ public function byId($id): array {
 
 [Read more](../digging-deeper/relay.md#global-object-identification).
 
-Behind the scenes, Lighthouse will decode the global id sent from the client
-to find the model by it's primary id in the database.
+Behind the scenes, Lighthouse will decode the global ID sent from the client
+to find the model by its primary key in the database.
 
 ## @notIn
 

--- a/docs/master/digging-deeper/relay.md
+++ b/docs/master/digging-deeper/relay.md
@@ -33,11 +33,11 @@ type User {
 You may rebind the `\Nuwave\Lighthouse\Support\Contracts\GlobalId` interface to add your
 own mechanism of encoding/decoding global ids.
 
-[Global Object Identification](https://facebook.github.io/relay/graphql/objectidentification.htm)
+[Global Object Identification](https://relay.dev/graphql/objectidentification.htm)
 
-[@node](../api-reference/directives.md#node)
-
-[@globalId](../api-reference/directives.md#globalid)
+Directives:
+- [@node](../api-reference/directives.md#node)
+- [@globalId](../api-reference/directives.md#globalid)
 
 ## Input Object Mutations
 

--- a/src/GlobalId/NodeDirective.php
+++ b/src/GlobalId/NodeDirective.php
@@ -9,6 +9,7 @@ use GraphQL\Language\Parser;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Database\Eloquent\Model;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Schema\RootType;
@@ -104,10 +105,12 @@ GRAPHQL;
             $queryType = $documentAST->types[RootType::QUERY];
             assert($queryType instanceof ObjectTypeDefinitionNode);
 
-            $queryType->fields[] = Parser::fieldDefinition(/** @lang GraphQL */ <<<GRAPHQL
-              node(id: ID! @globalId): Node @field(resolver: "{$nodeRegistryClass}@resolve")
-            GRAPHQL
-            );
+            if (! ASTHelper::hasNode($queryType->fields, 'node')) {
+                $queryType->fields[] = Parser::fieldDefinition(/** @lang GraphQL */ <<<GRAPHQL
+                  node(id: ID! @globalId): Node @field(resolver: "{$nodeRegistryClass}@resolve")
+                GRAPHQL
+                );
+            }
         }
     }
 }

--- a/src/GlobalId/NodeRegistry.php
+++ b/src/GlobalId/NodeRegistry.php
@@ -4,7 +4,6 @@ namespace Nuwave\Lighthouse\GlobalId;
 
 use GraphQL\Error\Error;
 use GraphQL\Type\Definition\Type;
-use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Execution\ResolveInfo;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
@@ -19,7 +18,7 @@ class NodeRegistry
      *
      * @var array<string, NodeResolverFn>
      */
-    protected array $nodeResolver = [];
+    protected array $nodeResolverFns = [];
 
     /**
      * The stashed current type.
@@ -43,7 +42,7 @@ class NodeRegistry
      */
     public function registerNode(string $typeName, callable $resolver): self
     {
-        $this->nodeResolver[$typeName] = $resolver;
+        $this->nodeResolverFns[$typeName] = $resolver;
 
         return $this;
     }
@@ -65,8 +64,9 @@ class NodeRegistry
             throw new Error("[{$decodedType}] is not a type and cannot be resolved.");
         }
 
+        $resolver = $this->nodeResolverFns[$decodedType] ?? null;
         // Check if we have a resolver registered for the given type
-        if (! $resolver = Arr::get($this->nodeResolver, $decodedType)) {
+        if (! $resolver) {
             throw new Error("[{$decodedType}] is not a registered node and cannot be resolved.");
         }
 

--- a/tests/Integration/GlobalId/NodeDirectiveDBTest.php
+++ b/tests/Integration/GlobalId/NodeDirectiveDBTest.php
@@ -217,4 +217,30 @@ final class NodeDirectiveDBTest extends DBTestCase
         }
         ');
     }
+
+    public function testPreservesCustomNodeField(): void
+    {
+        $result = 42;
+        $this->mockResolver($result);
+
+        $this->schema .= /** @lang GraphQL */ "
+        type Query {
+            node: Int! @mock
+        }
+
+        type User @node {
+            name: String!
+        }
+        ";
+
+        $this->graphQL(/** @lang GraphQL */ "
+        {
+            node
+        }
+        ")->assertExactJson([
+            'data' => [
+                'node' => $result,
+            ],
+        ]);
+    }
 }

--- a/tests/Integration/GlobalId/NodeDirectiveDBTest.php
+++ b/tests/Integration/GlobalId/NodeDirectiveDBTest.php
@@ -225,6 +225,8 @@ final class NodeDirectiveDBTest extends DBTestCase
 
         $this->schema .= /** @lang GraphQL */ '
         type Query {
+            # Nonsensical example, just done this way for ease of testing.
+            # Usually customization would have the purpose of adding middleware.
             node: Int! @mock
         }
 

--- a/tests/Integration/GlobalId/NodeDirectiveDBTest.php
+++ b/tests/Integration/GlobalId/NodeDirectiveDBTest.php
@@ -223,7 +223,7 @@ final class NodeDirectiveDBTest extends DBTestCase
         $result = 42;
         $this->mockResolver($result);
 
-        $this->schema .= /** @lang GraphQL */ "
+        $this->schema .= /** @lang GraphQL */ '
         type Query {
             node: Int! @mock
         }
@@ -231,13 +231,13 @@ final class NodeDirectiveDBTest extends DBTestCase
         type User @node {
             name: String!
         }
-        ";
+        ';
 
-        $this->graphQL(/** @lang GraphQL */ "
+        $this->graphQL(/** @lang GraphQL */ '
         {
             node
         }
-        ")->assertExactJson([
+        ')->assertExactJson([
             'data' => [
                 'node' => $result,
             ],

--- a/tests/Integration/Schema/Directives/WhereBetweenDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/WhereBetweenDirectiveTest.php
@@ -11,7 +11,7 @@ final class WhereBetweenDirectiveTest extends DBTestCase
     {
         $users = factory(User::class, 2)->create();
 
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         scalar DateTime @scalar(class: "Nuwave\\\Lighthouse\\\Schema\\\Types\\\Scalars\\\DateTime")
 
         type User {
@@ -30,7 +30,7 @@ final class WhereBetweenDirectiveTest extends DBTestCase
         ';
 
         $this
-            ->graphQL(/** @lang GraphQL */'
+            ->graphQL(/** @lang GraphQL */ '
             {
                 users(createdBetween: null) {
                     id

--- a/tests/Integration/Schema/Directives/WhereNotBetweenDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/WhereNotBetweenDirectiveTest.php
@@ -11,7 +11,7 @@ final class WhereNotBetweenDirectiveTest extends DBTestCase
     {
         $users = factory(User::class, 2)->create();
 
-        $this->schema = /** @lang GraphQL */'
+        $this->schema = /** @lang GraphQL */ '
         scalar DateTime @scalar(class: "Nuwave\\\Lighthouse\\\Schema\\\Types\\\Scalars\\\DateTime")
 
         type User {
@@ -30,7 +30,7 @@ final class WhereNotBetweenDirectiveTest extends DBTestCase
         ';
 
         $this
-            ->graphQL(/** @lang GraphQL */'
+            ->graphQL(/** @lang GraphQL */ '
             {
                 users(notCreatedBetween: null) {
                     id


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

This change allows customizing the behaviour of the automatically added `Query.node`.

**Breaking changes**

Custom definitions of field `Query.node` are no longer overwritten, I consider this more of a bugfix though.
