### PR TITLE
feat(ast): add path() getter method to ASTCache class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- Add `path()` method to `ASTCache` class https://github.com/nuwave/lighthouse/pull/2694
+
 ## v6.58.0
 
 ### Changed

--- a/src/Schema/AST/ASTCache.php
+++ b/src/Schema/AST/ASTCache.php
@@ -61,10 +61,11 @@ class ASTCache
     /** @param  callable(): DocumentAST  $build */
     public function fromCacheOrBuild(callable $build): DocumentAST
     {
-        if ($this->filesystem()->exists($this->path())) {
-            $ast = require $this->path();
+        $path = $this->path();
+        if ($this->filesystem()->exists($path)) {
+            $ast = require $path;
             if (! is_array($ast)) {
-                throw new InvalidSchemaCacheContentsException($this->path(), $ast);
+                throw new InvalidSchemaCacheContentsException($path, $ast);
             }
 
             /** @var SerializableDocumentAST $ast */

--- a/src/Schema/AST/ASTCache.php
+++ b/src/Schema/AST/ASTCache.php
@@ -34,6 +34,11 @@ class ASTCache
         return $this->enable;
     }
 
+    public function path(): string
+    {
+        return $this->path;
+    }
+
     public function set(DocumentAST $documentAST): void
     {
         $variable = var_export(
@@ -42,7 +47,7 @@ class ASTCache
         );
 
         $this->filesystem()->put(
-            path: $this->path,
+            path: $this->path(),
             contents: /** @lang PHP */ "<?php return {$variable};",
             lock: true,
         );
@@ -50,16 +55,16 @@ class ASTCache
 
     public function clear(): void
     {
-        $this->filesystem()->delete($this->path);
+        $this->filesystem()->delete($this->path());
     }
 
     /** @param  callable(): DocumentAST  $build */
     public function fromCacheOrBuild(callable $build): DocumentAST
     {
-        if ($this->filesystem()->exists($this->path)) {
-            $ast = require $this->path;
+        if ($this->filesystem()->exists($this->path())) {
+            $ast = require $this->path();
             if (! is_array($ast)) {
-                throw new InvalidSchemaCacheContentsException($this->path, $ast);
+                throw new InvalidSchemaCacheContentsException($this->path(), $ast);
             }
 
             /** @var SerializableDocumentAST $ast */


### PR DESCRIPTION
- [ ] Documented user facing changes
- [ ] Added or updated tests (not applicable for this change)
- [x] Updated CHANGELOG.md

**Changes**

Added a public `path()` getter method to the `ASTCache` class to improve API consistency and make the class easier to extend. The method returns the current schema cache file path and allows clean external access to override the cache path without relying on direct property access.

This change:
- Exposes the internal `$path` property via a consistent public API
- Improves extensibility for use cases with dynamic schema caching (e.g. multi-tenant or per-request schemas)
- Aligns with object-oriented encapsulation best practices

**Breaking changes**

None. This is a fully backward-compatible addition that does not affect existing behavior or usage.

