### PR TITLE
Directives from Scalar/Enum/Input/Type/Interface extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
-- Merge directives from Scalar/Enum/Type/Input/Interface extension node into target node.
+### Added
+
+- Merge directives from Scalar/Enum/Type/Input/Interface extension node into target node https://github.com/nuwave/lighthouse/pull/2512
 
 ## v6.33.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+- Merge directives from Scalar/Enum/Type/Input/Interface extension node into target node.
+
 ## v6.33.4
 
 ### Fixed

--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -10,6 +10,8 @@ use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
 use GraphQL\Language\AST\InterfaceTypeExtensionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeExtensionNode;
+use GraphQL\Language\AST\ScalarTypeDefinitionNode;
+use GraphQL\Language\AST\ScalarTypeExtensionNode;
 use GraphQL\Language\AST\UnionTypeDefinitionNode;
 use GraphQL\Language\AST\UnionTypeExtensionNode;
 use GraphQL\Language\Parser;
@@ -33,6 +35,7 @@ class ASTBuilder
         ObjectTypeExtensionNode::class => ObjectTypeDefinitionNode::class,
         InputObjectTypeExtensionNode::class => InputObjectTypeDefinitionNode::class,
         InterfaceTypeExtensionNode::class => InterfaceTypeDefinitionNode::class,
+        ScalarTypeExtensionNode::class => ScalarTypeDefinitionNode::class,
         EnumTypeExtensionNode::class => EnumTypeDefinitionNode::class,
         UnionTypeExtensionNode::class => UnionTypeDefinitionNode::class,
     ];
@@ -122,6 +125,8 @@ class ASTBuilder
                     || $typeExtension instanceof InterfaceTypeExtensionNode
                 ) {
                     $this->extendObjectLikeType($typeName, $typeExtension);
+                } elseif ($typeExtension instanceof ScalarTypeExtensionNode) {
+                    $this->extendScalarType($typeName, $typeExtension);
                 } elseif ($typeExtension instanceof EnumTypeExtensionNode) {
                     $this->extendEnumType($typeName, $typeExtension);
                 } elseif ($typeExtension instanceof UnionTypeExtensionNode) {
@@ -166,6 +171,17 @@ class ASTBuilder
         }
     }
 
+    protected function extendScalarType(string $typeName, ScalarTypeExtensionNode $typeExtension): void
+    {
+        $extendedScalar = $this->documentAST->types[$typeName]
+            ?? throw new DefinitionException($this->missingBaseDefinition($typeName, $typeExtension));
+        assert($extendedScalar instanceof ScalarTypeDefinitionNode);
+
+        $this->assertExtensionMatchesDefinition($typeExtension, $extendedScalar);
+
+        $extendedScalar->directives = $extendedScalar->directives->merge($typeExtension->directives);
+    }
+
     protected function extendEnumType(string $typeName, EnumTypeExtensionNode $typeExtension): void
     {
         $extendedEnum = $this->documentAST->types[$typeName]
@@ -195,12 +211,12 @@ class ASTBuilder
         );
     }
 
-    protected function missingBaseDefinition(string $typeName, ObjectTypeExtensionNode|InputObjectTypeExtensionNode|InterfaceTypeExtensionNode|EnumTypeExtensionNode|UnionTypeExtensionNode $typeExtension): string
+    protected function missingBaseDefinition(string $typeName, ObjectTypeExtensionNode|InputObjectTypeExtensionNode|InterfaceTypeExtensionNode|ScalarTypeExtensionNode|EnumTypeExtensionNode|UnionTypeExtensionNode $typeExtension): string
     {
         return "Could not find a base definition {$typeName} of kind {$typeExtension->kind} to extend.";
     }
 
-    protected function assertExtensionMatchesDefinition(ObjectTypeExtensionNode|InputObjectTypeExtensionNode|InterfaceTypeExtensionNode|EnumTypeExtensionNode|UnionTypeExtensionNode $extension, ObjectTypeDefinitionNode|InputObjectTypeDefinitionNode|InterfaceTypeDefinitionNode|EnumTypeDefinitionNode|UnionTypeDefinitionNode $definition): void
+    protected function assertExtensionMatchesDefinition(ObjectTypeExtensionNode|InputObjectTypeExtensionNode|InterfaceTypeExtensionNode|ScalarTypeExtensionNode|EnumTypeExtensionNode|UnionTypeExtensionNode $extension, ObjectTypeDefinitionNode|InputObjectTypeDefinitionNode|InterfaceTypeDefinitionNode|ScalarTypeDefinitionNode|EnumTypeDefinitionNode|UnionTypeDefinitionNode $definition): void
     {
         if (static::EXTENSION_TO_DEFINITION_CLASS[$extension::class] !== $definition::class) {
             throw new DefinitionException("The type extension {$extension->name->value} of kind {$extension->kind} can not extend a definition of kind {$definition->kind}.");

--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -161,6 +161,7 @@ class ASTBuilder
             // @phpstan-ignore-next-line
             $typeExtension->fields,
         );
+        $extendedObjectLikeType->directives = $extendedObjectLikeType->directives->merge($typeExtension->directives);
 
         if ($extendedObjectLikeType instanceof ObjectTypeDefinitionNode) {
             assert($typeExtension instanceof ObjectTypeExtensionNode, 'We know this because we passed assertExtensionMatchesDefinition().');

--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -217,7 +217,10 @@ class ASTBuilder
         return "Could not find a base definition {$typeName} of kind {$typeExtension->kind} to extend.";
     }
 
-    protected function assertExtensionMatchesDefinition(ObjectTypeExtensionNode|InputObjectTypeExtensionNode|InterfaceTypeExtensionNode|ScalarTypeExtensionNode|EnumTypeExtensionNode|UnionTypeExtensionNode $extension, ObjectTypeDefinitionNode|InputObjectTypeDefinitionNode|InterfaceTypeDefinitionNode|ScalarTypeDefinitionNode|EnumTypeDefinitionNode|UnionTypeDefinitionNode $definition): void
+    protected function assertExtensionMatchesDefinition(
+        ObjectTypeExtensionNode|InputObjectTypeExtensionNode|InterfaceTypeExtensionNode|ScalarTypeExtensionNode|EnumTypeExtensionNode|UnionTypeExtensionNode $extension,
+        ObjectTypeDefinitionNode|InputObjectTypeDefinitionNode|InterfaceTypeDefinitionNode|ScalarTypeDefinitionNode|EnumTypeDefinitionNode|UnionTypeDefinitionNode $definition,
+    ): void
     {
         if (static::EXTENSION_TO_DEFINITION_CLASS[$extension::class] !== $definition::class) {
             throw new DefinitionException("The type extension {$extension->name->value} of kind {$extension->kind} can not extend a definition of kind {$definition->kind}.");

--- a/src/Schema/AST/ASTBuilder.php
+++ b/src/Schema/AST/ASTBuilder.php
@@ -174,6 +174,7 @@ class ASTBuilder
 
         $this->assertExtensionMatchesDefinition($typeExtension, $extendedEnum);
 
+        $extendedEnum->directives = $extendedEnum->directives->merge($typeExtension->directives);
         $extendedEnum->values = ASTHelper::mergeUniqueNodeList(
             $extendedEnum->values,
             $typeExtension->values,

--- a/tests/Unit/Schema/AST/ASTBuilderTest.php
+++ b/tests/Unit/Schema/AST/ASTBuilderTest.php
@@ -54,6 +54,35 @@ final class ASTBuilderTest extends TestCase
         $this->assertCount(3, $queryType->fields);
     }
 
+    public function testMergeTypeExtensionDirectives(): void
+    {
+        $directive = new class() extends BaseDirective {
+            public static function definition(): string
+            {
+                return /** @lang GraphQL */ 'directive @foo on OBJECT';
+            }
+        };
+
+        $directiveLocator = $this->app->make(DirectiveLocator::class);
+        $directiveLocator->setResolved('foo', $directive::class);
+
+        $this->schema = /** @lang GraphQL */ '
+        type MyType {
+            field: String
+        }
+
+        extend type MyType @foo
+
+        extend type MyType @foo
+        ';
+        $documentAST = $this->astBuilder->documentAST();
+
+        $myType = $documentAST->types['MyType'];
+        assert($myType instanceof ObjectTypeDefinitionNode);
+
+        $this->assertCount(2, $myType->directives);
+    }
+
     public function testAllowsExtendingUndefinedRootTypes(): void
     {
         $this->schema = /** @lang GraphQL */ '
@@ -110,6 +139,35 @@ final class ASTBuilderTest extends TestCase
         $this->assertCount(3, $inputs->fields);
     }
 
+    public function testMergeInputExtensionDirectives(): void
+    {
+        $directive = new class() extends BaseDirective {
+            public static function definition(): string
+            {
+                return /** @lang GraphQL */ 'directive @foo on INPUT_OBJECT';
+            }
+        };
+
+        $directiveLocator = $this->app->make(DirectiveLocator::class);
+        $directiveLocator->setResolved('foo', $directive::class);
+
+        $this->schema = /** @lang GraphQL */ '
+        input MyInput {
+            field: String
+        }
+
+        extend input MyInput @foo
+
+        extend input MyInput @foo
+        ';
+        $documentAST = $this->astBuilder->documentAST();
+
+        $myInput = $documentAST->types['MyInput'];
+        assert($myInput instanceof InputObjectTypeDefinitionNode);
+
+        $this->assertCount(2, $myInput->directives);
+    }
+
     public function testMergeInterfaceExtensionFields(): void
     {
         $this->schema = /** @lang GraphQL */ '
@@ -131,6 +189,35 @@ final class ASTBuilderTest extends TestCase
         assert($named instanceof InterfaceTypeDefinitionNode);
 
         $this->assertCount(3, $named->fields);
+    }
+
+    public function testMergeInterfaceExtensionDirectives(): void
+    {
+        $directive = new class() extends BaseDirective {
+            public static function definition(): string
+            {
+                return /** @lang GraphQL */ 'directive @foo on INTERFACE';
+            }
+        };
+
+        $directiveLocator = $this->app->make(DirectiveLocator::class);
+        $directiveLocator->setResolved('foo', $directive::class);
+
+        $this->schema = /** @lang GraphQL */ '
+        interface MyInterface {
+            field: String
+        }
+
+        extend interface MyInterface @foo
+
+        extend interface MyInterface @foo
+        ';
+        $documentAST = $this->astBuilder->documentAST();
+
+        $myInterface = $documentAST->types['MyInterface'];
+        assert($myInterface instanceof InterfaceTypeDefinitionNode);
+
+        $this->assertCount(2, $myInterface->directives);
     }
 
     public function testMergeScalarExtensionDirectives(): void

--- a/tests/Unit/Schema/AST/ASTBuilderTest.php
+++ b/tests/Unit/Schema/AST/ASTBuilderTest.php
@@ -18,8 +18,6 @@ use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Schema\RootType;
 use Tests\TestCase;
 
-use function assert;
-
 final class ASTBuilderTest extends TestCase
 {
     protected ASTBuilder $astBuilder;
@@ -59,7 +57,7 @@ final class ASTBuilderTest extends TestCase
         $directive = new class() extends BaseDirective {
             public static function definition(): string
             {
-                return /** @lang GraphQL */ 'directive @foo on OBJECT';
+                return /** @lang GraphQL */ 'directive @foo repeatable on OBJECT';
             }
         };
 
@@ -144,7 +142,7 @@ final class ASTBuilderTest extends TestCase
         $directive = new class() extends BaseDirective {
             public static function definition(): string
             {
-                return /** @lang GraphQL */ 'directive @foo on INPUT_OBJECT';
+                return /** @lang GraphQL */ 'directive @foo repeatable on INPUT_OBJECT';
             }
         };
 
@@ -196,7 +194,7 @@ final class ASTBuilderTest extends TestCase
         $directive = new class() extends BaseDirective {
             public static function definition(): string
             {
-                return /** @lang GraphQL */ 'directive @foo on INTERFACE';
+                return /** @lang GraphQL */ 'directive @foo repeatable on INTERFACE';
             }
         };
 
@@ -225,7 +223,7 @@ final class ASTBuilderTest extends TestCase
         $directive = new class() extends BaseDirective {
             public static function definition(): string
             {
-                return /** @lang GraphQL */ 'directive @foo on SCALAR';
+                return /** @lang GraphQL */ 'directive @foo repeatable on SCALAR';
             }
         };
 
@@ -276,7 +274,7 @@ final class ASTBuilderTest extends TestCase
         $directive = new class() extends BaseDirective {
             public static function definition(): string
             {
-                return /** @lang GraphQL */ 'directive @foo on ENUM';
+                return /** @lang GraphQL */ 'directive @foo repeatable on ENUM';
             }
         };
 
@@ -327,7 +325,7 @@ final class ASTBuilderTest extends TestCase
         $directive = new class() extends BaseDirective {
             public static function definition(): string
             {
-                return /** @lang GraphQL */ 'directive @foo on SCALAR';
+                return /** @lang GraphQL */ 'directive @foo repeatable on SCALAR';
             }
         };
 


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
 
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md
- [x] Closes: #2509  

**Changes**

Directives defined in Scalar/Enum/Input/Type/Interface type extensions will be merged into target. The following schema will create type `A` with two directives `@foo` and `@bar` (previously only with `@foo`).

```graphql
type A @foo {
  field: String
}

extend type A @bar
```

Custom scalars seems fine, but for standard (`Int`/`String`/etc) the AST node is required. And I'm not sure how it should work.

Technically, it is possible to add `scalar Int`, but it will not work without `@scalar`[^1]. Adding `@scalar(class: "GraphQL\Type\Definition\IntType")` for standard scalars looks superfluous, IMHO. Moreover despite `scalar Int @scalar(class: "My\Custom\Class")` is fully valid, but seems useless, because `Type::getStandardTypes()` has a bigger priority and thus `My\Custom\Class` will not be used (at least in `Schema::getType()`).

Another issue - to get directives we need AST node, standard types don't have it, so we probably need to assign it somewhere. 

My proposal is to extend `TypeRegistry::resolveScalarType()` to

* Bind AST node to standard type if defined (required to add directives to standard types via `extend Int @mydirective`)[^2].
* Allow standard types without `@scalar`

What do you think?

Also, would be nice if someone can clarify usage of `scalar Int @scalar(class: "My\Custom\Class")` (allowed/should work or not).

**Breaking changes**

* Signature of `ASTBuilder::missingBaseDefinition()` and `ASTBuilder::assertExtensionMatchesDefinition()` changed to accept `ScalarTypeDefinitionNode`/`ScalarTypeExtensionNode` 
* if the `extend scalar X` is used alone (= no scalar X defined it the schema) there will be an error that was not present before. But I think this is ok, because it works the same as for extending other types.

[^1]: Failed to find class Int extends GraphQL\\Type\\Definition\\ScalarType in namespaces [App\\GraphQL\\Scalars] for the scalar Int.
[^2]: I'm not sure that is will work in all cases, will try to test it tomorrow