### PR TITLE
Remove Request from the ThrottleDirective constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Fix `ThrottleDirective` to not reuse the first `Request` it had encountered https://github.com/nuwave/lighthouse/pull/2511
+
 ## v6.33.0
 
 ### Added

--- a/src/Schema/Directives/ThrottleDirective.php
+++ b/src/Schema/Directives/ThrottleDirective.php
@@ -63,7 +63,7 @@ GRAPHQL;
 
         $fieldValue->wrapResolver(fn (callable $resolver): \Closure => function (mixed $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($resolver, $name, $prefix, $maxAttempts, $decayMinutes): mixed {
             $request = $context->request();
-            if ($request == null){
+            if ($request == null) {
                 return $resolver($root, $args, $context, $resolveInfo);
             }
 

--- a/src/Schema/Directives/ThrottleDirective.php
+++ b/src/Schema/Directives/ThrottleDirective.php
@@ -7,7 +7,6 @@ use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Unlimited;
-use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Exceptions\RateLimitException;
@@ -23,7 +22,6 @@ class ThrottleDirective extends BaseDirective implements FieldMiddleware, FieldM
 {
     public function __construct(
         protected RateLimiter $limiter,
-        protected Request $request,
     ) {}
 
     public static function definition(): string
@@ -58,45 +56,44 @@ GRAPHQL;
 
     public function handleField(FieldValue $fieldValue): void
     {
-        /** @var array<int, array{key: string, maxAttempts: int, decayMinutes: float}> $limits */
-        $limits = [];
-
         $name = $this->directiveArgValue('name');
-        if ($name !== null) {
-            // @phpstan-ignore-next-line limiter() can actually return null, some Laravel versions lie
-            $limiter = $this->limiter->limiter($name)
-                ?? throw new DefinitionException("Named limiter {$name} not found.");
+        $prefix = $this->directiveArgValue('prefix', '');
+        $maxAttempts = $this->directiveArgValue('maxAttempts', 60);
+        $decayMinutes = $this->directiveArgValue('decayMinutes', 1.0);
 
-            $limiterResponse = $limiter($this->request);
-            if ($limiterResponse instanceof Unlimited) {
-                return;
+        $fieldValue->wrapResolver(fn (callable $resolver): \Closure => function (mixed $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($resolver, $name, $prefix, $maxAttempts, $decayMinutes): mixed {
+            $request = $context->request();
+            if ($request == null){
+                return $resolver($root, $args, $context, $resolveInfo);
             }
 
-            if ($limiterResponse instanceof Response) {
-                throw new DefinitionException("Expected named limiter {$name} to return an array, got instance of " . $limiterResponse::class);
-            }
+            if ($name !== null) {
+                // @phpstan-ignore-next-line limiter() can actually return null, some Laravel versions lie
+                $limiter = $this->limiter->limiter($name)
+                    ?? throw new DefinitionException("Named limiter {$name} not found.");
 
-            foreach (Arr::wrap($limiterResponse) as $limit) {
-                $limits[] = [
-                    'key' => sha1($name . $limit->key),
-                    'maxAttempts' => $limit->maxAttempts,
-                    'decayMinutes' => $limit->decayMinutes,
-                ];
-            }
-        } else {
-            $limits[] = [
-                'key' => sha1($this->directiveArgValue('prefix') . $this->request->ip()),
-                'maxAttempts' => $this->directiveArgValue('maxAttempts', 60),
-                'decayMinutes' => $this->directiveArgValue('decayMinutes', 1.0),
-            ];
-        }
+                $limiterResponse = $limiter($request);
+                if ($limiterResponse instanceof Unlimited) {
+                    return $resolver($root, $args, $context, $resolveInfo);
+                }
 
-        $fieldValue->wrapResolver(fn (callable $resolver): \Closure => function (mixed $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($resolver, $limits) {
-            foreach ($limits as $limit) {
+                if ($limiterResponse instanceof Response) {
+                    throw new DefinitionException("Expected named limiter {$name} to return an array, got instance of " . $limiterResponse::class);
+                }
+
+                foreach (Arr::wrap($limiterResponse) as $limit) {
+                    $this->handleLimit(
+                        sha1($name . $limit->key),
+                        $limit->maxAttempts,
+                        $limit->decayMinutes,
+                        "{$resolveInfo->parentType}.{$resolveInfo->fieldName}",
+                    );
+                }
+            } else {
                 $this->handleLimit(
-                    $limit['key'],
-                    $limit['maxAttempts'],
-                    $limit['decayMinutes'],
+                    sha1($prefix . $request->ip()),
+                    $maxAttempts,
+                    $decayMinutes,
                     "{$resolveInfo->parentType}.{$resolveInfo->fieldName}",
                 );
             }

--- a/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Integration\Schema\Directives;
 
+use Faker\Factory;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Response;
@@ -58,27 +59,26 @@ final class ThrottleDirectiveTest extends TestCase
         }
         ';
 
+        $query = /** @lang GraphQL */ '
+        {
+            foo
+        }
+        ';
+
+
         $rateLimiter = $this->app->make(RateLimiter::class);
         $rateLimiter->for(
             'test',
             static fn (): Limit => Limit::perMinute(1),
         );
 
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            foo
-        }
-        ')->assertJson([
+        $this->graphQL($query)->assertJson([
             'data' => [
                 'foo' => Foo::THE_ANSWER,
             ],
         ]);
 
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            foo
-        }
-        ')->assertGraphQLError(
+        $this->graphQL($query)->assertGraphQLError(
             new RateLimitException('Query.foo'),
         );
     }
@@ -91,22 +91,30 @@ final class ThrottleDirectiveTest extends TestCase
         }
         ';
 
-        $this->graphQL(/** @lang GraphQL */ '
+        $query = /** @lang GraphQL */ '
         {
             foo
         }
-        ')->assertJson([
+        ';
+
+        $faker = Factory::create()->unique();
+        $ip = $faker->ipv4;
+        $ip2 = $faker->ipv4;
+
+        $this->graphQL($query, [], [], ['REMOTE_ADDR' => $ip])->assertJson([
             'data' => [
                 'foo' => Foo::THE_ANSWER,
             ],
         ]);
 
-        $this->graphQL(/** @lang GraphQL */ '
-        {
-            foo
-        }
-        ')->assertGraphQLError(
+        $this->graphQL($query, [], [], ['REMOTE_ADDR' => $ip])->assertGraphQLError(
             new RateLimitException('Query.foo'),
         );
+
+        $this->graphQL($query, [], [], ['REMOTE_ADDR' => $ip2])->assertJson([
+            'data' => [
+                'foo' => Foo::THE_ANSWER,
+            ],
+        ]);
     }
 }

--- a/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
@@ -65,7 +65,6 @@ final class ThrottleDirectiveTest extends TestCase
         }
         ';
 
-
         $rateLimiter = $this->app->make(RateLimiter::class);
         $rateLimiter->for(
             'test',


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Updated CHANGELOG.md

**Changes**

The PR fixes a case of "persistent" directive usage, when it is ran several times for different requests. This might happen in test or `Laravel Octane` environments. We can't get `Request` in the constructor in these cases. But must get it inside resolver from `GraphQLContext`
