### PR TITLE
Allow `@show`, `@hide`, and `@feature` directives to be used on types, arguments and input types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+- Allow `@show`, `@hide` and `@feature` directive to be used on types, arguments and input types. https://github.com/nuwave/lighthouse/pull/2638
+
 ## v6.45.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
-- Allow `@show`, `@hide` and `@feature` directive to be used on types, arguments and input types. https://github.com/nuwave/lighthouse/pull/2638
+## v6.46.0
+
+### Added
+
+- Allow `@show`, `@hide`, and `@feature` directives to be used on types, arguments and input types https://github.com/nuwave/lighthouse/pull/2638
 
 ## v6.45.1
 

--- a/docs/6/digging-deeper/feature-toggles.md
+++ b/docs/6/digging-deeper/feature-toggles.md
@@ -1,6 +1,6 @@
 # Feature Toggles
 
-Lighthouse allows you to conditionally show or hide elements of your schema.
+Lighthouse allows you to conditionally show or hide elements (fields, types, arguments or input fields) of your schema.
 
 ## @show and @hide
 
@@ -27,8 +27,8 @@ type Query {
 
 ## @feature
 
-The [@feature](../api-reference/directives.md#feature) directive allows to include fields in the schema depending
-on a [Laravel Pennant](https://laravel.com/docs/pennant) feature.
+The [@feature](../api-reference/directives.md#feature) directive allows to include fields, types, arguments, or input fields in the schema
+depending on whether a [Laravel Pennant](https://laravel.com/docs/pennant) feature is active.
 
 For example, you might want a new experimental field only to be available when the according feature is active:
 
@@ -54,6 +54,22 @@ the fully qualified class name must be used as the value for the `name` argument
 ```graphql
 type Query {
   experimentalField: String! @feature(name: "App\\Features\\NewApi")
+}
+```
+
+## Conditional Type Inclusion
+
+When you conditionally include a type using [@show](../api-reference/directives.md#show), [@hide](../api-reference/directives.md#hide) or [@feature](../api-reference/directives.md#feature),
+any fields using it must also be conditionally included.
+If the type is omitted but still used somewhere, the schema will be invalid.
+
+```graphql
+type ExperimentalType @feature(name: "new-api") {
+  field: String!
+}
+
+type Query {
+  experimentalField: ExperimentalType @feature(name: "new-api")
 }
 ```
 

--- a/docs/master/digging-deeper/feature-toggles.md
+++ b/docs/master/digging-deeper/feature-toggles.md
@@ -1,6 +1,6 @@
 # Feature Toggles
 
-Lighthouse allows you to conditionally show or hide elements of your schema.
+Lighthouse allows you to conditionally show or hide elements (fields, types, arguments or input fields) of your schema.
 
 ## @show and @hide
 
@@ -27,7 +27,7 @@ type Query {
 
 ## @feature
 
-The [@feature](../api-reference/directives.md#feature) directive allows to include fields in the schema depending
+The [@feature](../api-reference/directives.md#feature) directive allows to include fields, types, arguments or input fields, in the schema depending
 on a [Laravel Pennant](https://laravel.com/docs/pennant) feature.
 
 For example, you might want a new experimental field only to be available when the according feature is active:
@@ -54,6 +54,21 @@ the fully qualified class name must be used as the value for the `name` argument
 ```graphql
 type Query {
   experimentalField: String! @feature(name: "App\\Features\\NewApi")
+}
+```
+
+## Conditional Type Inclusion
+
+When you conditionally include a type, using [@show](../api-reference/directives.md#show), [@hide](../api-reference/directives.md#hide) or [@feature](../api-reference/directives.md#feature), any fields using it must 
+also be conditionally included, otherwise the schema might be invalid in case the type is missing.
+
+```graphql
+type ExperimentalType @feature(name: "new-api") {
+  field: String!
+}
+
+type Query {
+  experimentalField: ExperimentalType @feature(name: "new-api")
 }
 ```
 

--- a/docs/master/digging-deeper/feature-toggles.md
+++ b/docs/master/digging-deeper/feature-toggles.md
@@ -27,8 +27,8 @@ type Query {
 
 ## @feature
 
-The [@feature](../api-reference/directives.md#feature) directive allows to include fields, types, arguments or input fields, in the schema depending
-on a [Laravel Pennant](https://laravel.com/docs/pennant) feature.
+The [@feature](../api-reference/directives.md#feature) directive allows to include fields, types, arguments, or input fields in the schema
+depending on whether a [Laravel Pennant](https://laravel.com/docs/pennant) feature is active.
 
 For example, you might want a new experimental field only to be available when the according feature is active:
 
@@ -59,8 +59,9 @@ type Query {
 
 ## Conditional Type Inclusion
 
-When you conditionally include a type, using [@show](../api-reference/directives.md#show), [@hide](../api-reference/directives.md#hide) or [@feature](../api-reference/directives.md#feature), any fields using it must 
-also be conditionally included, otherwise the schema might be invalid in case the type is missing.
+When you conditionally include a type using [@show](../api-reference/directives.md#show), [@hide](../api-reference/directives.md#hide) or [@feature](../api-reference/directives.md#feature),
+any fields using it must also be conditionally included.
+If the type is omitted but still used somewhere, the schema will be invalid.
 
 ```graphql
 type ExperimentalType @feature(name: "new-api") {

--- a/src/Pennant/FeatureDirective.php
+++ b/src/Pennant/FeatureDirective.php
@@ -6,7 +6,7 @@ use Laravel\Pennant\FeatureManager;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\Directives\HideDirective;
 
-final class FeatureDirective extends HideDirective
+class FeatureDirective extends HideDirective
 {
     public function __construct(
         private FeatureManager $features,

--- a/src/Pennant/FeatureDirective.php
+++ b/src/Pennant/FeatureDirective.php
@@ -30,7 +30,7 @@ directive @feature(
     Specify what the state of the feature should be for the field to be included.
     """
     when: FeatureState! = ACTIVE
-) on FIELD_DEFINITION | OBJECT
+) repeatable on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION | OBJECT
 
 """
 Options for the `when` argument of `@feature`.

--- a/src/Schema/Directives/ShowDirective.php
+++ b/src/Schema/Directives/ShowDirective.php
@@ -15,7 +15,7 @@ directive @show(
   Specify which environments may use this field, e.g. ["testing"].
   """
   env: [String!]!
-) repeatable on FIELD_DEFINITION
+) repeatable on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION | OBJECT
 GRAPHQL;
     }
 

--- a/tests/Unit/Schema/Directives/HideDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/HideDirectiveTest.php
@@ -40,6 +40,91 @@ final class HideDirectiveTest extends TestCase
         $this->graphQL($query)->assertGraphQLErrorMessage('Cannot query field "hiddenField" on type "Query". Did you mean "shownField"?');
     }
 
+    public function testHiddenArgs(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            field(hiddenArg: String @hide(env: ["testing"])): String! @mock
+        }
+        ';
+
+        $introspectionQuery = /** @lang GraphQL */ '
+        {
+            __schema {
+                queryType {
+                    fields {
+                        args {
+                            name
+                        }
+                    }
+                }
+            }
+        }
+        ';
+
+        $this->graphQL($introspectionQuery)
+            ->assertJsonCount(0, 'data.__schema.queryType.fields.0.args');
+    }
+
+    public function testHiddenType(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            field: String! @mock
+        }
+        type HiddenType @hide(env: ["testing"]) {
+            field: String!
+        }
+        ';
+
+        $introspectionQuery = /** @lang GraphQL */ '
+        {
+            __schema {
+                types {
+                    name
+                }
+            }
+        }
+        ';
+
+        $types = $this->graphQL($introspectionQuery)
+            ->json('data.__schema.types.*.name');
+
+        $this->assertNotContains('HiddenType', $types);
+    }
+
+    public function testHiddenInputField(): void
+    {
+        $this->schema = /** @lang GraphQL */ '
+        type Query {
+            field: String! @mock
+        }
+
+        input Input {
+            hiddenInputField: String! @hide(env: ["testing"])
+        }
+        ';
+
+        $introspectionQuery = /** @lang GraphQL */ '
+        {
+            __schema {
+                types {
+                    name
+                    inputFields {
+                        name
+                    }
+                }
+            }
+        }
+        ';
+
+        $types = $this->graphQL($introspectionQuery)->json('data.__schema.types');
+
+        $input = array_find($types, fn (array $type): bool => $type['name'] === 'Input');
+
+        $this->assertEmpty($input['inputFields']);
+    }
+
     public function testHiddenWhenManuallySettingEnv(): void
     {
         $this->schema = /** @lang GraphQL */ '

--- a/tests/Unit/Schema/Directives/HideDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/HideDirectiveTest.php
@@ -118,7 +118,8 @@ final class HideDirectiveTest extends TestCase
         }
         ';
 
-        $types = $this->graphQL($introspectionQuery)->json('data.__schema.types');
+        $types = $this->graphQL($introspectionQuery)
+            ->json('data.__schema.types');
 
         $input = array_filter($types, fn (array $type): bool => $type['name'] === 'Input');
 

--- a/tests/Unit/Schema/Directives/HideDirectiveTest.php
+++ b/tests/Unit/Schema/Directives/HideDirectiveTest.php
@@ -120,9 +120,10 @@ final class HideDirectiveTest extends TestCase
 
         $types = $this->graphQL($introspectionQuery)->json('data.__schema.types');
 
-        $input = array_find($types, fn (array $type): bool => $type['name'] === 'Input');
+        $input = array_filter($types, fn (array $type): bool => $type['name'] === 'Input');
 
-        $this->assertEmpty($input['inputFields']);
+        $this->assertCount(1, $input);
+        $this->assertEmpty(current($input)['inputFields']);
     }
 
     public function testHiddenWhenManuallySettingEnv(): void


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
 
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Directives `@show`, `@hide` and `@feature` can now be used on types, arguments and input types.
Allow `FeatureDirective` class to be extended in user-land.

**Breaking changes**

None.