### PR TITLE
Add two failing tests to reproduce failing ConvertEmptyStringsToNullDirective

### DIFF
--- a/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
@@ -161,9 +161,6 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
     public function testConvertsEmptyStringToNullOnAField(): void
     {
         $this->schema = /** @lang GraphQL */ '
@@ -189,14 +186,11 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
             'data' => [
                 'foo' => [
                     'bar' => null,
-                ]
+                ],
             ],
         ]);
     }
 
-    /**
-     * @test
-     */
     public function testConvertsEmptyStringToNullWithGlobalFieldMiddleware(): void
     {
         config(['lighthouse.field_middleware' => [
@@ -225,7 +219,7 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
             'data' => [
                 'foo' => [
                     'bar' => null,
-                ]
+                ],
             ],
         ]);
     }

--- a/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
@@ -161,14 +161,13 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
         ]);
     }
 
-    public function testConvertsEmptyStringToNullOnAField(): void
+    public function testConvertsEmptyStringToNullWithFieldDirective(): void
     {
         $this->schema = /** @lang GraphQL */ '
         type Query {
-            foo(bar: String!): FooResponse
+            foo(bar: String): FooResponse
                 @convertEmptyStringsToNull
                 @field(resolver: "Tests\\\Utils\\\Mutations\\\ReturnReceivedInput")
-
         }
 
         type FooResponse {
@@ -199,9 +198,8 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
 
         $this->schema = /** @lang GraphQL */ '
         type Query {
-            foo(bar: String!): FooResponse
+            foo(bar: String): FooResponse
                 @field(resolver: "Tests\\\Utils\\\Mutations\\\ReturnReceivedInput")
-
         }
 
         type FooResponse {

--- a/tests/Utils/Mutations/ReturnReceivedInput.php
+++ b/tests/Utils/Mutations/ReturnReceivedInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Utils\Mutations;
+
+class ReturnReceivedInput
+{
+    public function __invoke($rootValue, array $args): array
+    {
+        return $args;
+    }
+}

--- a/tests/Utils/Mutations/ReturnReceivedInput.php
+++ b/tests/Utils/Mutations/ReturnReceivedInput.php
@@ -1,12 +1,15 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Tests\Utils\Mutations;
 
-class ReturnReceivedInput
+final class ReturnReceivedInput
 {
-    public function __invoke($rootValue, array $args): array
+    /**
+     * @param array<string, mixed> $args
+     *
+     * @return array<string, mixed>
+     */
+    public function __invoke(mixed $root, array $args): array
     {
         return $args;
     }


### PR DESCRIPTION
This MR merely serves as a means to reproduce the error described in https://github.com/nuwave/lighthouse/issues/2610