### PR TITLE
Add option `builder` to `@limit` to apply an actual `LIMIT` clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Added
 
-- Add option `builder` to `@limit` to apply an actual `LIMIT` clause
+- Add option `builder` to `@limit` to apply an actual `LIMIT` clause https://github.com/nuwave/lighthouse/pull/2571
 
 ## v6.37.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v6.38.0
+
+### Added
+
+- Add option `builder` to `@limit` to apply an actual `LIMIT` clause
+
 ## v6.37.1
 
 ### Fixed

--- a/docs/6/api-reference/directives.md
+++ b/docs/6/api-reference/directives.md
@@ -2027,13 +2027,13 @@ By default, this directive does not influence the number of results the resolver
 but limits how much of it is returned to clients. Use the `builder` argument to change this.
 """
 directive @limit(
-    """
-    You may set this to `true` if the field uses a query builder,
-    then this directive will apply a LIMIT clause to it.
-    Typically, this option should only be used for root fields,
-    as it may cause wrong results with batched relation queries.
-    """
-    builder: Boolean! = false
+  """
+  You may set this to `true` if the field uses a query builder,
+  then this directive will apply a LIMIT clause to it.
+  Typically, this option should only be used for root fields,
+  as it may cause wrong results with batched relation queries.
+  """
+  builder: Boolean! = false
 ) on ARGUMENT_DEFINITION | FIELD_DEFINITION
 ```
 

--- a/docs/6/api-reference/directives.md
+++ b/docs/6/api-reference/directives.md
@@ -2021,15 +2021,23 @@ directive @like(
 ```graphql
 """
 Allow clients to specify the maximum number of results to return when used on an argument,
-or statically limits them when used on a field.
+or statically limit them when used on a field.
 
-This directive does not influence the number of results the resolver queries internally,
-but limits how much of it is returned to clients.
+By default, this directive does not influence the number of results the resolver queries internally,
+but limits how much of it is returned to clients. Use the `builder` argument to change this.
 """
-directive @limit on ARGUMENT_DEFINITION | FIELD_DEFINITION
+directive @limit(
+    """
+    You may set this to `true` if the field uses a query builder,
+    then this directive will apply a LIMIT clause to it.
+    Typically, this option should only be used for root fields,
+    as it may cause wrong results with batched relation queries.
+    """
+    builder: Boolean! = false
+) on ARGUMENT_DEFINITION | FIELD_DEFINITION
 ```
 
-Place this on any argument to a field that returns a list of results.
+You may place this on any argument to a field that returns a list of results.
 
 ```graphql
 type Query {
@@ -2041,7 +2049,7 @@ Lighthouse will return at most the number of results that the client requested.
 
 ```graphql
 {
-  users(limit: 5) {
+  users(limit: 4) {
     name
   }
 }
@@ -2054,9 +2062,18 @@ Lighthouse will return at most the number of results that the client requested.
       { "name": "Never" },
       { "name": "more" },
       { "name": "than" },
-      { "name": "5" }
+      { "name": "4" }
     ]
   }
+}
+```
+
+If your field is resolved through a database query, you may add the `builder` argument to apply
+an actual `LIMIT` clause to your SQL:
+
+```graphql
+type Query {
+  users(limit: Int @limit(builder: true)): [User!]! @all
 }
 ```
 

--- a/docs/6/custom-directives/input-value-directives.md
+++ b/docs/6/custom-directives/input-value-directives.md
@@ -119,7 +119,7 @@ An [`\Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective`](https://github.c
 directive allows using arguments passed by the client to dynamically
 modify the database query that Lighthouse creates for a field.
 
-Currently, the following directives use the defined filters for resolving the query:
+Currently, the following directives use arguments to modify the query:
 
 - [@all](../api-reference/directives.md#all)
 - [@paginate](../api-reference/directives.md#paginate)

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2027,13 +2027,13 @@ By default, this directive does not influence the number of results the resolver
 but limits how much of it is returned to clients. Use the `builder` argument to change this.
 """
 directive @limit(
-    """
-    You may set this to `true` if the field uses a query builder,
-    then this directive will apply a LIMIT clause to it.
-    Typically, this option should only be used for root fields,
-    as it may cause wrong results with batched relation queries.
-    """
-    builder: Boolean! = false
+  """
+  You may set this to `true` if the field uses a query builder,
+  then this directive will apply a LIMIT clause to it.
+  Typically, this option should only be used for root fields,
+  as it may cause wrong results with batched relation queries.
+  """
+  builder: Boolean! = false
 ) on ARGUMENT_DEFINITION | FIELD_DEFINITION
 ```
 

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2021,15 +2021,23 @@ directive @like(
 ```graphql
 """
 Allow clients to specify the maximum number of results to return when used on an argument,
-or statically limits them when used on a field.
+or statically limit them when used on a field.
 
-This directive does not influence the number of results the resolver queries internally,
-but limits how much of it is returned to clients.
+By default, this directive does not influence the number of results the resolver queries internally,
+but limits how much of it is returned to clients. Use the `builder` argument to change this.
 """
-directive @limit on ARGUMENT_DEFINITION | FIELD_DEFINITION
+directive @limit(
+    """
+    You may set this to `true` if the field uses a query builder,
+    then this directive will apply a LIMIT clause to it.
+    Typically, this option should only be used for root fields,
+    as it may cause wrong results with batched relation queries.
+    """
+    builder: Boolean! = false
+) on ARGUMENT_DEFINITION | FIELD_DEFINITION
 ```
 
-Place this on any argument to a field that returns a list of results.
+You may place this on any argument to a field that returns a list of results.
 
 ```graphql
 type Query {
@@ -2041,7 +2049,7 @@ Lighthouse will return at most the number of results that the client requested.
 
 ```graphql
 {
-  users(limit: 5) {
+  users(limit: 4) {
     name
   }
 }
@@ -2054,9 +2062,18 @@ Lighthouse will return at most the number of results that the client requested.
       { "name": "Never" },
       { "name": "more" },
       { "name": "than" },
-      { "name": "5" }
+      { "name": "4" }
     ]
   }
+}
+```
+
+If your field is resolved through a database query, you may add the `builder` argument to apply
+an actual `LIMIT` clause to your SQL:
+
+```graphql
+type Query {
+  users(limit: Int @limit(builder: true)): [User!]! @all
 }
 ```
 

--- a/docs/master/custom-directives/input-value-directives.md
+++ b/docs/master/custom-directives/input-value-directives.md
@@ -119,7 +119,7 @@ An [`\Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective`](https://github.c
 directive allows using arguments passed by the client to dynamically
 modify the database query that Lighthouse creates for a field.
 
-Currently, the following directives use the defined filters for resolving the query:
+Currently, the following directives use arguments to modify the query:
 
 - [@all](../api-reference/directives.md#all)
 - [@paginate](../api-reference/directives.md#paginate)

--- a/src/Schema/Directives/LimitDirective.php
+++ b/src/Schema/Directives/LimitDirective.php
@@ -29,7 +29,7 @@ class LimitDirective extends BaseDirective implements ArgDirective, ArgBuilderDi
         return /* @lang GraphQL */ <<<'GRAPHQL'
 """
 Allow clients to specify the maximum number of results to return when used on an argument,
-or statically limits them when used on a field.
+or statically limit them when used on a field.
 
 By default, this directive does not influence the number of results the resolver queries internally,
 but limits how much of it is returned to clients. Use the `builder` argument to change this.

--- a/src/Schema/Directives/LimitDirective.php
+++ b/src/Schema/Directives/LimitDirective.php
@@ -7,18 +7,22 @@ use GraphQL\Language\AST\InputValueDefinitionNode;
 use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Type\Definition\Type;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Execution\ResolveInfo;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgManipulator;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 use Nuwave\Lighthouse\Support\Utils;
 
-class LimitDirective extends BaseDirective implements ArgDirective, ArgManipulator, FieldMiddleware
+class LimitDirective extends BaseDirective implements ArgDirective, ArgBuilderDirective, ArgManipulator, FieldMiddleware
 {
     public static function definition(): string
     {
@@ -27,10 +31,18 @@ class LimitDirective extends BaseDirective implements ArgDirective, ArgManipulat
 Allow clients to specify the maximum number of results to return when used on an argument,
 or statically limits them when used on a field.
 
-This directive does not influence the number of results the resolver queries internally,
-but limits how much of it is returned to clients.
+By default, this directive does not influence the number of results the resolver queries internally,
+but limits how much of it is returned to clients. Use the `builder` argument to change this.
 """
-directive @limit on ARGUMENT_DEFINITION | FIELD_DEFINITION
+directive @limit(
+    """
+    You may set this to `true` if the field uses a query builder,
+    then this directive will apply a LIMIT clause to it.
+    Typically, this option should only be used for root fields,
+    as it may cause wrong results with batched relation queries.
+    """
+    builder: Boolean! = false
+) on ARGUMENT_DEFINITION | FIELD_DEFINITION
 GRAPHQL;
     }
 
@@ -40,6 +52,10 @@ GRAPHQL;
         FieldDefinitionNode &$parentField,
         ObjectTypeDefinitionNode|InterfaceTypeDefinitionNode &$parentType,
     ): void {
+        if ($this->shouldApplyToQueryBuilders()) {
+            return;
+        }
+
         $argType = ASTHelper::getUnderlyingTypeName($argDefinition->type);
         $expectedArgType = Type::INT;
         if ($expectedArgType !== $argType) {
@@ -51,6 +67,10 @@ GRAPHQL;
 
     public function handleField(FieldValue $fieldValue): void
     {
+        if ($this->shouldApplyToQueryBuilders()) {
+            return;
+        }
+
         $fieldValue->resultHandler(static function (?iterable $result, array $args, GraphQLContext $context, ResolveInfo $resolveInfo): ?iterable {
             if ($result === null) {
                 return null;
@@ -87,5 +107,21 @@ GRAPHQL;
 
             return $limited;
         });
+    }
+
+    public function handleBuilder(Relation|EloquentBuilder|QueryBuilder $builder, mixed $value): QueryBuilder|EloquentBuilder|Relation
+    {
+        if (! $this->shouldApplyToQueryBuilders()) {
+            return $builder;
+        }
+
+        assert(is_int($value));
+
+        return $builder->limit($value);
+    }
+
+    protected function shouldApplyToQueryBuilders(): bool
+    {
+        return $this->directiveArgValue('builder') ?? false;
     }
 }

--- a/tests/Integration/Auth/CanFindDirectiveDBTest.php
+++ b/tests/Integration/Auth/CanFindDirectiveDBTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Auth;
+namespace Tests\Integration\Auth;
 
 use GraphQL\Error\Error;
 use Nuwave\Lighthouse\Auth\CanDirective;

--- a/tests/Integration/Auth/CanQueryDirectiveDBTest.php
+++ b/tests/Integration/Auth/CanQueryDirectiveDBTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Auth;
+namespace Tests\Integration\Auth;
 
 use Tests\DBTestCase;
 use Tests\Utils\Models\Post;

--- a/tests/Integration/Auth/CanResolvedDirectiveDBTest.php
+++ b/tests/Integration/Auth/CanResolvedDirectiveDBTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Auth;
+namespace Tests\Integration\Auth;
 
 use Tests\DBTestCase;
 use Tests\Utils\Models\Company;

--- a/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
+++ b/tests/Integration/Execution/MutationExecutor/BelongsToTest.php
@@ -515,7 +515,6 @@ GRAPHQL
 
         $queries = [];
         DB::listen(static function (QueryExecuted $query) use (&$queries): void {
-            dump($query->sql);
             $queries[] = $query->sql;
         });
 

--- a/tests/Integration/Schema/Directives/InDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/InDirectiveTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Schema\Directives;
+namespace Tests\Integration\Schema\Directives;
 
 use Tests\DBTestCase;
 use Tests\Utils\Models\User;

--- a/tests/Integration/Schema/Directives/NotInDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/NotInDirectiveTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Schema\Directives;
+namespace Tests\Integration\Schema\Directives;
 
 use Tests\DBTestCase;
 use Tests\Utils\Models\User;

--- a/tests/Integration/Schema/Directives/WhereBetweenDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/WhereBetweenDirectiveTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Schema\Directives;
+namespace Tests\Integration\Schema\Directives;
 
 use Tests\DBTestCase;
 use Tests\Utils\Models\User;

--- a/tests/Integration/Schema/Directives/WhereBetweenDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/WhereBetweenDirectiveTest.php
@@ -2,11 +2,65 @@
 
 namespace Tests\Integration\Schema\Directives;
 
+use Carbon\Carbon;
 use Tests\DBTestCase;
 use Tests\Utils\Models\User;
 
 final class WhereBetweenDirectiveTest extends DBTestCase
 {
+    public function testBetween(): void
+    {
+        $user1 = factory(User::class)->make();
+        assert($user1 instanceof User);
+        $user1->created_at = Carbon::createStrict(2022);
+        $user1->save();
+
+        $user2 = factory(User::class)->make();
+        assert($user2 instanceof User);
+        $user2->created_at = Carbon::createStrict(2023);
+        $user2->save();
+
+        $user3 = factory(User::class)->make();
+        assert($user3 instanceof User);
+        $user3->created_at = Carbon::createStrict(2024);
+        $user3->save();
+
+        $this->schema = /** @lang GraphQL */ '
+        scalar DateTime @scalar(class: "Nuwave\\\Lighthouse\\\Schema\\\Types\\\Scalars\\\DateTime")
+
+        type User {
+            id: ID!
+        }
+
+        type Query {
+            users(createdBetween: DateTimeRange @whereBetween(key: "created_at")): [User!]! @all
+        }
+
+        input DateTimeRange {
+            from: DateTime!
+            to: DateTime!
+        }
+        ';
+
+        $this
+            ->graphQL(/** @lang GraphQL */ '
+            {
+                users(createdBetween: { from: "2022-06-06 00:00:00", to: "2023-06-06 00:00:00" }) {
+                    id
+                }
+            }
+            ')
+            ->assertExactJson([
+                'data' => [
+                    'users' => [
+                        [
+                            'id' => (string) $user2->id,
+                        ],
+                    ],
+                ],
+            ]);
+    }
+
     public function testExplicitNull(): void
     {
         $users = factory(User::class, 2)->create();
@@ -16,7 +70,6 @@ final class WhereBetweenDirectiveTest extends DBTestCase
 
         type User {
             id: ID!
-            created_at: DateTime!
         }
 
         type Query {

--- a/tests/Integration/Schema/Directives/WhereBetweenDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/WhereBetweenDirectiveTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Integration\Schema\Directives;
 
-use Carbon\Carbon;
+use Illuminate\Support\Carbon;
 use Tests\DBTestCase;
 use Tests\Utils\Models\User;
 

--- a/tests/Integration/Schema/Directives/WhereNotBetweenDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/WhereNotBetweenDirectiveTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Schema\Directives;
+namespace Tests\Integration\Schema\Directives;
 
 use Tests\DBTestCase;
 use Tests\Utils\Models\User;

--- a/tests/Integration/Schema/Directives/WhereNotNullDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/WhereNotNullDirectiveTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Schema\Directives;
+namespace Tests\Integration\Schema\Directives;
 
 use Tests\DBTestCase;
 use Tests\Utils\Models\User;

--- a/tests/Integration/Schema/Directives/WhereNullDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/WhereNullDirectiveTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Schema\Directives;
+namespace Tests\Integration\Schema\Directives;
 
 use Tests\DBTestCase;
 use Tests\Utils\Models\User;

--- a/tests/Unit/Auth/CanModelDirectiveTest.php
+++ b/tests/Unit/Auth/CanModelDirectiveTest.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Auth;
-
-use Tests\Unit\Auth\CanDirectiveTestBase;
+namespace Tests\Unit\Auth;
 
 final class CanModelDirectiveTest extends CanDirectiveTestBase
 {

--- a/tests/Unit/Auth/CanRootDirectiveTest.php
+++ b/tests/Unit/Auth/CanRootDirectiveTest.php
@@ -1,9 +1,8 @@
 <?php declare(strict_types=1);
 
-namespace Auth;
+namespace Tests\Unit\Auth;
 
 use Illuminate\Contracts\Auth\Access\Gate;
-use Tests\Unit\Auth\CanDirectiveTestBase;
 use Tests\Utils\Models\User;
 use Tests\Utils\Policies\UserPolicy;
 


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

If your field is resolved through a database query, you may add the `builder` argument to apply
an actual `LIMIT` clause to your SQL:

```graphql
type Query {
  users(limit: Int @limit(builder: true)): [User!]! @all
}
```

**Breaking changes**

None, the default behaviour is the same.