### PR TITLE
Change all links from graphql-rules.com to github 

### DIFF
--- a/docs/6/the-basics/best-practices.md
+++ b/docs/6/the-basics/best-practices.md
@@ -1,12 +1,12 @@
 # Best Practices
 
 When starting out with developing a GraphQL API, it is a good idea to look at existing best practices.
-We recommend you use [GraphQL Rules](https://graphql-rules.com) and the following tips as a starting point
+We recommend you use [GraphQL Rules](https://github.com/graphql-rules/graphql-rules/tree/master/docs/rules) and the following tips as a starting point
 to develop a set of guidelines that works for you.
 
 ## In the mutation response, return a field of type Query
 
-If you decide to [return the `Query` object in every mutation payload](https://graphql-rules.com/rules/mutation-payload-query),
+If you decide to [return the `Query` object in every mutation payload](https://github.com/graphql-rules/graphql-rules/blob/master/docs/rules/06-mutations/mutation-payload-query.md),
 Lighthouse makes it very easy.
 
 ```graphql

--- a/docs/6/the-basics/best-practices.md
+++ b/docs/6/the-basics/best-practices.md
@@ -1,7 +1,7 @@
 # Best Practices
 
 When starting out with developing a GraphQL API, it is a good idea to look at existing best practices.
-We recommend you use [GraphQL Rules](https://github.com/graphql-rules/graphql-rules/tree/master/docs/rules) and the following tips as a starting point
+We recommend you use [GraphQL Rules](https://github.com/graphql-rules/graphql-rules/blob/master/docs/rules/README.md) and the following tips as a starting point
 to develop a set of guidelines that works for you.
 
 ## In the mutation response, return a field of type Query

--- a/docs/master/the-basics/best-practices.md
+++ b/docs/master/the-basics/best-practices.md
@@ -1,12 +1,12 @@
 # Best Practices
 
 When starting out with developing a GraphQL API, it is a good idea to look at existing best practices.
-We recommend you use [GraphQL Rules](https://graphql-rules.com) and the following tips as a starting point
+We recommend you use [GraphQL Rules](https://github.com/graphql-rules/graphql-rules/tree/master/docs/rules) and the following tips as a starting point
 to develop a set of guidelines that works for you.
 
 ## In the mutation response, return a field of type Query
 
-If you decide to [return the `Query` object in every mutation payload](https://graphql-rules.com/rules/mutation-payload-query),
+If you decide to [return the `Query` object in every mutation payload](https://github.com/graphql-rules/graphql-rules/blob/master/docs/rules/06-mutations/mutation-payload-query.md),
 Lighthouse makes it very easy.
 
 ```graphql

--- a/docs/master/the-basics/best-practices.md
+++ b/docs/master/the-basics/best-practices.md
@@ -1,7 +1,7 @@
 # Best Practices
 
 When starting out with developing a GraphQL API, it is a good idea to look at existing best practices.
-We recommend you use [GraphQL Rules](https://github.com/graphql-rules/graphql-rules/tree/master/docs/rules) and the following tips as a starting point
+We recommend you use [GraphQL Rules](https://github.com/graphql-rules/graphql-rules/blob/master/docs/rules/README.md) and the following tips as a starting point
 to develop a set of guidelines that works for you.
 
 ## In the mutation response, return a field of type Query

--- a/tests/Integration/Schema/ResolverProviderTest.php
+++ b/tests/Integration/Schema/ResolverProviderTest.php
@@ -60,7 +60,7 @@ final class ResolverProviderTest extends TestCase
         ]);
     }
 
-    /** @see https://graphql-rules.com/rules/mutation-payload-query */
+    /** @see https://github.com/graphql-rules/graphql-rules/blob/master/docs/rules/06-mutations/mutation-payload-query.md */
     public function testRootQueryMutationPayload(): void
     {
         $fooResult = 1;


### PR DESCRIPTION

Resolves #2458 
 
**Changes**

Changes all links in documentation from graphql-rules.com to their github as the domain graphql-rules.com is dead

