### PR TITLE
Fix current workflow issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "webonyx/graphql-php": "^15"
     },
     "require-dev": {
-        "algolia/algoliasearch-client-php": "^3 || ^4",
+        "algolia/algoliasearch-client-php": "^3",
         "bensampo/laravel-enum": "^5 || ^6",
         "dms/phpunit-arraysubset-asserts": "^0.4 || ^0.5",
         "ergebnis/composer-normalize": "^2.2.2",

--- a/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
+++ b/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
@@ -101,6 +101,8 @@ final class RedisStorageManagerTest extends TestCase
             ))
             ->willReturnOnConsecutiveCalls(
                 serialize($subscriber),
+                true,
+                true
             );
 
         $manager = new RedisStorageManager($config, $redisFactory);

--- a/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
+++ b/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
@@ -102,7 +102,7 @@ final class RedisStorageManagerTest extends TestCase
             ->willReturnOnConsecutiveCalls(
                 serialize($subscriber),
                 true,
-                true
+                true,
             );
 
         $manager = new RedisStorageManager($config, $redisFactory);


### PR DESCRIPTION
Some workflows errors out even for unchanged source code.

### allow only algolia ^3, otherwise phpstan won't work

It is required for creating Laravel Scout manager. It was restricted to "^3" by something else (see previous successful run at https://github.com/nuwave/lighthouse/actions/runs/10253420278/job/28365987820)

the last items of full phpstan stack trace:
```
   Post the following stack trace to https://github.com/phpstan/phpstan/issues/new?template=Bug_report.yaml:
     ## /app/koka/lighthouse/vendor/laravel/scout/src/EngineManager.php(87)
     #0 /app/koka/lighthouse/vendor/laravel/scout/src/EngineManager.php(40): Laravel\Scout\EngineManager->ensureAlgoliaClientIsInstalled()
     #1 /app/koka/lighthouse/vendor/laravel/framework/src/Illuminate/Support/Manager.php(105): Laravel\Scout\EngineManager->createAlgoliaDriver()
     #2 /app/koka/lighthouse/vendor/laravel/framework/src/Illuminate/Support/Manager.php(80): Illuminate\Support\Manager->createDriver()
     #3 /app/koka/lighthouse/vendor/larastan/larastan/src/Methods/Pipes/Managers.php(33): Illuminate\Support\Manager->driver()
     #4 /app/koka/lighthouse/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): Larastan\Larastan\Methods\Pipes\Managers->handle()
     #5 /app/koka/lighthouse/vendor/larastan/larastan/src/Methods/Pipes/Facades.php(68): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
     #6 /app/koka/lighthouse/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): Larastan\Larastan\Methods\Pipes\Facades->handle()
     #7 /app/koka/lighthouse/vendor/larastan/larastan/src/Methods/Pipes/Contracts.php(35): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
     #8 /app/koka/lighthouse/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): Larastan\Larastan\Methods\Pipes\Contracts->handle()
     #9 /app/koka/lighthouse/vendor/larastan/larastan/src/Methods/Pipes/SelfClass.php(23): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
     #10 /app/koka/lighthouse/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): Larastan\Larastan\Methods\Pipes\SelfClass->handle()
     #11 /app/koka/lighthouse/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(116): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
     #12 /app/koka/lighthouse/vendor/larastan/larastan/src/Methods/Kernel.php(43): Illuminate\Pipeline\Pipeline->then()
     #13 /app/koka/lighthouse/vendor/larastan/larastan/src/Methods/Extension.php(39): Larastan\Larastan\Methods\Kernel->handle()
     #14 phar:///app/koka/lighthouse/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/ClassReflection.php(512): Larastan\Larastan\Methods\Extension->hasMethod()
     #15 phar:///app/koka/lighthouse/vendor/phpstan/phpstan/phpstan.phar/src/Type/ObjectType.php(562): PHPStan\Reflection\ClassReflection->hasMethod()
     #16 phar:///app/koka/lighthouse/vendor/phpstan/phpstan/phpstan.phar/src/Type/IntersectionType.php(428): PHPStan\Type\ObjectType->hasMethod()
     #17 phar:///app/koka/lighthouse/vendor/phpstan/phpstan/phpstan.phar/src/TrinaryLogic.php(174): PHPStan\Type\IntersectionType::PHPStan\Type\{closure}()
     #18 phar:///app/koka/lighthouse/vendor/phpstan/phpstan/phpstan.phar/src/Type/IntersectionType.php(1030): PHPStan\TrinaryLogic::lazyMaxMin()
     #19 phar:///app/koka/lighthouse/vendor/phpstan/phpstan/phpstan.phar/src/Type/IntersectionType.php(429): PHPStan\Type\IntersectionType->intersectResults()
```


### pass more responses to `willReturnOnConsecutiveCalls` in `RedisStorageManagerTest::testDeleteSubscriber` test. 

Previous versions of phpunit allows empty returns values for consecutive calls. The new one requires the same number of returns as the number of calls.