### PR TITLE
Fix guard type in stateful authentication example

### DIFF
--- a/docs/master/security/authentication.md
+++ b/docs/master/security/authentication.md
@@ -201,7 +201,7 @@ final class Logout
     public function __invoke($_, array $args): ?User
     {
         // Plain Laravel: Auth::guard()
-        // Laravel Sanctum: Auth::guard(config('sanctum.guard', 'web'))
+        // Laravel Sanctum: Auth::guard(Arr::first(config('sanctum.guard', 'web')))
         $guard = ?;
 
         $user = $guard->user();


### PR DESCRIPTION
Logout sanctum example is missing a Arr::first() call, which causes an illegal offset exception