### PR TITLE
fix: return deleted models that have relations

### DIFF
--- a/src/Execution/BatchLoader/RelationBatchLoader.php
+++ b/src/Execution/BatchLoader/RelationBatchLoader.php
@@ -49,13 +49,13 @@ class RelationBatchLoader
                 $this->resolve();
             }
 
-            return $this->results[$modelKey];
+            return $this->results[$modelKey] ?? null;
         });
     }
 
     protected function resolve(): void
     {
-        $parentModels = new EloquentCollection($this->parents);
+        $parentModels = (new EloquentCollection($this->parents))->filter(fn (Model $model): bool => $model->exists);
 
         // Monomorphize the models to simplify eager loading relations onto them
         $parentsGroupedByClass = $parentModels->groupBy(


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
 
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

Right now, it's not possible to return deleted models and query relations at the same time. For example, when running a mutation that deletes a model I would like to still return the model that was just deleted but if any of its relations is queried as well it will run into an exception, e.g.:
````
Error: Call to a member function getAttributes() on null in /app/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Collection.php:96
Stack trace:
#0 /app/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Collection.php(119): Illuminate\Database\Eloquent\Collection->loadAggregate(Array, '*', 'count')
#1 /app/vendor/nuwave/lighthouse/src/Execution/ModelsLoader/CountModelsLoader.php(18): Illuminate\Database\Eloquent\Collection->loadCount(Array)
#2 /app/vendor/nuwave/lighthouse/src/Execution/BatchLoader/RelationBatchLoader.php(68): Nuwave\Lighthouse\Execution\ModelsLoader\CountModelsLoader->load(Object(Illuminate\Database\Eloquent\Collection))
#3 /app/vendor/nuwave/lighthouse/src/Execution/BatchLoader/RelationBatchLoader.php(49): Nuwave\Lighthouse\Execution\BatchLoader\RelationBatchLoader->resolve()
#4 /app/vendor/webonyx/graphql-php/src/Executor/Promise/Adapter/SyncPromise.php(63): Nuwave\Lighthouse\Execution\BatchLoader\RelationBatchLoader->Nuwave\Lighthouse\Execution\BatchLoader\{closure}()
````

This PR serves as a draft and is open to discussion how to handle for example the following cases:
- Shall we return null or 0 on related counts?
- Shall we return null or empty array on related collections?

**Breaking changes**

tbd