### PR TITLE
Silence Lumen errors for Laravel 11 support

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,6 +20,8 @@ parameters:
   - src/Pennant
   - tests/Integration/Pennant
   - src/Tracing/FederatedTracing/Proto # Generated classes from protobuf
+  # Ignore errors caused by the absence of Lumen in the dev dependencies
+  - tests/Unit/Testing/TestingTraitDummyLumen.php
   ignoreErrors:
   # PHPStan does not get it
   - '#Parameter \#1 \$callback of static method Closure::fromCallable\(\) expects callable\(\): mixed, array{object, .*} given\.#'
@@ -64,3 +66,21 @@ parameters:
 
   # Older versions of bensampo/laravel-enum are not generic yet
   - '#contains generic type BenSampo\\Enum\\Enum<.+> but class BenSampo\\Enum\\Enum is not generic\.#'
+
+  # Ignore errors caused by the absence of Lumen in the dev dependencies
+  - path: src/Support/AppVersion.php
+    message: '#PHPDoc tag @var for variable \$container contains unknown class Laravel\\Lumen\\Application.#'
+  - path: src/Support/AppVersion.php
+    message: '#Call to method version\(\) on an unknown class Laravel\\Lumen\\Application.#'
+  - path: src/Subscriptions/SubscriptionRouter.php
+    messages:
+      - '#Parameter \$router of method Nuwave\\Lighthouse\\Subscriptions\\SubscriptionRouter::pusher\(\) has invalid type Laravel\\Lumen\\Routing\\Router\.#'
+      - '#Call to method post\(\) on an unknown class Laravel\\Lumen\\Routing\\Router\.#'
+      - '#Parameter \$router of method Nuwave\\Lighthouse\\Subscriptions\\SubscriptionRouter::echoRoutes\(\) has invalid type Laravel\\Lumen\\Routing\\Router\.#'
+  - path: src/Http/routes.php
+    messages:
+      - '#PHPDoc tag @var for variable \$router contains unknown class Laravel\\Lumen\\Routing\\Router\.#'
+      - '#Call to method addRoute\(\) on an unknown class Laravel\\Lumen\\Routing\\Router\.#'
+
+
+


### PR DESCRIPTION
Related to #2508 

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
 
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

This PR silences the errors raised by PHPStan after removing Lumen from the `devDependencies`.

Checks are expected to fail here, because the PR does not address the other PHPStan errors.