### PR TITLE
Fix shortcut foreign key selection when including __typename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Changed
+
+- Apply shortcut foreign key selection logic when `__typename` is included in related model's field selection https://github.com/nuwave/lighthouse/pull/2666
+
 ## v6.50.0
 
 ### Added

--- a/src/Schema/Directives/RelationDirective.php
+++ b/src/Schema/Directives/RelationDirective.php
@@ -54,7 +54,7 @@ abstract class RelationDirective extends BaseDirective implements FieldResolver
             // that we know to be present on the parent model.
             if (
                 $this->lighthouseConfig['shortcut_foreign_key_selection']
-                && ['id' => true] === $resolveInfo->getFieldSelection()
+                && (array_diff_assoc($resolveInfo->getFieldSelection(), ['id' => true, '__typename' => true]) === [])
                 && $relation instanceof BelongsTo
                 && $args === []
             ) {


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

When selecting the foreign key of a belongs to relation and including  `__typename` in the related models field selection no queries will be fired.

**Breaking changes**

None.
