### PR TITLE
Update batch reference resolvers example code snippet

### DIFF
--- a/docs/6/federation/reference-resolvers.md
+++ b/docs/6/federation/reference-resolvers.md
@@ -101,11 +101,11 @@ final class Product implements BatchedEntityResolver
 {
     public function __invoke(array $representations): iterable
     {
-        $products = ProductRepository::byIDs(Arr::pluck($representations, 'id'));
+        $products = ProductRepository::byIDs(Arr::pluck($representations, 'id'))->keyBy('id');
 
         $result = [];
         foreach ($representations as $key => $representation) {
-            $result[$key] = $products->firstWhere('id', $representation['id']);
+            $result[$key] = $products->get($representation['id']);
         }
 
         return $result;

--- a/docs/master/federation/reference-resolvers.md
+++ b/docs/master/federation/reference-resolvers.md
@@ -101,11 +101,11 @@ final class Product implements BatchedEntityResolver
 {
     public function __invoke(array $representations): iterable
     {
-        $products = ProductRepository::byIDs(Arr::pluck($representations, 'id'));
+        $products = ProductRepository::byIDs(Arr::pluck($representations, 'id'))->keyBy('id');
 
         $result = [];
         foreach ($representations as $key => $representation) {
-            $result[$key] = $products->firstWhere('id', $representation['id']);
+            $result[$key] = $products->get($representation['id']);
         }
 
         return $result;


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
 
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

The suggested code snippet for batch reference resolvers uses the `firstWhere` method on Collection of results. This means that for every representation it searches the value with the ID in the collection (O(n) complexity). It's not a problem on small amounts of entities, however when a number of representations is quite large, it becomes slower and slower. In the project I was using it, it was 2x slower (40s vs 20s)

With the suggested change the collection is mapped by key (ID) and then uses simple array access by key to find the value (O(1) complexity), or if not found, `get` method will return `NULL` by default. 

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
