### PR TITLE
Support reverb as a broadcasting driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- Support Laravel Reverb as a subscriptions broadcasting driver https://github.com/nuwave/lighthouse/pull/2639
+
 ## v6.46.0
 
 ### Added

--- a/benchmarks/QueryBench.php
+++ b/benchmarks/QueryBench.php
@@ -20,10 +20,10 @@ abstract class QueryBench extends TestCase
     {
         parent::setUp();
 
-        $configRepository = $this->app->make(ConfigRepository::class);
-        assert($configRepository instanceof ConfigRepository);
+        $config = $this->app->make(ConfigRepository::class);
+        assert($config instanceof ConfigRepository);
 
-        $routeName = $configRepository->get('lighthouse.route.name');
+        $routeName = $config->get('lighthouse.route.name');
         $this->graphQLEndpoint = route($routeName);
     }
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -86,9 +86,8 @@ parameters:
     message: '#Call to method version\(\) on an unknown class Laravel\\Lumen\\Application.#'
   - path: src/Subscriptions/SubscriptionRouter.php
     messages:
-      - '#Parameter \$router of method Nuwave\\Lighthouse\\Subscriptions\\SubscriptionRouter::pusher\(\) has invalid type Laravel\\Lumen\\Routing\\Router\.#'
+      - '#Parameter \$router of method Nuwave\\Lighthouse\\Subscriptions\\SubscriptionRouter::.+\(\) has invalid type Laravel\\Lumen\\Routing\\Router\.#'
       - '#Call to method post\(\) on an unknown class Laravel\\Lumen\\Routing\\Router\.#'
-      - '#Parameter \$router of method Nuwave\\Lighthouse\\Subscriptions\\SubscriptionRouter::echoRoutes\(\) has invalid type Laravel\\Lumen\\Routing\\Router\.#'
   - path: src/Http/routes.php
     messages:
       - '#PHPDoc tag @var for variable \$router contains unknown class Laravel\\Lumen\\Routing\\Router\.#'

--- a/src/Subscriptions/BroadcastDriverManager.php
+++ b/src/Subscriptions/BroadcastDriverManager.php
@@ -17,7 +17,7 @@ use Pusher\Pusher;
  * @method \Symfony\Component\HttpFoundation\Response authorized(\Illuminate\Http\Request $request)
  * @method \Symfony\Component\HttpFoundation\Response unauthorized(\Illuminate\Http\Request $request)
  */
-class BroadcastManager extends DriverManager
+class BroadcastDriverManager extends DriverManager
 {
     protected function configKey(): string
     {
@@ -38,11 +38,9 @@ class BroadcastManager extends DriverManager
     protected function createPusherDriver(array $config): PusherBroadcaster
     {
         $connection = $config['connection'] ?? 'pusher';
-        $driverConfig = config("broadcasting.connections.{$connection}");
 
-        if (empty($driverConfig) || $driverConfig['driver'] !== 'pusher') {
-            throw new \RuntimeException("Could not initialize Pusher broadcast driver for connection: {$connection}.");
-        }
+        $driverConfig = config("broadcasting.connections.{$connection}")
+            ?? throw new \RuntimeException("Missing connection {$connection} from config/broadcasting.php.");
 
         $pusher = new Pusher(
             $driverConfig['key'],

--- a/src/Subscriptions/SubscriptionBroadcaster.php
+++ b/src/Subscriptions/SubscriptionBroadcaster.php
@@ -19,7 +19,7 @@ class SubscriptionBroadcaster implements BroadcastsSubscriptions
         protected AuthorizesSubscriptions $subscriptionAuthorizer,
         protected StoresSubscriptions $subscriptionStorage,
         protected SubscriptionIterator $subscriptionIterator,
-        protected BroadcastManager $broadcastManager,
+        protected BroadcastDriverManager $broadcastDriverManager,
         protected BusDispatcher $busDispatcher,
     ) {}
 
@@ -50,7 +50,7 @@ class SubscriptionBroadcaster implements BroadcastsSubscriptions
                     $subscriber->variables,
                     $subscriber,
                 );
-                $this->broadcastManager->broadcast($subscriber, $result);
+                $this->broadcastDriverManager->broadcast($subscriber, $result);
             },
         );
     }
@@ -58,7 +58,7 @@ class SubscriptionBroadcaster implements BroadcastsSubscriptions
     public function authorize(Request $request): Response
     {
         return $this->subscriptionAuthorizer->authorize($request)
-            ? $this->broadcastManager->authorized($request)
-            : $this->broadcastManager->unauthorized($request);
+            ? $this->broadcastDriverManager->authorized($request)
+            : $this->broadcastDriverManager->unauthorized($request);
     }
 }

--- a/src/Subscriptions/SubscriptionController.php
+++ b/src/Subscriptions/SubscriptionController.php
@@ -13,8 +13,8 @@ class SubscriptionController
         return $broadcaster->authorize($request);
     }
 
-    public function webhook(Request $request, BroadcastManager $broadcastManager): Response
+    public function webhook(Request $request, BroadcastDriverManager $broadcastDriverManager): Response
     {
-        return $broadcastManager->hook($request);
+        return $broadcastDriverManager->hook($request);
     }
 }

--- a/src/Subscriptions/SubscriptionRouter.php
+++ b/src/Subscriptions/SubscriptionRouter.php
@@ -7,7 +7,7 @@ use Laravel\Lumen\Routing\Router;
 
 class SubscriptionRouter
 {
-    /** Register the routes for pusher based subscriptions. */
+    /** Register the routes for Pusher based subscriptions. */
     public function pusher(Registrar|Router $router): void
     {
         $router->post('graphql/subscriptions/auth', [
@@ -21,6 +21,16 @@ class SubscriptionRouter
         ]);
     }
 
+    /** Register the routes for Laravel Reverb based subscriptions. */
+    public function reverb(Registrar|Router $router): void
+    {
+        $router->post('graphql/subscriptions/auth', [
+            'as' => 'lighthouse.subscriptions.auth',
+            'uses' => SubscriptionController::class . '@authorize',
+        ]);
+    }
+
+    /** Register the routes for Laravel Echo based subscriptions. */
     public function echoRoutes(Registrar|Router $router): void
     {
         $router->post('graphql/subscriptions/auth', [

--- a/src/Subscriptions/SubscriptionServiceProvider.php
+++ b/src/Subscriptions/SubscriptionServiceProvider.php
@@ -26,7 +26,7 @@ class SubscriptionServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        $this->app->singleton(BroadcastManager::class);
+        $this->app->singleton(BroadcastDriverManager::class);
         $this->app->singleton(SubscriptionRegistry::class);
         $this->app->singleton(StoresSubscriptions::class, static function (Container $app): StoresSubscriptions {
             $configRepository = $app->make(ConfigRepository::class);

--- a/src/Testing/MakesGraphQLRequests.php
+++ b/src/Testing/MakesGraphQLRequests.php
@@ -8,8 +8,8 @@ use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Support\Arr;
 use Illuminate\Testing\TestResponse;
 use Nuwave\Lighthouse\Http\Responses\MemoryStream;
+use Nuwave\Lighthouse\Subscriptions\BroadcastDriverManager;
 use Nuwave\Lighthouse\Subscriptions\Broadcasters\LogBroadcaster;
-use Nuwave\Lighthouse\Subscriptions\BroadcastManager;
 use Nuwave\Lighthouse\Subscriptions\Contracts\Broadcaster;
 use Nuwave\Lighthouse\Support\Contracts\CanStreamResponse;
 use PHPUnit\Framework\Assert;
@@ -246,11 +246,11 @@ trait MakesGraphQLRequests
             $config->get('lighthouse.subscriptions.broadcasters.log'),
         ));
 
-        $broadcastManager = $app->make(BroadcastManager::class);
-        assert($broadcastManager instanceof BroadcastManager);
+        $broadcastDriverManager = $app->make(BroadcastDriverManager::class);
+        assert($broadcastDriverManager instanceof BroadcastDriverManager);
 
         // adding a custom driver which is a spied version of log driver
-        $broadcastManager->extend('mock', fn () => $this->spy(LogBroadcaster::class)->makePartial());
+        $broadcastDriverManager->extend('mock', fn () => $this->spy(LogBroadcaster::class)->makePartial());
 
         // set the custom driver as the default driver
         $config->set('lighthouse.subscriptions.broadcaster', 'mock');

--- a/src/Testing/MakesGraphQLRequestsLumen.php
+++ b/src/Testing/MakesGraphQLRequestsLumen.php
@@ -8,8 +8,8 @@ use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Support\Arr;
 use Illuminate\Testing\TestResponse;
 use Nuwave\Lighthouse\Http\Responses\MemoryStream;
+use Nuwave\Lighthouse\Subscriptions\BroadcastDriverManager;
 use Nuwave\Lighthouse\Subscriptions\Broadcasters\LogBroadcaster;
-use Nuwave\Lighthouse\Subscriptions\BroadcastManager;
 use Nuwave\Lighthouse\Subscriptions\Contracts\Broadcaster;
 use Nuwave\Lighthouse\Support\Contracts\CanStreamResponse;
 use PHPUnit\Framework\Assert;
@@ -265,11 +265,11 @@ trait MakesGraphQLRequestsLumen
             $config->get('lighthouse.subscriptions.broadcasters.log'),
         ));
 
-        $broadcastManager = $app->make(BroadcastManager::class);
-        assert($broadcastManager instanceof BroadcastManager);
+        $broadcastDriverManager = $app->make(BroadcastDriverManager::class);
+        assert($broadcastDriverManager instanceof BroadcastDriverManager);
 
         // adding a custom driver which is a spied version of log driver
-        $broadcastManager->extend('mock', fn () => $this->spy(LogBroadcaster::class)->makePartial());
+        $broadcastDriverManager->extend('mock', fn () => $this->spy(LogBroadcaster::class)->makePartial());
 
         // set the custom driver as the default driver
         $config->set('lighthouse.subscriptions.broadcaster', 'mock');

--- a/src/Testing/TestResponseMixin.php
+++ b/src/Testing/TestResponseMixin.php
@@ -8,15 +8,13 @@ use Illuminate\Support\Arr;
 use Illuminate\Testing\TestResponse;
 use Mockery\LegacyMockInterface;
 use Mockery\MockInterface;
-use Nuwave\Lighthouse\Subscriptions\BroadcastManager;
+use Nuwave\Lighthouse\Subscriptions\BroadcastDriverManager;
 use Nuwave\Lighthouse\Subscriptions\Contracts\Broadcaster;
 use Nuwave\Lighthouse\Subscriptions\Subscriber;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @mixin \Illuminate\Testing\TestResponse
- */
+/** @mixin \Illuminate\Testing\TestResponse */
 class TestResponseMixin
 {
     public function assertGraphQLValidationError(): \Closure
@@ -155,12 +153,13 @@ class TestResponseMixin
     public function graphQLSubscriptionMock(): \Closure
     {
         return function (): MockInterface {
-            $broadcastManager = Container::getInstance()->make(BroadcastManager::class);
-            assert($broadcastManager instanceof BroadcastManager);
-            $mock = $broadcastManager->driver();
-            assert($mock instanceof Broadcaster && $mock instanceof MockInterface);
+            $broadcastDriverManager = Container::getInstance()->make(BroadcastDriverManager::class);
+            assert($broadcastDriverManager instanceof BroadcastDriverManager);
 
-            return $mock;
+            $broadcastDriver = $broadcastDriverManager->driver();
+            assert($broadcastDriver instanceof Broadcaster && $broadcastDriver instanceof MockInterface);
+
+            return $broadcastDriver;
         };
     }
 

--- a/src/Testing/TestsSubscriptions.php
+++ b/src/Testing/TestsSubscriptions.php
@@ -4,13 +4,11 @@ namespace Nuwave\Lighthouse\Testing;
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Nuwave\Lighthouse\Subscriptions\BroadcastDriverManager;
 use Nuwave\Lighthouse\Subscriptions\Broadcasters\LogBroadcaster;
-use Nuwave\Lighthouse\Subscriptions\BroadcastManager;
 use Nuwave\Lighthouse\Subscriptions\Contracts\Broadcaster;
 
-/**
- * Sets up the environment for testing subscriptions.
- */
+/** Sets up the environment for testing subscriptions. */
 trait TestsSubscriptions
 {
     protected function setUpTestsSubscriptions(): void
@@ -27,11 +25,11 @@ trait TestsSubscriptions
             $config->get('lighthouse.subscriptions.broadcasters.log'),
         ));
 
-        $broadcastManager = $app->make(BroadcastManager::class);
-        assert($broadcastManager instanceof BroadcastManager);
+        $broadcastDriverManager = $app->make(BroadcastDriverManager::class);
+        assert($broadcastDriverManager instanceof BroadcastDriverManager);
 
         // adding a custom driver which is a spied version of log driver
-        $broadcastManager->extend('mock', fn () => $this->spy(LogBroadcaster::class)->makePartial());
+        $broadcastDriverManager->extend('mock', fn () => $this->spy(LogBroadcaster::class)->makePartial());
 
         // set the custom driver as the default driver
         $config->set('lighthouse.subscriptions.broadcaster', 'mock');

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -435,15 +435,20 @@ return [
             'log' => [
                 'driver' => 'log',
             ],
-            'pusher' => [
-                'driver' => 'pusher',
-                'routes' => Nuwave\Lighthouse\Subscriptions\SubscriptionRouter::class . '@pusher',
-                'connection' => 'pusher',
-            ],
             'echo' => [
                 'driver' => 'echo',
                 'connection' => env('LIGHTHOUSE_SUBSCRIPTION_REDIS_CONNECTION', 'default'),
                 'routes' => Nuwave\Lighthouse\Subscriptions\SubscriptionRouter::class . '@echoRoutes',
+            ],
+            'pusher' => [
+                'driver' => 'pusher',
+                'connection' => 'pusher',
+                'routes' => Nuwave\Lighthouse\Subscriptions\SubscriptionRouter::class . '@pusher',
+            ],
+            'reverb' => [
+                'driver' => 'pusher',
+                'connection' => 'reverb',
+                'routes' => Nuwave\Lighthouse\Subscriptions\SubscriptionRouter::class . '@reverb',
             ],
         ],
 

--- a/tests/Unit/Subscriptions/Broadcasters/PusherBroadcasterTest.php
+++ b/tests/Unit/Subscriptions/Broadcasters/PusherBroadcasterTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Unit\Subscriptions\Broadcasters;
 
 use Illuminate\Config\Repository as ConfigRepository;
+use Nuwave\Lighthouse\Subscriptions\BroadcastDriverManager;
 use Nuwave\Lighthouse\Subscriptions\Broadcasters\PusherBroadcaster;
-use Nuwave\Lighthouse\Subscriptions\BroadcastManager;
 use Nuwave\Lighthouse\Subscriptions\Subscriber;
 use Psr\Log\LoggerInterface;
 use Tests\EnablesSubscriptionServiceProvider;
@@ -56,8 +56,9 @@ final class PusherBroadcasterTest extends TestCase
     /** @param  \Nuwave\Lighthouse\Subscriptions\Subscriber&\PHPUnit\Framework\MockObject\MockObject  $subscriber */
     private function broadcast(object $subscriber): void
     {
-        $broadcastManager = $this->app->make(BroadcastManager::class);
-        $pusherBroadcaster = $broadcastManager->driver('pusher');
+        $broadcastDriverManager = $this->app->make(BroadcastDriverManager::class);
+
+        $pusherBroadcaster = $broadcastDriverManager->driver('pusher');
         assert($pusherBroadcaster instanceof PusherBroadcaster);
 
         $pusherBroadcaster->broadcast($subscriber, 'foo');


### PR DESCRIPTION
Resolves https://github.com/nuwave/lighthouse/issues/2564

Supersedes https://github.com/nuwave/lighthouse/pull/2612
 
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Adds a configuration option for `lighthouse.subscriptions.broadcasters` to support Laravel Reverb.

**Breaking changes**

Some internals were renamed, they should not be publicly used.