### PR TITLE
Enable worktree support

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+vendor/
+.php-cs-fixer.cache
+.phpunit.result.cache

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ fix: rector php-cs-fixer prettier ## Automatically refactor and format code
 
 .PHONY: rector
 rector: ## Refactor code with Rector
-	docker compose run --rm php vendor/bin/rector process
+	docker compose run --rm --no-deps php vendor/bin/rector process
 
 .PHONY: php-cs-fixer
 php-cs-fixer: ## Format code with php-cs-fixer
-	docker compose run --rm php vendor/bin/php-cs-fixer fix
+	docker compose run --rm --no-deps php vendor/bin/php-cs-fixer fix
 
 .PHONY: prettier
 prettier: ## Format code with prettier
@@ -30,7 +30,7 @@ prettier: ## Format code with prettier
 
 .PHONY: stan
 stan: ## Run static analysis with PHPStan
-	docker compose run --rm php vendor/bin/phpstan --verbose
+	docker compose run --rm --no-deps php vendor/bin/phpstan --verbose
 
 .PHONY: test
 test: ## Run tests with PHPUnit
@@ -41,9 +41,9 @@ bench: ## Run benchmarks with PHPBench
 	docker compose run --rm php vendor/bin/phpbench run --report=aggregate
 
 vendor: composer.json ## Install composer dependencies
-	docker compose run --rm php composer update
-	docker compose run --rm php composer validate --strict
-	docker compose run --rm php composer normalize
+	docker compose run --rm --no-deps php composer update
+	docker compose run --rm --no-deps php composer validate --strict
+	docker compose run --rm --no-deps php composer normalize
 
 .PHONY: php
 php: ## Open an interactive shell into the PHP container
@@ -71,11 +71,11 @@ ai-sync: ## Generate local agent configuration from .ai
 
 .PHONY: proto/update-reports
 proto/update-reports:
-	docker compose run --rm php curl --silent --show-error --fail --output src/Tracing/FederatedTracing/reports.proto https://usage-reporting.api.apollographql.com/proto/reports.proto
-	docker compose run --rm php sed --in-place 's/ \[(js_use_toArray) = true]//g' src/Tracing/FederatedTracing/reports.proto
-	docker compose run --rm php sed --in-place 's/ \[(js_preEncoded) = true]//g' src/Tracing/FederatedTracing/reports.proto
-	docker compose run --rm php sed --in-place '3 i option php_namespace = "Nuwave\\\\Lighthouse\\\\Tracing\\\\FederatedTracing\\\\Proto";' src/Tracing/FederatedTracing/reports.proto
-	docker compose run --rm php sed --in-place '4 i option php_metadata_namespace = "Nuwave\\\\Lighthouse\\\\Tracing\\\\FederatedTracing\\\\Proto\\\\Metadata";' src/Tracing/FederatedTracing/reports.proto
+	docker compose run --rm --no-deps php curl --silent --show-error --fail --output src/Tracing/FederatedTracing/reports.proto https://usage-reporting.api.apollographql.com/proto/reports.proto
+	docker compose run --rm --no-deps php sed --in-place 's/ \[(js_use_toArray) = true]//g' src/Tracing/FederatedTracing/reports.proto
+	docker compose run --rm --no-deps php sed --in-place 's/ \[(js_preEncoded) = true]//g' src/Tracing/FederatedTracing/reports.proto
+	docker compose run --rm --no-deps php sed --in-place '3 i option php_namespace = "Nuwave\\\\Lighthouse\\\\Tracing\\\\FederatedTracing\\\\Proto";' src/Tracing/FederatedTracing/reports.proto
+	docker compose run --rm --no-deps php sed --in-place '4 i option php_metadata_namespace = "Nuwave\\\\Lighthouse\\\\Tracing\\\\FederatedTracing\\\\Proto\\\\Metadata";' src/Tracing/FederatedTracing/reports.proto
 
 .PHONY: proto
 proto:

--- a/Makefile
+++ b/Makefile
@@ -13,73 +13,69 @@ build: ## Build the local Docker containers
 	# Using short options of `id` to ensure compatibility with macOS, see https://github.com/nuwave/lighthouse/pull/2504
 	docker compose build --pull --build-arg="USER_ID=$(shell id -u)" --build-arg="GROUP_ID=$(shell id -g)"
 
-.PHONY: up
-up: ## Bring up the docker compose stack
-	docker compose up --detach
-
 .PHONY: fix
 fix: rector php-cs-fixer prettier ## Automatically refactor and format code
 
 .PHONY: rector
-rector: up ## Refactor code with Rector
-	docker compose exec php vendor/bin/rector process
+rector: ## Refactor code with Rector
+	docker compose run --rm php vendor/bin/rector process
 
 .PHONY: php-cs-fixer
-php-cs-fixer: up ## Format code with php-cs-fixer
-	docker compose exec php vendor/bin/php-cs-fixer fix
+php-cs-fixer: ## Format code with php-cs-fixer
+	docker compose run --rm php vendor/bin/php-cs-fixer fix
 
 .PHONY: prettier
-prettier: up ## Format code with prettier
-	docker compose exec node-docs yarn run prettify
+prettier: ## Format code with prettier
+	docker compose run --rm node-docs yarn run prettify
 
 .PHONY: stan
-stan: up ## Run static analysis with PHPStan
-	docker compose exec php vendor/bin/phpstan --verbose
+stan: ## Run static analysis with PHPStan
+	docker compose run --rm php vendor/bin/phpstan --verbose
 
 .PHONY: test
-test: up ## Run tests with PHPUnit
-	docker compose exec php vendor/bin/phpunit
+test: ## Run tests with PHPUnit
+	docker compose run --rm php vendor/bin/phpunit
 
 .PHONY: bench
-bench: up ## Run benchmarks with PHPBench
-	docker compose exec php vendor/bin/phpbench run --report=aggregate
+bench: ## Run benchmarks with PHPBench
+	docker compose run --rm php vendor/bin/phpbench run --report=aggregate
 
-vendor: up composer.json ## Install composer dependencies
-	docker compose exec php composer update
-	docker compose exec php composer validate --strict
-	docker compose exec php composer normalize
+vendor: composer.json ## Install composer dependencies
+	docker compose run --rm php composer update
+	docker compose run --rm php composer validate --strict
+	docker compose run --rm php composer normalize
 
 .PHONY: php
-php: up ## Open an interactive shell into the PHP container
-	docker compose exec php bash
+php: ## Open an interactive shell into the PHP container
+	docker compose run --rm php bash
 
 .PHONY: node
-node: up ## Open an interactive shell into the Node container
-	docker compose exec node-docs bash
+node: ## Open an interactive shell into the Node container
+	docker compose run --rm node-docs bash
 
 .PHONY: release
 release: ## Prepare the docs for a new release
 	rm -rf docs/6 && cp -r docs/master docs/6
 
 .PHONY: docs
-docs: up ## Render the docs in a development server
-	docker compose exec node-docs yarn run start
+docs: ## Render the docs in a development server
+	docker compose run --rm --service-ports node-docs yarn run start
 
-docs/node_modules: up docs/package.json docs/yarn.lock ## Install yarn dependencies
-	docker compose exec node-docs yarn
+docs/node_modules: docs/package.json docs/yarn.lock ## Install yarn dependencies
+	docker compose run --rm node-docs yarn
 
 .PHONY: ai-sync
-ai-sync: up ## Generate local agent configuration from .ai
+ai-sync: ## Generate local agent configuration from .ai
 	# https://github.com/KrystianJonca/lnai/releases
-	docker compose exec node-tools npx --yes lnai@0.6.7 sync
+	docker compose run --rm node-tools npx --yes lnai@0.6.7 sync
 
 .PHONY: proto/update-reports
 proto/update-reports:
-	docker compose exec php curl --silent --show-error --fail --output src/Tracing/FederatedTracing/reports.proto https://usage-reporting.api.apollographql.com/proto/reports.proto
-	docker compose exec php sed --in-place 's/ \[(js_use_toArray) = true]//g' src/Tracing/FederatedTracing/reports.proto
-	docker compose exec php sed --in-place 's/ \[(js_preEncoded) = true]//g' src/Tracing/FederatedTracing/reports.proto
-	docker compose exec php sed --in-place '3 i option php_namespace = "Nuwave\\\\Lighthouse\\\\Tracing\\\\FederatedTracing\\\\Proto";' src/Tracing/FederatedTracing/reports.proto
-	docker compose exec php sed --in-place '4 i option php_metadata_namespace = "Nuwave\\\\Lighthouse\\\\Tracing\\\\FederatedTracing\\\\Proto\\\\Metadata";' src/Tracing/FederatedTracing/reports.proto
+	docker compose run --rm php curl --silent --show-error --fail --output src/Tracing/FederatedTracing/reports.proto https://usage-reporting.api.apollographql.com/proto/reports.proto
+	docker compose run --rm php sed --in-place 's/ \[(js_use_toArray) = true]//g' src/Tracing/FederatedTracing/reports.proto
+	docker compose run --rm php sed --in-place 's/ \[(js_preEncoded) = true]//g' src/Tracing/FederatedTracing/reports.proto
+	docker compose run --rm php sed --in-place '3 i option php_namespace = "Nuwave\\\\Lighthouse\\\\Tracing\\\\FederatedTracing\\\\Proto";' src/Tracing/FederatedTracing/reports.proto
+	docker compose run --rm php sed --in-place '4 i option php_metadata_namespace = "Nuwave\\\\Lighthouse\\\\Tracing\\\\FederatedTracing\\\\Proto\\\\Metadata";' src/Tracing/FederatedTracing/reports.proto
 
 .PHONY: proto
 proto:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - label:disable
     depends_on:
       - mysql
+      - redis
 
   mysql:
     # TODO switch to MySQL 8 https://github.com/nuwave/lighthouse/issues/1784

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: lighthouse
+
 services:
   php:
     build:
@@ -11,7 +13,6 @@ services:
       - label:disable
     depends_on:
       - mysql
-    tty: true
 
   mysql:
     # TODO switch to MySQL 8 https://github.com/nuwave/lighthouse/issues/1784
@@ -39,7 +40,6 @@ services:
       - NODE_OPTIONS="--max-old-space-size=8192"
     ports:
       - 8081:8080
-    tty: true
 
   node-tools:
     build:
@@ -48,4 +48,3 @@ services:
     volumes:
       - ./:/workdir
     working_dir: /workdir
-    tty: true


### PR DESCRIPTION
## Summary

- Migrate from `docker compose exec` (requires running containers) to `docker compose run --rm` (ephemeral containers mounting the current directory)
- Add `name: lighthouse` to `docker-compose.yml` so worktrees share the same Docker image
- Remove the `up` target — `run --rm` handles container lifecycle per-command
- Add `.worktreeinclude` declaring gitignored files to copy into new worktrees
- Add `--service-ports` to the `docs` target so port mapping works with `run`

This enables parallel development via git worktrees without requiring a persistent `docker compose up` stack.

🤖 Generated with Claude Code