### PR TITLE
namespaced directive ISO #2266

### DIFF
--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2279,6 +2279,51 @@ extend type Query @namespace(field: "App\\Blog") {
 
 A [@namespace](#namespace) directive defined on a field directive wins in case of a conflict.
 
+## @namespaced
+
+```graphql
+"""
+A no-op nested field resolver that allows nesting of queries and mutations.
+"""
+directive @namespaced on FIELD_DEFINITION
+```
+
+The following example shows how one can namespace queries and mutations.
+
+```graphql
+type Query {
+    posts: PostQueries! @namespaced
+}
+
+type PostQueries {
+    single(
+        id: ID @eq
+    ): Post! @find
+
+    list(
+        title: String @where(operator: "like")
+    ): [Post!]! @paginate(defaultCount: 10)
+}
+
+type Mutation {
+    posts: PostMutations! @namespaced
+}
+
+type PostMutations {
+    create(
+        input: PostCreateInput @spread
+    ): Post! @create
+
+    update(
+        input: PostUpdateInput @spread
+    ): Post! @update
+
+    delete(
+        id: ID! @whereKey
+    ): Post @delete
+}
+```
+
 ## @neq
 
 ```graphql

--- a/src/Schema/Directives/NamespacedDirective.php
+++ b/src/Schema/Directives/NamespacedDirective.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace App\GraphQL\Directives;
+
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
+
+final class NamespacedDirective extends BaseDirective implements FieldResolver
+{
+    public static function definition(): string
+    {
+        return /** @lang GraphQL */ <<<'GRAPHQL'
+"""
+A no-op nested field resolver that allows nesting of queries and mutations.
+"""          
+directive @namespaced on FIELD_DEFINITION
+GRAPHQL;
+    }
+
+    public function resolveField(FieldValue $fieldValue): callable
+    {
+        return static fn (mixed $root): mixed => true;
+    }
+}


### PR DESCRIPTION
Helps to address #2266 in the main package without users having to create a custom field resolver.
 
- [ ] Added or updated tests
- [ X ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

Adds a `@namespaced` directive; allowing mutations and queries to be posted.

Allows:
```
type Mutation {
    createPost(input: CreatePostInput! @spread): Post! @create
    updatePost(input: UpdatePostInput! @spread): Post! @update
    deletePost(input: DeletePostInput! @spread): Post @delete
}
```
to become:
```
type Mutation {
    posts: PostMutations! @namespaced
}

type PostMutations {
    create(input: CreatePostInput! @spread): Post! @create
    update(input: UpdatePostInput! @spread): Post! @update
    delete(input: DeletePostInput! @spread): Post @delete
}
```

ref: https://www.apollographql.com/docs/technotes/TN0012-namespacing-by-separation-of-concern/