### PR TITLE
fix federation schema printer

### DIFF
--- a/src/Federation/SchemaPrinter.php
+++ b/src/Federation/SchemaPrinter.php
@@ -16,8 +16,12 @@ class SchemaPrinter extends GraphQLSchemaPrinter
 {
     protected static function printSchemaDefinition(Schema $schema): string
     {
-        $schemaExtensionDirectives = self::printDirectives(FederationHelper::schemaExtensionDirectives($schema));
-        $result = "extend schema{$schemaExtensionDirectives}\n";
+        $result = '';
+
+        $schemaExtensionDirectives = FederationHelper::schemaExtensionDirectives($schema);
+        if ($schemaExtensionDirectives !== []) {
+            $result .= sprintf('extend schema%s', self::printDirectives($schemaExtensionDirectives));
+        }
 
         $directivesToCompose = FederationHelper::directivesToCompose($schema);
 
@@ -30,7 +34,7 @@ class SchemaPrinter extends GraphQLSchemaPrinter
                     ->definition(),
                 $directivesToCompose,
             );
-            $result .= "\n" . implode("\n\n", $directivesToComposeDefinitions);
+            $result .= "\n\n" . implode("\n\n", $directivesToComposeDefinitions);
         }
 
         return $result;

--- a/src/Federation/SchemaPrinter.php
+++ b/src/Federation/SchemaPrinter.php
@@ -20,7 +20,7 @@ class SchemaPrinter extends GraphQLSchemaPrinter
 
         $schemaExtensionDirectives = FederationHelper::schemaExtensionDirectives($schema);
         if ($schemaExtensionDirectives !== []) {
-            $result .= sprintf('extend schema%s', self::printDirectives($schemaExtensionDirectives));
+            $result .= 'extend schema' . self::printDirectives($schemaExtensionDirectives);
         }
 
         $directivesToCompose = FederationHelper::directivesToCompose($schema);

--- a/tests/Console/PrintFederationSchemaCommandTest.php
+++ b/tests/Console/PrintFederationSchemaCommandTest.php
@@ -38,9 +38,11 @@ GRAPHQL;
         $tester = $this->commandTester(new PrintSchemaCommand());
         $tester->execute(['--federation' => true]);
 
-        $this->assertStringContainsString(self::SCHEMA_TYPE, $tester->getDisplay());
-        $this->assertStringContainsString(self::SCHEMA_QUERY, $tester->getDisplay());
-        $this->assertStringNotContainsString('extend schema', $tester->getDisplay());
+        $sdl = $tester->getDisplay();
+
+        $this->assertStringContainsString(self::SCHEMA_TYPE, $sdl);
+        $this->assertStringContainsString(self::SCHEMA_QUERY, $sdl);
+        $this->assertStringNotContainsString('extend schema', $sdl);
     }
 
     public function testWritesSchema(): void

--- a/tests/Console/PrintFederationSchemaCommandTest.php
+++ b/tests/Console/PrintFederationSchemaCommandTest.php
@@ -40,6 +40,7 @@ GRAPHQL;
 
         $this->assertStringContainsString(self::SCHEMA_TYPE, $tester->getDisplay());
         $this->assertStringContainsString(self::SCHEMA_QUERY, $tester->getDisplay());
+        $this->assertStringNotContainsString('extend schema', $tester->getDisplay());
     }
 
     public function testWritesSchema(): void


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

Fix a bug in the federation printer introduced in #2460.

It was always printing `extend schema` even when there are no extensions.

