### PR TITLE
Allow custom model name in @canFind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v6.33.2
+
+### Fixed
+
+- Allow custom model name in `@canFind` https://github.com/nuwave/lighthouse/pull/2515
+
 ## v6.33.1
 
 ### Fixed

--- a/docs/6/api-reference/directives.md
+++ b/docs/6/api-reference/directives.md
@@ -746,7 +746,7 @@ directive @canFind(
 ) repeatable on FIELD_DEFINITION
 ```
 
-### canModel
+### canRoot
 
 ```graphql
 """

--- a/docs/6/api-reference/directives.md
+++ b/docs/6/api-reference/directives.md
@@ -650,11 +650,11 @@ Deprecated. Use the [@can\* family of directives](#can-family-of-directives) ins
 
 ## @can\* family of directives
 
-All @can\* directives have common arguments. These arguments specify how gates are checked and what to do if the user is not authorized.
+All `@can*` directives have common arguments. These arguments specify how gates are checked and what to do if the user is not authorized.
 Each directive has its own set of arguments that specify what to check against.
 
 ```graphql
-  """
+"""
 The ability to check permissions for.
 """
 ability: String!
@@ -727,6 +727,12 @@ directive @canFind(
   You may pass the string in dot notation to use nested inputs.
   """
   find: String!
+
+  """
+  Specify the class name of the model to use.
+  This is only needed when the default model detection does not work.
+  """
+  model: String
 
   """
   Should the query fail when the models of `find` were not found?

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -746,7 +746,7 @@ directive @canFind(
 ) repeatable on FIELD_DEFINITION
 ```
 
-### canModel
+### canRoot
 
 ```graphql
 """

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -650,11 +650,11 @@ Deprecated. Use the [@can\* family of directives](#can-family-of-directives) ins
 
 ## @can\* family of directives
 
-All @can\* directives have common arguments. These arguments specify how gates are checked and what to do if the user is not authorized.
+All `@can*` directives have common arguments. These arguments specify how gates are checked and what to do if the user is not authorized.
 Each directive has its own set of arguments that specify what to check against.
 
 ```graphql
-  """
+"""
 The ability to check permissions for.
 """
 ability: String!
@@ -727,6 +727,12 @@ directive @canFind(
   You may pass the string in dot notation to use nested inputs.
   """
   find: String!
+
+  """
+  Specify the class name of the model to use.
+  This is only needed when the default model detection does not work.
+  """
+  model: String
 
   """
   Should the query fail when the models of `find` were not found?

--- a/src/Auth/CanFindDirective.php
+++ b/src/Auth/CanFindDirective.php
@@ -40,6 +40,12 @@ directive @canFind(
   find: String!
 
   """
+  Specify the class name of the model to use.
+  This is only needed when the default model detection does not work.
+  """
+  model: String
+
+  """
   Should the query fail when the models of `find` were not found?
   """
   findOrFail: Boolean! = true


### PR DESCRIPTION
Resolves https://github.com/nuwave/lighthouse/issues/2513
 
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Fixes the directive definition.

**Breaking changes**

None.