### PR TITLE
Pass PHPStan for Laravel 12

### DIFF
--- a/src/Testing/MocksResolvers.php
+++ b/src/Testing/MocksResolvers.php
@@ -16,7 +16,7 @@ trait MocksResolvers
      *
      * @param  callable|mixed|null  $resolverOrValue
      *
-     * @return \PHPUnit\Framework\MockObject\Builder\InvocationMocker<\stdClass>
+     * @return \PHPUnit\Framework\MockObject\Builder\InvocationMocker
      */
     protected function mockResolver($resolverOrValue = null, string $key = 'default'): InvocationMocker
     {
@@ -36,7 +36,7 @@ trait MocksResolvers
      *
      * @param  \PHPUnit\Framework\MockObject\Rule\InvocationOrder  $invocationOrder
      *
-     * @return \PHPUnit\Framework\MockObject\Builder\InvocationMocker<\stdClass>
+     * @return \PHPUnit\Framework\MockObject\Builder\InvocationMocker
      */
     protected function mockResolverExpects(object $invocationOrder, string $key = 'default'): InvocationMocker
     {

--- a/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
+++ b/tests/Unit/Subscriptions/Storage/RedisStorageManagerTest.php
@@ -94,11 +94,11 @@ final class RedisStorageManagerTest extends TestCase
         $subscriber = new DummySubscriber($channel, 'test-topic');
         $redisConnection->expects($this->exactly(3))
             ->method('command')
-            ->with(...$this->withConsecutive(
+            ->with(...array_values([...$this->withConsecutive(
                 ['get', [$prefixedChannel]],
                 ['del', [$prefixedChannel]],
                 ['srem', ["graphql.topic.{$subscriber->topic}", $channel]],
-            ))
+            )]))
             ->willReturnOnConsecutiveCalls(
                 serialize($subscriber),
                 true,
@@ -128,7 +128,7 @@ final class RedisStorageManagerTest extends TestCase
         $topicKey = 'graphql.topic.some-topic';
         $redisConnection->expects($this->exactly(3))
             ->method('command')
-            ->with(...$this->withConsecutive(
+            ->with(...array_values([...$this->withConsecutive(
                 ['sadd', [
                     $topicKey,
                     $channel,
@@ -142,7 +142,7 @@ final class RedisStorageManagerTest extends TestCase
                     $ttl,
                     serialize($subscriberUnderTopic),
                 ]],
-            ));
+            )]));
 
         $manager = new RedisStorageManager($config, $redisFactory);
         $manager->storeSubscriber($subscriber, $storedTopic);
@@ -166,7 +166,7 @@ final class RedisStorageManagerTest extends TestCase
         $topicKey = 'graphql.topic.some-topic';
         $redisConnection->expects($this->exactly(2))
             ->method('command')
-            ->with(...$this->withConsecutive(
+            ->with(...array_values([...$this->withConsecutive(
                 ['sadd', [
                     $topicKey,
                     $channel,
@@ -175,7 +175,7 @@ final class RedisStorageManagerTest extends TestCase
                     'graphql.subscriber.private-lighthouse-foo',
                     serialize($subscriberUnderTopic),
                 ]],
-            ));
+            )]));
 
         $manager = new RedisStorageManager($config, $redisFactory);
         $manager->storeSubscriber($subscriber, $storedTopic);
@@ -199,7 +199,7 @@ final class RedisStorageManagerTest extends TestCase
 
         $redisConnection->expects($this->exactly(3))
             ->method('command')
-            ->with(...$this->withConsecutive(
+            ->with(...array_values([...$this->withConsecutive(
                 ['smembers', ["graphql.topic.{$topic}"]],
                 ['mget', [[
                     'graphql.subscriber.foo1',
@@ -208,7 +208,7 @@ final class RedisStorageManagerTest extends TestCase
                     'graphql.subscriber.foo4',
                 ]]],
                 ['srem', ["graphql.topic.{$topic}", 'foo3', 'foo4']],
-            ))
+            )]))
             ->willReturnOnConsecutiveCalls(
                 ['foo1', 'foo2', 'foo3', 'foo4'],
                 [


### PR DESCRIPTION
Fixes : 
- PHPDoc tag @return contains generic type PHPUnit\Framework\MockObject\Builder\InvocationMocker<stdClass> but class PHPUnit\Framework\MockObject\Builder\InvocationMocker is not generic.
- Method PHPUnit\Framework\MockObject\Builder\InvocationMocker::with() invoked with unpacked array with possibly string key, but it's not allowed because of @no-named-arguments.  
 
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
