### PR TITLE
ci: update deprecated action

### DIFF
--- a/.github/workflows/generate-proto-code.yml
+++ b/.github/workflows/generate-proto-code.yml
@@ -15,7 +15,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
 
       - run: |
           buf generate


### PR DESCRIPTION
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->
This updates from `bufbuild/buf-setup-action` to `bufbuild/buf-action` as the `buf-setup-action` has been deprecated.

See: https://github.com/bufbuild/buf-action/blob/main/MIGRATION.md#buf-setup-action

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
