### PR TITLE
fix: ensure `deprecationReason` is set for arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+- Ensure `deprecationReason` is set on arguments and input fields https://github.com/nuwave/lighthouse/pull/2609
+
 ## v6.44.0
 
 ### Added

--- a/src/Schema/AST/ASTHelper.php
+++ b/src/Schema/AST/ASTHelper.php
@@ -327,7 +327,7 @@ class ASTHelper
     }
 
     /** Given a collection of directives, returns the string value for the deprecation reason. */
-    public static function deprecationReason(EnumValueDefinitionNode|FieldDefinitionNode $node): ?string
+    public static function deprecationReason(EnumValueDefinitionNode|FieldDefinitionNode|InputValueDefinitionNode $node): ?string
     {
         $deprecated = Values::getDirectiveValues(
             DirectiveDefinition::deprecatedDirective(),

--- a/src/Schema/Factories/ArgumentFactory.php
+++ b/src/Schema/Factories/ArgumentFactory.php
@@ -50,6 +50,7 @@ class ArgumentFactory
             'name' => $definitionNode->name->value,
             'description' => $definitionNode->description?->value,
             'type' => $type,
+            'deprecationReason' => ASTHelper::deprecationReason($definitionNode),
             'astNode' => $definitionNode,
         ];
 


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
 
- [ ] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

Without this, the `deprecationReason` is never set, and `@deprecated` directives for input fields / arguments are stripped from `lighthouse:print-schema` output.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
