### PR TITLE
Allow checking root model in @can directive

### DIFF
--- a/docs/6/api-reference/directives.md
+++ b/docs/6/api-reference/directives.md
@@ -621,7 +621,7 @@ directive @can(
   Check the policy against the model instances returned by the field resolver.
   Only use this if the field does not mutate data, it is run before checking.
 
-  Mutually exclusive with `query` and `find`.
+  Mutually exclusive with `query`, `find`, and `rootModel`.
   """
   resolved: Boolean! = false
 
@@ -648,7 +648,7 @@ directive @can(
   Query for specific model instances to check the policy against, using arguments
   with directives that add constraints to the query builder, such as `@eq`.
 
-  Mutually exclusive with `resolved` and `find`.
+  Mutually exclusive with `resolved`, `find`, and `rootModel`.
   """
   query: Boolean! = false
 
@@ -663,7 +663,7 @@ directive @can(
 
   You may pass the string in dot notation to use nested inputs.
 
-  Mutually exclusive with `resolved` and `query`.
+  Mutually exclusive with `resolved`, `query`, and `rootModel`.
   """
   find: String
 
@@ -671,6 +671,13 @@ directive @can(
   Should the query fail when the models of `find` were not found?
   """
   findOrFail: Boolean! = true
+
+  """
+  If your policy should check against the root value.
+
+  Mutually exclusive with `resolved`, `query`, and `find`.
+  """
+  rootModel: Boolean! = false
 ) repeatable on FIELD_DEFINITION
 
 """

--- a/docs/6/api-reference/directives.md
+++ b/docs/6/api-reference/directives.md
@@ -621,7 +621,7 @@ directive @can(
   Check the policy against the model instances returned by the field resolver.
   Only use this if the field does not mutate data, it is run before checking.
 
-  Mutually exclusive with `query`, `find`, and `rootModel`.
+  Mutually exclusive with `query` and `find`.
   """
   resolved: Boolean! = false
 
@@ -648,7 +648,7 @@ directive @can(
   Query for specific model instances to check the policy against, using arguments
   with directives that add constraints to the query builder, such as `@eq`.
 
-  Mutually exclusive with `resolved`, `find`, and `rootModel`.
+  Mutually exclusive with `resolved` and `find`.
   """
   query: Boolean! = false
 
@@ -663,7 +663,7 @@ directive @can(
 
   You may pass the string in dot notation to use nested inputs.
 
-  Mutually exclusive with `resolved`, `query`, and `rootModel`.
+  Mutually exclusive with `resolved` and `query`.
   """
   find: String
 
@@ -671,13 +671,6 @@ directive @can(
   Should the query fail when the models of `find` were not found?
   """
   findOrFail: Boolean! = true
-
-  """
-  If your policy should check against the root value.
-
-  Mutually exclusive with `resolved`, `query`, and `find`.
-  """
-  rootModel: Boolean! = false
 ) repeatable on FIELD_DEFINITION
 
 """

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -621,7 +621,7 @@ directive @can(
   Check the policy against the model instances returned by the field resolver.
   Only use this if the field does not mutate data, it is run before checking.
 
-  Mutually exclusive with `query` and `find`.
+  Mutually exclusive with `query`, `find`, and `root`.
   """
   resolved: Boolean! = false
 
@@ -648,7 +648,7 @@ directive @can(
   Query for specific model instances to check the policy against, using arguments
   with directives that add constraints to the query builder, such as `@eq`.
 
-  Mutually exclusive with `resolved` and `find`.
+  Mutually exclusive with `resolved`, `find`, and `root`.
   """
   query: Boolean! = false
 
@@ -663,7 +663,7 @@ directive @can(
 
   You may pass the string in dot notation to use nested inputs.
 
-  Mutually exclusive with `resolved` and `query`.
+  Mutually exclusive with `resolved`, `query`, and `root`.
   """
   find: String
 
@@ -671,6 +671,13 @@ directive @can(
   Should the query fail when the models of `find` were not found?
   """
   findOrFail: Boolean! = true
+
+  """
+  If your policy should check against the root value.
+
+  Mutually exclusive with `resolved`, `query`, and `find`.
+  """
+  root: Boolean! = false
 ) repeatable on FIELD_DEFINITION
 
 """

--- a/src/Auth/CanDirective.php
+++ b/src/Auth/CanDirective.php
@@ -53,7 +53,7 @@ directive @can(
   Check the policy against the model instances returned by the field resolver.
   Only use this if the field does not mutate data, it is run before checking.
 
-  Mutually exclusive with `query` and `find`.
+  Mutually exclusive with `query`, `find`, and `rootModel`.
   """
   resolved: Boolean! = false
 
@@ -80,7 +80,7 @@ directive @can(
   Query for specific model instances to check the policy against, using arguments
   with directives that add constraints to the query builder, such as `@eq`.
 
-  Mutually exclusive with `resolved` and `find`.
+  Mutually exclusive with `resolved`, `find`, and `rootModel`.
   """
   query: Boolean! = false
 
@@ -95,7 +95,7 @@ directive @can(
 
   You may pass the string in dot notation to use nested inputs.
 
-  Mutually exclusive with `resolved` and `query`.
+  Mutually exclusive with `resolved`, `query`, and `rootModel`.
   """
   find: String
 
@@ -103,6 +103,13 @@ directive @can(
   Should the query fail when the models of `find` were not found?
   """
   findOrFail: Boolean! = true
+
+  """
+  If your policy should check against the root value.
+
+  Mutually exclusive with `resolved`, `query`, and `find`.
+  """
+  rootModel: Boolean! = false
 ) repeatable on FIELD_DEFINITION
 
 """
@@ -148,7 +155,10 @@ GRAPHQL;
     }
 
     /**
-     * @param  array<string, mixed>  $args
+     * @param mixed                $root
+     * @param array<string, mixed> $args
+     * @param GraphQLContext       $context
+     * @param ResolveInfo          $resolveInfo
      *
      * @return iterable<\Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>>
      */
@@ -165,6 +175,10 @@ GRAPHQL;
                     $resolveInfo,
                 )
                 ->get();
+        }
+
+        if ($this->directiveArgValue('rootModel')) {
+            return [$root];
         }
 
         if ($find = $this->directiveArgValue('find')) {
@@ -276,7 +290,7 @@ GRAPHQL;
 
     public function manipulateFieldDefinition(DocumentAST &$documentAST, FieldDefinitionNode &$fieldDefinition, ObjectTypeDefinitionNode|InterfaceTypeDefinitionNode &$parentType): void
     {
-        $this->validateMutuallyExclusiveArguments(['resolved', 'query', 'find']);
+        $this->validateMutuallyExclusiveArguments(['resolved', 'query', 'find', 'rootModel']);
 
         if ($this->directiveHasArgument('resolved') && $parentType->name->value === RootType::MUTATION) {
             throw self::resolvedIsUnsafeInMutations($fieldDefinition->name->value);

--- a/src/Auth/CanDirective.php
+++ b/src/Auth/CanDirective.php
@@ -53,7 +53,7 @@ directive @can(
   Check the policy against the model instances returned by the field resolver.
   Only use this if the field does not mutate data, it is run before checking.
 
-  Mutually exclusive with `query`, `find`, and `rootModel`.
+  Mutually exclusive with `query`, `find`, and `root`.
   """
   resolved: Boolean! = false
 
@@ -80,7 +80,7 @@ directive @can(
   Query for specific model instances to check the policy against, using arguments
   with directives that add constraints to the query builder, such as `@eq`.
 
-  Mutually exclusive with `resolved`, `find`, and `rootModel`.
+  Mutually exclusive with `resolved`, `find`, and `root`.
   """
   query: Boolean! = false
 
@@ -95,7 +95,7 @@ directive @can(
 
   You may pass the string in dot notation to use nested inputs.
 
-  Mutually exclusive with `resolved`, `query`, and `rootModel`.
+  Mutually exclusive with `resolved`, `query`, and `root`.
   """
   find: String
 
@@ -109,7 +109,7 @@ directive @can(
 
   Mutually exclusive with `resolved`, `query`, and `find`.
   """
-  rootModel: Boolean! = false
+  root: Boolean! = false
 ) repeatable on FIELD_DEFINITION
 
 """
@@ -174,7 +174,7 @@ GRAPHQL;
                 ->get();
         }
 
-        if ($this->directiveArgValue('rootModel')) {
+        if ($this->directiveArgValue('root')) {
             return [$root];
         }
 
@@ -287,7 +287,7 @@ GRAPHQL;
 
     public function manipulateFieldDefinition(DocumentAST &$documentAST, FieldDefinitionNode &$fieldDefinition, ObjectTypeDefinitionNode|InterfaceTypeDefinitionNode &$parentType): void
     {
-        $this->validateMutuallyExclusiveArguments(['resolved', 'query', 'find', 'rootModel']);
+        $this->validateMutuallyExclusiveArguments(['resolved', 'query', 'find', 'root']);
 
         if ($this->directiveHasArgument('resolved') && $parentType->name->value === RootType::MUTATION) {
             throw self::resolvedIsUnsafeInMutations($fieldDefinition->name->value);

--- a/src/Auth/CanDirective.php
+++ b/src/Auth/CanDirective.php
@@ -155,10 +155,7 @@ GRAPHQL;
     }
 
     /**
-     * @param mixed                $root
-     * @param array<string, mixed> $args
-     * @param GraphQLContext       $context
-     * @param ResolveInfo          $resolveInfo
+     * @param  array<string, mixed>  $args
      *
      * @return iterable<\Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>>
      */

--- a/tests/Unit/Auth/CanDirectiveTest.php
+++ b/tests/Unit/Auth/CanDirectiveTest.php
@@ -281,6 +281,40 @@ final class CanDirectiveTest extends TestCase
         ]);
     }
 
+    public function testChecksAgainstRootModel(): void
+    {
+        $this->be(new User());
+
+        $this->mockResolver(function (): User {
+            return $this->resolveUser();
+        });
+
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            user(foo: String): User!
+                @mock
+        }
+
+        type User {
+            name: String @can(ability:"view", rootModel: true)
+        }
+        ';
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            user(foo: "bar"){
+                name
+            }
+        }
+        ')->assertJson([
+            'data' => [
+                'user' => [
+                    'name' => 'foo',
+                ],
+            ],
+        ]);
+    }
+
     public function testInjectedArgsAndStaticArgs(): void
     {
         $this->be(new User());


### PR DESCRIPTION
No issue for this that I'm aware of, but it's a feature I've built into a custom directive I thought would be useful in the upstream as it came up recently in the community Slack.

- [X] Added or updated tests
- [X] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

This PR allows users to check the root value against a Policy so a field can be controlled by its parent model Policy.

**Breaking changes**

None
