### PR TITLE
Eliminate redundant `Model::save()` calls in nested mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v6.37.1
+
+### Fixed
+
+- Eliminate redundant `Model::save()` calls in nested mutations
+
 ## v6.37.0
 
 ### Changed

--- a/src/Execution/Arguments/NestedBelongsTo.php
+++ b/src/Execution/Arguments/NestedBelongsTo.php
@@ -8,20 +8,18 @@ use Nuwave\Lighthouse\Support\Contracts\ArgResolver;
 class NestedBelongsTo implements ArgResolver
 {
     public function __construct(
-        /**
-         * @var \Illuminate\Database\Eloquent\Relations\BelongsTo<\Illuminate\Database\Eloquent\Model, \Illuminate\Database\Eloquent\Model> $relation
-         */
+        /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo<\Illuminate\Database\Eloquent\Model, \Illuminate\Database\Eloquent\Model> $relation */
         protected BelongsTo $relation,
     ) {}
 
     /**
-     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  ArgumentSet  $args
      */
-    public function __invoke($parent, $args): void
+    public function __invoke($model, $args): void
     {
         if ($args->has('create')) {
-            $saveModel = new ResolveNested(new SaveModel($this->relation));
+            $saveModel = new ResolveNested(new SaveModel());
             $related = $saveModel(
                 $this->relation->make(),
                 $args->arguments['create']->value,
@@ -34,7 +32,7 @@ class NestedBelongsTo implements ArgResolver
         }
 
         if ($args->has('update')) {
-            $updateModel = new ResolveNested(new UpdateModel(new SaveModel($this->relation)));
+            $updateModel = new ResolveNested(new UpdateModel(new SaveModel()));
             $related = $updateModel(
                 $this->relation->make(),
                 $args->arguments['update']->value,
@@ -43,7 +41,7 @@ class NestedBelongsTo implements ArgResolver
         }
 
         if ($args->has('upsert')) {
-            $upsertModel = new ResolveNested(new UpsertModel(new SaveModel($this->relation)));
+            $upsertModel = new ResolveNested(new UpsertModel(new SaveModel()));
             $related = $upsertModel(
                 $this->relation->make(),
                 $args->arguments['upsert']->value,

--- a/src/Execution/Arguments/NestedMorphTo.php
+++ b/src/Execution/Arguments/NestedMorphTo.php
@@ -16,10 +16,10 @@ class NestedMorphTo implements ArgResolver
     ) {}
 
     /**
-     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  ArgumentSet  $args
      */
-    public function __invoke($parent, $args): void
+    public function __invoke($model, $args): void
     {
         // TODO implement create and update once we figure out how to do polymorphic input types https://github.com/nuwave/lighthouse/issues/900
 

--- a/src/Execution/Arguments/NestedOneToOne.php
+++ b/src/Execution/Arguments/NestedOneToOne.php
@@ -13,28 +13,28 @@ class NestedOneToOne implements ArgResolver
     ) {}
 
     /**
-     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  ArgumentSet  $args
      */
-    public function __invoke($parent, $args): void
+    public function __invoke($model, $args): void
     {
-        $relation = $parent->{$this->relationName}();
+        $relation = $model->{$this->relationName}();
         assert($relation instanceof HasOne || $relation instanceof MorphOne);
 
         if ($args->has('create')) {
-            $saveModel = new ResolveNested(new SaveModel($relation));
+            $saveModel = new ResolveNested(new SaveModel());
 
             $saveModel($relation->make(), $args->arguments['create']->value);
         }
 
         if ($args->has('update')) {
-            $updateModel = new ResolveNested(new UpdateModel(new SaveModel($relation)));
+            $updateModel = new ResolveNested(new UpdateModel(new SaveModel()));
 
             $updateModel($relation->make(), $args->arguments['update']->value);
         }
 
         if ($args->has('upsert')) {
-            $upsertModel = new ResolveNested(new UpsertModel(new SaveModel($relation)));
+            $upsertModel = new ResolveNested(new UpsertModel(new SaveModel()));
 
             $upsertModel($relation->make(), $args->arguments['upsert']->value);
         }

--- a/src/Execution/Arguments/SaveModel.php
+++ b/src/Execution/Arguments/SaveModel.php
@@ -13,9 +13,7 @@ use Nuwave\Lighthouse\Support\Contracts\ArgResolver;
 class SaveModel implements ArgResolver
 {
     public function __construct(
-        /**
-         * @var \Illuminate\Database\Eloquent\Relations\Relation<\Illuminate\Database\Eloquent\Model>|null $parentRelation
-         */
+        /** @var \Illuminate\Database\Eloquent\Relations\Relation<\Illuminate\Database\Eloquent\Model>|null $parentRelation */
         protected ?Relation $parentRelation = null,
     ) {}
 
@@ -73,13 +71,13 @@ class SaveModel implements ArgResolver
         $model->save();
 
         if ($this->parentRelation instanceof BelongsTo) {
-            $parentModel = $this->parentRelation->associate($model);
+            $childModel = $this->parentRelation->associate($model);
 
-            // If the parent Model does not exist (still to be saved),
+            // If the child Model does not exist (still to be saved),
             // a save could break any pending belongsTo relations that still
-            // needs to be created and associated with the parent model
-            if ($parentModel->exists) {
-                $parentModel->save();
+            // need to be created and associated with it.
+            if ($childModel->exists) {
+                $childModel->save();
             }
         }
 

--- a/src/Schema/Directives/DeleteDirective.php
+++ b/src/Schema/Directives/DeleteDirective.php
@@ -60,17 +60,17 @@ GRAPHQL;
     /**
      * Delete one or more related models.
      *
-     * @param  Model  $parent
+     * @param  Model  $model
      * @param  mixed|array<mixed>  $idOrIds
      */
-    public function __invoke($parent, $idOrIds): void
+    public function __invoke($model, $idOrIds): void
     {
         $relationName = $this->directiveArgValue(
             'relation',
             // Use the name of the argument if no explicit relation name is given
             $this->nodeName(),
         );
-        $relation = $parent->{$relationName}();
+        $relation = $model->{$relationName}();
         assert($relation instanceof Relation);
 
         // Those types of relations may only have one related model attached to

--- a/src/Schema/Directives/MutationExecutorDirective.php
+++ b/src/Schema/Directives/MutationExecutorDirective.php
@@ -40,12 +40,12 @@ abstract class MutationExecutorDirective extends BaseDirective implements FieldR
     }
 
     /**
-     * @param  Model  $parent
+     * @param  Model  $model
      * @param  \Nuwave\Lighthouse\Execution\Arguments\ArgumentSet|array<\Nuwave\Lighthouse\Execution\Arguments\ArgumentSet>  $args
      *
      * @return \Illuminate\Database\Eloquent\Model|array<\Illuminate\Database\Eloquent\Model>
      */
-    public function __invoke($parent, $args): mixed
+    public function __invoke($model, $args): mixed
     {
         $relationName = $this->directiveArgValue(
             'relation',
@@ -53,7 +53,7 @@ abstract class MutationExecutorDirective extends BaseDirective implements FieldR
             $this->nodeName(),
         );
 
-        $relation = $parent->{$relationName}();
+        $relation = $model->{$relationName}();
         assert($relation instanceof Relation);
 
         // @phpstan-ignore-next-line Relation&Builder mixin not recognized

--- a/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
@@ -514,7 +514,7 @@ GRAPHQL
         $user->save();
 
         $queries = [];
-        DB::listen(function (QueryExecuted $query) use (&$queries): void {
+        DB::listen(static function (QueryExecuted $query) use (&$queries): void {
             dump($query->sql);
             $queries[] = $query->sql;
         });
@@ -566,7 +566,7 @@ GRAPHQL
             ],
         ]);
 
-        $updateUsersQueries = array_filter($queries, fn (string $sql): bool => str_starts_with($sql, 'update `users`'));
+        $updateUsersQueries = array_filter($queries, static fn (string $sql): bool => str_starts_with($sql, 'update `users`'));
         $this->assertCount(1, $updateUsersQueries);
     }
 


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Because `NestedBelongsTo` unnecessarily passed through the `$parentRelation` to `SaveModel`, updating multiple `BelongsTo` relations of a model in a single nested mutation resulted in multiple save operations. See the repeated calls to ``update `users` set`` in the following log:

```
"select * from `users` where `users`.`id` = ? limit 1" // /workdir/tests/Integration/Execution/MutationExecutor/BelongsToTest.php:518
"select * from `companies` where `companies`.`id` = ? limit 1" // /workdir/tests/Integration/Execution/MutationExecutor/BelongsToTest.php:518
"update `companies` set `name` = ?, `companies`.`updated_at` = ? where `id` = ?" // /workdir/tests/Integration/Execution/MutationExecutor/BelongsToTest.php:518
"update `users` set `name` = ?, `company_id` = ?, `users`.`updated_at` = ? where `id` = ?" // /workdir/tests/Integration/Execution/MutationExecutor/BelongsToTest.php:518
"select * from `teams` where `teams`.`id` = ? limit 1" // /workdir/tests/Integration/Execution/MutationExecutor/BelongsToTest.php:518
"update `teams` set `name` = ?, `teams`.`updated_at` = ? where `id` = ?" // /workdir/tests/Integration/Execution/MutationExecutor/BelongsToTest.php:518
"update `users` set `team_id` = ?, `users`.`updated_at` = ? where `id` = ?" // /workdir/tests/Integration/Execution/MutationExecutor/BelongsToTest.php:518
"select * from `users` where `id` = ? limit 1" // /workdir/tests/Integration/Execution/MutationExecutor/BelongsToTest.php:518
"select * from `companies` where `companies`.`id` in (1)" // /workdir/tests/Integration/Execution/MutationExecutor/BelongsToTest.php:518
"select * from `teams` where `teams`.`id` in (1)" // /workdir/tests/Integration/Execution/MutationExecutor/BelongsToTest.php:518

Failed asserting that actual size 2 matches expected size 1.
/workdir/tests/Integration/Execution/MutationExecutor/BelongsToTest.php:570
```

**Breaking changes**

Should be none.
