### PR TITLE
Add failing test cases

### DIFF
--- a/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToManyTest.php
@@ -682,6 +682,61 @@ GRAPHQL
     /**
      * @dataProvider existingModelMutations
      */
+    public function testDoNotDeleteWithoutRelationWithBelongsToMany(string $action): void
+    {
+        $users = [factory(User::class)->create(), factory(User::class)->create()];
+        factory(Role::class)
+            ->createMany([[], []])
+            ->each(function (Role $role, int $index) use ($users): void {
+                $role->users()->attach($users[$index]);
+            });
+
+        $this->graphQL(/** @lang GraphQL */ <<<GRAPHQL
+        mutation {
+            {$action}Role(input: {
+                id: 1
+                name: "is_user"
+                users: {
+                    delete: [2]
+                }
+            }) {
+                id
+                name
+                users {
+                    id
+                }
+            }
+        }
+GRAPHQL
+        )->assertJson([
+            'data' => [
+                "{$action}Role" => [
+                    'id' => '1',
+                    'name' => 'is_user',
+                    'users' => [
+                        [
+                            'id' => '1',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        /** @var Role $role */
+        $role = Role::find(1);
+        $this->assertCount(1, $role->users()->get());
+        $this->assertSame('is_user', $role->name);
+
+        /** @var Role $role */
+        $role = Role::find(2);
+        $this->assertCount(1, $role->users()->get());
+        $this->assertNotNull(User::find(1));
+        $this->assertNotNull(User::find(2));
+    }
+
+    /**
+     * @dataProvider existingModelMutations
+     */
     public function testConnectWithBelongsToMany(string $action): void
     {
         factory(User::class)->create();

--- a/tests/Integration/Execution/MutationExecutor/HasManyTest.php
+++ b/tests/Integration/Execution/MutationExecutor/HasManyTest.php
@@ -506,6 +506,59 @@ GRAPHQL
     /**
      * @dataProvider existingModelMutations
      */
+    public function testDeleteHasManyWithoutRelation(string $action): void
+    {
+        $tasks = [factory(Task::class)->create(), factory(Task::class)->create()];
+        factory(User::class)
+            ->createMany([[], []])
+            ->each(function (User $user, int $index) use ($tasks): void {
+                $user->tasks()->save($tasks[$index]);
+            });
+
+        $this->graphQL(/** @lang GraphQL */ <<<GRAPHQL
+        mutation {
+            ${$action}User(input: {
+                id: 1
+                name: "foo"
+                tasks: {
+                    delete: [{$tasks[1]->id}]
+                }
+            }) {
+                id
+                name
+                tasks {
+                    id
+                }
+            }
+        }
+GRAPHQL
+        )->assertJson([
+            'data' => [
+                "${$action}User" => [
+                    'id' => '1',
+                    'name' => 'foo',
+                    'tasks' => [
+                        [
+                            'id' => (string) $tasks[0]->id,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        /** @var User $user */
+        $user = User::find(1);
+        $this->assertCount(1, $user->tasks()->get());
+
+        /** @var User $user */
+        $user = User::find(2);
+        $this->assertCount(1, $user->tasks()->get());
+        $this->assertNotNull(Task::find($tasks[1]->id));
+    }
+
+    /**
+     * @dataProvider existingModelMutations
+     */
     public function testConnectHasMany(string $action): void
     {
         $user = factory(User::class)->create();


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
 
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

Add failing test cases for a bug concerning the delete field in nested mutations. Documentation says: `delete the related model and the association to it` ([link](https://lighthouse-php.com/6/eloquent/nested-mutations.html#belongsto)). 
These failing test cases show that actually any object can be deleted no matter of the relationship status to the root object. 
This should not be possible!

**Breaking changes**

I am not aware of any breaking changes.

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
