### PR TITLE
Introduce ClientSafeModelNotFoundException for `@can` and `@canFind` directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+- Add `ClientSafeModelNotFoundException` to wrap original exception in `@can` and `@canFind`
+
 ## v6.34.1
 
 ### Fixed

--- a/src/Auth/CanDirective.php
+++ b/src/Auth/CanDirective.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
+use Nuwave\Lighthouse\Exceptions\ClientSafeModelNotFoundException;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Execution\Resolved;
 use Nuwave\Lighthouse\Execution\ResolveInfo;
@@ -217,7 +218,7 @@ GRAPHQL;
                     ? $enhancedBuilder->findOrFail($findValue)
                     : $enhancedBuilder->find($findValue);
             } catch (ModelNotFoundException $modelNotFoundException) {
-                throw new Error($modelNotFoundException->getMessage());
+                throw new ClientSafeModelNotFoundException($modelNotFoundException->getMessage(), previous: $modelNotFoundException);
             }
 
             if ($modelOrModels instanceof Model) {

--- a/src/Auth/CanDirective.php
+++ b/src/Auth/CanDirective.php
@@ -218,7 +218,7 @@ GRAPHQL;
                     ? $enhancedBuilder->findOrFail($findValue)
                     : $enhancedBuilder->find($findValue);
             } catch (ModelNotFoundException $modelNotFoundException) {
-                throw new ClientSafeModelNotFoundException($modelNotFoundException->getMessage(), previous: $modelNotFoundException);
+                throw ClientSafeModelNotFoundException::fromLaravel($modelNotFoundException);
             }
 
             if ($modelOrModels instanceof Model) {

--- a/src/Auth/CanFindDirective.php
+++ b/src/Auth/CanFindDirective.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Arr;
+use Nuwave\Lighthouse\Exceptions\ClientSafeModelNotFoundException;
 use Nuwave\Lighthouse\Execution\ResolveInfo;
 use Nuwave\Lighthouse\SoftDeletes\ForceDeleteDirective;
 use Nuwave\Lighthouse\SoftDeletes\RestoreDirective;
@@ -115,7 +116,7 @@ GRAPHQL;
                 ? $enhancedBuilder->findOrFail($findValue)
                 : $enhancedBuilder->find($findValue);
         } catch (ModelNotFoundException $modelNotFoundException) {
-            throw new Error($modelNotFoundException->getMessage());
+            throw new ClientSafeModelNotFoundException($modelNotFoundException->getMessage(), previous: $modelNotFoundException);
         }
 
         if ($modelOrModels instanceof Model) {

--- a/src/Auth/CanFindDirective.php
+++ b/src/Auth/CanFindDirective.php
@@ -116,7 +116,7 @@ GRAPHQL;
                 ? $enhancedBuilder->findOrFail($findValue)
                 : $enhancedBuilder->find($findValue);
         } catch (ModelNotFoundException $modelNotFoundException) {
-            throw new ClientSafeModelNotFoundException($modelNotFoundException->getMessage(), previous: $modelNotFoundException);
+            throw ClientSafeModelNotFoundException::fromLaravel($modelNotFoundException);
         }
 
         if ($modelOrModels instanceof Model) {

--- a/src/Exceptions/ClientSafeModelNotFoundException.php
+++ b/src/Exceptions/ClientSafeModelNotFoundException.php
@@ -3,11 +3,26 @@
 namespace Nuwave\Lighthouse\Exceptions;
 
 use GraphQL\Error\ClientAware;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
-class ClientSafeModelNotFoundException extends \Exception implements ClientAware
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ * @extends ModelNotFoundException<TModel>
+ */
+class ClientSafeModelNotFoundException extends ModelNotFoundException implements ClientAware
 {
     public function isClientSafe(): bool
     {
         return true;
+    }
+
+    /**
+     * @param  ModelNotFoundException<TModel>  $laravelException
+     * @return self<TModel>
+     */
+    public static function fromLaravel(ModelNotFoundException $laravelException): self
+    {
+        return (new static($laravelException->getMessage(), $laravelException->getCode()))
+            ->setModel($laravelException->getModel(), $laravelException->getIds());
     }
 }

--- a/src/Exceptions/ClientSafeModelNotFoundException.php
+++ b/src/Exceptions/ClientSafeModelNotFoundException.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Exceptions;
+
+use GraphQL\Error\ClientAware;
+
+class ClientSafeModelNotFoundException extends \Exception implements ClientAware
+{
+    public function isClientSafe(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Integration/Auth/CanDirectiveDBTest.php
+++ b/tests/Integration/Auth/CanDirectiveDBTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Integration\Auth;
 
+use GraphQL\Error\Error;
 use Nuwave\Lighthouse\Auth\CanDirective;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
+use Nuwave\Lighthouse\Exceptions\ClientSafeModelNotFoundException;
 use Tests\DBTestCase;
 use Tests\Utils\Models\Company;
 use Tests\Utils\Models\Post;
@@ -90,6 +92,43 @@ final class CanDirectiveDBTest extends DBTestCase
                 ],
             ],
         ]);
+    }
+    public function testThrowsCustomExceptionWhenFailsToFindModel(): void
+    {
+        $user = new User();
+        $user->name = UserPolicy::ADMIN;
+        $this->be($user);
+
+        $this->mockResolverExpects(
+            $this->never(),
+        );
+
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            user(id: ID @whereKey): User
+                @can(ability: "view", find: "id")
+                @mock
+        }
+
+        type User {
+            name: String!
+        }
+        ';
+
+        $this->rethrowGraphQLErrors();
+
+        try {
+            $this->graphQL(/** @lang GraphQL */ '
+            {
+                user(id: "not-present") {
+                    name
+                }
+            }
+            ');
+        } catch (Error $error) {
+            $this->assertNotEmpty($error->getPrevious());
+            $this->assertEquals(ClientSafeModelNotFoundException::class, get_class($error->getPrevious()));
+        }
     }
 
     public function testFailsToFindSpecificModelWithFindOrFailFalse(): void

--- a/tests/Integration/Auth/CanDirectiveDBTest.php
+++ b/tests/Integration/Auth/CanDirectiveDBTest.php
@@ -126,8 +126,10 @@ final class CanDirectiveDBTest extends DBTestCase
             }
             ');
         } catch (Error $error) {
-            $this->assertNotEmpty($error->getPrevious());
-            $this->assertEquals(ClientSafeModelNotFoundException::class, get_class($error->getPrevious()));
+            $previous = $error->getPrevious();
+
+            $this->assertNotNull($previous);
+            $this->assertSame(ClientSafeModelNotFoundException::class, get_class($previous));
         }
     }
 

--- a/tests/Integration/Auth/CanFindDirectiveDBTest.php
+++ b/tests/Integration/Auth/CanFindDirectiveDBTest.php
@@ -163,8 +163,10 @@ final class CanFindDirectiveDBTest extends DBTestCase
             }
             ');
         } catch (Error $error) {
-            $this->assertNotEmpty($error->getPrevious());
-            $this->assertEquals(ClientSafeModelNotFoundException::class, get_class($error->getPrevious()));
+            $previous = $error->getPrevious();
+
+            $this->assertNotNull($previous);
+            $this->assertSame(ClientSafeModelNotFoundException::class, get_class($previous));
         }
     }
 


### PR DESCRIPTION
Resolves #2521 
 
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Added custom `ClientSafeModelNotFoundException` to wrap around `ModelNotFoundException` in `@can` and `@canFind` directives.
New exception is linked to previous exception, allowing for usage in custom error handlers. With this change developers could be able to modify original exception how they want, formatting or replacing conditionally

**Breaking changes**

Probably none, as new exception being safely catched into same `GraphQL\Error` and maintain original message
