### PR TITLE
Handle errors thrown in lifecycle events per operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v6.41.1
+
+### Fixed
+
+- Handle errors thrown in lifecycle events per operation
+
 ## v6.41.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Handle errors thrown in lifecycle events per operation
+- Handle errors thrown in lifecycle events per operation https://github.com/nuwave/lighthouse/pull/2584
 
 ## v6.41.0
 

--- a/docs/6/digging-deeper/extending-lighthouse.md
+++ b/docs/6/digging-deeper/extending-lighthouse.md
@@ -18,13 +18,13 @@ Add your custom directives to Lighthouse by listening for the [`RegisterDirectiv
 ```php
 namespace SomeVendor\SomePackage;
 
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 
 final class SomePackageServiceProvider extends ServiceProvider
 {
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(
             RegisterDirectiveNamespaces::class,

--- a/docs/master/digging-deeper/extending-lighthouse.md
+++ b/docs/master/digging-deeper/extending-lighthouse.md
@@ -18,13 +18,13 @@ Add your custom directives to Lighthouse by listening for the [`RegisterDirectiv
 ```php
 namespace SomeVendor\SomePackage;
 
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 
 final class SomePackageServiceProvider extends ServiceProvider
 {
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(
             RegisterDirectiveNamespaces::class,

--- a/src/Async/AsyncServiceProvider.php
+++ b/src/Async/AsyncServiceProvider.php
@@ -2,13 +2,13 @@
 
 namespace Nuwave\Lighthouse\Async;
 
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 
 class AsyncServiceProvider extends ServiceProvider
 {
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
     }

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -4,13 +4,13 @@ namespace Nuwave\Lighthouse\Auth;
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 
 class AuthServiceProvider extends ServiceProvider
 {
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
     }

--- a/src/Cache/CacheServiceProvider.php
+++ b/src/Cache/CacheServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Nuwave\Lighthouse\Cache;
 
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 
@@ -13,7 +13,7 @@ class CacheServiceProvider extends ServiceProvider
         $this->app->bind(CacheKeyAndTags::class, CacheKeyAndTagsGenerator::class);
     }
 
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
     }

--- a/src/CacheControl/CacheControlServiceProvider.php
+++ b/src/CacheControl/CacheControlServiceProvider.php
@@ -10,7 +10,7 @@ use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\WrappingType;
 use GraphQL\Utils\TypeInfo;
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\EndRequest;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
@@ -25,7 +25,7 @@ class CacheControlServiceProvider extends ServiceProvider
         $this->app->singleton(CacheControl::class);
     }
 
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
         $dispatcher->listen(StartExecution::class, function (StartExecution $startExecution): void {

--- a/src/Defer/DeferServiceProvider.php
+++ b/src/Defer/DeferServiceProvider.php
@@ -3,7 +3,7 @@
 namespace Nuwave\Lighthouse\Defer;
 
 use GraphQL\Language\Parser;
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\ManipulateAST;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
@@ -19,7 +19,7 @@ class DeferServiceProvider extends ServiceProvider
         $this->app->singleton(CreatesResponse::class, Defer::class);
     }
 
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
         $dispatcher->listen(ManipulateAST::class, fn (ManipulateAST $manipulateAST) => $this->handleManipulateAST($manipulateAST));

--- a/src/Federation/FederationServiceProvider.php
+++ b/src/Federation/FederationServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Nuwave\Lighthouse\Federation;
 
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\ManipulateAST;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
@@ -15,7 +15,7 @@ class FederationServiceProvider extends ServiceProvider
         $this->app->singleton(EntityResolverProvider::class);
     }
 
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__ . '\\Directives');
         $dispatcher->listen(ManipulateAST::class, ASTManipulator::class);

--- a/src/GlobalId/GlobalIdServiceProvider.php
+++ b/src/GlobalId/GlobalIdServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Nuwave\Lighthouse\GlobalId;
 
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 
@@ -14,7 +14,7 @@ class GlobalIdServiceProvider extends ServiceProvider
         $this->app->singleton(NodeRegistry::class);
     }
 
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
     }

--- a/src/OrderBy/OrderByServiceProvider.php
+++ b/src/OrderBy/OrderByServiceProvider.php
@@ -4,7 +4,7 @@ namespace Nuwave\Lighthouse\OrderBy;
 
 use GraphQL\Language\AST\InputObjectTypeDefinitionNode;
 use GraphQL\Language\Parser;
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\ManipulateAST;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
@@ -13,7 +13,7 @@ class OrderByServiceProvider extends ServiceProvider
 {
     public const DEFAULT_ORDER_BY_CLAUSE = 'OrderByClause';
 
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
         $dispatcher->listen(ManipulateAST::class, static function (ManipulateAST $manipulateAST): void {

--- a/src/Pagination/PaginationServiceProvider.php
+++ b/src/Pagination/PaginationServiceProvider.php
@@ -2,13 +2,13 @@
 
 namespace Nuwave\Lighthouse\Pagination;
 
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 
 class PaginationServiceProvider extends ServiceProvider
 {
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
     }

--- a/src/Pennant/PennantServiceProvider.php
+++ b/src/Pennant/PennantServiceProvider.php
@@ -2,13 +2,13 @@
 
 namespace Nuwave\Lighthouse\Pennant;
 
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 
 final class PennantServiceProvider extends ServiceProvider
 {
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
     }

--- a/src/Scout/ScoutServiceProvider.php
+++ b/src/Scout/ScoutServiceProvider.php
@@ -2,13 +2,13 @@
 
 namespace Nuwave\Lighthouse\Scout;
 
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 
 class ScoutServiceProvider extends ServiceProvider
 {
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
     }

--- a/src/SoftDeletes/SoftDeletesServiceProvider.php
+++ b/src/SoftDeletes/SoftDeletesServiceProvider.php
@@ -3,7 +3,7 @@
 namespace Nuwave\Lighthouse\SoftDeletes;
 
 use GraphQL\Language\Parser;
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\ManipulateAST;
@@ -27,7 +27,7 @@ class SoftDeletesServiceProvider extends ServiceProvider
         }
     }
 
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
         $dispatcher->listen(ManipulateAST::class, static function (ManipulateAST $manipulateAST): void {

--- a/src/Subscriptions/SubscriptionServiceProvider.php
+++ b/src/Subscriptions/SubscriptionServiceProvider.php
@@ -5,7 +5,7 @@ namespace Nuwave\Lighthouse\Subscriptions;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Nuwave\Lighthouse\Events\BuildExtensionsResponse;
@@ -44,7 +44,7 @@ class SubscriptionServiceProvider extends ServiceProvider
         $this->app->bind(ProvidesSubscriptionResolver::class, SubscriptionResolverProvider::class);
     }
 
-    public function boot(Dispatcher $dispatcher, ConfigRepository $configRepository): void
+    public function boot(EventsDispatcher $dispatcher, ConfigRepository $configRepository): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__ . '\\Directives');
         $dispatcher->listen(StartExecution::class, SubscriptionRegistry::class . '@handleStartExecution');

--- a/src/Testing/TestingServiceProvider.php
+++ b/src/Testing/TestingServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Nuwave\Lighthouse\Testing;
 
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Testing\TestResponse;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
@@ -15,7 +15,7 @@ class TestingServiceProvider extends ServiceProvider
         TestResponse::mixin(new TestResponseMixin());
     }
 
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
     }

--- a/src/Tracing/TracingServiceProvider.php
+++ b/src/Tracing/TracingServiceProvider.php
@@ -4,7 +4,7 @@ namespace Nuwave\Lighthouse\Tracing;
 
 use GraphQL\Language\Parser;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\BuildExtensionsResponse;
@@ -21,7 +21,7 @@ class TracingServiceProvider extends ServiceProvider
         $this->app->scoped(Tracing::class, static fn (Application $app): Tracing => $app->make(config('lighthouse.tracing.driver')));
     }
 
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
         $dispatcher->listen(ManipulateAST::class, static fn (ManipulateAST $manipulateAST) => ASTHelper::attachDirectiveToObjectTypeFields(

--- a/src/Validation/ValidationServiceProvider.php
+++ b/src/Validation/ValidationServiceProvider.php
@@ -2,13 +2,13 @@
 
 namespace Nuwave\Lighthouse\Validation;
 
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 
 class ValidationServiceProvider extends ServiceProvider
 {
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
     }

--- a/src/WhereConditions/WhereConditionsServiceProvider.php
+++ b/src/WhereConditions/WhereConditionsServiceProvider.php
@@ -5,7 +5,7 @@ namespace Nuwave\Lighthouse\WhereConditions;
 use GraphQL\Language\AST\InputObjectTypeDefinitionNode;
 use GraphQL\Language\Parser;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\ServiceProvider;
 use MLL\GraphQLScalars\MixedScalar;
 use Nuwave\Lighthouse\Events\ManipulateAST;
@@ -24,7 +24,7 @@ class WhereConditionsServiceProvider extends ServiceProvider
         $this->app->bind(Operator::class, SQLOperator::class);
     }
 
-    public function boot(Dispatcher $dispatcher): void
+    public function boot(EventsDispatcher $dispatcher): void
     {
         $dispatcher->listen(RegisterDirectiveNamespaces::class, static fn (): string => __NAMESPACE__);
         $dispatcher->listen(ManipulateAST::class, function (ManipulateAST $manipulateAST): void {

--- a/tests/Unit/Events/BuildSchemaStringTest.php
+++ b/tests/Unit/Events/BuildSchemaStringTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Unit\Events;
 
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Nuwave\Lighthouse\Events\BuildSchemaString;
 use Tests\TestCase;
 
@@ -10,7 +10,7 @@ final class BuildSchemaStringTest extends TestCase
 {
     public function testInjectsSourceSchemaIntoEvent(): void
     {
-        $dispatcher = $this->app->make(Dispatcher::class);
+        $dispatcher = $this->app->make(EventsDispatcher::class);
         $dispatcher->listen(BuildSchemaString::class, function (BuildSchemaString $buildSchemaString): void {
             $this->assertSame(self::PLACEHOLDER_QUERY, $buildSchemaString->userSchema);
         });
@@ -20,7 +20,7 @@ final class BuildSchemaStringTest extends TestCase
 
     public function testAddAdditionalSchemaThroughEvent(): void
     {
-        $dispatcher = $this->app->make(Dispatcher::class);
+        $dispatcher = $this->app->make(EventsDispatcher::class);
         $dispatcher->listen(BuildSchemaString::class, fn (): string => "
             extend type Query {
                 sayHello: String @field(resolver: \"{$this->qualifyTestResolver('resolveSayHello')}\")


### PR DESCRIPTION
Resolves https://github.com/nuwave/lighthouse/issues/2583
 
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Handle errors during handling of individual GraphQL operations gracefully and include them in per-operation errors.

**Breaking changes**

Error responses are now improved in certain cases.
