### PR TITLE
File based query cache

### DIFF
--- a/docs/master/performance/query-caching.md
+++ b/docs/master/performance/query-caching.md
@@ -18,6 +18,28 @@ Lighthouse supports Automatic Persisted Queries (APQ), compatible with the
 
 APQ is enabled by default, but depends on query caching being enabled.
 
+## File based caching
+
+Similar to how schema caching works by storing the compiled schema in a php file
+in your bootstrap/cache directory, you may enable the file based query cache.
+This will allow opcache to pick up the compiled queries, and it also reduces 
+network load, if you have been using redis before.
+
+```dotenv
+LIGHTHOUSE_QUERY_CACHE_USE_FILE_CACHE=true
+```
+
+One downside with this approach is, that there is no automatic cleanup like with
+a TTL in a caching system. You may run this command to regularly remove old query
+files from the filesystem.
+
+```shell
+# remove all files
+php artisan lighthouse:clear-query-cache
+# only removes files older than 48 hours
+php artisan lighthouse:clear-query-cache --hours=48
+```
+
 ## Query validation caching
 
 Lighthouse can cache the result of the query validation process as well.

--- a/src/Cache/QueryCache.php
+++ b/src/Cache/QueryCache.php
@@ -25,8 +25,10 @@ class QueryCache
         $this->enable = $config['enable'];
         $this->store = $config['store'];
         $this->ttl = $config['ttl'];
-        $this->useFileCache = $config['use_file_cache'];
-        $this->fileCachePath = rtrim($config['file_cache_path'], '/') . '/';
+
+        $this->useFileCache = $config['use_file_cache'] ?? false;
+        $path = $config['file_cache_path'] ?? base_path('bootstrap/cache');
+        $this->fileCachePath = rtrim($path, '/') . '/';
     }
 
     public function isEnabled(): bool
@@ -42,7 +44,7 @@ class QueryCache
     public function clearFileCache(): void
     {
         $this->filesystem->delete(
-            $this->filesystem->files($this->fileCachePath())
+            $this->filesystem->glob($this->fileCachePath() . 'query-*.php')
         );
     }
 
@@ -70,7 +72,7 @@ class QueryCache
      */
     private function fromFileCacheOrBuild(string $hash, callable $build): DocumentNode
     {
-        $filename = $this->fileCachePath() . $hash . '.php';
+        $filename = $this->fileCachePath() . 'query-' . $hash . '.php';
         if ($this->filesystem->exists($filename)) {
             $queryData = require $filename;
             // todo no array exception

--- a/src/Cache/QueryCache.php
+++ b/src/Cache/QueryCache.php
@@ -8,6 +8,7 @@ use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Filesystem\Filesystem;
+use Nuwave\Lighthouse\Exceptions\InvalidQueryCacheContentsException;
 
 class QueryCache
 {
@@ -81,7 +82,9 @@ class QueryCache
         $filename = $this->fileCachePath() . 'query-' . $hash . '.php';
         if ($this->filesystem->exists($filename)) {
             $queryData = require $filename;
-            // todo no array exception
+            if (!is_array($queryData)) {
+                throw new InvalidQueryCacheContentsException($filename, $queryData);
+            }
             $query = AST::fromArray($queryData);
             assert($query instanceof DocumentNode);
 

--- a/src/Cache/QueryCache.php
+++ b/src/Cache/QueryCache.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Nuwave\Lighthouse\Cache;
+
+use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Utils\AST;
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Filesystem\Filesystem;
+
+class QueryCache
+{
+    private bool $enable;
+    private ?string $store;
+    private ?int $ttl;
+    private bool $useFileCache;
+    private string $fileCachePath;
+
+    public function __construct(
+        private ConfigRepository $configRepository,
+        protected Filesystem $filesystem,
+    ) {
+        $config = $this->configRepository->get('lighthouse.query_cache');
+        $this->enable = $config['enable'];
+        $this->store = $config['store'];
+        $this->ttl = $config['ttl'];
+        $this->useFileCache = $config['use_file_cache'];
+        $this->fileCachePath = rtrim($config['file_cache_path'], '/') . '/';
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enable;
+    }
+
+    public function fileCachePath(): string
+    {
+        return $this->fileCachePath;
+    }
+
+    public function clearFileCache(): void
+    {
+        $this->filesystem->delete(
+            $this->filesystem->files($this->fileCachePath())
+        );
+    }
+
+    /**
+     * @param callable(): DocumentNode $build
+     */
+    public function fromCacheOrBuild(string $hash, callable $build): DocumentNode
+    {
+        if ($this->useFileCache) {
+            return $this->fromFileCacheOrBuild($hash, $build);
+        }
+
+        $cacheFactory = Container::getInstance()->make(CacheFactory::class);
+        $store = $cacheFactory->store($this->store);
+
+        return $store->remember(
+            "lighthouse:query:{$hash}",
+            $this->ttl,
+            $build,
+        );
+    }
+
+    /**
+     * @param callable(): DocumentNode $build
+     */
+    private function fromFileCacheOrBuild(string $hash, callable $build): DocumentNode
+    {
+        $filename = $this->fileCachePath() . $hash . '.php';
+        if ($this->filesystem->exists($filename)) {
+            $queryData = require $filename;
+            // todo no array exception
+            $query = AST::fromArray($queryData);
+            assert($query instanceof DocumentNode);
+
+            return $query;
+        }
+
+        $query = $build();
+
+        $variable = var_export(
+            value: $query->toArray(),
+            return: true,
+        );
+        $contents = /** @lang PHP */ "<?php return {$variable};";
+
+        // To prevent opcache from picking up an incomplete file while it is written,
+        // we write a temporary file first. Then, we move the temporary file
+        // to the final location, which is an atomic operation.
+        $partialPath = "{$filename}.partial";
+        $this->filesystem->put(path: $partialPath, contents: $contents, lock: true);
+        $this->filesystem->move(path: $partialPath, target: $filename);
+
+        return $query;
+    }
+}

--- a/src/Cache/QueryCache.php
+++ b/src/Cache/QueryCache.php
@@ -41,11 +41,17 @@ class QueryCache
         return $this->fileCachePath;
     }
 
-    public function clearFileCache(): void
+    public function clearFileCache(?int $hours = null): void
     {
-        $this->filesystem->delete(
-            $this->filesystem->glob($this->fileCachePath() . 'query-*.php')
-        );
+        $files = $this->filesystem->glob($this->fileCachePath() . 'query-*.php');
+        if (is_int($hours)) {
+            $threshold = now()->subHours($hours)->timestamp;
+            $files = array_filter(
+                $files,
+                fn(string $file) => $this->filesystem->lastModified($file) < $threshold
+            );
+        }
+        $this->filesystem->delete($files);
     }
 
     /**

--- a/src/Console/ClearQueryCacheCommand.php
+++ b/src/Console/ClearQueryCacheCommand.php
@@ -7,13 +7,13 @@ use Nuwave\Lighthouse\Cache\QueryCache;
 
 class ClearQueryCacheCommand extends Command
 {
-    protected $name = 'lighthouse:clear-query-cache';
+    protected $signature = 'lighthouse:clear-query-cache {--hours=}';
 
     protected $description = 'Clears the file based GraphQL query cache.';
 
     public function handle(QueryCache $cache): void
     {
-        $cache->clearFileCache();
+        $cache->clearFileCache($this->option('hours'));
 
         $this->info('GraphQL query cache deleted.');
     }

--- a/src/Console/ClearQueryCacheCommand.php
+++ b/src/Console/ClearQueryCacheCommand.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Console;
+
+use Illuminate\Console\Command;
+use Nuwave\Lighthouse\Cache\QueryCache;
+
+class ClearQueryCacheCommand extends Command
+{
+    protected $name = 'lighthouse:clear-query-cache';
+
+    protected $description = 'Clears the file based GraphQL query cache.';
+
+    public function handle(QueryCache $cache): void
+    {
+        $cache->clearFileCache();
+
+        $this->info('GraphQL query cache deleted.');
+    }
+}

--- a/src/Exceptions/InvalidQueryCacheContentsException.php
+++ b/src/Exceptions/InvalidQueryCacheContentsException.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Exceptions;
+
+use GraphQL\Utils\Utils;
+
+class InvalidQueryCacheContentsException extends \Exception
+{
+    /** @param  mixed  $value the non-array result of `require $path` */
+    public function __construct(string $path, mixed $value)
+    {
+        $notArray = Utils::printSafe($value);
+        parent::__construct("Expected the file at {$path} to return an array representation of the query AST, got: {$notArray}.");
+    }
+}

--- a/src/LighthouseServiceProvider.php
+++ b/src/LighthouseServiceProvider.php
@@ -14,6 +14,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Console\CacheCommand;
 use Nuwave\Lighthouse\Console\ClearCacheCommand;
+use Nuwave\Lighthouse\Console\ClearQueryCacheCommand;
 use Nuwave\Lighthouse\Console\DirectiveCommand;
 use Nuwave\Lighthouse\Console\FieldCommand;
 use Nuwave\Lighthouse\Console\IdeHelperCommand;
@@ -56,6 +57,7 @@ class LighthouseServiceProvider extends ServiceProvider
     protected const COMMANDS = [
         CacheCommand::class,
         ClearCacheCommand::class,
+        ClearQueryCacheCommand::class,
         DirectiveCommand::class,
         FieldCommand::class,
         IdeHelperCommand::class,

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -132,6 +132,19 @@ return [
          * Duration in seconds the query should remain cached, null means forever.
          */
         'ttl' => env('LIGHTHOUSE_QUERY_CACHE_TTL', 24 * 60 * 60),
+
+        /*
+         * Instead of putting serialised php code into a cache and producing network requests,
+         * this option will store the parsed queries as php files in the filesystem, allowing
+         * opcache to pick them up and reducing network requests from and to your cache system.
+         */
+        'use_file_cache' => env('LIGHTHOUSE_QUERY_CACHE_USE_FILE_CACHE', false),
+
+        /*
+         * If `use_file_cache` is true, this option will specify the path where the files are stored.
+         * The given path must be a folder, as every query will produce its own file.
+         */
+        'file_cache_path' => env('LIGHTHOUSE_QUERY_CACHE_FILE_CACHE_PATH', base_path('bootstrap/cache/queries/')),
     ],
 
     /*

--- a/src/lighthouse.php
+++ b/src/lighthouse.php
@@ -144,7 +144,7 @@ return [
          * If `use_file_cache` is true, this option will specify the path where the files are stored.
          * The given path must be a folder, as every query will produce its own file.
          */
-        'file_cache_path' => env('LIGHTHOUSE_QUERY_CACHE_FILE_CACHE_PATH', base_path('bootstrap/cache/queries/')),
+        'file_cache_path' => env('LIGHTHOUSE_QUERY_CACHE_FILE_CACHE_PATH', base_path('bootstrap/cache')),
     ],
 
     /*

--- a/tests/Console/ClearQueryCacheCommandTest.php
+++ b/tests/Console/ClearQueryCacheCommandTest.php
@@ -44,6 +44,7 @@ class ClearQueryCacheCommandTest extends TestCase
 
         $this->assertFileDoesNotExist(self::STORAGE_DIR . '/query-1.php');
         $this->assertFileDoesNotExist(self::STORAGE_DIR . '/query-2.php');
+        $this->assertFileExists(self::STORAGE_DIR . '/unrelated.php');
     }
 
     public function testDeleteThreshold()
@@ -55,5 +56,6 @@ class ClearQueryCacheCommandTest extends TestCase
         $this->commandTester(new ClearQueryCacheCommand())->execute(['--hours' => 2]);
         $this->assertFileExists(self::STORAGE_DIR . '/query-1.php');
         $this->assertFileDoesNotExist(self::STORAGE_DIR . '/query-2.php');
+        $this->assertFileExists(self::STORAGE_DIR . '/unrelated.php');
     }
 }

--- a/tests/Console/ClearQueryCacheCommandTest.php
+++ b/tests/Console/ClearQueryCacheCommandTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Console;
+
+use Carbon\Carbon;
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Filesystem\Filesystem;
+use Nuwave\Lighthouse\Console\ClearQueryCacheCommand;
+use Tests\TestCase;
+
+class ClearQueryCacheCommandTest extends TestCase
+{
+    const STORAGE_DIR = __DIR__ . '/../storage';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $config = $this->app->make(ConfigRepository::class);
+        $config->set('lighthouse.query_cache.enable', true);
+        $config->set('lighthouse.query_cache.use_file_cache', true);
+        $config->set('lighthouse.query_cache.file_cache_path', self::STORAGE_DIR);
+
+        $filesystem = $this->app->make(Filesystem::class);
+        $filesystem->put(self::STORAGE_DIR . '/query-1.php', '<?php');
+        $filesystem->put(self::STORAGE_DIR . '/query-2.php', '<?php');
+        $filesystem->put(self::STORAGE_DIR . '/unrelated.php', '<?php');
+    }
+
+    protected function tearDown(): void
+    {
+        $filesystem = $this->app->make(Filesystem::class);
+        // remove all files except dotfiles
+        $filesystem->delete(
+            $filesystem->files(self::STORAGE_DIR)
+        );
+
+        parent::tearDown();
+    }
+
+    public function testDeleteAll()
+    {
+        $this->commandTester(new ClearQueryCacheCommand())->execute([]);
+
+        $this->assertFileDoesNotExist(self::STORAGE_DIR . '/query-1.php');
+        $this->assertFileDoesNotExist(self::STORAGE_DIR . '/query-2.php');
+    }
+
+    public function testDeleteThreshold()
+    {
+        $this->travelTo('2025-06-01 12:00:00');
+        \Safe\touch(self::STORAGE_DIR . '/query-1.php', Carbon::parse('2025-06-01 10:00:00')->timestamp);
+        \Safe\touch(self::STORAGE_DIR . '/query-2.php', Carbon::parse('2025-06-01 09:59:59')->timestamp);
+
+        $this->commandTester(new ClearQueryCacheCommand())->execute(['--hours' => 2]);
+        $this->assertFileExists(self::STORAGE_DIR . '/query-1.php');
+        $this->assertFileDoesNotExist(self::STORAGE_DIR . '/query-2.php');
+    }
+}

--- a/tests/Integration/FileBasedQueryCacheTest.php
+++ b/tests/Integration/FileBasedQueryCacheTest.php
@@ -4,11 +4,22 @@ namespace Tests\Integration;
 
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Filesystem\Filesystem;
+use Nuwave\Lighthouse\Exceptions\InvalidQueryCacheContentsException;
 use Tests\TestCase;
 
 class FileBasedQueryCacheTest extends TestCase
 {
     const STORAGE_DIR = __DIR__ . '/../storage';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $config = $this->app->make(ConfigRepository::class);
+        $config->set('lighthouse.query_cache.enable', true);
+        $config->set('lighthouse.query_cache.use_file_cache', true);
+        $config->set('lighthouse.query_cache.file_cache_path', self::STORAGE_DIR);
+    }
 
     protected function tearDown(): void
     {
@@ -23,17 +34,28 @@ class FileBasedQueryCacheTest extends TestCase
 
     public function testFileCacheGetsCreated()
     {
-        $config = $this->app->make(ConfigRepository::class);
-        $config->set('lighthouse.query_cache.enable', true);
-        $config->set('lighthouse.query_cache.use_file_cache', true);
-        $config->set('lighthouse.query_cache.file_cache_path', self::STORAGE_DIR);
-
         $this->graphQL(/** @lang GraphQL */<<<GQL
         query AskFoo {
             foo
         }
         GQL);
 
-        $this->assertFileExists(self::STORAGE_DIR . '/0f0be96218c966b815fd0a976801668f6c7dae61e184d85825ced04a0bb6f139.php');
+        $this->assertFileExists(self::STORAGE_DIR . '/query-0f0be96218c966b815fd0a976801668f6c7dae61e184d85825ced04a0bb6f139.php');
+    }
+
+    public function testCacheFileContainsNonsense()
+    {
+        $filesystem = $this->app->make(Filesystem::class);
+        $filesystem->put(
+            self::STORAGE_DIR . '/query-0f0be96218c966b815fd0a976801668f6c7dae61e184d85825ced04a0bb6f139.php',
+            '<?php return "foo";'
+        );
+
+        $this->expectException(InvalidQueryCacheContentsException::class);
+        $this->graphQL(/** @lang GraphQL */<<<GQL
+        query AskFoo {
+            foo
+        }
+        GQL);
     }
 }

--- a/tests/Integration/FileBasedQueryCacheTest.php
+++ b/tests/Integration/FileBasedQueryCacheTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Integration;
+
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Filesystem\Filesystem;
+use Tests\TestCase;
+
+class FileBasedQueryCacheTest extends TestCase
+{
+    const STORAGE_DIR = __DIR__ . '/../storage';
+
+    protected function tearDown(): void
+    {
+        $filesystem = $this->app->make(Filesystem::class);
+        // remove all files except dotfiles
+        $filesystem->delete(
+            $filesystem->files(self::STORAGE_DIR)
+        );
+        parent::tearDown();
+    }
+
+    public function testFileCacheGetsCreated()
+    {
+        $config = $this->app->make(ConfigRepository::class);
+        $config->set('lighthouse.query_cache.enable', true);
+        $config->set('lighthouse.query_cache.use_file_cache', true);
+        $config->set('lighthouse.query_cache.file_cache_path', self::STORAGE_DIR);
+
+        $this->graphQL(/** @lang GraphQL */<<<GQL
+        query AskFoo {
+            foo
+        }
+        GQL);
+
+        $this->assertFileExists(self::STORAGE_DIR . '/0f0be96218c966b815fd0a976801668f6c7dae61e184d85825ced04a0bb6f139.php');
+    }
+}

--- a/tests/Integration/FileBasedQueryCacheTest.php
+++ b/tests/Integration/FileBasedQueryCacheTest.php
@@ -17,6 +17,7 @@ class FileBasedQueryCacheTest extends TestCase
         $filesystem->delete(
             $filesystem->files(self::STORAGE_DIR)
         );
+
         parent::tearDown();
     }
 

--- a/tests/Integration/QueryCachingTest.php
+++ b/tests/Integration/QueryCachingTest.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+namespace Tests\Integration;
+
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\KeyWritten;


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

Just like the schema cache, now the query cache can be picked up by opcache.

**Breaking changes**

None expected.
