### PR TITLE
Apollo federation v2

### DIFF
--- a/src/Federation/Directives/ComposeDirectiveDirective.php
+++ b/src/Federation/Directives/ComposeDirectiveDirective.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Federation\Directives;
+
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+
+class ComposeDirectiveDirective extends BaseDirective
+{
+    public const NAME = 'composeDirective';
+
+    public static function definition(): string
+    {
+        return /* @lang GraphQL */ <<<'GRAPHQL'
+"""
+Indicates to composition that all uses of a particular custom type system directive
+in the subgraph schema should be preserved in the supergraph schema
+(by default, composition omits most directives from the supergraph schema).
+
+```graphql
+extend schema
+    @link(url: "https://myspecs.dev/myDirective/v1.0", import: ["@myDirective"])
+    @composeDirective(name: "@myDirective")
+```
+
+https://www.apollographql.com/docs/federation/federated-types/federated-directives#composedirective
+"""
+directive @composeDirective(name: String!) repeatable on SCHEMA
+GRAPHQL;
+    }
+}

--- a/src/Federation/Directives/InaccessibleDirective.php
+++ b/src/Federation/Directives/InaccessibleDirective.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Federation\Directives;
+
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+
+class InaccessibleDirective extends BaseDirective
+{
+    public const NAME = 'inaccessible';
+
+    public static function definition(): string
+    {
+        return /* @lang GraphQL */ <<<'GRAPHQL'
+"""
+Indicates that a definition in the subgraph schema should be omitted from the router's API schema,
+even if that definition is also present in other subgraphs.
+This means that the field is not exposed to clients at all.
+
+```graphql
+type Position @shareable {
+  x: Int!
+  y: Int!
+  z: Int! @inaccessible
+}
+```
+
+An @inaccessible field or type is not omitted from the supergraph schema, so the router
+still knows it exists (but clients can't include it in operations).
+This is what enables the router to use an @inaccessible field as part of an entity's @key
+when combining entity fields from multiple subgraphs.
+
+If a type is marked @inaccessible, all fields that return that type must also be marked @inaccessible.
+Otherwise, a composition error occurs.
+
+https://www.apollographql.com/docs/federation/federated-types/federated-directives#inaccessible
+"""
+directive @inaccessible on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+GRAPHQL;
+    }
+}

--- a/src/Federation/Directives/InterfaceObjectDirective.php
+++ b/src/Federation/Directives/InterfaceObjectDirective.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Federation\Directives;
+
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+
+class InterfaceObjectDirective extends BaseDirective
+{
+    public const NAME = 'interfaceObject';
+
+    public static function definition(): string
+    {
+        return /* @lang GraphQL */ <<<'GRAPHQL'
+"""
+Indicates that an object definition serves as an abstraction of another subgraph's entity interface.
+This abstraction enables a subgraph to automatically contribute fields to all entities that implement a particular entity interface.
+
+During composition, the fields of every @interfaceObject are added both to their corresponding interface definition
+and to all entity types that implement that interface.
+
+https://www.apollographql.com/docs/federation/federated-types/federated-directives#interfaceobject
+"""
+directive @interfaceObject on OBJECT
+GRAPHQL;
+    }
+}

--- a/src/Federation/Directives/LinkDirective.php
+++ b/src/Federation/Directives/LinkDirective.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Federation\Directives;
+
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+
+class LinkDirective extends BaseDirective
+{
+    public const NAME = 'link';
+
+    public static function definition(): string
+    {
+        return /* @lang GraphQL */ <<<'GRAPHQL'
+"""
+This directive links definitions from an external specification to this schema.
+Every Federation 2 subgraph uses the @link directive to import the other federation-specific directives.
+
+```graphql
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3")
+```
+
+https://www.apollographql.com/docs/federation/federated-types/federated-directives#the-link-directive
+"""
+directive @link(url: String!, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+GRAPHQL;
+    }
+}

--- a/src/Federation/Directives/OverrideDirective.php
+++ b/src/Federation/Directives/OverrideDirective.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Federation\Directives;
+
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+
+class OverrideDirective extends BaseDirective
+{
+    public const NAME = 'override';
+
+    public static function definition(): string
+    {
+        return /* @lang GraphQL */ <<<'GRAPHQL'
+"""
+Indicates that an object field is now resolved by this subgraph instead of another subgraph
+where it's also defined. This enables you to migrate a field from one subgraph to another.
+
+You can apply @override to entity fields and fields of the root operation types (such as Query and Mutation).
+
+```graphql
+type Product @key(fields: "id") {
+  id: ID!
+  inStock: Boolean! @override(from: "Products")
+}
+```
+
+You can apply @override to a @shareable field. If you do, only the subgraph you provide
+in the from argument no longer resolves that field. Other subgraphs can still resolve the field.
+
+Only one subgraph can @override any given field.
+If multiple subgraphs attempt to @override the same field, a composition error occurs.
+
+https://www.apollographql.com/docs/federation/federated-types/federated-directives#override
+"""
+directive @override(from: String!) on FIELD_DEFINITION
+GRAPHQL;
+    }
+}

--- a/src/Federation/Directives/ShareableDirective.php
+++ b/src/Federation/Directives/ShareableDirective.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Federation\Directives;
+
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+
+class ShareableDirective extends BaseDirective
+{
+    public const NAME = 'shareable';
+
+    public static function definition(): string
+    {
+        return /* @lang GraphQL */ <<<'GRAPHQL'
+"""
+Indicates that an object type's field is allowed to be resolved by multiple subgraphs
+(by default in Federation 2, object fields can be resolved by only one subgraph).
+If applied to an object type definition, all of that type's fields are considered @shareable.
+
+```graphql
+type Position {
+  x: Int! @shareable
+  y: Int! @shareable
+}
+
+type Position @shareable {
+  x: Int!
+  y: Int!
+}
+```
+
+If a field is marked @shareable in any subgraph, it must be marked as either
+@shareable or @external in every Federation 2 subgraph that defines it.
+
+If a field is included in an entity's @key directive, that field is automatically
+considered @shareable and the directive is not required in the corresponding subgraph(s).
+
+https://www.apollographql.com/docs/federation/federated-types/federated-directives#shareable
+"""
+directive @shareable on FIELD_DEFINITION | OBJECT
+GRAPHQL;
+    }
+}

--- a/src/Federation/Directives/TagDirective.php
+++ b/src/Federation/Directives/TagDirective.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Federation\Directives;
+
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+
+class TagDirective extends BaseDirective
+{
+    public const NAME = 'tag';
+
+    public static function definition(): string
+    {
+        return /* @lang GraphQL */ <<<'GRAPHQL'
+"""
+Applies arbitrary string metadata to a schema location. Custom tooling can use this metadata
+during any step of the schema delivery flow, including composition, static analysis, and documentation.
+
+```graphql
+extend schema
+    @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@tag"])
+
+type Query {
+  customer(id: String!): Customer @tag(name: "team-customers")
+  employee(id: String!): Employee @tag(name: "team-admin")
+}
+
+interface User @tag(name: "team-accounts") {
+  id: String!
+  name: String!
+}
+
+type Customer implements User @tag(name: "team-customers") {
+  id: String!
+  name: String!
+}
+
+type Employee implements User @tag(name: "team-admin") {
+  id: String!
+  name: String!
+  ssn: String!
+}
+```
+
+https://www.apollographql.com/docs/federation/federated-types/federated-directives#tag
+"""
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+GRAPHQL;
+    }
+}

--- a/src/Federation/FederationPrinter.php
+++ b/src/Federation/FederationPrinter.php
@@ -2,6 +2,8 @@
 
 namespace Nuwave\Lighthouse\Federation;
 
+use GraphQL\Language\AST\ArgumentNode;
+use GraphQL\Language\AST\DirectiveNode;
 use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Type\Definition\Argument;
@@ -18,11 +20,18 @@ use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Schema;
 use GraphQL\Type\SchemaConfig;
 use Illuminate\Support\Arr;
+use Nuwave\Lighthouse\Federation\Directives\ComposeDirectiveDirective;
 use Nuwave\Lighthouse\Federation\Directives\ExtendsDirective;
 use Nuwave\Lighthouse\Federation\Directives\ExternalDirective;
+use Nuwave\Lighthouse\Federation\Directives\InaccessibleDirective;
+use Nuwave\Lighthouse\Federation\Directives\InterfaceObjectDirective;
 use Nuwave\Lighthouse\Federation\Directives\KeyDirective;
+use Nuwave\Lighthouse\Federation\Directives\LinkDirective;
+use Nuwave\Lighthouse\Federation\Directives\OverrideDirective;
 use Nuwave\Lighthouse\Federation\Directives\ProvidesDirective;
 use Nuwave\Lighthouse\Federation\Directives\RequiresDirective;
+use Nuwave\Lighthouse\Federation\Directives\ShareableDirective;
+use Nuwave\Lighthouse\Federation\Directives\TagDirective;
 use Nuwave\Lighthouse\Schema\RootType;
 
 class FederationPrinter
@@ -45,6 +54,13 @@ class FederationPrinter
         KeyDirective::NAME,
         ProvidesDirective::NAME,
         RequiresDirective::NAME,
+        ShareableDirective::NAME,
+        InaccessibleDirective::NAME,
+        InterfaceObjectDirective::NAME,
+        OverrideDirective::NAME,
+        TagDirective::NAME,
+        LinkDirective::NAME,
+        ComposeDirectiveDirective::NAME,
     ];
 
     public static function print(Schema $schema): string
@@ -78,12 +94,19 @@ class FederationPrinter
 
         $config->setTypes($types);
 
+        $federationDirectives = array_merge(
+            static::FEDERATION_DIRECTIVES,
+            static::getComposedDirectives($schema),
+        );
+
         $config->setDirectives(array_filter(
             $schema->getDirectives(),
-            static fn (Directive $directive): bool => ! in_array($directive->name, static::FEDERATION_DIRECTIVES),
+            static fn (Directive $directive): bool => ! in_array($directive->name, $federationDirectives),
         ));
 
-        $printDirectives = static function ($definition): string {
+        $config->setExtensionASTNodes($schema->extensionASTNodes);
+
+        $printDirectives = static function ($definition) use ($federationDirectives): string {
             assert(
                 $definition instanceof EnumType
                 || $definition instanceof InputObjectType
@@ -100,34 +123,28 @@ class FederationPrinter
             $astNode = $definition->astNode;
 
             if ($astNode instanceof ObjectTypeDefinitionNode) {
-                $federationDirectives = [];
+                $directivesToPrint = [];
                 foreach ($astNode->directives as $directive) {
                     $name = $directive->name->value;
 
-                    if ($name === KeyDirective::NAME
-                        || $name === ExtendsDirective::NAME
-                    ) {
-                        $federationDirectives[] = $directive;
+                    if (in_array($name, $federationDirectives)) {
+                        $directivesToPrint[] = $directive;
                     }
                 }
 
-                return SchemaPrinter::printDirectives($federationDirectives);
+                return SchemaPrinter::printDirectives($directivesToPrint);
             }
-
             if ($astNode instanceof FieldDefinitionNode) {
-                $federationDirectives = [];
+                $directivesToPrint = [];
                 foreach ($astNode->directives as $directive) {
                     $name = $directive->name->value;
 
-                    if ($name === ProvidesDirective::NAME
-                        || $name === RequiresDirective::NAME
-                        || $name === ExternalDirective::NAME
-                    ) {
-                        $federationDirectives[] = $directive;
+                    if (in_array($name, $federationDirectives)) {
+                        $directivesToPrint[] = $directive;
                     }
                 }
 
-                return SchemaPrinter::printDirectives($federationDirectives);
+                return SchemaPrinter::printDirectives($directivesToPrint);
             }
 
             return '';
@@ -137,5 +154,29 @@ class FederationPrinter
             new Schema($config),
             ['printDirectives' => $printDirectives],
         );
+    }
+
+    /** @return array<string> */
+    protected static function getComposedDirectives(Schema $schema): array
+    {
+        $composedDirectives = [];
+
+        foreach ($schema->extensionASTNodes as $extension) {
+            foreach ($extension->directives as $directive) {
+                assert($directive instanceof DirectiveNode);
+
+                if ($directive->name->value === 'composeDirective') {
+                    foreach ($directive->arguments as $argument) {
+                        assert($argument instanceof ArgumentNode);
+
+                        if ($argument->name->value === 'name') {
+                            $composedDirectives[] = ltrim($argument->value->value, '@');
+                        }
+                    }
+                }
+            }
+        }
+
+        return $composedDirectives;
     }
 }

--- a/src/Federation/FederationPrinter.php
+++ b/src/Federation/FederationPrinter.php
@@ -134,6 +134,7 @@ class FederationPrinter
 
                 return SchemaPrinter::printDirectives($directivesToPrint);
             }
+
             if ($astNode instanceof FieldDefinitionNode) {
                 $directivesToPrint = [];
                 foreach ($astNode->directives as $directive) {

--- a/src/Schema/AST/DocumentAST.php
+++ b/src/Schema/AST/DocumentAST.php
@@ -6,6 +6,7 @@ use GraphQL\Error\SyntaxError;
 use GraphQL\Language\AST\DirectiveDefinitionNode;
 use GraphQL\Language\AST\NodeList;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use GraphQL\Language\AST\SchemaExtensionNode;
 use GraphQL\Language\AST\TypeDefinitionNode;
 use GraphQL\Language\AST\TypeExtensionNode;
 use GraphQL\Language\Parser;
@@ -80,6 +81,9 @@ class DocumentAST implements Arrayable
      */
     public array $classNameToObjectTypeNames = [];
 
+    /** @var array<int,SchemaExtensionNode> */
+    public array $schemaExtensions = [];
+
     /** Create a new DocumentAST instance from a schema. */
     public static function fromSource(string $schema): self
     {
@@ -132,6 +136,8 @@ class DocumentAST implements Arrayable
                 $instance->typeExtensions[$definition->getName()->value][] = $definition;
             } elseif ($definition instanceof DirectiveDefinitionNode) {
                 $instance->directives[$definition->name->value] = $definition;
+            } elseif ($definition instanceof SchemaExtensionNode) {
+                $instance->schemaExtensions[] = $definition;
             } else {
                 throw new \Exception('Unknown definition type: ' . $definition::class);
             }

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -81,6 +81,8 @@ class SchemaBuilder
             array_merge(GraphQL::getStandardDirectives(), $directives),
         );
 
+        $config->setExtensionASTNodes($documentAST->schemaExtensions);
+
         return new Schema($config);
     }
 }


### PR DESCRIPTION
This PR adds support for [Apollo Federation v2](https://www.apollographql.com/docs/federation/subgraph-spec/) (except for federated tracing).

I've tested this changes with the apollo compatibility test suite and I will make a PR with the required changes to the test app ([here](https://github.com/cappuc/apollo-federation-subgraph-compatibility/tree/lighthouse-v2) you can see the changes for the compatibility test). 

Resolves #2160 
 
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

In order to support Federation v2 the subgraph needs to extend the `schema` with the link to the spec version and import the used directives:

```graphql
extend schema
  @link(
    url: "https://specs.apollo.dev/federation/v2.3",
    import: [
      "@composeDirective",
      "@extends",
      "@external",
      "@inaccessible",
      "@interfaceObject",
      "@key",
      "@override",
      "@provides",
      "@requires",
      "@shareable",
      "@tag"
    ]
  )
```

With this implementation the schema extension must be manually added by the user to the graphql schema.

I've added the new directives of v2 but right now there is no check on usage of this new directives without the schema extension.

The other required changes are on the `FederationPrinter` because we need to print in the service sdl the schema extension and the definition of directives passed to [`@composeDirective`](https://www.apollographql.com/docs/federation/federated-types/federated-directives#composedirective).


**Possible improvements**

The apollo spec allow to use federation directives without the import, adding the spec prefix:

```graphql
extend schema
  @link(url: "https://specs.apollo.dev/federation/v2.3")

type Product @federation__key(fields: "id") {
 id: ID!
}
```

or with alias: 

```graphql
extend schema
  @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed")

type Product @fed__key(fields: "id") {
 id: ID!
}
```


and also renaming imported directives: 

```graphql
extend schema
  @link(url: "https://specs.apollo.dev/federation/v2.3", import: [{ name: "@key", as: "@uniqueKey"}])

type Product @uniqueKey(fields: "id") {
 id: ID!
}
```

This options are not supported right now.


**Breaking changes**

It should be backward compatible with v1 because the schema extension required for v2 must be manually added by the user.
