### PR TITLE
Refresh schema cache lazily when GraphQL requests are made through `MakesGraphQLRequests`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v6.62.0
+
+### Changed
+
+- Refresh schema cache lazily when GraphQL requests are made through `MakesGraphQLRequests`
+
+### Deprecated
+
+- Deprecate Lumen support
+
 ## v6.61.1
 
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,11 +11,12 @@ Compare your `lighthouse.php` against the latest [default configuration](src/lig
 
 ### Leverage automatic test trait setup
 
-Methods you need to explicitly call to set up test traits were removed in favor of automatically set up test traits.
-Keep in mind they only work when your test class extends `Illuminate\Foundation\Testing\TestCase`.
+Methods you need to explicitly call to set up test traits were removed in favor of automatic setup.
 
 - Remove calls to `Nuwave\Lighthouse\Testing\RefreshesSchemaCache::bootRefreshesSchemaCache()`.
+  This only works when your test class uses the trait `Nuwave\Lighthouse\Testing\MakesGraphQLRequests`.
 - Replace calls to `Nuwave\Lighthouse\Testing\MakesGraphQLRequests::setUpSubscriptionEnvironment()` with ` use Nuwave\Lighthouse\Testing\TestsSubscriptions`.
+  This only works when your test class extends `Illuminate\Foundation\Testing\TestCase`.
 
 ### `EnsureXHR` is enabled in the default configuration
 

--- a/src/Testing/MakesGraphQLRequests.php
+++ b/src/Testing/MakesGraphQLRequests.php
@@ -74,6 +74,8 @@ trait MakesGraphQLRequests
      */
     protected function postGraphQL(array $data, array $headers = [], array $routeParams = []): TestResponse
     {
+        $this->refreshSchemaCacheIfNecessary();
+
         return $this->postJson(
             $this->graphQLEndpointUrl($routeParams),
             $data,
@@ -100,6 +102,8 @@ trait MakesGraphQLRequests
         array $headers = [],
         array $routeParams = [],
     ): TestResponse {
+        $this->refreshSchemaCacheIfNecessary();
+
         $parameters = [
             'operations' => \Safe\json_encode($operations),
             'map' => \Safe\json_encode($map),
@@ -253,5 +257,12 @@ trait MakesGraphQLRequests
 
         // set the custom driver as the default driver
         $config->set('lighthouse.subscriptions.broadcaster', 'mock');
+    }
+
+    protected function refreshSchemaCacheIfNecessary(): void
+    {
+        if (in_array(RefreshesSchemaCache::class, class_uses_recursive(static::class), true)) {
+            $this->refreshSchemaCache(); // @phpstan-ignore method.notFound (present in RefreshesSchemaCache)
+        }
     }
 }

--- a/src/Testing/MakesGraphQLRequestsLumen.php
+++ b/src/Testing/MakesGraphQLRequestsLumen.php
@@ -19,6 +19,8 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  * Testing helpers for making requests to the GraphQL endpoint.
  *
  * @mixin \Laravel\Lumen\Testing\Concerns\MakesHttpRequests
+ *
+ * @deprecated lumen support will be removed in the next major version
  */
 trait MakesGraphQLRequestsLumen // @phpstan-ignore trait.unused (hard to set up testing for)
 {

--- a/src/Testing/RefreshesSchemaCache.php
+++ b/src/Testing/RefreshesSchemaCache.php
@@ -7,7 +7,7 @@ use Safe\Exceptions\FilesystemException;
 /**
  * Refreshes the schema cache once before any tests are run.
  *
- * This is a bootable test trait, @see \Illuminate\Foundation\Testing\Concerns\InteractsWithTestCaseLifecycle::setUpTraits
+ * This trait only works in combination with @see \Nuwave\Lighthouse\Testing\MakesGraphQLRequests.
  *
  * @mixin \Illuminate\Foundation\Testing\Concerns\InteractsWithConsole
  */
@@ -24,7 +24,7 @@ trait RefreshesSchemaCache
     /** Path to the file used for coordinating exactly-one semantics. */
     protected static string $lockFilePath = __DIR__ . '/schema-cache-refreshing';
 
-    protected function setUpRefreshesSchemaCache(): void
+    protected function refreshSchemaCache(): void
     {
         if (! static::$schemaCacheWasRefreshed) {
             // We use the filesystem as shared mutable state to coordinate between processes,
@@ -48,9 +48,9 @@ trait RefreshesSchemaCache
         }
     }
 
-    /** @deprecated TODO leverage automatic test trait setup, this method will be removed in the next major version */
+    /** @deprecated TODO leverage automatic setup through MakesGraphQLRequests, this method will be removed in the next major version */
     protected function bootRefreshesSchemaCache(): void
     {
-        $this->setUpRefreshesSchemaCache();
+        $this->refreshSchemaCache();
     }
 }

--- a/tests/Unit/Testing/TestingTraitDummyLumen.php
+++ b/tests/Unit/Testing/TestingTraitDummyLumen.php
@@ -11,6 +11,8 @@ use Orchestra\Testbench\TestCase;
 
 /**
  * Just a placeholder in order for PHPStan to be able to analyze those traits, see https://phpstan.org/blog/how-phpstan-analyses-traits.
+ *
+ * @deprecated lumen support will be removed in the next major version
  */
 final class TestingTraitDummyLumen extends TestCase
 {


### PR DESCRIPTION
- [x] ~Added or updated tests~ Tested manually in a project that uses schema caching
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Make `RefreshesSchemaCache` non-bootable by renaming its main method.
The schema cache is now refreshed only when methods from `MakesGraphQLRequests` that use the schema are called.

**Breaking changes**

Only test code is potentially affected, so no issues in production can occur.
When `RefreshesSchemaCache` is used and relied upon in test cases that use other methods than the ones in `MakesGraphQLRequests`, the schema cache will not be refreshed.
I reckon few if any users could have such a setup, they can fix their tests by calling `refreshSchemaCache` manually.