### PR TITLE
Compare raw attributes only when ensuring uniqueness of paginated related models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- Compare raw attributes only https://github.com/nuwave/lighthouse/pull/2540
+
 ## v6.36.0
 
 ### Added

--- a/src/Execution/ModelsLoader/PaginatedModelsLoader.php
+++ b/src/Execution/ModelsLoader/PaginatedModelsLoader.php
@@ -84,7 +84,9 @@ class PaginatedModelsLoader implements ModelsLoader
         return $relatedModels->unique(
             // Compare all attributes because there might not be a unique primary key
             // or there could be differing pivot attributes.
-            static fn (Model $relatedModel): string => $relatedModel->toJson(),
+            static function (Model $relatedModel): string {
+                return json_encode($relatedModel->getOriginal());
+            },
         );
     }
 

--- a/src/Execution/ModelsLoader/PaginatedModelsLoader.php
+++ b/src/Execution/ModelsLoader/PaginatedModelsLoader.php
@@ -85,9 +85,7 @@ class PaginatedModelsLoader implements ModelsLoader
         return $relatedModels->unique(
             // Compare all attributes because there might not be a unique primary key
             // or there could be differing pivot attributes.
-            static function (Model $relatedModel): string {
-                return json_encode($relatedModel->getOriginal());
-            },
+            static fn (Model $relatedModel): string => json_encode($relatedModel->getOriginal()),
         );
     }
 

--- a/src/Execution/ModelsLoader/PaginatedModelsLoader.php
+++ b/src/Execution/ModelsLoader/PaginatedModelsLoader.php
@@ -12,6 +12,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Nuwave\Lighthouse\Pagination\PaginationArgs;
 use Nuwave\Lighthouse\Pagination\ZeroPerPageLengthAwarePaginator;
 use Nuwave\Lighthouse\Support\Utils;
+use function Safe\json_encode;
 
 class PaginatedModelsLoader implements ModelsLoader
 {


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
 
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Right now, `toJson` is used which "is recursive, so all attributes and relations will be converted to JSON" (see https://laravel.com/docs/11.x/eloquent-serialization#serializing-to-json). This means that all accessors are executed as well which can affect the performance of an application. The new approach simply compares the raw attributes of the models which should be enough in almost all cases as far as I can see.

**Breaking changes**

There might be a tiny chance that something doesn't work as before because accessors are not compared anymore.
