### PR TITLE
Correct decay value calculation in `@throttle` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Fixed bug where decay value in ThrottleDirective was calculated incorrectly
+
 ## v6.38.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Fixed bug where decay value in ThrottleDirective was calculated incorrectly
+- Correct decay value calculation in `@throttle` directive https://github.com/nuwave/lighthouse/pull/2573
 
 ## v6.38.0
 

--- a/src/Schema/Directives/ThrottleDirective.php
+++ b/src/Schema/Directives/ThrottleDirective.php
@@ -84,7 +84,7 @@ GRAPHQL;
                         sha1($name . $limit->key),
                         $limit->maxAttempts,
                         // Laravel 11 switched to using seconds
-                        $limit->decayMinutes ?? $limit->decaySeconds * 60,
+                        $limit->decayMinutes ?? $limit->decaySeconds / 60,
                         "{$resolveInfo->parentType}.{$resolveInfo->fieldName}",
                     );
                 }

--- a/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
@@ -103,7 +103,7 @@ final class ThrottleDirectiveTest extends TestCase
             static fn (): Limit => Limit::perMinute(1),
         );
 
-        $knownDate = Carbon::create(2020, 1, 1, 1); // arbitrary known date
+        $knownDate = Carbon::createStrict(2020, 1, 1, 1); // arbitrary known date
         Carbon::setTestNow($knownDate);
 
         $this->graphQL($query)->assertJson([

--- a/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ThrottleDirectiveTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Integration\Schema\Directives;
 
+use Carbon\Carbon;
 use Faker\Factory;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Limit;
@@ -80,6 +81,51 @@ final class ThrottleDirectiveTest extends TestCase
         $this->graphQL($query)->assertGraphQLError(
             new RateLimitException('Query.foo'),
         );
+    }
+    
+    public function testLimitClears(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo: Int @throttle(name: "test")
+        }
+        ';
+
+        $query = /** @lang GraphQL */ '
+        {
+            foo
+        }
+        ';
+
+        $rateLimiter = $this->app->make(RateLimiter::class);
+        $rateLimiter->for(
+            'test',
+            static fn (): Limit => Limit::perMinute(1),
+        );
+
+        $knownDate = Carbon::create(2020, 1, 1, 1); // arbitrary known date
+        Carbon::setTestNow($knownDate);
+
+        $this->graphQL($query)->assertJson([
+            'data' => [
+                'foo' => Foo::THE_ANSWER,
+            ],
+        ]);
+
+        $this->graphQL($query)->assertGraphQLError(
+            new RateLimitException('Query.foo'),
+        );
+
+        // wait two minutes and assert that the limit is reset
+        Carbon::setTestNow($knownDate->copy()->addMinutes(2));
+
+        $this->graphQL($query)->assertJson([
+            'data' => [
+                'foo' => Foo::THE_ANSWER,
+            ],
+        ]);
+
+        Carbon::setTestNow();
     }
 
     public function testInlineLimiter(): void


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
Resolves https://github.com/nuwave/lighthouse/issues/2569
 
- [X] Added or updated tests
- [ ] Documented user facing changes
- [X] Updated CHANGELOG.md

**Changes**

Fix bug when converting seconds to minutes - use `/` instead of `*`

**Breaking changes**

n/a
