### PR TITLE
Improve validation message when using output types as inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v6.42.1
+
+### Changed
+
+- Improve validation message when using output types as inputs https://github.com/nuwave/lighthouse/pull/2594
+
 ## v6.42.0
 
 ### Added

--- a/src/Schema/Factories/ArgumentFactory.php
+++ b/src/Schema/Factories/ArgumentFactory.php
@@ -3,7 +3,6 @@
 namespace Nuwave\Lighthouse\Schema\Factories;
 
 use GraphQL\Language\AST\InputValueDefinitionNode;
-use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Container\Container;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;

--- a/src/Schema/Factories/ArgumentFactory.php
+++ b/src/Schema/Factories/ArgumentFactory.php
@@ -46,7 +46,6 @@ class ArgumentFactory
     {
         $definitionNodeConverter = Container::getInstance()->make(ExecutableTypeNodeConverter::class);
         $type = $definitionNodeConverter->convert($definitionNode->type);
-        assert($type instanceof Type && $type instanceof InputType);
 
         $config = [
             'name' => $definitionNode->name->value,

--- a/tests/Integration/Schema/ValidatorTest.php
+++ b/tests/Integration/Schema/ValidatorTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Integration\Schema;
+
+use GraphQL\Error\InvariantViolation;
+use Nuwave\Lighthouse\Schema\Validator as SchemaValidator;
+use Tests\TestCase;
+
+final class ValidatorTest extends TestCase
+{
+    public function testOutputTypeUsedAsInput(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            foo(foo: Foo): Int
+        }
+
+        type Foo {
+            foo: Int
+        }
+        ';
+
+        $schemaValidator = $this->app->make(SchemaValidator::class);
+
+        $this->expectExceptionObject(new InvariantViolation('The type of Query.foo(foo:) must be Input Type but got: Foo.'));
+        $schemaValidator->validate();
+    }
+}

--- a/tests/Unit/Http/Middleware/LogGraphQLQueriesTest.php
+++ b/tests/Unit/Http/Middleware/LogGraphQLQueriesTest.php
@@ -4,13 +4,14 @@ namespace Tests\Unit\Http\Middleware;
 
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Nuwave\Lighthouse\Http\Middleware\LogGraphQLQueries;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Tests\TestCase;
 
 final class LogGraphQLQueriesTest extends TestCase
 {
     /** @var \PHPUnit\Framework\MockObject\MockObject&\Psr\Log\LoggerInterface */
-    protected $logger;
+    protected MockObject $logger;
 
     protected function getEnvironmentSetUp($app): void
     {
@@ -28,10 +29,10 @@ final class LogGraphQLQueriesTest extends TestCase
     public function testLogsEveryQuery(): void
     {
         $query = /** @lang GraphQL */ <<<'GRAPHQL'
-{
-    foo
-}
-GRAPHQL;
+        {
+            foo
+        }
+        GRAPHQL;
 
         $this->logger
             ->expects($this->once())


### PR DESCRIPTION
Resolves https://github.com/nuwave/lighthouse/issues/2593
 
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

The following schema will now trigger a better error message when calling `php artisan lighthouse:validate-schema`:

```graphql
type Query {
    foo(foo: Foo): Int
}

type Foo {
    foo: Int
}
```

Before:

```
 AssertionError 

 assert($type instanceof Type && $type instanceof InputType)
 at vendor/nuwave/lighthouse/src/Schema/Factories/ArgumentFactory.php:52
```

After:

```
GraphQL\Error\InvariantViolation: The type of Query.foo(foo:) must be Input Type but got: Foo.
```

**Breaking changes**

None.