### PR TITLE
Update tooling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,10 @@
         "psr-4": {
             "Benchmarks\\": "benchmarks/",
             "Tests\\": "tests/"
-        }
+        },
+        "files": [
+            "vendor/dms/phpunit-arraysubset-asserts/src/ArraySubsetAsserts.php"
+        ]
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "mll-lab/php-cs-fixer-config": "^5",
         "mockery/mockery": "^1.5",
         "nesbot/carbon": "^2.62.1",
-        "orchestra/testbench": "^7.7 || ^8.8 || ^9",
+        "orchestra/testbench": "^7.11 || ^8.8 || ^9",
         "phpbench/phpbench": "^1.2.6",
         "phpstan/extension-installer": "^1",
         "phpstan/phpstan": "^1.10.3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,6 @@
     "scripts": {
         "start": "vuepress dev .",
         "build": "vuepress build .",
-        "prettify": "prettier --write --tab-width=2 **/**/*.md **/*.js .vuepress/*.js"
+        "prettify": "prettier --write --tab-width=2 --list-different **/**/*.md **/*.js .vuepress/*.js"
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,7 @@ parameters:
   - benchmarks
   - src
   - tests
-  # Temporarily comment out before running rector, do not forget to put it back in
+  # Does not work with rector, comment in to diagnose potential issues with Octane
   #checkOctaneCompatibility: true
   reportUnmatchedIgnoredErrors: false # As long as we support multiple Laravel versions at once, there will be some dead spots
   # Install https://plugins.jetbrains.com/plugin/7677-awesome-console to make those links clickable

--- a/rector.php
+++ b/rector.php
@@ -34,7 +34,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
     $rectorConfig->skip([
         __DIR__ . '/src/Tracing/FederatedTracing/Proto', // Generated code
-        __DIR__ . '/tests/database/migrations', // Does not fit autoloading standards
+        __DIR__ . '/tests/database/migrations', // Does not fit autoloader standards
         __DIR__ . '/tests/LaravelPhpdocAlignmentFixer.php', // Copied from Laravel
         CallableThisArrayToAnonymousFunctionRector::class, // Callable in array form is shorter and more efficient
         IssetOnPropertyObjectToPropertyExistsRector::class, // isset() is nice when moving towards typed properties

--- a/src/Async/AsyncDirective.php
+++ b/src/Async/AsyncDirective.php
@@ -71,7 +71,7 @@ GRAPHQL;
         $parentName = $parentType->name->value;
         if ($parentName !== RootType::MUTATION) {
             $location = "{$parentName}.{$fieldDefinition->name->value}";
-            throw new DefinitionException("The @async directive must only be used on fields of the root type mutation, found it on {$location}.");
+            throw new DefinitionException("The @async directive must only be used on root mutation fields, found it on {$location}.");
         }
     }
 }

--- a/src/Pagination/PaginationManipulator.php
+++ b/src/Pagination/PaginationManipulator.php
@@ -378,6 +378,7 @@ GRAPHQL
     /** If federation v2 is used, add the @shareable directive to the pagination generic types. */
     private function maybeAddShareableDirective(): string
     {
+        // Not using Illuminate\Container\Container::getInstance() here as it causes PHPStan issues
         if (app()->providerIsLoaded(FederationServiceProvider::class) && FederationHelper::isUsingFederationV2($this->documentAST)) {
             return /** @lang GraphQL */ '@shareable';
         }

--- a/tests/Integration/Async/AsyncDirectiveTest.php
+++ b/tests/Integration/Async/AsyncDirectiveTest.php
@@ -80,7 +80,7 @@ final class AsyncDirectiveTest extends DBTestCase
     public function testOnlyOnMutations(): void
     {
         $this->expectExceptionObject(new DefinitionException(
-            'The @async directive must only be used on fields of the root type mutation, found it on Query.foo.',
+            'The @async directive must only be used on root mutation fields, found it on Query.foo.',
         ));
         $this->buildSchema(/** @lang GraphQL */ '
         type Query {

--- a/tests/Unit/Schema/Directives/HideDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/HideDirectiveTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Schema\Directives;
 
+use Illuminate\Container\Container;
 use Tests\TestCase;
 
 final class HideDirectiveTest extends TestCase
@@ -59,7 +60,7 @@ final class HideDirectiveTest extends TestCase
         }
         ';
 
-        app()->instance('env', 'production');
+        Container::getInstance()->instance('env', 'production');
         $this->graphQL($introspectionQuery)
             ->assertJsonCount(0, 'data.__schema.queryType.fields');
     }

--- a/tests/Unit/Schema/Directives/ShowDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/ShowDirectiveTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Schema\Directives;
 
+use Illuminate\Container\Container;
 use Tests\TestCase;
 
 final class ShowDirectiveTest extends TestCase
@@ -59,7 +60,7 @@ final class ShowDirectiveTest extends TestCase
         }
         ';
 
-        app()->instance('env', 'production');
+        Container::getInstance()->instance('env', 'production');
         $this->graphQL($introspectionQuery)
             ->assertJsonCount(1, 'data.__schema.queryType.fields')
             ->assertJsonPath('data.__schema.queryType.fields.0.name', 'hiddenField');


### PR DESCRIPTION
Fixes the following error by applying the tips from https://getrector.com/documentation/static-reflection-and-autoload:

```
 [ERROR] Could not process some files, due to:                                                                          
         "Child process error: Fatal error: Trait "DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts" not found in   
         tests/TestCase.php34                                                                                           
         ". 
```

Should fix the flaky PHPStan pipelines through https://github.com/larastan/larastan/issues/1424.

Limits prettier output.