### PR TITLE
Add `@async` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v6.32.0
+
+### Added
+
+- Add `@async` directive https://github.com/nuwave/lighthouse/pull/2501
+
+### Changed
+
+- Move and rename `Nuwave\Lighthouse\Subscriptions\Contracts\ContextSerializer` to `Nuwave\Lighthouse\Support\Contracts\SerializesContext` https://github.com/nuwave/lighthouse/pull/2501
+- Do not bind `CreatesContext` and `CanStreamResponse` as singletons https://github.com/nuwave/lighthouse/pull/2501
+
+### Fixed
+
+- Fix parsing reserialized `LaravelEnumType` from `ResolveInfo::$variableValues` https://github.com/nuwave/lighthouse/pull/2501
+
 ## v6.31.1
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -108,6 +108,7 @@
         "laravel": {
             "providers": [
                 "Nuwave\\Lighthouse\\LighthouseServiceProvider",
+                "Nuwave\\Lighthouse\\Async\\AsyncServiceProvider",
                 "Nuwave\\Lighthouse\\Auth\\AuthServiceProvider",
                 "Nuwave\\Lighthouse\\Cache\\CacheServiceProvider",
                 "Nuwave\\Lighthouse\\GlobalId\\GlobalIdServiceProvider",

--- a/docs/6/api-reference/directives.md
+++ b/docs/6/api-reference/directives.md
@@ -148,6 +148,30 @@ type Query {
 }
 ```
 
+## @async
+
+```graphql
+"""
+Defer the execution of mutations to [queued jobs](https://laravel.com/docs/queues).
+
+This directive must only be used on fields of the root mutation type.
+When the field is executed, a `Nuwave\Lighthouse\Async\AsyncMutation` job is dispatched
+and the value `true` is returned - thus the fields return type must be `Boolean!`.
+
+Once a [queue worker](https://laravel.com/docs/queues#running-the-queue-worker) picks up the job,
+it will actually execute the underlying field resolver.
+The result is not checked for errors, ensure your GraphQL error handling reports relevant exceptions.
+"""
+directive @async(
+  """
+  Name of the queue to dispatch the job on.
+  If not specified, jobs will be dispatched to the default queue.
+  See https://laravel.com/docs/queues#customizing-the-queue-and-connection.
+  """
+  queue: String
+) on FIELD_DEFINITION
+```
+
 ## @auth
 
 ```graphql

--- a/docs/6/custom-directives/input-field-directives.md
+++ b/docs/6/custom-directives/input-field-directives.md
@@ -21,7 +21,7 @@ final class TranslateDescriptionDirective extends BaseDirective implements Input
     {
         return /** @lang GraphQL */ <<<'GRAPHQL'
 """
-Extends the description with automatic translations. 
+Extends the description with automatic translations.
 """
 directive @translateDescription on INPUT_FIELD_DEFINITION
 GRAPHQL;

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -163,12 +163,12 @@ it will actually execute the underlying field resolver.
 The result is not checked for errors, ensure your GraphQL error handling reports relevant exceptions.
 """
 directive @async(
-    """
-    Name of the queue to dispatch the job on.
-    If not specified, jobs will be dispatched to the default queue.
-    See https://laravel.com/docs/queues#customizing-the-queue-and-connection.
-    """
-    queue: String
+  """
+  Name of the queue to dispatch the job on.
+  If not specified, jobs will be dispatched to the default queue.
+  See https://laravel.com/docs/queues#customizing-the-queue-and-connection.
+  """
+  queue: String
 ) on FIELD_DEFINITION
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -148,6 +148,30 @@ type Query {
 }
 ```
 
+## @async
+
+```graphql
+"""
+Defer the execution of mutations to [queued jobs](https://laravel.com/docs/queues).
+
+This directive must only be used on fields of the root mutation type.
+When the field is executed, a `Nuwave\Lighthouse\Async\AsyncMutation` job is dispatched
+and the value `true` is returned - thus the fields return type must be `Boolean!`.
+
+Once a [queue worker](https://laravel.com/docs/queues#running-the-queue-worker) picks up the job,
+it will actually execute the underlying field resolver.
+The result is not checked for errors, ensure your GraphQL error handling reports relevant exceptions.
+"""
+directive @async(
+    """
+    Name of the queue to dispatch the job on.
+    If not specified, jobs will be dispatched to the default queue.
+    See https://laravel.com/docs/queues#customizing-the-queue-and-connection.
+    """
+    queue: String
+) on FIELD_DEFINITION
+```
+
 ## @auth
 
 ```graphql

--- a/docs/master/custom-directives/input-field-directives.md
+++ b/docs/master/custom-directives/input-field-directives.md
@@ -21,7 +21,7 @@ final class TranslateDescriptionDirective extends BaseDirective implements Input
     {
         return /** @lang GraphQL */ <<<'GRAPHQL'
 """
-Extends the description with automatic translations. 
+Extends the description with automatic translations.
 """
 directive @translateDescription on INPUT_FIELD_DEFINITION
 GRAPHQL;

--- a/src/Async/AsyncDirective.php
+++ b/src/Async/AsyncDirective.php
@@ -41,7 +41,6 @@ GRAPHQL;
                 $serializedContext = $contextSerializer->serialize($context);
 
                 AsyncMutation::dispatch(
-                    $args,
                     $serializedContext,
                     $resolveInfo->fragments,
                     $resolveInfo->operation,

--- a/src/Async/AsyncDirective.php
+++ b/src/Async/AsyncDirective.php
@@ -32,7 +32,7 @@ GRAPHQL;
 
     public function handleField(FieldValue $fieldValue): void
     {
-        $fieldValue->wrapResolver(fn (callable $resolver): \Closure => function (mixed $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($resolver) {
+        $fieldValue->wrapResolver(fn (callable $resolver): \Closure => function (mixed $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($resolver): bool {
             if ($root instanceof AsyncRoot) {
                 $resolver($root, $args, $context, $resolveInfo);
             } else {

--- a/src/Async/AsyncDirective.php
+++ b/src/Async/AsyncDirective.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Async;
+
+use GraphQL\Language\AST\FieldDefinitionNode;
+use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
+use Nuwave\Lighthouse\Execution\ResolveInfo;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Nuwave\Lighthouse\Schema\RootType;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
+use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+
+class AsyncDirective extends BaseDirective implements FieldMiddleware, FieldManipulator
+{
+    public static function definition(): string
+    {
+        return <<<GRAPHQL
+"Dispatches a mutation to be "
+directive @async(
+    "Name of the queue to dispatch the job on."
+    queue: String
+) on FIELD_DEFINITION
+GRAPHQL;
+    }
+
+    public function handleField(FieldValue $fieldValue): void
+    {
+        $fieldValue->wrapResolver(fn (callable $resolver): \Closure => function (mixed $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($resolver): bool {
+            dispatch(static fn (): mixed => $resolver($root, $args, $context, $resolveInfo))
+                ->onQueue($this->directiveArgValue('queue'));
+
+            return true;
+        });
+    }
+
+    public function manipulateFieldDefinition(DocumentAST &$documentAST, FieldDefinitionNode &$fieldDefinition, ObjectTypeDefinitionNode|InterfaceTypeDefinitionNode &$parentType): void
+    {
+        $parentName = $parentType->name->value;
+        if ($parentName !== RootType::MUTATION) {
+            $location = "{$parentName}.{$fieldDefinition->name->value}";
+            throw new DefinitionException("The @async directive must only be used on fields of the root type mutation, found it on {$location}.");
+        }
+    }
+}

--- a/src/Async/AsyncDirective.php
+++ b/src/Async/AsyncDirective.php
@@ -22,9 +22,23 @@ class AsyncDirective extends BaseDirective implements FieldMiddleware, FieldMani
     public static function definition(): string
     {
         return <<<GRAPHQL
-"Dispatches a mutation to be executed later as a job."
+"""
+Defer the execution of mutations to [queued jobs](https://laravel.com/docs/queues).
+
+This directive must only be used on fields of the root mutation type.
+When the field is executed, a `Nuwave\Lighthouse\Async\AsyncMutation` job is dispatched
+and the value `true` is returned - thus the fields return type must be `Boolean!`.
+
+Once a [queue worker](https://laravel.com/docs/queues#running-the-queue-worker) picks up the job,
+it will actually execute the underlying field resolver.
+The result is not checked for errors, ensure your GraphQL error handling reports relevant exceptions.
+"""
 directive @async(
-    "Name of the queue to dispatch the job on."
+    """
+    Name of the queue to dispatch the job on.
+    If not specified, jobs will be dispatched to the default queue.
+    See https://laravel.com/docs/queues#customizing-the-queue-and-connection.
+    """
     queue: String
 ) on FIELD_DEFINITION
 GRAPHQL;

--- a/src/Async/AsyncMutation.php
+++ b/src/Async/AsyncMutation.php
@@ -21,9 +21,10 @@ class AsyncMutation implements ShouldQueue
 
     public function __construct(
         public string $serializedContext,
-        /** array<string, FragmentDefinitionNode> */
+        /** @var array<string, FragmentDefinitionNode> */
         public array $fragments,
         public OperationDefinitionNode $operation,
+        /** @var array<string, mixed> */
         public array $variableValues,
     ) {}
 

--- a/src/Async/AsyncMutation.php
+++ b/src/Async/AsyncMutation.php
@@ -20,8 +20,6 @@ class AsyncMutation implements ShouldQueue
     use Queueable;
 
     public function __construct(
-        /** @var array<string, mixed> */
-        public array $args,
         public string $serializedContext,
         /** array<string, FragmentDefinitionNode> */
         public array $fragments,

--- a/src/Async/AsyncMutation.php
+++ b/src/Async/AsyncMutation.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Async;
+
+use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Language\AST\FragmentDefinitionNode;
+use GraphQL\Language\AST\NodeList;
+use GraphQL\Language\AST\OperationDefinitionNode;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Nuwave\Lighthouse\GraphQL;
+use Nuwave\Lighthouse\Support\Contracts\SerializesContext;
+
+class AsyncMutation implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+
+    public function __construct(
+        /** @var array<string, mixed> */
+        public array $args,
+        public string $serializedContext,
+        /** array<string, FragmentDefinitionNode> */
+        public array $fragments,
+        public OperationDefinitionNode $operation,
+        public array $variableValues,
+    ) {}
+
+    public function handle(GraphQL $graphQL, SerializesContext $serializesContext): void
+    {
+        $graphQL->executeParsedQuery(
+            $this->query(),
+            $serializesContext->unserialize($this->serializedContext),
+            $this->variableValues,
+            AsyncRoot::instance(),
+            $this->operation->name?->value,
+        );
+    }
+
+    protected function query(): DocumentNode
+    {
+        return new DocumentNode([
+            'definitions' => new NodeList(array_merge(
+                $this->fragments,
+                [$this->operation],
+            )),
+        ]);
+    }
+}

--- a/src/Async/AsyncRoot.php
+++ b/src/Async/AsyncRoot.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Async;
+
+/** Used as a marker to signify we are running an async mutation. */
+class AsyncRoot
+{
+    public static function instance(): static
+    {
+        static $instance;
+
+        return $instance ??= new static();
+    }
+
+    protected function __construct() {}
+}

--- a/src/Async/AsyncServiceProvider.php
+++ b/src/Async/AsyncServiceProvider.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Async;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\ServiceProvider;
+use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
+
+class AsyncServiceProvider extends ServiceProvider
+{
+    public function boot(Dispatcher $dispatcher): void
+    {
+        $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
+    }
+}

--- a/src/Execution/ContextSerializer.php
+++ b/src/Execution/ContextSerializer.php
@@ -1,15 +1,15 @@
 <?php declare(strict_types=1);
 
-namespace Nuwave\Lighthouse\Subscriptions;
+namespace Nuwave\Lighthouse\Execution;
 
 use Illuminate\Http\Request;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 use Illuminate\Support\Arr;
-use Nuwave\Lighthouse\Subscriptions\Contracts\ContextSerializer;
 use Nuwave\Lighthouse\Support\Contracts\CreatesContext;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+use Nuwave\Lighthouse\Support\Contracts\SerializesContext;
 
-class Serializer implements ContextSerializer
+class ContextSerializer implements SerializesContext
 {
     use SerializesAndRestoresModelIdentifiers;
 

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -87,13 +87,9 @@ class GraphQL
     }
 
     /**
-     * Execute a GraphQL query on the Lighthouse schema and return the raw result.
+     * Execute a GraphQL query on the Lighthouse schema and return the serializable result.
      *
      * @api
-     *
-     * To render the @see ExecutionResult
-     * you will probably want to call `->toArray($debug)` on it,
-     * with $debug being a combination of flags in @see DebugFlag
      *
      * @param  array<string, mixed>|null  $variables
      *

--- a/src/LighthouseServiceProvider.php
+++ b/src/LighthouseServiceProvider.php
@@ -28,6 +28,7 @@ use Nuwave\Lighthouse\Console\ValidateSchemaCommand;
 use Nuwave\Lighthouse\Console\ValidatorCommand;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 use Nuwave\Lighthouse\Execution\ContextFactory;
+use Nuwave\Lighthouse\Execution\ContextSerializer;
 use Nuwave\Lighthouse\Execution\ErrorPool;
 use Nuwave\Lighthouse\Execution\SingleResponse;
 use Nuwave\Lighthouse\Execution\ValidationRulesProvider;
@@ -47,6 +48,7 @@ use Nuwave\Lighthouse\Support\Contracts\CreatesResponse;
 use Nuwave\Lighthouse\Support\Contracts\ProvidesResolver;
 use Nuwave\Lighthouse\Support\Contracts\ProvidesSubscriptionResolver;
 use Nuwave\Lighthouse\Support\Contracts\ProvidesValidationRules;
+use Nuwave\Lighthouse\Support\Contracts\SerializesContext;
 
 class LighthouseServiceProvider extends ServiceProvider
 {
@@ -78,9 +80,10 @@ class LighthouseServiceProvider extends ServiceProvider
         $this->app->singleton(DirectiveLocator::class);
         $this->app->singleton(TypeRegistry::class);
         $this->app->singleton(ErrorPool::class);
-        $this->app->singleton(CreatesContext::class, ContextFactory::class);
-        $this->app->singleton(CanStreamResponse::class, ResponseStream::class);
 
+        $this->app->bind(CanStreamResponse::class, ResponseStream::class);
+        $this->app->bind(CreatesContext::class, ContextFactory::class);
+        $this->app->bind(SerializesContext::class, ContextSerializer::class);
         $this->app->bind(CreatesResponse::class, SingleResponse::class);
 
         $this->app->singleton(SchemaSourceProvider::class, static fn (): SchemaStitcher => new SchemaStitcher(

--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -243,8 +243,8 @@ class ASTBuilder
                 }
             }
         }
-    }    
-    
+    }
+
     /** Apply directives on input fields that can manipulate the AST. */
     protected function applyInputFieldManipulators(): void
     {

--- a/src/Schema/Types/LaravelEnumType.php
+++ b/src/Schema/Types/LaravelEnumType.php
@@ -151,4 +151,13 @@ class LaravelEnumType extends EnumType
 
         return $key;
     }
+
+    public function parseValue($value)
+    {
+        if ($value instanceof $this->enumClass) {
+            return $value;
+        }
+
+        return parent::parseValue($value);
+    }
 }

--- a/src/Subscriptions/Storage/CacheStorageManager.php
+++ b/src/Subscriptions/Storage/CacheStorageManager.php
@@ -21,10 +21,8 @@ class CacheStorageManager implements StoresSubscriptions
     /** The cache to store channels and topics. */
     protected CacheRepository $cache;
 
-    /**
-     * The time to live for items in the cache.
-     */
-    protected int|null $ttl = null;
+    /** The time to live for items in the cache. */
+    protected ?int $ttl = null;
 
     public function __construct(CacheFactory $cacheFactory, ConfigRepository $config)
     {

--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -29,10 +29,8 @@ class RedisStorageManager implements StoresSubscriptions
 
     protected RedisConnection $connection;
 
-    /**
-     * The time to live in seconds for items in the cache.
-     */
-    protected int|null $ttl = null;
+    /** The time to live in seconds for items in the cache. */
+    protected ?int $ttl = null;
 
     public function __construct(ConfigRepository $config, RedisFactory $redis)
     {

--- a/src/Subscriptions/Subscriber.php
+++ b/src/Subscriptions/Subscriber.php
@@ -8,8 +8,8 @@ use GraphQL\Utils\AST;
 use Illuminate\Container\Container;
 use Illuminate\Support\Str;
 use Nuwave\Lighthouse\Execution\ResolveInfo;
-use Nuwave\Lighthouse\Subscriptions\Contracts\ContextSerializer;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+use Nuwave\Lighthouse\Support\Contracts\SerializesContext;
 
 class Subscriber
 {
@@ -122,8 +122,8 @@ class Subscriber
         return 'private-lighthouse-' . Str::random(32) . '-' . time();
     }
 
-    protected function contextSerializer(): ContextSerializer
+    protected function contextSerializer(): SerializesContext
     {
-        return Container::getInstance()->make(ContextSerializer::class);
+        return Container::getInstance()->make(SerializesContext::class);
     }
 }

--- a/src/Subscriptions/Subscriber.php
+++ b/src/Subscriptions/Subscriber.php
@@ -33,9 +33,7 @@ class Subscriber
     /**
      * The name of the queried field.
      *
-     * Guaranteed be be unique because of
-     *
-     * @see \GraphQL\Validator\Rules\SingleFieldSubscription
+     * Guaranteed to be unique because of @see \GraphQL\Validator\Rules\SingleFieldSubscription
      */
     public string $fieldName;
 
@@ -56,9 +54,7 @@ class Subscriber
          * @var array<string, mixed> $args
          */
         public array $args,
-        /**
-         * The context passed to the query.
-         */
+        /** The context passed to the query. */
         public GraphQLContext $context,
         ResolveInfo $resolveInfo,
     ) {

--- a/src/Subscriptions/SubscriptionRegistry.php
+++ b/src/Subscriptions/SubscriptionRegistry.php
@@ -14,8 +14,8 @@ use Nuwave\Lighthouse\Execution\ExtensionsResponse;
 use Nuwave\Lighthouse\Schema\SchemaBuilder;
 use Nuwave\Lighthouse\Schema\Types\GraphQLSubscription;
 use Nuwave\Lighthouse\Schema\Types\NotFoundSubscription;
-use Nuwave\Lighthouse\Subscriptions\Contracts\ContextSerializer;
 use Nuwave\Lighthouse\Subscriptions\Contracts\StoresSubscriptions;
+use Nuwave\Lighthouse\Support\Contracts\SerializesContext;
 use Nuwave\Lighthouse\Support\Utils;
 
 class SubscriptionRegistry
@@ -35,7 +35,7 @@ class SubscriptionRegistry
     protected array $subscriptions = [];
 
     public function __construct(
-        protected ContextSerializer $serializer,
+        protected SerializesContext $serializer,
         protected StoresSubscriptions $storage,
         protected SchemaBuilder $schemaBuilder,
         protected ConfigRepository $configRepository,

--- a/src/Subscriptions/SubscriptionServiceProvider.php
+++ b/src/Subscriptions/SubscriptionServiceProvider.php
@@ -13,7 +13,6 @@ use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 use Nuwave\Lighthouse\Events\StartExecution;
 use Nuwave\Lighthouse\Subscriptions\Contracts\AuthorizesSubscriptions;
 use Nuwave\Lighthouse\Subscriptions\Contracts\BroadcastsSubscriptions;
-use Nuwave\Lighthouse\Subscriptions\Contracts\ContextSerializer;
 use Nuwave\Lighthouse\Subscriptions\Contracts\StoresSubscriptions;
 use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionExceptionHandler;
 use Nuwave\Lighthouse\Subscriptions\Contracts\SubscriptionIterator;
@@ -38,7 +37,6 @@ class SubscriptionServiceProvider extends ServiceProvider
             };
         });
 
-        $this->app->bind(ContextSerializer::class, Serializer::class);
         $this->app->bind(AuthorizesSubscriptions::class, Authorizer::class);
         $this->app->bind(SubscriptionIterator::class, SyncIterator::class);
         $this->app->bind(SubscriptionExceptionHandler::class, ExceptionHandler::class);

--- a/src/Support/Contracts/SerializesContext.php
+++ b/src/Support/Contracts/SerializesContext.php
@@ -1,10 +1,8 @@
 <?php declare(strict_types=1);
 
-namespace Nuwave\Lighthouse\Subscriptions\Contracts;
+namespace Nuwave\Lighthouse\Support\Contracts;
 
-use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
-
-interface ContextSerializer
+interface SerializesContext
 {
     /** Serialize the context. */
     public function serialize(GraphQLContext $context): string;

--- a/tests/Integration/Async/AsyncDirectiveTest.php
+++ b/tests/Integration/Async/AsyncDirectiveTest.php
@@ -14,7 +14,7 @@ final class AsyncDirectiveTest extends DBTestCase
 {
     public function testDispatchesMutation(): void
     {
-        $this->mockResolver(fn (mixed $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) => null);
+        $this->mockResolver(static fn (mixed $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) => null);
 
         $this->schema .= /** @lang GraphQL */ '
         type Mutation {
@@ -46,7 +46,7 @@ final class AsyncDirectiveTest extends DBTestCase
 
     public function testDispatchesMutationOnCustomQueue(): void
     {
-        $this->mockResolver(fn (mixed $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) => null);
+        $this->mockResolver(static fn (mixed $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) => null);
 
         $this->schema .= /** @lang GraphQL */ '
         type Mutation {
@@ -80,7 +80,7 @@ final class AsyncDirectiveTest extends DBTestCase
     public function testOnlyOnMutations(): void
     {
         $this->expectExceptionObject(new DefinitionException(
-            'The @async directive must only be used on fields of the root type mutation, found it on Query.foo.'
+            'The @async directive must only be used on fields of the root type mutation, found it on Query.foo.',
         ));
         $this->buildSchema(/** @lang GraphQL */ '
         type Query {

--- a/tests/Integration/Async/AsyncDirectiveTest.php
+++ b/tests/Integration/Async/AsyncDirectiveTest.php
@@ -5,6 +5,7 @@ namespace Tests\Integration\Async;
 use Illuminate\Container\Container;
 use Illuminate\Support\Facades\Queue;
 use Nuwave\Lighthouse\Async\AsyncMutation;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Execution\ResolveInfo;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 use Tests\DBTestCase;
@@ -74,5 +75,17 @@ final class AsyncDirectiveTest extends DBTestCase
             assert($jobCycledThroughSerialization instanceof AsyncMutation);
             Container::getInstance()->call([$jobCycledThroughSerialization, 'handle']);
         }
+    }
+
+    public function testOnlyOnMutations(): void
+    {
+        $this->expectExceptionObject(new DefinitionException(
+            'The @async directive must only be used on fields of the root type mutation, found it on Query.foo.'
+        ));
+        $this->buildSchema(/** @lang GraphQL */ '
+        type Query {
+            foo: Boolean! @async
+        }
+        ');
     }
 }

--- a/tests/Integration/Async/AsyncDirectiveTest.php
+++ b/tests/Integration/Async/AsyncDirectiveTest.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Integration\Async;
+
+use Illuminate\Queue\CallQueuedClosure;
+use Illuminate\Support\Facades\Queue;
+use Tests\DBTestCase;
+
+final class AsyncDirectiveTest extends DBTestCase
+{
+    public function testDispatchesMutation(): void
+    {
+        $this->mockResolver('bar');
+
+        $this->schema .= /** @lang GraphQL */ '
+        type Mutation {
+            fooAsync: Boolean! @mock @async
+        }
+        ';
+
+        $queue = Queue::fake();
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            fooAsync
+        }
+        ')->assertExactJson([
+            'data' => [
+                'fooAsync' => true,
+            ],
+        ]);
+
+        $jobs = $queue->pushed(CallQueuedClosure::class);
+        $this->assertCount(1, $jobs);
+        foreach ($jobs as $job) {
+            assert($job instanceof CallQueuedClosure);
+            $job->handle($this->app);
+        }
+    }
+
+    public function testDispatchesMutationOnCustomQueue(): void
+    {
+        $this->mockResolver('bar');
+
+        $this->schema .= /** @lang GraphQL */ '
+        type Mutation {
+            fooAsync: Boolean! @mock @async(queue: "custom")
+        }
+        ';
+
+        $queue = Queue::fake();
+        $this->graphQL(/** @lang GraphQL */ '
+        mutation {
+            fooAsync
+        }
+        ')->assertExactJson([
+            'data' => [
+                'fooAsync' => true,
+            ],
+        ]);
+
+        $jobs = $queue->pushed(CallQueuedClosure::class);
+        $this->assertCount(1, $jobs);
+        foreach ($jobs as $job) {
+            assert($job instanceof CallQueuedClosure);
+            $this->assertSame('custom', $job->queue);
+            $job->handle($this->app);
+        }
+    }
+}

--- a/tests/Integration/Subscriptions/SerializerTest.php
+++ b/tests/Integration/Subscriptions/SerializerTest.php
@@ -4,7 +4,7 @@ namespace Tests\Integration\Subscriptions;
 
 use Illuminate\Http\Request;
 use Nuwave\Lighthouse\Execution\ContextFactory;
-use Nuwave\Lighthouse\Subscriptions\Serializer;
+use Nuwave\Lighthouse\Execution\ContextSerializer;
 use Tests\DBTestCase;
 use Tests\EnablesSubscriptionServiceProvider;
 use Tests\Utils\Models\User;
@@ -18,7 +18,7 @@ final class SerializerTest extends DBTestCase
         $user = factory(User::class)->create();
 
         $contextFactory = new ContextFactory();
-        $serializer = new Serializer($contextFactory);
+        $serializer = new ContextSerializer($contextFactory);
 
         $request = new Request();
         $request->setUserResolver(static fn () => $user);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Redis\RedisServiceProvider;
 use Laravel\Scout\ScoutServiceProvider as LaravelScoutServiceProvider;
+use Nuwave\Lighthouse\Async\AsyncServiceProvider;
 use Nuwave\Lighthouse\Auth\AuthServiceProvider as LighthouseAuthServiceProvider;
 use Nuwave\Lighthouse\Cache\CacheServiceProvider;
 use Nuwave\Lighthouse\CacheControl\CacheControlServiceProvider;
@@ -78,6 +79,7 @@ GRAPHQL;
 
             // Lighthouse's own
             LighthouseServiceProvider::class,
+            AsyncServiceProvider::class,
             LighthouseAuthServiceProvider::class,
             CacheServiceProvider::class,
             CacheControlServiceProvider::class,

--- a/tests/TestsSerialization.php
+++ b/tests/TestsSerialization.php
@@ -6,15 +6,15 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Http\Request;
-use Nuwave\Lighthouse\Subscriptions\Contracts\ContextSerializer;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+use Nuwave\Lighthouse\Support\Contracts\SerializesContext;
 use Tests\Utils\Models\User;
 
 trait TestsSerialization
 {
     protected function fakeContextSerializer(): void
     {
-        $contextSerializer = new class() implements ContextSerializer {
+        $contextSerializer = new class() implements SerializesContext {
             public function serialize(GraphQLContext $context): string
             {
                 return 'foo';
@@ -38,7 +38,7 @@ trait TestsSerialization
             }
         };
 
-        Container::getInstance()->instance(ContextSerializer::class, $contextSerializer);
+        Container::getInstance()->instance(SerializesContext::class, $contextSerializer);
     }
 
     protected function useSerializingArrayStore(): void

--- a/tests/Utils/Models/User.php
+++ b/tests/Utils/Models/User.php
@@ -129,7 +129,7 @@ final class User extends Authenticatable
         return $this->belongsTo(Team::class);
     }
 
-    public function getCompanyNameAttribute(): string|null
+    public function getCompanyNameAttribute(): ?string
     {
         return $this->company?->name;
     }

--- a/tests/Utils/Queries/MissingInvoke.php
+++ b/tests/Utils/Queries/MissingInvoke.php
@@ -2,7 +2,5 @@
 
 namespace Tests\Utils\Queries;
 
-/**
- * This class intentionally misses a resolver function __invoke().
- */
+/** This class intentionally misses a resolver function __invoke(). */
 final class MissingInvoke {}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Add the `@async` directive to postpone execution of a mutation through a job.

**Breaking changes**

None in public APIs, but I did change the following:
- Move and rename `Nuwave\Lighthouse\Subscriptions\Contracts\ContextSerializer` to `Nuwave\Lighthouse\Support\Contracts\SerializesContext`
- Do not bind `CreatesContext` and `CanStreamResponse` as singletons
