### PR TITLE
test: support SQLite

### DIFF
--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -34,7 +34,7 @@ abstract class DBTestCase extends TestCase
         // We cannot use transactions, as they do not reset autoincrement
         $databaseName = env('LIGHTHOUSE_TEST_DB_DATABASE') ?? 'lighthouse';
         $columnName = "Tables_in_{$databaseName}";
-        foreach (DB::select('SHOW TABLES') as $table) {
+        foreach (DB::select($this->databaseDriver() === 'mysql' ? 'SHOW TABLES' : sprintf("SELECT name as '%s' FROM sqlite_master WHERE type = 'table';", $columnName)) as $table) {
             DB::table($table->{$columnName})->truncate();
         }
 
@@ -47,20 +47,37 @@ abstract class DBTestCase extends TestCase
 
         $config = $app->make(ConfigRepository::class);
         $config->set('database.default', self::DEFAULT_CONNECTION);
-        $config->set('database.connections.' . self::DEFAULT_CONNECTION, $this->mysqlOptions());
-        $config->set('database.connections.' . self::ALTERNATE_CONNECTION, $this->mysqlOptions());
+        $config->set('database.connections.' . self::DEFAULT_CONNECTION, $this->databaseOptions());
+        $config->set('database.connections.' . self::ALTERNATE_CONNECTION, $this->databaseOptions());
+    }
+
+    protected function databaseDriver(): string
+    {
+        return env('LIGHTHOUSE_TEST_DB_DRIVER', 'mysql');
     }
 
     /** @return array<string, mixed> */
-    protected function mysqlOptions(): array
+    protected function databaseOptions(): array
     {
+        if ($this->databaseDriver() === 'mysql') {
+            return [
+                'driver' => 'mysql',
+                'database' => env('LIGHTHOUSE_TEST_DB_DATABASE', 'test'),
+                'username' => env('LIGHTHOUSE_TEST_DB_USERNAME', 'root'),
+                'password' => env('LIGHTHOUSE_TEST_DB_PASSWORD', ''),
+                'host' => env('LIGHTHOUSE_TEST_DB_HOST', 'mysql'),
+                'port' => env('LIGHTHOUSE_TEST_DB_PORT', '3306'),
+                'unix_socket' => env('LIGHTHOUSE_TEST_DB_UNIX_SOCKET', null),
+            ];
+        }
+
         return [
-            'driver' => 'mysql',
-            'database' => env('LIGHTHOUSE_TEST_DB_DATABASE', 'test'),
-            'username' => env('LIGHTHOUSE_TEST_DB_USERNAME', 'root'),
+            'driver' => 'sqlite',
+            'database' => env('LIGHTHOUSE_TEST_DB_DATABASE', 'test.sqlite'),
+            'username' => env('LIGHTHOUSE_TEST_DB_USERNAME', ''),
             'password' => env('LIGHTHOUSE_TEST_DB_PASSWORD', ''),
-            'host' => env('LIGHTHOUSE_TEST_DB_HOST', 'mysql'),
-            'port' => env('LIGHTHOUSE_TEST_DB_PORT', '3306'),
+            'host' => env('LIGHTHOUSE_TEST_DB_HOST', ''),
+            'port' => env('LIGHTHOUSE_TEST_DB_PORT', ''),
             'unix_socket' => env('LIGHTHOUSE_TEST_DB_UNIX_SOCKET', null),
         ];
     }


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
 
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

This PR allows developers to easily use SQLite during testing without setting up a MySQL database.

**Breaking changes**

n/a
