### PR TITLE
Fix using incorrect root for decorator when paginating

### DIFF
--- a/src/Schema/Directives/RelationDirectiveHelpers.php
+++ b/src/Schema/Directives/RelationDirectiveHelpers.php
@@ -42,6 +42,11 @@ trait RelationDirectiveHelpers
             $resolveInfo->enhanceBuilder(
                 $builder,
                 $this->scopes(),
+                /**
+                 * Sometimes overridden to use a different model than the usual root.
+                 * @see \Nuwave\Lighthouse\Execution\ModelsLoader\PaginatedModelsLoader::loadRelatedModels
+                 * @see \Tests\Integration\Schema\Directives\BuilderDirectiveTest::testCallsCustomBuilderMethodOnFieldWithSpecificModel
+                 */
                 $specificRoot ?? $root,
                 $args,
                 $context,

--- a/src/Schema/Directives/RelationDirectiveHelpers.php
+++ b/src/Schema/Directives/RelationDirectiveHelpers.php
@@ -33,8 +33,6 @@ trait RelationDirectiveHelpers
     protected function makeBuilderDecorator(mixed $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo): \Closure
     {
         return function (object $builder, mixed $specificRoot = null) use ($root, $args, $context, $resolveInfo): void {
-            $effectiveRoot = $specificRoot ?? $root;
-
             if ($builder instanceof Relation) {
                 $builder = $builder->getQuery();
             }
@@ -44,7 +42,7 @@ trait RelationDirectiveHelpers
             $resolveInfo->enhanceBuilder(
                 $builder,
                 $this->scopes(),
-                $effectiveRoot,
+                $specificRoot ?? $root,
                 $args,
                 $context,
                 $resolveInfo,

--- a/src/Schema/Directives/RelationDirectiveHelpers.php
+++ b/src/Schema/Directives/RelationDirectiveHelpers.php
@@ -28,11 +28,13 @@ trait RelationDirectiveHelpers
     /**
      * @param  array<string, mixed>  $args
      *
-     * @return \Closure(QueryBuilder|\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>|\Illuminate\Database\Eloquent\Relations\Relation<\Illuminate\Database\Eloquent\Model>): void
+     * @return \Closure(QueryBuilder|\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>|\Illuminate\Database\Eloquent\Relations\Relation<\Illuminate\Database\Eloquent\Model>, ?mixed = null): void
      */
     protected function makeBuilderDecorator(mixed $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo): \Closure
     {
-        return function (object $builder) use ($root, $args, $context, $resolveInfo): void {
+        return function (object $builder, mixed $specificRoot = null) use ($root, $args, $context, $resolveInfo): void {
+            $effectiveRoot = $specificRoot ?? $root;
+
             if ($builder instanceof Relation) {
                 $builder = $builder->getQuery();
             }
@@ -42,7 +44,7 @@ trait RelationDirectiveHelpers
             $resolveInfo->enhanceBuilder(
                 $builder,
                 $this->scopes(),
-                $root,
+                $effectiveRoot,
                 $args,
                 $context,
                 $resolveInfo,

--- a/tests/Integration/Schema/Directives/BuilderDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/BuilderDirectiveTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 use Nuwave\Lighthouse\Execution\ResolveInfo;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 use Tests\DBTestCase;
+use Tests\Utils\Models\Task;
 use Tests\Utils\Models\User;
 
 final class BuilderDirectiveTest extends DBTestCase
@@ -155,6 +156,47 @@ final class BuilderDirectiveTest extends DBTestCase
         ')->assertJsonCount(2, 'data.users');
     }
 
+    public function testCallsCustomBuilderMethodOnFieldWithSpecificModel(): void
+    {
+        $this->schema = /** @lang GraphQL */ <<<GRAPHQL
+        type Query {
+            users: [User!]! @all
+        }
+
+        type User {
+            id: ID
+            tasks: [Task!]! @hasMany(type: SIMPLE) @builder(method: "{$this->qualifyTestResolver('specificModel')}")
+        }
+
+        type Task {
+            id: ID
+        }
+        GRAPHQL;
+
+        $users = factory(User::class, 2)->create();
+
+        foreach ($users as $user) {
+            $tasks = factory(Task::class, 3)->make();
+            $tasks[0]->name = $user->name;
+            $user->tasks()->saveMany($tasks);
+        }
+
+        $this->graphQL(/** @lang GraphQL */ '
+        {
+            users {
+                id
+                tasks(first: 10) {
+                    data {
+                        id
+                    }
+                }
+            }
+        }
+        ')
+            ->assertJsonCount(1, 'data.users.0.tasks.data')
+            ->assertJsonCount(1, 'data.users.1.tasks.data');
+    }
+
     /**
      * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<\Tests\Utils\Models\User>  $builder
      *
@@ -163,5 +205,18 @@ final class BuilderDirectiveTest extends DBTestCase
     public static function limit(QueryBuilder|EloquentBuilder $builder, ?int $value): QueryBuilder|EloquentBuilder
     {
         return $builder->limit($value ?? 2);
+    }
+
+    /**
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<\Tests\Utils\Models\User>  $builder
+     *
+     * @return \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<\Tests\Utils\Models\User>
+     */
+    public static function specificModel(
+        QueryBuilder|EloquentBuilder $builder,
+        ?int $value,
+        User $user,
+    ): QueryBuilder|EloquentBuilder {
+        return $builder->where('name', $user->name);
     }
 }

--- a/tests/Integration/Schema/Directives/BuilderDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/BuilderDirectiveTest.php
@@ -178,15 +178,18 @@ final class BuilderDirectiveTest extends DBTestCase
         foreach ($users as $user) {
             assert($user instanceof User);
 
+            $userName = $user->name;
+            assert(is_string($userName), 'set by UserFactory');
+
             $taskWithSameName = factory(Task::class)->make();
             assert($taskWithSameName instanceof Task);
-            $taskWithSameName->name = $user->name;
+            $taskWithSameName->name = $userName;
             $taskWithSameName->user()->associate($user);
             $taskWithSameName->save();
 
             $taskWithOtherName = factory(Task::class)->make();
             assert($taskWithOtherName instanceof Task);
-            $taskWithOtherName->name = "Different from {$user->name}";
+            $taskWithOtherName->name = "Different from {$userName}";
             $taskWithOtherName->user()->associate($user);
             $taskWithOtherName->save();
         }

--- a/tests/Integration/Schema/Directives/BuilderDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/BuilderDirectiveTest.php
@@ -221,15 +221,15 @@ final class BuilderDirectiveTest extends DBTestCase
     }
 
     /**
-     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<\Tests\Utils\Models\User>  $builder
+     * @param  \Illuminate\Database\Eloquent\Builder<\Tests\Utils\Models\User>  $builder
      *
-     * @return \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<\Tests\Utils\Models\User>
+     * @return \Illuminate\Database\Eloquent\Builder<\Tests\Utils\Models\User>
      */
     public static function specificModel(
-        QueryBuilder|EloquentBuilder $builder,
+        EloquentBuilder $builder,
         ?int $value,
         User $user,
-    ): QueryBuilder|EloquentBuilder {
+    ): EloquentBuilder {
         return $builder->where('name', $user->name);
     }
 }

--- a/tests/Integration/Schema/Directives/BuilderDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/BuilderDirectiveTest.php
@@ -176,9 +176,19 @@ final class BuilderDirectiveTest extends DBTestCase
         $users = factory(User::class, 2)->create();
 
         foreach ($users as $user) {
-            $tasks = factory(Task::class, 3)->make();
-            $tasks[0]->name = $user->name;
-            $user->tasks()->saveMany($tasks);
+            assert($user instanceof User);
+
+            $taskWithSameName = factory(Task::class)->make();
+            assert($taskWithSameName instanceof Task);
+            $taskWithSameName->name = $user->name;
+            $taskWithSameName->user()->associate($user);
+            $taskWithSameName->save();
+
+            $taskWithOtherName = factory(Task::class)->make();
+            assert($taskWithOtherName instanceof Task);
+            $taskWithOtherName->name = "Different from {$user->name}";
+            $taskWithOtherName->user()->associate($user);
+            $taskWithOtherName->save();
         }
 
         $this->graphQL(/** @lang GraphQL */ '


### PR DESCRIPTION
In the PaginatedModelsLoader, the decorateBuilder closure has an optional second parameter to pass a specific model:
https://github.com/nuwave/lighthouse/blob/master/src/Execution/ModelsLoader/PaginatedModelsLoader.php#L58C17-L58C18 

Currently, this option does not work as expected. The builder always uses the first model that created the batch loader instance, instead of the provided model.

- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**
Updated the decorateBuilder closure to correctly use the specific model when provided.

**Breaking changes**
None 
<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
