### PR TITLE
Discover directive classes via Composer's autoload maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Changed
+
+- Discover directive classes through Composer's autoload maps instead of `haydenpierce/class-finder`, making `lighthouse:ide-helper` faster https://github.com/nuwave/lighthouse/pull/2768
+
+### Removed
+
+- Dependency on `haydenpierce/class-finder` https://github.com/nuwave/lighthouse/pull/2768
+
 ## v6.66.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     "require": {
         "php": "^8",
         "ext-json": "*",
-        "haydenpierce/class-finder": "^0.4 || ^0.5",
         "illuminate/auth": "^9 || ^10 || ^11 || ^12 || ^13",
         "illuminate/bus": "^9 || ^10 || ^11 || ^12 || ^13",
         "illuminate/contracts": "^9 || ^10 || ^11 || ^12 || ^13",

--- a/src/Console/IdeHelperCommand.php
+++ b/src/Console/IdeHelperCommand.php
@@ -8,13 +8,13 @@ use GraphQL\Type\Definition\Directive as DirectiveDefinition;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Introspection;
 use GraphQL\Utils\SchemaPrinter;
-use HaydenPierce\ClassFinder\ClassFinder;
 use Illuminate\Console\Command;
 use Nuwave\Lighthouse\Schema\AST\ASTCache;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Schema\DirectiveLocator;
 use Nuwave\Lighthouse\Schema\SchemaBuilder;
 use Nuwave\Lighthouse\Schema\Source\SchemaSourceProvider;
+use Nuwave\Lighthouse\Support\ComposerClassFinder;
 use Nuwave\Lighthouse\Support\Contracts\Directive as DirectiveInterface;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -107,7 +107,7 @@ GRAPHQL;
 
         foreach ($directiveNamespaces as $directiveNamespace) {
             /** @var array<class-string> $classesInNamespace */
-            $classesInNamespace = ClassFinder::getClassesInNamespace($directiveNamespace);
+            $classesInNamespace = ComposerClassFinder::directClassesInNamespace($directiveNamespace);
 
             foreach ($classesInNamespace as $class) {
                 $reflection = new \ReflectionClass($class);

--- a/src/Schema/DirectiveLocator.php
+++ b/src/Schema/DirectiveLocator.php
@@ -4,7 +4,6 @@ namespace Nuwave\Lighthouse\Schema;
 
 use GraphQL\Language\AST\DirectiveNode;
 use GraphQL\Language\AST\Node;
-use HaydenPierce\ClassFinder\ClassFinder;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Support\Collection;
@@ -13,6 +12,7 @@ use Nuwave\Lighthouse\Events\RegisterDirectiveNamespaces;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Schema\AST\ASTHelper;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Nuwave\Lighthouse\Support\ComposerClassFinder;
 use Nuwave\Lighthouse\Support\Contracts\Directive;
 use Nuwave\Lighthouse\Support\Utils;
 
@@ -81,7 +81,7 @@ class DirectiveLocator
 
         foreach ($this->namespaces() as $directiveNamespace) {
             /** @var array<class-string> $classesInNamespace */
-            $classesInNamespace = ClassFinder::getClassesInNamespace($directiveNamespace);
+            $classesInNamespace = ComposerClassFinder::directClassesInNamespace($directiveNamespace);
 
             foreach ($classesInNamespace as $class) {
                 $reflection = new \ReflectionClass($class);

--- a/src/Support/ComposerClassFinder.php
+++ b/src/Support/ComposerClassFinder.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Support;
+
+use Composer\Autoload\ClassLoader;
+
+class ComposerClassFinder
+{
+    /**
+     * Find class-strings declared directly in the given namespace using Composer.
+     *
+     * @return list<class-string>
+     */
+    public static function directClassesInNamespace(string $namespace): array
+    {
+        $namespace = rtrim($namespace, '\\') . '\\';
+        $loader = self::composerClassLoader();
+
+        /** @var array<class-string, true> $classes */
+        $classes = [];
+
+        // Authoritative classmap (populated by `composer dump-autoload --optimize`).
+        foreach ($loader->getClassMap() as $fqcn => $_) {
+            if (! str_starts_with($fqcn, $namespace)) {
+                continue;
+            }
+
+            if (str_contains(substr($fqcn, strlen($namespace)), '\\')) {
+                continue;
+            }
+
+            if (class_exists($fqcn)) {
+                $classes[$fqcn] = true;
+            }
+        }
+
+        // PSR-4 prefix map: scan the matching directory's direct *.php children.
+        foreach ($loader->getPrefixesPsr4() as $prefix => $directories) {
+            if (! str_starts_with($namespace, $prefix)) {
+                continue;
+            }
+
+            $sub = str_replace('\\', DIRECTORY_SEPARATOR, substr($namespace, strlen($prefix)));
+            foreach ($directories as $directory) {
+                $target = rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $sub;
+                if (! is_dir($target)) {
+                    continue;
+                }
+
+                foreach (\Safe\scandir($target) as $entry) {
+                    if (! str_ends_with($entry, '.php')) {
+                        continue;
+                    }
+
+                    /** @var class-string $fqcn */
+                    $fqcn = $namespace . substr($entry, 0, -4);
+                    if (class_exists($fqcn)) {
+                        $classes[$fqcn] = true;
+                    }
+                }
+            }
+        }
+
+        /** @var list<class-string> $result */
+        $result = array_keys($classes);
+
+        return $result;
+    }
+
+    protected static function composerClassLoader(): ClassLoader
+    {
+        foreach (spl_autoload_functions() ?: [] as $autoloader) {
+            if (is_array($autoloader) && $autoloader[0] instanceof ClassLoader) {
+                return $autoloader[0];
+            }
+        }
+
+        throw new \RuntimeException('Composer ClassLoader was not found among registered autoloaders.');
+    }
+}

--- a/tests/Unit/Support/ComposerClassFinderTest.php
+++ b/tests/Unit/Support/ComposerClassFinderTest.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Support;
+
+use Nuwave\Lighthouse\Cache\CacheDirective;
+use Nuwave\Lighthouse\Cache\CacheKeyAndTags;
+use Nuwave\Lighthouse\Cache\CacheServiceProvider;
+use Nuwave\Lighthouse\Support\AppVersion;
+use Nuwave\Lighthouse\Support\ComposerClassFinder;
+use Nuwave\Lighthouse\Support\DriverManager;
+use Nuwave\Lighthouse\Support\Utils;
+use Tests\Console\UnionDirective;
+use Tests\TestCase;
+
+final class ComposerClassFinderTest extends TestCase
+{
+    public function testReturnsConcreteClassesInNamespace(): void
+    {
+        $classes = ComposerClassFinder::directClassesInNamespace('Nuwave\\Lighthouse\\Cache');
+
+        $this->assertContains(CacheDirective::class, $classes);
+        $this->assertContains(CacheServiceProvider::class, $classes);
+    }
+
+    public function testFiltersInterfacesAndTraits(): void
+    {
+        $classes = ComposerClassFinder::directClassesInNamespace('Nuwave\\Lighthouse\\Cache');
+
+        $this->assertNotContains(CacheKeyAndTags::class, $classes, 'Interfaces must not be returned.');
+    }
+
+    public function testDoesNotRecurseIntoSubNamespaces(): void
+    {
+        $classes = ComposerClassFinder::directClassesInNamespace('Nuwave\\Lighthouse\\Support');
+
+        $this->assertContains(ComposerClassFinder::class, $classes);
+        $this->assertContains(Utils::class, $classes);
+        $this->assertContains(AppVersion::class, $classes);
+        $this->assertContains(DriverManager::class, $classes);
+
+        foreach ($classes as $class) {
+            $this->assertStringNotContainsString(
+                'Nuwave\\Lighthouse\\Support\\Contracts\\',
+                $class,
+                'Sub-namespace Contracts must not be recursed into.',
+            );
+            $this->assertStringNotContainsString(
+                'Nuwave\\Lighthouse\\Support\\Traits\\',
+                $class,
+                'Sub-namespace Traits must not be recursed into.',
+            );
+        }
+    }
+
+    public function testReturnsEmptyArrayForUnknownNamespace(): void
+    {
+        $this->assertSame([], ComposerClassFinder::directClassesInNamespace('Definitely\\Not\\A\\Real\\Namespace'));
+    }
+
+    public function testReturnsEmptyArrayForLeadingBackslash(): void
+    {
+        // Matches the strict behavior of `HaydenPierce\ClassFinder` in `STANDARD_MODE`,
+        // which does not normalize a leading backslash.
+        $this->assertSame([], ComposerClassFinder::directClassesInNamespace('\\Nuwave\\Lighthouse\\Cache'));
+    }
+
+    public function testTolerateTrailingBackslash(): void
+    {
+        $without = ComposerClassFinder::directClassesInNamespace('Nuwave\\Lighthouse\\Cache');
+        $with = ComposerClassFinder::directClassesInNamespace('Nuwave\\Lighthouse\\Cache\\');
+
+        sort($without);
+        sort($with);
+
+        $this->assertSame($without, $with);
+    }
+
+    public function testDiscoversClassesFromAutoloadDevPrefix(): void
+    {
+        $classes = ComposerClassFinder::directClassesInNamespace('Tests\\Console');
+
+        $this->assertContains(UnionDirective::class, $classes);
+    }
+}


### PR DESCRIPTION
Hi!

First time contributing to Lighthouse, so happy to take any feedback on the approach.

On a personal Laravel app I noticed `php artisan lighthouse:ide-helper` was taking ~18s, which felt long for what the command actually does.

Dug a bit with the Xdebug profiler, ended up on this old issue (#1449) that already describes the problem.
A quick rewrite of the directive discovery dropped the same command to ~1s on my project, so I figured it was worth a PR.

- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md (skip for docs-only changes)

**Changes**

`IdeHelperCommand::scanForDirectives` and `DirectiveLocator::classes()` both call `HaydenPierce\ClassFinder::getClassesInNamespace`, which rescans the entire vendor PSR-4 tree from scratch on every call (no caching, recurses into every subdir of every package).

This PR replaces those calls with a small `ComposerClassFinder` that reads Composer's already-built maps (`getClassMap()` + `getPrefixesPsr4()`).

It is meant as a drop-in for `ClassFinder::STANDARD_MODE`: same inputs, same outputs, same implementation details.
Notably we keep the strict leading-backslash behavior of the old lib (a FQN like `\Foo\Bar` returns an empty set instead of being normalized), so existing callers cannot break.
This is locked in by unit test `testReturnsEmptyArrayForLeadingBackslash`.

The `haydenpierce/class-finder` dependency is dropped.

**Profiling (Xdebug profile mode, on a real Laravel 12 + Lighthouse 6.66 app)**

| function                                      | inclusive ms | self ms | calls |
|-----------------------------------------------| --- | --- | --- |
| `IdeHelperCommand::handle`                    | 24943 | 0.1 | 1 |
| - `scanForDirectives`                         | **23405** | 0.7 | 1 |
| -- `ClassFinder::getClassesInNamespace`       | 23403 | 0.3 | 12 |
| --- `PSR4NamespaceFactory::getPSR4Namespaces` | 21312 | 11.6 | **23** |
| ---- `PSR4NamespaceFactory::createNamespace`  | 55228 | 684 | **87 906** |
| `php::scandir`                                | 9936 | 9936 | **88 170** |
| `php::is_dir`                                 | 1569 | 1569 | **429 633** |

For 12 directive namespaces, `getPSR4Namespaces()` runs 23 times (twice per `getClassesInNamespace`, once in `isNamespaceKnown` and once in `findBestPSR4Namespace`).
Each run walks the whole PSR-4 tree of every vendor package.

**`php artisan lighthouse:ide-helper` benchmark on the same app**

|                 | Before | After          |
|-----------------| --- |----------------|
| Total time      | ~18 s | ~1.1 s         |
| Speedup         | | ~16x           |
| Generated files | | identical |

3 sample runs after the change: 1.43 s / 1.07 s / 1.10 s.

**New implementation vs the old lib**

I ran both implementations side by side on representative namespaces (flat ns, ns with sub-namespaces, autoload-dev ns, unknown ns, leading/trailing backslash variants).
After switching `trim` to `rtrim` to match the old strict behavior on leading `\`, both return identical sets on every case.

The unit test pins the behavior we replicate: concrete classes only (interfaces and traits filtered via `class_exists`), no recursion into sub-namespaces, trailing `\` tolerated, leading `\` returns empty (matches old lib), discovery from PSR-4 prefixes and from the optimized classmap.

**Breaking changes**

None.
The new finder is an internal detail and the generated IDE helper files are unchanged.