### PR TITLE
fix typo in docs

### DIFF
--- a/docs/6/api-reference/directives.md
+++ b/docs/6/api-reference/directives.md
@@ -747,7 +747,7 @@ directive @canFind(
 ) repeatable on FIELD_DEFINITION
 ```
 
-### canRoot
+### @canModel
 
 ```graphql
 """
@@ -755,7 +755,7 @@ Check a Laravel Policy to ensure the current user is authorized to access a fiel
 
 Check the policy against the root model.
 """
-directive @canRoot(
+directive @canModel(
   """
   The model name to check against.
   """

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -747,7 +747,7 @@ directive @canFind(
 ) repeatable on FIELD_DEFINITION
 ```
 
-### canRoot
+### @canModel
 
 ```graphql
 """
@@ -755,7 +755,7 @@ Check a Laravel Policy to ensure the current user is authorized to access a fiel
 
 Check the policy against the root model.
 """
-directive @canRoot(
+directive @canModel(
   """
   The model name to check against.
   """


### PR DESCRIPTION
fixes https://github.com/nuwave/lighthouse/discussions/2598

**Changes**

Fix a typo "@canModel" was named as "canRoot".


