### PR TITLE
for Laravel 11: add service provider to bootstrap/providers.php

### DIFF
--- a/docs/master/eloquent/complex-where-conditions.md
+++ b/docs/master/eloquent/complex-where-conditions.md
@@ -9,7 +9,7 @@ and allow them to apply complex, dynamic WHERE conditions to queries.
 
 ## Setup
 
-For Laravel 11 and higher: add the service provider to your `bootstrap/providers.php`:
+For Laravel 11 and higher, add the service provider to your `bootstrap/providers.php`:
 
 ```php
 return [

--- a/docs/master/eloquent/complex-where-conditions.md
+++ b/docs/master/eloquent/complex-where-conditions.md
@@ -9,7 +9,16 @@ and allow them to apply complex, dynamic WHERE conditions to queries.
 
 ## Setup
 
-Add the service provider to your `config/app.php`:
+For Laravel 11 and higher: add the service provider to your `bootstrap/providers.php`:
+
+```php
+return [
+    // ...
+    \Nuwave\Lighthouse\WhereConditions\WhereConditionsServiceProvider::class,
+]
+```
+
+For other versions, add the service provider to your `config/app.php`:
 
 ```php
 'providers' => [


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
 
- [ ] Added or updated tests
- [x] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

Updated the documentation. Laravel 11 has new location for registering service providers: `bootstrap/providers.php`

**Breaking changes**

None.
