### PR TITLE
Allow combining `@lazyLoad` and `@paginate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Changed
+
+- Allow combining `@lazyLoad` and `@paginate` https://github.com/nuwave/lighthouse/pull/2695
+
 ## v6.59.0
 
 ### Added

--- a/src/Schema/Directives/LazyLoadDirective.php
+++ b/src/Schema/Directives/LazyLoadDirective.php
@@ -6,7 +6,7 @@ use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\AbstractPaginator;
 use Nuwave\Lighthouse\Exceptions\DefinitionException;
 use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
@@ -35,8 +35,8 @@ GRAPHQL;
     {
         $relations = $this->directiveArgValue('relations');
 
-        $fieldValue->resultHandler(static function (EloquentCollection|LengthAwarePaginator $items) use ($relations): EloquentCollection|LengthAwarePaginator {
-            // @phpstan-ignore-next-line LengthAwarePaginator forwards calls to EloquentCollection
+        $fieldValue->resultHandler(static function (EloquentCollection|AbstractPaginator $items) use ($relations): EloquentCollection|AbstractPaginator {
+            // @phpstan-ignore-next-line AbstractPaginator forwards calls to EloquentCollection
             $items->load($relations);
 
             return $items;


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Previously #1867 removed the `Collection` type-hint from the `LazyLoadDirective` field `resultHandler`. This had the primary intent of accepting `LengthAwarePaginator` (as can be seen in the added PHPdoc), but would implicitly handle all Laravel paginators. When the PHPdoc got converted back into a type-hint utilizing DNF types in #1706, this accidentally stopped working.

I believe the type-hint can be widened to `AbstractPaginator` without issue, allowing `@lazyLoad` to combine with `@paginate` once more.

**Breaking changes**

Since this widens the accepted parameters, no compatibility break expected.
