### PR TITLE
Encrypted subscription channels

### DIFF
--- a/docs/master/subscriptions/getting-started.md
+++ b/docs/master/subscriptions/getting-started.md
@@ -50,7 +50,7 @@ to set an expiration time in seconds (e.g. `LIGHTHOUSE_SUBSCRIPTION_STORAGE_TTL=
 Lighthouse supports encrypted subscriptions for the drivers Pusher and Echo.
 The main goal is to ensure that all data in a private-encrypted channel is encrypted in transit. 
 
-To enable encrypted subscriptions, just set the `subscriptions.encrypted_channels` to `true` in `lighthouse.php`.
+To enable encrypted subscriptions, set `subscriptions.encrypted_channels` to `true` in `config/lighthouse.php`.
 
 For Pusher, the shared secret can be updated in `config/broadcasting.php`:
 

--- a/docs/master/subscriptions/getting-started.md
+++ b/docs/master/subscriptions/getting-started.md
@@ -47,7 +47,8 @@ to set an expiration time in seconds (e.g. `LIGHTHOUSE_SUBSCRIPTION_STORAGE_TTL=
 
 ## Encrypted Subscriptions
 
-Lighthouse supports encrypted subscriptions for both Pusher and Echo drivers. The main goal is to ensure that all data in transit in a private-encrypted channel is encrypted. 
+Lighthouse supports encrypted subscriptions for the drivers Pusher and Echo.
+The main goal is to ensure that all data in a private-encrypted channel is encrypted in transit. 
 
 To enable encrypted subscriptions, set the environment variable `LIGHTHOUSE_SUBSCRIPTION_ENCRYPTED=true`.
 
@@ -61,7 +62,7 @@ For Pusher, the shared secret can be updated in `config/broadcasting.php`:
 ],
 ```
 
-More details on how to enable encryption are defined in the [Pusher documentation](https://pusher.com/docs/channels/using_channels/encrypted-channels/).
+More details on how to enable encryption are defined in the [Pusher documentation](https://pusher.com/docs/channels/using_channels/encrypted-channels).
 
 ### Pusher Expiration Webhook
 

--- a/docs/master/subscriptions/getting-started.md
+++ b/docs/master/subscriptions/getting-started.md
@@ -50,7 +50,7 @@ to set an expiration time in seconds (e.g. `LIGHTHOUSE_SUBSCRIPTION_STORAGE_TTL=
 Lighthouse supports encrypted subscriptions for the drivers Pusher and Echo.
 The main goal is to ensure that all data in a private-encrypted channel is encrypted in transit. 
 
-To enable encrypted subscriptions, set the environment variable `LIGHTHOUSE_SUBSCRIPTION_ENCRYPTED=true`.
+To enable encrypted subscriptions, just set the `subscriptions.encrypted_channels` to `true` in `lighthouse.php`.
 
 For Pusher, the shared secret can be updated in `config/broadcasting.php`:
 

--- a/docs/master/subscriptions/getting-started.md
+++ b/docs/master/subscriptions/getting-started.md
@@ -45,6 +45,24 @@ Unless you delete a subscription, it will continue to broadcast events after the
 The easiest way to expire subscriptions automatically is to use the env `LIGHTHOUSE_SUBSCRIPTION_STORAGE_TTL`
 to set an expiration time in seconds (e.g. `LIGHTHOUSE_SUBSCRIPTION_STORAGE_TTL=3600` to expire in one hour).
 
+## Encrypted Subscriptions
+
+Lighthouse supports encrypted subscriptions for both Pusher and Echo drivers. The main goal is to ensure that all data in transit in a private-encrypted channel is encrypted. 
+
+To enable encrypted subscriptions, set the environment variable `LIGHTHOUSE_SUBSCRIPTION_ENCRYPTED=true`.
+
+For Pusher, the shared secret can be updated in `config/broadcasting.php`:
+
+```php
+// in config/broadcasting.php
+'options' => [
+  'useTLS' => true,
+  'encryption_master_key_base64' => 'YOUR_MASTER_KEY', // generate this with, e.g. 'openssl rand -base64 32'
+],
+```
+
+More details on how to enable encryption are defined in the [Pusher documentation](https://pusher.com/docs/channels/using_channels/encrypted-channels/).
+
 ### Pusher Expiration Webhook
 
 If you are using the Pusher driver, you can use a [`channel existence`](https://pusher.com/docs/channels/server_api/webhooks/#channel-existence-events) webhook to mitigate this problem.

--- a/src/Schema/AST/DocumentAST.php
+++ b/src/Schema/AST/DocumentAST.php
@@ -273,7 +273,7 @@ class DocumentAST implements Arrayable
                 continue;
             }
 
-            if (\is_array($value)) {
+            if (is_array($value)) {
                 $value = isset($value[0]) || $value === []
                     ? new NodeList($value)
                     : AST::fromArray($value);

--- a/src/Subscriptions/Subscriber.php
+++ b/src/Subscriptions/Subscriber.php
@@ -119,7 +119,9 @@ class Subscriber
     /** Generate a unique private channel name. */
     public static function uniqueChannelName(): string
     {
-        $channelType = config('lighthouse.subscriptions.encrypted_channel') ? 'private-encrypted' : 'private';
+        $channelType = config('lighthouse.subscriptions.encrypted_channels', false)
+            ? 'private-encrypted'
+            : 'private';
 
         return $channelType . '-lighthouse-' . Str::random(32) . '-' . time();
     }

--- a/src/Subscriptions/Subscriber.php
+++ b/src/Subscriptions/Subscriber.php
@@ -119,7 +119,9 @@ class Subscriber
     /** Generate a unique private channel name. */
     public static function uniqueChannelName(): string
     {
-        return 'private-lighthouse-' . Str::random(32) . '-' . time();
+        $channelType = config('lighthouse.subscriptions.encrypted_channel') ? 'private-encrypted' : 'private';
+
+        return $channelType. '-lighthouse-' . Str::random(32) . '-' . time();
     }
 
     protected function contextSerializer(): SerializesContext

--- a/src/Subscriptions/Subscriber.php
+++ b/src/Subscriptions/Subscriber.php
@@ -121,7 +121,7 @@ class Subscriber
     {
         $channelType = config('lighthouse.subscriptions.encrypted_channel') ? 'private-encrypted' : 'private';
 
-        return $channelType. '-lighthouse-' . Str::random(32) . '-' . time();
+        return $channelType . '-lighthouse-' . Str::random(32) . '-' . time();
     }
 
     protected function contextSerializer(): SerializesContext

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -424,7 +424,7 @@ return [
         'storage_ttl' => env('LIGHTHOUSE_SUBSCRIPTION_STORAGE_TTL', null),
 
         /*
-         * Subscriptions channel names will be created as private encrypted channels.
+         * Encrypt subscription channels by prefixing their names with "private-encrypted-"?
          */
         'encrypted_channels' => env('LIGHTHOUSE_SUBSCRIPTION_ENCRYPTED', false),
 

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -424,15 +424,14 @@ return [
         'storage_ttl' => env('LIGHTHOUSE_SUBSCRIPTION_STORAGE_TTL', null),
 
         /*
+         * Subscriptions channel names will be created as private encrypted channels.
+         */
+        'encrypted_channels' => env('LIGHTHOUSE_SUBSCRIPTION_ENCRYPTED', false),
+
+        /*
          * Default subscription broadcaster.
          */
         'broadcaster' => env('LIGHTHOUSE_BROADCASTER', 'pusher'),
-
-        /*
-         * Subscriptions channel names will be created as private encrypted channels.
-         */
-        'encrypted_channel' => env('LIGHTHOUSE_SUBSCRIPTION_ENCRYPTED', false),
-
         /*
          * Subscription broadcasting drivers with config options.
          */

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -429,6 +429,11 @@ return [
         'broadcaster' => env('LIGHTHOUSE_BROADCASTER', 'pusher'),
 
         /*
+         * Subscriptions channel names will be created as private encrypted channels.
+         */
+        'encrypted_channel' => env('LIGHTHOUSE_SUBSCRIPTION_ENCRYPTED', false),
+
+        /*
          * Subscription broadcasting drivers with config options.
          */
         'broadcasters' => [

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -432,6 +432,7 @@ return [
          * Default subscription broadcaster.
          */
         'broadcaster' => env('LIGHTHOUSE_BROADCASTER', 'pusher'),
+
         /*
          * Subscription broadcasting drivers with config options.
          */

--- a/tests/Unit/Subscriptions/SubscriberTest.php
+++ b/tests/Unit/Subscriptions/SubscriberTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Subscriptions;
 
 use GraphQL\Language\AST\OperationDefinitionNode;
+use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Http\Request;
 use Nuwave\Lighthouse\Execution\HttpGraphQLContext;
 use Nuwave\Lighthouse\Execution\ResolveInfo;
@@ -51,5 +52,43 @@ final class SubscriberTest extends TestCase
         $this->assertSame($channel, $serialized->channel);
         $this->assertSame($topic, $serialized->topic);
         $this->assertSame($fieldName, $serialized->fieldName);
+    }
+
+    public function testEncryptedChannels(): void
+    {
+        $args = ['foo' => 'bar'];
+
+        $resolveInfo = $this->createMock(ResolveInfo::class);
+        $fieldName = 'baz';
+        $resolveInfo->fieldName = $fieldName;
+
+        $resolveInfo->operation = new OperationDefinitionNode([]);
+        $resolveInfo->fragments = [];
+
+        $context = new HttpGraphQLContext(new Request());
+
+        $config = $this->app->make(ConfigRepository::class);
+
+        $config->set('lighthouse.subscriptions.encrypted_channels', true);
+
+        $encryptedSubscriber = new Subscriber($args, $context, $resolveInfo);
+
+        $topic = 'topic';
+        $encryptedSubscriber->topic = $topic;
+
+        $channel = $encryptedSubscriber->channel;
+
+        $this->assertStringStartsWith('private-encrypted-lighthouse-', $channel);
+
+        $config->set('lighthouse.subscriptions.encrypted_channels', false);
+
+        $encryptedSubscriber = new Subscriber($args, $context, $resolveInfo);
+
+        $topic = 'topic';
+        $encryptedSubscriber->topic = $topic;
+
+        $channel = $encryptedSubscriber->channel;
+
+        $this->assertStringStartsWith('private-lighthouse-', $channel);
     }
 }


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
 
- [x] Added or updated tests
- [x] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

Pusher and Echo support private encrypted channels. This allows the data to be encrypted in transit, and the shared secret will be provided by default by the SDK when the channel is prefixed with `private-encrypted-`.  
This PR aims to add a configuration to enable the generation of all channels with that prefix instead of only `private-`.

**Breaking changes**

The flag is `false` by default, so no breaking change.
