### PR TITLE
Add failing test for ConvertEmptyStringsToNullDirective when used on mutation with input type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v6.44.2
+
+### Fixed
+
+- Apply `@convertEmptyStringsToNull` to input fields when used upon fields https://github.com/nuwave/lighthouse/issues/2610
+
 ## v6.44.1
 
 ### Fixed

--- a/src/Schema/Directives/ConvertEmptyStringsToNullDirective.php
+++ b/src/Schema/Directives/ConvertEmptyStringsToNullDirective.php
@@ -44,12 +44,13 @@ GRAPHQL;
     {
         foreach ($argumentSet->arguments as $argument) {
             $namedType = $argument->namedType();
-            if (
-                $namedType !== null
+            $argumentValue = $argument->value;
+
+            $isNullableStringType = $namedType !== null
                 && $namedType->name === ScalarType::STRING
-                && ! $namedType->nonNull
-            ) {
-                $argument->value = $this->sanitize($argument->value);
+                && ! $namedType->nonNull;
+            if ($isNullableStringType || $argumentValue instanceof ArgumentSet) {
+                $argument->value = $this->sanitize($argumentValue);
             }
         }
 
@@ -63,10 +64,8 @@ GRAPHQL;
      */
     protected function transformLeaf(mixed $value): mixed
     {
-        if ($value === '') {
-            return null;
-        }
-
-        return $value;
+        return $value === ''
+            ? null
+            : $value;
     }
 }

--- a/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/ConvertEmptyStringsToNullDirectiveTest.php
@@ -231,15 +231,15 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
                 @field(resolver: "Tests\\\Utils\\\Mutations\\\ReturnReceivedInput")
         }
 
+        input FooInput {
+            bar: String
+        }
+
         type FooInputResponse {
             input: FooResponse
         }
 
         type FooResponse {
-            bar: String
-        }
-
-        input FooInput {
             bar: String
         }
         ';
@@ -277,15 +277,15 @@ final class ConvertEmptyStringsToNullDirectiveTest extends TestCase
                 @field(resolver: "Tests\\\Utils\\\Mutations\\\ReturnReceivedInput")
         }
 
+        input FooInput {
+            bar: String
+        }
+
         type FooInputResponse {
             input: FooResponse
         }
 
         type FooResponse {
-            bar: String
-        }
-
-        input FooInput {
             bar: String
         }
         ';


### PR DESCRIPTION
@spawnia Terribly sorry to have to bother you once more, but I think I now have two tests that lay out exactly the scenario that I am facing. The difference with the previous tests is in this case, an input type is used.

This relates to https://github.com/nuwave/lighthouse/issues/2610. Would you like me to create a new issue or can we reopen that one? Thanks again!