### PR TITLE
Extend union support

### DIFF
--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -10,6 +10,8 @@ use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
 use GraphQL\Language\AST\InterfaceTypeExtensionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeExtensionNode;
+use GraphQL\Language\AST\UnionTypeDefinitionNode;
+use GraphQL\Language\AST\UnionTypeExtensionNode;
 use GraphQL\Language\Parser;
 use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\Arr;
@@ -31,6 +33,7 @@ class ASTBuilder
         InputObjectTypeExtensionNode::class => InputObjectTypeDefinitionNode::class,
         InterfaceTypeExtensionNode::class => InterfaceTypeDefinitionNode::class,
         EnumTypeExtensionNode::class => EnumTypeDefinitionNode::class,
+        UnionTypeExtensionNode::class => UnionTypeDefinitionNode::class,
     ];
 
     /** Initialized lazily in $this->documentAST(). */
@@ -119,6 +122,8 @@ class ASTBuilder
                     $this->extendObjectLikeType($typeName, $typeExtension);
                 } elseif ($typeExtension instanceof EnumTypeExtensionNode) {
                     $this->extendEnumType($typeName, $typeExtension);
+                } elseif ($typeExtension instanceof UnionTypeExtensionNode) {
+                    $this->extendUnionType($typeName, $typeExtension);
                 }
             }
         }
@@ -173,12 +178,26 @@ class ASTBuilder
         );
     }
 
-    protected function missingBaseDefinition(string $typeName, ObjectTypeExtensionNode|InputObjectTypeExtensionNode|InterfaceTypeExtensionNode|EnumTypeExtensionNode $typeExtension): string
+    protected function extendUnionType(string $typeName, UnionTypeExtensionNode $typeExtension): void
+    {
+        $extendedUnion = $this->documentAST->types[$typeName]
+            ?? throw new DefinitionException($this->missingBaseDefinition($typeName, $typeExtension));
+        assert($extendedUnion instanceof UnionTypeDefinitionNode);
+
+        $this->assertExtensionMatchesDefinition($typeExtension, $extendedUnion);
+
+        $extendedUnion->types = ASTHelper::mergeUniqueNodeList(
+            $extendedUnion->types,
+            $typeExtension->types,
+        );
+    }
+
+    protected function missingBaseDefinition(string $typeName, ObjectTypeExtensionNode|InputObjectTypeExtensionNode|InterfaceTypeExtensionNode|EnumTypeExtensionNode|UnionTypeExtensionNode $typeExtension): string
     {
         return "Could not find a base definition {$typeName} of kind {$typeExtension->kind} to extend.";
     }
 
-    protected function assertExtensionMatchesDefinition(ObjectTypeExtensionNode|InputObjectTypeExtensionNode|InterfaceTypeExtensionNode|EnumTypeExtensionNode $extension, ObjectTypeDefinitionNode|InputObjectTypeDefinitionNode|InterfaceTypeDefinitionNode|EnumTypeDefinitionNode $definition): void
+    protected function assertExtensionMatchesDefinition(ObjectTypeExtensionNode|InputObjectTypeExtensionNode|InterfaceTypeExtensionNode|EnumTypeExtensionNode|UnionTypeExtensionNode $extension, ObjectTypeDefinitionNode|InputObjectTypeDefinitionNode|InterfaceTypeDefinitionNode|EnumTypeDefinitionNode|UnionTypeDefinitionNode $definition): void
     {
         if (static::EXTENSION_TO_DEFINITION_CLASS[$extension::class] !== $definition::class) {
             throw new DefinitionException("The type extension {$extension->name->value} of kind {$extension->kind} can not extend a definition of kind {$definition->kind}.");


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
 Resolves https://github.com/nuwave/lighthouse/issues/2462

- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->
This MR adds support for extending unions. The `extend union` syntax was already supported by the parser, but was not yet implemented in the `ASTBuilder`.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
Code that already uses the syntax might expect it to silently be ignored, which is no longer the case with this MR.
