### PR TITLE
Ensure Argument::$type is initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v6.56.1
+
+### Fixed
+
+- Initialize `Argument::$type` with `null` and make it nullable https://github.com/nuwave/lighthouse/pull/2682
+
 ## v6.56.0
 
 ### Added

--- a/src/Execution/Arguments/Argument.php
+++ b/src/Execution/Arguments/Argument.php
@@ -26,9 +26,7 @@ class Argument
      */
     public Collection $directives;
 
-    /**
-     * A resolver that handles the given value.
-     */
+    /** A resolver that handles the given value. */
     public ?ArgResolver $resolver = null;
 
     public function __construct()

--- a/src/Execution/Arguments/Argument.php
+++ b/src/Execution/Arguments/Argument.php
@@ -17,7 +17,7 @@ class Argument
     /**
      * The type of the argument.
      */
-    public ListType|NamedType $type;
+    public ListType|NamedType|null $type = null;
 
     /**
      * A list of directives associated with that argument.
@@ -26,7 +26,9 @@ class Argument
      */
     public Collection $directives;
 
-    /** An argument may have a resolver that handles its given value. */
+    /**
+     * A resolver that handles the given value.
+     */
     public ?ArgResolver $resolver = null;
 
     public function __construct()

--- a/src/Execution/Arguments/ArgumentSetFactory.php
+++ b/src/Execution/Arguments/ArgumentSetFactory.php
@@ -86,9 +86,9 @@ class ArgumentSetFactory
         $type = $this->argumentTypeNodeConverter->convert($definition->type);
 
         $argument = new Argument();
-        $argument->directives = $this->directiveLocator->associated($definition);
-        $argument->type = $type;
         $argument->value = $this->wrapWithType($value, $type);
+        $argument->type = $type;
+        $argument->directives = $this->directiveLocator->associated($definition);
 
         return $argument;
     }

--- a/tests/Unit/Execution/Arguments/ArgumentSetTest.php
+++ b/tests/Unit/Execution/Arguments/ArgumentSetTest.php
@@ -127,7 +127,11 @@ final class ArgumentSetTest extends TestCase
         $set = new ArgumentSet();
         $set->addValue('foo', 42);
 
-        $this->assertSame(42, $set->arguments['foo']->value);
+        $argument = $set->arguments['foo'];
+        $this->assertSame(42, $argument->value);
+        $this->assertNull($argument->type);
+        $this->assertEmpty($argument->directives);
+        $this->assertNull($argument->resolver);
     }
 
     public function testAddValueDeep(): void
@@ -135,8 +139,18 @@ final class ArgumentSetTest extends TestCase
         $set = new ArgumentSet();
         $set->addValue('foo.bar', 42);
 
-        $foo = $set->arguments['foo']->value;
+        $foo = $set->arguments['foo'];
+        $this->assertNull($foo->type);
+        $this->assertEmpty($foo->directives);
+        $this->assertNull($foo->resolver);
 
-        $this->assertSame(42, $foo->arguments['bar']->value);
+        $fooValue = $foo->value;
+        $this->assertInstanceOf(ArgumentSet::class, $fooValue);;
+
+        $bar = $fooValue->arguments['bar'];
+        $this->assertSame(42, $bar->value);
+        $this->assertNull($bar->type);
+        $this->assertEmpty($bar->directives);
+        $this->assertNull($bar->resolver);
     }
 }

--- a/tests/Unit/Execution/Arguments/ArgumentSetTest.php
+++ b/tests/Unit/Execution/Arguments/ArgumentSetTest.php
@@ -145,7 +145,7 @@ final class ArgumentSetTest extends TestCase
         $this->assertNull($foo->resolver);
 
         $fooValue = $foo->value;
-        $this->assertInstanceOf(ArgumentSet::class, $fooValue);;
+        $this->assertInstanceOf(ArgumentSet::class, $fooValue);
 
         $bar = $fooValue->arguments['bar'];
         $this->assertSame(42, $bar->value);


### PR DESCRIPTION
Resolves https://github.com/nuwave/lighthouse/issues/2681
 
- [x] Added or updated tests
- [x] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

Initialize `Argument::$type` with `null` and make it nullable.

**Breaking changes**

None.
