### PR TITLE
feat: make location parse configurable

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -244,8 +244,11 @@ class GraphQL
     {
         $cacheConfig = $this->configRepository->get('lighthouse.query_cache');
 
+        $options = [
+            'noLocation' => $this->configRepository->get('lighthouse.no_location_on_query_parse'),
+        ];
         if (! $cacheConfig['enable']) {
-            return Parser::parse($query);
+            return Parser::parse($query, $options);
         }
 
         $cacheFactory = Container::getInstance()->make(CacheFactory::class);
@@ -256,7 +259,7 @@ class GraphQL
         return $store->remember(
             "lighthouse:query:{$sha256}",
             $cacheConfig['ttl'],
-            static fn (): DocumentNode => Parser::parse($query),
+            static fn (): DocumentNode => Parser::parse($query, $options),
         );
     }
 

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -476,4 +476,14 @@ return [
          */
         'driver' => Nuwave\Lighthouse\Tracing\ApolloTracing\ApolloTracing::class,
     ],
+
+    /*
+    | No Location on query parsing
+    |--------------------------------------------------------------------------
+    | By default, the parser creates AST nodes that know the location in the source that they correspond to.
+    | This configuration flag, if set to true, disables that behavior for performance or testing.
+    | see: https://webonyx.github.io/graphql-php/class-reference/#graphqllanguageparser
+    */
+
+    'no_location_on_query_parse' => false,
 ];

--- a/tests/Integration/Validation/ValidationTest.php
+++ b/tests/Integration/Validation/ValidationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Integration\Validation;
 
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator as ValidatorFactory;
@@ -20,6 +21,7 @@ final class ValidationTest extends TestCase
     {
         parent::getEnvironmentSetUp($app);
 
+        /** @var ConfigRepository $config */
         $config = $app->make(ConfigRepository::class);
         // Ensure we test for the result the end user receives
         $config->set('app.debug', false);
@@ -89,6 +91,47 @@ final class ValidationTest extends TestCase
                 ],
             ]);
     }
+
+    public function testFullValidationErrorWithoutLocationParse(): void
+    {
+        /** @var ConfigRepository $config */
+        $config = Container::getInstance()->make(ConfigRepository::class);
+        $config->set('lighthouse.no_location_on_query_parse', true);
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo(
+                bar: String @rules(apply: ["required"])
+            ): Int
+        }
+        ';
+
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            {
+                foo
+            }
+            ')
+            ->assertExactJson([
+                'errors' => [
+                    [
+                        'message' => 'Validation failed for the field [foo].',
+                        'extensions' => [
+                            'category' => ValidationException::CATEGORY,
+                            ValidationException::CATEGORY => [
+                                'bar' => [
+                                    'The bar field is required.',
+                                ],
+                            ],
+                        ],
+                        'path' => ['foo'],
+                    ],
+                ],
+                'data' => [
+                    'foo' => null,
+                ],
+            ]);
+    }
+
 
     public function testRunsOnNonRootFields(): void
     {


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
 
- [x] Added or updated tests
- [x] Documented user-facing changes
- [ ] Updated CHANGELOG.md

Solves #2496 by putting a configurable option to remove the location from the parsed AST. to improve performances or to avoid segmentation faults on large payloads.

<!-- Detail the changes in behavior this PR introduces. -->

**Breaking changes**

No breaking changes, the default behavior remains unchanged.

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
