### PR TITLE
Remove expired members from subscription topic stored in Redis set map

### DIFF
--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -62,7 +62,7 @@ class RedisStorageManager implements StoresSubscriptions
         // As explained in storeSubscriber, we use redis sets to store the names of subscribers of a topic.
         // We can retrieve all members of a set using the command smembers.
         $subscriberIds = $this->connection->command('smembers', [$this->topicKey($topic)]);
-        if (count($subscriberIds) === 0) {
+        if ($subscriberIds === []) {
             return new Collection();
         }
 
@@ -100,7 +100,7 @@ class RedisStorageManager implements StoresSubscriptions
             ->filter();
 
         // Remove expired subscribers from the set of subscribers of this topic.
-        if (! empty($missingKeys)) {
+        if ($missingKeys !== []) {
             $this->connection->command('srem', [
                 $this->topicKey($topic),
                 ...$missingKeys,

--- a/src/Subscriptions/Storage/RedisStorageManager.php
+++ b/src/Subscriptions/Storage/RedisStorageManager.php
@@ -12,6 +12,7 @@ use Nuwave\Lighthouse\Subscriptions\Subscriber;
 
 /**
  * Stores subscribers and topics in redis.
+ *
  * - Topics are subscriptions like "userCreated" or "userDeleted".
  * - Subscribers are clients that are listening to channels like "private-lighthouse-a7ef3d".
  *
@@ -84,7 +85,7 @@ class RedisStorageManager implements StoresSubscriptions
                     return null;
                 }
 
-                // Other entries may contain invalid values
+                // Other entries may contain invalid values.
                 try {
                     $subscriber = unserialize($subscriber);
 
@@ -114,7 +115,7 @@ class RedisStorageManager implements StoresSubscriptions
         $subscriber->topic = $topic;
 
         // In contrast to the CacheStorageManager, we use redis sets.
-        // Instead of reading the entire list, adding the subscriber and storing the list;
+        // Instead of reading the entire list, adding the subscriber, and storing the list;
         // we simply add the name of the subscriber to the set of subscribers of this topic using the sadd command...
         $topicKey = $this->topicKey($topic);
         $this->connection->command('sadd', [
@@ -126,7 +127,7 @@ class RedisStorageManager implements StoresSubscriptions
             $this->connection->command('expire', [$topicKey, $this->ttl]);
         }
 
-        // Lastly, we store the subscriber as a serialized string...
+        // Lastly, we store the subscriber as a serialized string.
         $setCommand = 'set';
         $setArguments = [
             $this->channelKey($subscriber->channel),

--- a/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
+++ b/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
@@ -195,7 +195,7 @@ final class RedisStorageManagerTest extends TestCase
             $subscriber2,
         ];
 
-        $redisConnection->expects($this->exactly(2))
+        $redisConnection->expects($this->exactly(3))
             ->method('command')
             ->with(...$this->withConsecutive(
                 ['smembers', ["graphql.topic.{$topic}"]],
@@ -203,10 +203,12 @@ final class RedisStorageManagerTest extends TestCase
                     'graphql.subscriber.foo1',
                     'graphql.subscriber.foo2',
                     'graphql.subscriber.foo3',
+                    'graphql.subscriber.foo4',
                 ]]],
+                ['srem', ["graphql.topic.{$topic}", 'foo3', 'foo4']],
             ))
             ->willReturnOnConsecutiveCalls(
-                ['foo1', 'foo2', 'foo3'],
+                ['foo1', 'foo2', 'foo3', 'foo4'],
                 [
                     serialize($subscriber1),
                     serialize($subscriber2),
@@ -217,6 +219,7 @@ final class RedisStorageManagerTest extends TestCase
                     // mget non-existing-entry
                     false,
                 ],
+                null,
             );
 
         $this->assertEquals(


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

When lighthouse subscriptions storage TTL is set every new subscription to channel will create a redis key with channel serializzed information and add the channel id to a map set related to specific topic and both keys will have TTL, but when channel is expired or closed without a webhook triggered the map set will keep filling with "dead" channels, `subscribersByTopic` method will already filter out the channel ids that expired, so this PR is going to collect those missing channel keys and then run SREM command to remove them from set map 
