### PR TITLE
Fixed build command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ setup: build docs/node_modules vendor ## Setup the local environment
 
 .PHONY: build
 build: ## Build the local Docker containers
-	docker-compose build --pull --build-arg USER_ID=$(shell id --user) --build-arg GROUP_ID=$(shell id --group)
+	docker-compose build --pull --build-arg USER_ID=$(shell id -u) --build-arg GROUP_ID=$(shell id -g)
 
 .PHONY: up
 up: ## Bring up the docker-compose stack


### PR DESCRIPTION
Resolves #2503

- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

If updating `CHANGELOG.md` is necessary, could you tell me that?
I'll update it, too.

**Changes**

Changed `id` command options in `Makefile` to finish successfully both macOS and Linux.

**Notes**

I checked that `make setup` finished successfully on macOS, but I've not checked whether `make setup` also finish successfully on Linux.
The environment I checked is below.

- OS: macOS 13.6.4 (22G513)
- processor: 2.3 GHz Dual-Core Intel Core i5
- docker-compose: v2.23.3-desktop.2
- make: GNU Make 3.81
