### PR TITLE
Register missing WhereConditionsServiceProvider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,8 @@
                 "Nuwave\\Lighthouse\\Pagination\\PaginationServiceProvider",
                 "Nuwave\\Lighthouse\\SoftDeletes\\SoftDeletesServiceProvider",
                 "Nuwave\\Lighthouse\\Testing\\TestingServiceProvider",
-                "Nuwave\\Lighthouse\\Validation\\ValidationServiceProvider"
+                "Nuwave\\Lighthouse\\Validation\\ValidationServiceProvider",
+                "Nuwave\\Lighthouse\\WhereConditions\\WhereConditionsServiceProvider"
             ]
         }
     },


### PR DESCRIPTION
WhereConditionsServiceProvider is missing to be registered in composer.json. Found it because when trying to use the directive @whereHasConditions, it was telling me that it was not found.