### PR TITLE
Enum support for morph types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+- Native PHP Enums registered through the TypeRegistry may be used as morph type in nested MorphTo relations 
+
 ## v6.36.0
 
 ### Added

--- a/src/Execution/Arguments/NestedMorphTo.php
+++ b/src/Execution/Arguments/NestedMorphTo.php
@@ -25,8 +25,20 @@ class NestedMorphTo implements ArgResolver
         if ($args->has('connect')) {
             $connectArgs = $args->arguments['connect']->value;
 
+            $morphType = $connectArgs->arguments['type']->value;
+            if (PHP_VERSION_ID >= 80100)
+            {
+                if ($morphType instanceof \BackedEnum)
+                {
+                    $morphType = $morphType->value;
+                }
+                else if ($morphType instanceof \UnitEnum)
+                {
+                    $morphType = $morphType->name;
+                }
+            }
             $morphToModel = $this->relation->createModelByType(
-                (string) $connectArgs->arguments['type']->value,
+                (string) $morphType,
             );
             $morphToModel->setAttribute(
                 $morphToModel->getKeyName(),

--- a/tests/Integration/Execution/MutationExecutor/MorphToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToTest.php
@@ -1,4 +1,4 @@
-<?php declare( strict_types=1 );
+<?php declare(strict_types=1);
 
 namespace Tests\Integration\Execution\MutationExecutor;
 

--- a/tests/Utils/Enums/ImageableType.php
+++ b/tests/Utils/Enums/ImageableType.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Utils\Enums;
+
+enum ImageableType: string
+{
+    case TASK = \Tests\Utils\Models\Task::class;
+}


### PR DESCRIPTION
Resolves #2543
 
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Native PHP Enums registered through the TypeRegistry may be used as morph type in nested MorphTo relations 

**Breaking changes**

None