### PR TITLE
Fix stub for type resolvers used in `lighthouse:union` and `lighthouse:interface` artisan commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Fix stub for type resolvers used in `lighthouse:union` and `lighthouse:interface` artisan commands
+- Fix stub for type resolvers used in `lighthouse:union` and `lighthouse:interface` artisan commands https://github.com/nuwave/lighthouse/pull/2518
 
 ## v6.33.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v6.33.4
+
+### Fixed
+
+- Fix stub for type resolvers used in `lighthouse:union` and `lighthouse:interface` artisan commands
+
 ## v6.33.3
 
 ### Fixed

--- a/src/Console/stubs/typeResolver.stub
+++ b/src/Console/stubs/typeResolver.stub
@@ -2,8 +2,8 @@
 
 namespace DummyNamespace;
 
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
-use Nuwave\Lighthouse\Execution\ResolveInfo;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 


### PR DESCRIPTION
Resolves https://github.com/nuwave/lighthouse/issues/2517
 
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Fixes the import of `ResolveInfo`.

**Breaking changes**

None.
