### PR TITLE
Support haydenpierce/class-finder ^0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Changed
+
+- Support `haydenpierce/class-finder` `^0.6`, which makes `lighthouse:ide-helper` and `DirectiveLocator` significantly faster https://github.com/nuwave/lighthouse/pull/2769
+
 ## v6.66.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8",
         "ext-json": "*",
-        "haydenpierce/class-finder": "^0.4 || ^0.5",
+        "haydenpierce/class-finder": "^0.4 || ^0.5 || ^0.6",
         "illuminate/auth": "^9 || ^10 || ^11 || ^12 || ^13",
         "illuminate/bus": "^9 || ^10 || ^11 || ^12 || ^13",
         "illuminate/contracts": "^9 || ^10 || ^11 || ^12 || ^13",


### PR DESCRIPTION
Hi!

Follow-up to #2768 after the upstream changes landed in https://gitlab.com/hpierce1102/ClassFinder/-/merge_requests/33. 0.6 ships several optimizations that drop the cost of directive class discovery.

- [ ] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md (skip for docs-only changes)

**Changes**

`IdeHelperCommandTest` + `DirectiveLocatorTest` go from ~8.2s to ~0.5s. On my Laravel app, `php artisan lighthouse:ide-helper` goes from ~28s to ~1.4s.

**Breaking changes**

None.