### PR TITLE
Federation v2 `@shareable` types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,14 +73,14 @@
         "thecodingmachine/phpstan-safe-rule": "^1.2"
     },
     "suggest": {
+        "ext-protobuf": "Improve protobuf serialization performance (used for tracing)",
         "bensampo/laravel-enum": "Convenient enum definitions that can easily be registered in your Schema",
+        "google/protobuf": "Required when using the tracing driver federated-tracing",
         "laravel/pennant": "Required for the @feature directive",
         "laravel/scout": "Required for the @search directive",
         "mll-lab/graphql-php-scalars": "Useful scalar types, required for @whereConditions",
         "mll-lab/laravel-graphiql": "A graphical interactive in-browser GraphQL IDE - integrated with Laravel",
-        "pusher/pusher-php-server": "Required when using the Pusher Subscriptions driver",
-        "google/protobuf": "Required when using the tracing driver federated-tracing",
-        "ext-protobuf": "Improve protobuf serialization performance (used for tracing)"
+        "pusher/pusher-php-server": "Required when using the Pusher Subscriptions driver"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/Federation/FederationHelper.php
+++ b/src/Federation/FederationHelper.php
@@ -5,6 +5,7 @@ namespace Nuwave\Lighthouse\Federation;
 use GraphQL\Language\AST\DirectiveNode;
 use GraphQL\Type\Schema;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 
 class FederationHelper
 {
@@ -42,5 +43,24 @@ class FederationHelper
         }
 
         return $schemaDirectives;
+    }
+
+    public static function isUsingFederationV2(Schema|DocumentAST $schemaOrDocument): bool
+    {
+        $schemaExtensionNodes = $schemaOrDocument instanceof Schema
+            ? $schemaOrDocument->extensionASTNodes
+            : $schemaOrDocument->schemaExtensions;
+
+        foreach ($schemaExtensionNodes as $extension) {
+            foreach (ASTHelper::directiveDefinitions($extension, 'link') as $directive) {
+                $url = ASTHelper::directiveArgValue($directive, 'url');
+
+                if (str_starts_with($url, 'https://specs.apollo.dev/federation/')) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Tracing/FederatedTracing/Proto/FieldStat.php
+++ b/src/Tracing/FederatedTracing/Proto/FieldStat.php
@@ -89,7 +89,7 @@ class FieldStat extends \Google\Protobuf\Internal\Message
      *           field_execution_weight).
      *     @var int|string $observed_execution_count
      *           Number of times that the resolver for this field is directly observed being
-     *           executed.
+     *           executed
      *     @var int|string $estimated_execution_count
      *           Same as `observed_execution_count` but potentially scaled upwards if the server was only
      *           performing field-level instrumentation on a sampling of operations.  For

--- a/src/Tracing/FederatedTracing/Proto/QueryLatencyStats.php
+++ b/src/Tracing/FederatedTracing/Proto/QueryLatencyStats.php
@@ -106,7 +106,7 @@ class QueryLatencyStats extends \Google\Protobuf\Internal\Message
      *     @var int|string $persisted_query_misses
      *     @var array<int>|array<string>|\Google\Protobuf\Internal\RepeatedField $cache_latency_count
      *           This array includes the latency buckets for all operations included in cache_hits
-     *           See comment on latency_count for details.
+     *           See comment on latency_count for details
      *     @var \Nuwave\Lighthouse\Tracing\FederatedTracing\Proto\PathErrorStats $root_error_stats
      *           Paths and counts for each error. The total number of requests with errors within this object should be the same as
      *           requests_with_errors_count below.

--- a/src/Tracing/FederatedTracing/Proto/Trace.php
+++ b/src/Tracing/FederatedTracing/Proto/Trace.php
@@ -170,15 +170,15 @@ class Trace extends \Google\Protobuf\Internal\Message
      *     Optional. Data for populating the Message object.
      *
      *     @var \Google\Protobuf\Timestamp $start_time
-     *           Wallclock time when the trace began.
+     *           Wallclock time when the trace began
      *     @var \Google\Protobuf\Timestamp $end_time
-     *           Wallclock time when the trace ended.
+     *           Wallclock time when the trace ended
      *     @var int|string $duration_ns
      *           High precision duration of the trace; may not equal end_time-start_time
-     *           (eg, if your machine's clock changed during the trace).
+     *           (eg, if your machine's clock changed during the trace)
      *     @var \Nuwave\Lighthouse\Tracing\FederatedTracing\Proto\Trace\Node $root
      *           A tree containing information about all resolvers run directly by this
-     *           service, including errors.
+     *           service, including errors
      *     @var bool $is_incomplete
      *           If this is true, the trace is potentially missing some nodes that were
      *           present on the query plan. This can happen if the trace span buffer used
@@ -201,7 +201,7 @@ class Trace extends \Google\Protobuf\Internal\Message
      *     @var string $unexecutedOperationBody
      *           Optional: when GraphQL parsing or validation against the GraphQL schema fails, these fields
      *           can include reference to the operation being sent for users to dig into the set of operations
-     *           that are failing validation.
+     *           that are failing validation
      *     @var string $unexecutedOperationName
      *     @var \Nuwave\Lighthouse\Tracing\FederatedTracing\Proto\Trace\Details $details
      *     @var string $client_name

--- a/src/Tracing/FederatedTracing/Proto/Trace/QueryPlanNode/FetchNode.php
+++ b/src/Tracing/FederatedTracing/Proto/Trace/QueryPlanNode/FetchNode.php
@@ -66,12 +66,12 @@ class FetchNode extends \Google\Protobuf\Internal\Message
      *     @var \Nuwave\Lighthouse\Tracing\FederatedTracing\Proto\Trace $trace
      *           This Trace only contains start_time, end_time, duration_ns, and root;
      *           all timings were calculated **on the subgraph**, and clock skew
-     *           will be handled by the ingress server.
+     *           will be handled by the ingress server
      *     @var int|string $sent_time_offset
-     *           relative to the outer trace's start_time, in ns, measured in the Router/Gateway.
+     *           relative to the outer trace's start_time, in ns, measured in the Router/Gateway
      *     @var \Google\Protobuf\Timestamp $sent_time
      *           Wallclock times measured in the Router/Gateway for when this operation was
-     *           sent and received.
+     *           sent and received
      *     @var \Google\Protobuf\Timestamp $received_time
      * }
      */

--- a/tests/Integration/Federation/FederationSchemaTest.php
+++ b/tests/Integration/Federation/FederationSchemaTest.php
@@ -8,6 +8,10 @@ use Tests\TestCase;
 
 final class FederationSchemaTest extends TestCase
 {
+    protected string $federationV2SchemaExtension = /** @lang GraphQL */ <<<'GRAPHQL'
+extend schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.3", import: ["@composeDirective", "@extends", "@external", "@inaccessible", "@interfaceObject", "@key", "@override", "@provides", "@requires", "@shareable", "@tag"])
+GRAPHQL;
+
     protected function getPackageProviders($app): array
     {
         return array_merge(
@@ -125,6 +129,51 @@ GRAPHQL;
         $this->assertStringContainsString('directive @foo on FIELD_DEFINITION', $sdl);
         $this->assertStringContainsString('directive @bar on FIELD_DEFINITION', $sdl);
         $this->assertStringContainsString($typeFoo, $sdl);
+    }
+
+    public function testPaginationTypesAreNotMarkedAsSharableWhenUsingFederationV1(): void
+    {
+        $this->schema = /** @lang GraphQL */ <<<GRAPHQL
+        type User @key(fields: "id") {
+            id: ID!
+        }
+
+        type Query {
+            users1: [User!]! @paginate
+            users2: [User!]! @paginate(type: CONNECTION)
+            users3: [User!]! @paginate(type: SIMPLE)
+        }
+        GRAPHQL;
+
+        $sdl = $this->_serviceSdl();
+
+        $this->assertStringContainsString('type PaginatorInfo {', $sdl);
+        $this->assertStringContainsString('type PageInfo {', $sdl);
+        $this->assertStringContainsString('type SimplePaginatorInfo {', $sdl);
+        $this->assertStringNotContainsString('@shareable', $sdl);
+    }
+
+    public function testPaginationTypesAreMarkedAsSharableWhenUsingFederationV2(): void
+    {
+        $this->schema = /** @lang GraphQL */ <<<GRAPHQL
+        {$this->federationV2SchemaExtension}
+
+        type User @key(fields: "id") {
+            id: ID!
+        }
+
+        type Query {
+            users1: [User!]! @paginate
+            users2: [User!]! @paginate(type: CONNECTION)
+            users3: [User!]! @paginate(type: SIMPLE)
+        }
+        GRAPHQL;
+
+        $sdl = $this->_serviceSdl();
+
+        $this->assertStringContainsString('type PaginatorInfo @shareable {', $sdl);
+        $this->assertStringContainsString('type PageInfo @shareable {', $sdl);
+        $this->assertStringContainsString('type SimplePaginatorInfo @shareable {', $sdl);
     }
 
     protected function _serviceSdl(): string


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

This PR marks shared types (types that can be shared by multiple services) with the `@shareable` directive when federation v2 is enabled.

Right now I've updated the pagination types. @spawnia do you think there are other types that makes sense to mark as `@shareable`?

**Breaking changes**

None.
 When using federation v2, types declared in multiple services must be marked as `@shareable` so right now you must override this types in order to use federation v2
