### PR TITLE
Native PHP Enums registered through the `TypeRegistry` may be used as morph type in nested `MorphTo` relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
-- Native PHP Enums registered through the TypeRegistry may be used as morph type in nested MorphTo relations 
+### Fixed
+
+- Native PHP Enums registered through the `TypeRegistry` may be used as morph type in nested `MorphTo` relations https://github.com/nuwave/lighthouse/pull/2544
 
 ## v6.36.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+- Native PHP Enums registered through the TypeRegistry may be used as morph type in nested MorphTo relations 
+
 ## v6.36.0
 
 ### Added

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,6 +22,9 @@ parameters:
   - src/Tracing/FederatedTracing/Proto # Generated classes from protobuf
   # Ignore errors caused by the absence of Lumen in the dev dependencies
   - tests/Unit/Testing/TestingTraitDummyLumen.php
+  # Native enums
+  - tests/Utils/Enums/ImageableType.php
+  - tests/Utils/Enums/ImageableType.php
   ignoreErrors:
   # PHPStan does not get it
   - '#Parameter \#1 \$callback of static method Closure::fromCallable\(\) expects callable\(\): mixed, array{object, .*} given\.#'

--- a/src/Execution/Arguments/NestedMorphTo.php
+++ b/src/Execution/Arguments/NestedMorphTo.php
@@ -47,7 +47,8 @@ class NestedMorphTo implements ArgResolver
             if ($morphType instanceof \BackedEnum) {
                 $value = $morphType->value;
                 if (! is_string($value)) {
-                    throw new DefinitionException("Enum {$morphType::class} must be string backed.");
+                    $enumClass = $morphType::class;
+                    throw new DefinitionException("Enum {$enumClass} must be string backed.");
                 }
 
                 return $value;

--- a/src/Execution/Arguments/NestedMorphTo.php
+++ b/src/Execution/Arguments/NestedMorphTo.php
@@ -3,6 +3,7 @@
 namespace Nuwave\Lighthouse\Execution\Arguments;
 
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Support\Contracts\ArgResolver;
 
 class NestedMorphTo implements ArgResolver
@@ -44,7 +45,12 @@ class NestedMorphTo implements ArgResolver
     {
         if (PHP_VERSION_ID >= 80100) {
             if ($morphType instanceof \BackedEnum) {
-                return $morphType->value;
+                $value = $morphType->value;
+                if (! is_string($value)) {
+                    throw new DefinitionException("Enum {$morphType::class} must be string backed.");
+                }
+
+                return $value;
             }
 
             if ($morphType instanceof \UnitEnum) {

--- a/src/Execution/Arguments/NestedMorphTo.php
+++ b/src/Execution/Arguments/NestedMorphTo.php
@@ -24,30 +24,34 @@ class NestedMorphTo implements ArgResolver
 
         if ($args->has('connect')) {
             $connectArgs = $args->arguments['connect']->value;
+            $connectArgsArguments = $connectArgs->arguments;
 
-            $morphType = $connectArgs->arguments['type']->value;
-            if (PHP_VERSION_ID >= 80100)
-            {
-                if ($morphType instanceof \BackedEnum)
-                {
-                    $morphType = $morphType->value;
-                }
-                else if ($morphType instanceof \UnitEnum)
-                {
-                    $morphType = $morphType->name;
-                }
-            }
             $morphToModel = $this->relation->createModelByType(
-                (string) $morphType,
+                $this->morphTypeValue($connectArgsArguments['type']->value),
             );
             $morphToModel->setAttribute(
                 $morphToModel->getKeyName(),
-                $connectArgs->arguments['id']->value,
+                $connectArgsArguments['id']->value,
             );
 
             $this->relation->associate($morphToModel);
         }
 
         NestedBelongsTo::disconnectOrDelete($this->relation, $args);
+    }
+
+    protected function morphTypeValue(mixed $morphType): string
+    {
+        if (PHP_VERSION_ID >= 80100) {
+            if ($morphType instanceof \BackedEnum) {
+                return $morphType->value;
+            }
+
+            if ($morphType instanceof \UnitEnum) {
+                return $morphType->name;
+            }
+        }
+
+        return (string) $morphType;
     }
 }

--- a/src/Execution/Arguments/NestedMorphTo.php
+++ b/src/Execution/Arguments/NestedMorphTo.php
@@ -25,8 +25,20 @@ class NestedMorphTo implements ArgResolver
         if ($args->has('connect')) {
             $connectArgs = $args->arguments['connect']->value;
 
+            $morphType = $connectArgs->arguments['type']->value;
+            if (PHP_VERSION_ID >= 80100)
+            {
+                if ($morphType instanceof \BackedEnum)
+                {
+                    $morphType = $morphType->value;
+                }
+                else if ($morphType instanceof \UnitEnum)
+                {
+                    $morphType = $morphType->name;
+                }
+            }
             $morphToModel = $this->relation->createModelByType(
-                (string) $connectArgs->arguments['type']->value,
+                (string) $morphType,
             );
             $morphToModel->setAttribute(
                 $morphToModel->getKeyName(),

--- a/tests/Integration/Execution/MutationExecutor/MorphToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToTest.php
@@ -134,7 +134,8 @@ final class MorphToTest extends DBTestCase
     public function testConnectsMorphToWithEnumType(): void
     {
         $typeRegistry = $this->app->make(TypeRegistry::class);
-        $typeRegistry->register(new PhpEnumType(ImageableType::class));
+        $phpEnumType = new PhpEnumType(ImageableType::class); // @phpstan-ignore-line native enums not supported in all versions
+        $typeRegistry->register($phpEnumType);
 
         $task = factory(Task::class)->make();
         assert($task instanceof Task);

--- a/tests/Integration/Execution/MutationExecutor/MorphToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToTest.php
@@ -133,6 +133,10 @@ final class MorphToTest extends DBTestCase
 
     public function testConnectsMorphToWithEnumType(): void
     {
+        if (PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Requires native enums.');
+        }
+
         $typeRegistry = $this->app->make(TypeRegistry::class);
         $phpEnumType = new PhpEnumType(ImageableType::class); // @phpstan-ignore-line native enums not supported in all versions
         $typeRegistry->register($phpEnumType);

--- a/tests/Integration/Execution/MutationExecutor/MorphToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToTest.php
@@ -1,4 +1,4 @@
-<?php declare( strict_types=1 );
+<?php declare(strict_types=1);
 
 namespace Tests\Integration\Execution\MutationExecutor;
 

--- a/tests/Integration/Execution/MutationExecutor/MorphToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/MorphToTest.php
@@ -91,16 +91,6 @@ final class MorphToTest extends DBTestCase
     }
     ' . self::PLACEHOLDER_QUERY;
 
-    /** @var TypeRegistry */
-    protected $typeRegistry;
-
-    protected function setUp () : void
-    {
-        parent::setUp();
-
-        $this->typeRegistry = $this->app->make( TypeRegistry::class );
-    }
-
     public function testConnectsMorphTo(): void
     {
         $task = factory(Task::class)->make();
@@ -141,9 +131,10 @@ final class MorphToTest extends DBTestCase
         ]);
     }
 
-    public function testConnectsMorphToWithEnumType () : void
+    public function testConnectsMorphToWithEnumType(): void
     {
-        $this->typeRegistry->register( new PhpEnumType( ImageableType::class ) );
+        $typeRegistry = $this->app->make(TypeRegistry::class);
+        $typeRegistry->register(new PhpEnumType(ImageableType::class));
 
         $task = factory(Task::class)->make();
         assert($task instanceof Task);

--- a/tests/Utils/Enums/ImageableType.php
+++ b/tests/Utils/Enums/ImageableType.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Utils\Enums;
+
+enum ImageableType: string
+{
+    case TASK = \Tests\Utils\Models\Task::class;
+}

--- a/tests/Utils/Enums/ImageableType.php
+++ b/tests/Utils/Enums/ImageableType.php
@@ -1,8 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tests\Utils\Enums;
 
+use Tests\Utils\Models\Task;
+
 enum ImageableType: string
 {
-    case TASK = \Tests\Utils\Models\Task::class;
+    case TASK = Task::class;
 }


### PR DESCRIPTION
Resolves https://github.com/nuwave/lighthouse/pull/2544/files