### PR TITLE
feat: make `loadPersistedQuery` public

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -49,13 +49,6 @@ class GraphQL
      */
     protected $errorsHandler;
 
-    /**
-     * Previously persisted queries.
-     *
-     * @var array<string, DocumentNode>
-     */
-    protected array $persistedQueries = [];
-
     public function __construct(
         protected SchemaBuilder $schemaBuilder,
         protected Pipeline $pipeline,
@@ -313,19 +306,10 @@ class GraphQL
             );
         }
 
-        if (in_array($sha256hash, $this->persistedQueries)) {
-            return $this->persistedQueries[$sha256hash];
-        }
-
         $cacheFactory = Container::getInstance()->make(CacheFactory::class);
         $store = $cacheFactory->store($cacheConfig['store']);
-        $persistedQuery = $store->get("lighthouse:query:{$sha256hash}");
 
-        if ($persistedQuery) {
-            $this->persistedQueries[$sha256hash] = $persistedQuery;
-        }
-
-        return $persistedQuery
+        return $store->get("lighthouse:query:{$sha256hash}")
             // https://github.com/apollographql/apollo-server/blob/37a5c862261806817a1d71852c4e1d9cdb59eab2/packages/apollo-server-errors/src/index.ts#L230-L239
             ?? throw new Error(
                 'PersistedQueryNotFound',

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -49,6 +49,13 @@ class GraphQL
      */
     protected $errorsHandler;
 
+    /**
+     * Previously loaded queries.
+     *
+     * @var array<string, DocumentNode>
+     */
+    protected array $persistedQueries = [];
+
     public function __construct(
         protected SchemaBuilder $schemaBuilder,
         protected Pipeline $pipeline,
@@ -286,8 +293,12 @@ class GraphQL
     }
 
     /** Loads persisted query from the query cache. */
-    protected function loadPersistedQuery(string $sha256hash): DocumentNode
+    public function loadPersistedQuery(string $sha256hash): DocumentNode
     {
+        if (in_array($sha256Hash, $this->persistedQueries)) {
+            return $this->persistedQueries[$sha256hash];
+        }
+
         $lighthouseConfig = $this->configRepository->get('lighthouse');
         $cacheConfig = $lighthouseConfig['query_cache'] ?? null;
         if (

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -285,7 +285,11 @@ class GraphQL
         return $result->toArray($this->debugFlag());
     }
 
-    /** Loads persisted query from the query cache. */
+    /**
+     * Loads persisted query from the query cache.
+     *
+     * @api
+     */
     public function loadPersistedQuery(string $sha256hash): DocumentNode
     {
         $lighthouseConfig = $this->configRepository->get('lighthouse');


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
 
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

This PR will remember persisted queries locally. The idea is related to https://github.com/nuwave/lighthouse/discussions/2561. Right now, I use the `StartOperationOrOperations` event to determine whether the query is allowed or not. This works fine but previously defined queries will not work anymore as soon as I release another version. Hence, I would like to check first if the query was persisted before:
```php
$query = rescue(fn () => $graphql->loadPersistedQuery($operationId), null, false);

if ($query) {
  return true;
}
```

This PR makes `loadPersistedQuery` public and also remembers persisted queries locally to avoid hitting the cache twice.

Please let me know what you think and I can try to implement tests as well.

**Breaking changes**

n/a