### PR TITLE
Add `--sort` flag for `lighthouse:print-schema` console command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- Add `--sort` option to `lighthouse:print-schema` command to sort the compiled
+  schema before printing.
+
 ## v6.60.0
 
 ### Changed

--- a/docs/master/api-reference/commands.md
+++ b/docs/master/api-reference/commands.md
@@ -96,6 +96,7 @@ Schema imports, native PHP types and schema manipulation may influence the final
 
 Use the `-W` / `--write` option to output the schema to the default file storage (usually `storage/app`) as `lighthouse-schema.graphql`.
 You can output your schema in JSON format by using the `--json` flag.
+You can sort the final compiled schema by using the `--sort` flag.
 
 The `--federation` option should be used to produce a schema file suitable for [Apollo Federation](https://www.apollographql.com/docs/federation).
 

--- a/src/Console/PrintSchemaCommand.php
+++ b/src/Console/PrintSchemaCommand.php
@@ -24,6 +24,7 @@ lighthouse:print-schema
 {--D|disk= : The disk to write the file to}
 {--json : Output JSON instead of GraphQL SDL}
 {--federation : Include federation directives and exclude federation spec additions, like _service.sdl}
+{--sort: Sort all types, fields, and arguments in alphabetical order, when possible}
 SIGNATURE;
 
     protected $description = 'Compile the GraphQL schema and print the result.';
@@ -42,14 +43,37 @@ SIGNATURE;
                 return;
             }
 
+            if ($this->option('sort')) {
+                $this->error('--sort option is not supported with --federation');
+
+                return;
+            }
+
             $filename = self::GRAPHQL_FEDERATION_FILENAME;
             $schemaString = FederationPrinter::print($schema);
         } elseif ($this->option('json')) {
+            if ($this->option('sort')) {
+                $this->error('--sort option is not supported with --json');
+
+                return;
+            }
+
             $filename = self::JSON_FILENAME;
             $schemaString = \Safe\json_encode(Introspection::fromSchema($schema));
         } else {
+            $options = [];
+            if ($this->option('sort')) {
+                $options = [
+                    'sortArguments' => true,
+                    'sortEnumValues' => true,
+                    'sortFields' => true,
+                    'sortInputFields' => true,
+                    'sortTypes' => true,
+                ];
+            }
+
             $filename = self::GRAPHQL_FILENAME;
-            $schemaString = SchemaPrinter::doPrint($schema);
+            $schemaString = SchemaPrinter::doPrint($schema, $options);
         }
 
         if ($this->option('write')) {


### PR DESCRIPTION
- [ ] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Adds a `--sort` flag for the `lighthouse:print-schema` console command.

The main motivation behind this is to allow for stronger normalization of the final compiled schema, which can be useful for ex: compiled schemas tracked by source control. Currently, the order in which items are defined in the raw schema determines their order in the output, which means that moving items around in the raw schema can result in the compiled schema changing, even when it is logically identical. Using this flag, any identical raw schema should always compile down to the exact same output.

**Breaking changes**

None, since this is opt-in.
