### PR TITLE
Force `int` cast on ModelsLoader count

### DIFF
--- a/src/Execution/ModelsLoader/CountModelsLoader.php
+++ b/src/Execution/ModelsLoader/CountModelsLoader.php
@@ -32,9 +32,12 @@ class CountModelsLoader implements ModelsLoader
          */
         $countAttributeName = Str::snake("{$relationName}_count");
 
-        $count = (int) $model->getAttribute($countAttributeName);
-        assert(is_int($count), 'avoid runtime check in production since the return type validates this anyway');
+        $count = $model->getAttribute($countAttributeName);
+        if (! is_numeric($count)) {
+            $nonNumericCount = Utils::printSafe($count);
+            throw new \Exception('Expected numeric count, got: {$nonNumericCount}.");
+        }
 
-        return $count;
+        return (int) $count;
     }
 }

--- a/src/Execution/ModelsLoader/CountModelsLoader.php
+++ b/src/Execution/ModelsLoader/CountModelsLoader.php
@@ -27,7 +27,7 @@ class CountModelsLoader implements ModelsLoader
     public static function extractCount(Model $model, string $relationName): int
     {
         /**
-         * This is the name that Eloquent gives to the attribute that contains the count.
+         * This is the name that Eloquent gives to the attribute that contains the count 
          *
          * @see \Illuminate\Database\Eloquent\Concerns\QueriesRelationships::withCount()
          */

--- a/src/Execution/ModelsLoader/CountModelsLoader.php
+++ b/src/Execution/ModelsLoader/CountModelsLoader.php
@@ -27,7 +27,7 @@ class CountModelsLoader implements ModelsLoader
     public static function extractCount(Model $model, string $relationName): int
     {
         /**
-         * This is the name that Eloquent gives to the attribute that contains the count 
+         * This is the name that Eloquent gives to the attribute that contains the count.
          *
          * @see \Illuminate\Database\Eloquent\Concerns\QueriesRelationships::withCount()
          */

--- a/src/Execution/ModelsLoader/CountModelsLoader.php
+++ b/src/Execution/ModelsLoader/CountModelsLoader.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Execution\ModelsLoader;
 
+use GraphQL\Utils\Utils;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;

--- a/src/Execution/ModelsLoader/CountModelsLoader.php
+++ b/src/Execution/ModelsLoader/CountModelsLoader.php
@@ -35,7 +35,7 @@ class CountModelsLoader implements ModelsLoader
         $count = $model->getAttribute($countAttributeName);
         if (! is_numeric($count)) {
             $nonNumericCount = Utils::printSafe($count);
-            throw new \Exception('Expected numeric count, got: {$nonNumericCount}.");
+            throw new \Exception("Expected numeric count, got: {$nonNumericCount}.");
         }
 
         return (int) $count;

--- a/src/Execution/ModelsLoader/CountModelsLoader.php
+++ b/src/Execution/ModelsLoader/CountModelsLoader.php
@@ -32,7 +32,7 @@ class CountModelsLoader implements ModelsLoader
          */
         $countAttributeName = Str::snake("{$relationName}_count");
 
-        $count = $model->getAttribute($countAttributeName);
+        $count = (int) $model->getAttribute($countAttributeName);
         assert(is_int($count), 'avoid runtime check in production since the return type validates this anyway');
 
         return $count;


### PR DESCRIPTION
When dealing with **legacy databases**  the count for this related model returns a string like `"88"`, not `88`.

```
comments: [Comment] @hasMany(type: PAGINATOR)
```

After upgrading to PHP 8.4 this does not work anymore. And it throws a error 

_"Nuwave\Lighthouse\Execution\ModelsLoader\CountModelsLoader::extractCount(): Return value must be of type int, string returned"_


**Changes**

Always cast to integer. Because, this count must be an integer, always.

**Breaking changes**

No.

