### PR TITLE
Apollo authorization directives

### DIFF
--- a/docs/6/federation/getting-started.md
+++ b/docs/6/federation/getting-started.md
@@ -28,8 +28,9 @@ See [the Apollo documentation on federated directives](https://www.apollographql
 ```graphql
 extend schema
   @link(
-    url: "https://specs.apollo.dev/federation/v2.3"
+    url: "https://specs.apollo.dev/federation/v2.9"
     import: [
+      "@authenticated"
       "@composeDirective"
       "@extends"
       "@external"
@@ -37,8 +38,10 @@ extend schema
       "@interfaceObject"
       "@key"
       "@override"
+      "@policy"
       "@provides"
       "@requires"
+      "@requiresScopes"
       "@shareable"
       "@tag"
     ]

--- a/src/Federation/Directives/AuthenticatedDirective.php
+++ b/src/Federation/Directives/AuthenticatedDirective.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Federation\Directives;
+
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+
+class AuthenticatedDirective extends BaseDirective
+{
+    public const NAME = 'authenticated';
+
+    public static function definition(): string
+    {
+        return /* @lang GraphQL */ <<<'GRAPHQL'
+"""
+Indicates to composition that the target element is accessible only to authenticated users.
+
+```graphql
+extend schema
+    @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@authenticated"])
+
+type User @key(fields: "id") @authenticated {
+  id: ID!
+  email: String!
+}
+```
+
+https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/directives#authenticated
+"""
+directive @authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+GRAPHQL;
+    }
+}

--- a/src/Federation/Directives/PolicyDirective.php
+++ b/src/Federation/Directives/PolicyDirective.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Federation\Directives;
+
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+
+class PolicyDirective extends BaseDirective
+{
+    public const NAME = 'policy';
+
+    public static function definition(): string
+    {
+        return /* @lang GraphQL */ <<<'GRAPHQL'
+"""
+Indicates to composition that the target element is restricted based on authorization policies.
+
+```graphql
+extend schema
+    @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@policy"])
+
+type User @key(fields: "id")
+@policy(policies: [["read:user"], ["admin"]]) {
+  id: ID!
+  email: String!
+}
+```
+
+https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/directives#policy
+"""
+directive @policy(policies: [[federation__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+"""
+An authorization policy value required by `@policy`.
+"""
+scalar federation__Policy
+GRAPHQL;
+    }
+}

--- a/src/Federation/Directives/RequiresScopesDirective.php
+++ b/src/Federation/Directives/RequiresScopesDirective.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Federation\Directives;
+
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+
+class RequiresScopesDirective extends BaseDirective
+{
+    public const NAME = 'requiresScopes';
+
+    public static function definition(): string
+    {
+        return /* @lang GraphQL */ <<<'GRAPHQL'
+"""
+Indicates to composition that the target element is accessible only to authenticated users
+with the appropriate JWT scopes.
+
+```graphql
+extend schema
+    @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@requiresScopes"])
+
+type User @key(fields: "id")
+@requiresScopes(scopes: [["profile.read"], ["admin"]]) {
+  id: ID!
+  email: String!
+}
+```
+
+https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/directives#requiresscopes
+"""
+directive @requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+"""
+A JWT scope required by `@requiresScopes`.
+"""
+scalar federation__Scope
+GRAPHQL;
+    }
+}

--- a/src/Federation/FederationPrinter.php
+++ b/src/Federation/FederationPrinter.php
@@ -21,13 +21,16 @@ use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Federation\Directives\ComposeDirectiveDirective;
 use Nuwave\Lighthouse\Federation\Directives\ExtendsDirective;
 use Nuwave\Lighthouse\Federation\Directives\ExternalDirective;
+use Nuwave\Lighthouse\Federation\Directives\AuthenticatedDirective;
 use Nuwave\Lighthouse\Federation\Directives\InaccessibleDirective;
 use Nuwave\Lighthouse\Federation\Directives\InterfaceObjectDirective;
 use Nuwave\Lighthouse\Federation\Directives\KeyDirective;
 use Nuwave\Lighthouse\Federation\Directives\LinkDirective;
 use Nuwave\Lighthouse\Federation\Directives\OverrideDirective;
+use Nuwave\Lighthouse\Federation\Directives\PolicyDirective;
 use Nuwave\Lighthouse\Federation\Directives\ProvidesDirective;
 use Nuwave\Lighthouse\Federation\Directives\RequiresDirective;
+use Nuwave\Lighthouse\Federation\Directives\RequiresScopesDirective;
 use Nuwave\Lighthouse\Federation\Directives\ShareableDirective;
 use Nuwave\Lighthouse\Federation\Directives\TagDirective;
 use Nuwave\Lighthouse\Schema\RootType;
@@ -59,6 +62,9 @@ class FederationPrinter
         TagDirective::NAME,
         LinkDirective::NAME,
         ComposeDirectiveDirective::NAME,
+        AuthenticatedDirective::NAME,
+        RequiresScopesDirective::NAME,
+        PolicyDirective::NAME,
     ];
 
     public static function print(Schema $schema): string

--- a/tests/Integration/Federation/FederationSchemaTest.php
+++ b/tests/Integration/Federation/FederationSchemaTest.php
@@ -175,6 +175,28 @@ final class FederationSchemaTest extends TestCase
         $this->assertStringContainsString('type SimplePaginatorInfo @shareable {', $sdl);
     }
 
+    public function testServiceQueryShouldReturnFederationV2AccessControlDirectives(): void
+    {
+        $schemaExtension = /** @lang GraphQL */ <<<'GRAPHQL'
+        extend schema @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@key", "@authenticated", "@requiresScopes", "@policy"])
+        GRAPHQL;
+
+        $typeUser = /** @lang GraphQL */ <<<'GRAPHQL'
+        type User @key(fields: "id") @authenticated @requiresScopes(scopes: [["profile.read"], ["admin"]]) @policy(policies: [["read:user"], ["admin"]]) {
+          id: ID!
+          email: String! @authenticated @requiresScopes(scopes: [["email.read"]]) @policy(policies: [["email_policy"]])
+        }
+        GRAPHQL;
+
+        $this->schema = "{$schemaExtension} {$typeUser}";
+
+        $sdl = $this->_serviceSdl();
+
+        $this->assertSdlContainsString($schemaExtension, $sdl);
+        $this->assertStringContainsString('type User @key(fields: "id") @authenticated @requiresScopes(scopes: [["profile.read"], ["admin"]]) @policy(policies: [["read:user"], ["admin"]]) {', $sdl);
+        $this->assertStringContainsString('email: String! @authenticated @requiresScopes(scopes: [["email.read"]]) @policy(policies: [["email_policy"]])', $sdl);
+    }
+
     private function _serviceSdl(): string
     {
         $response = $this->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'


### PR DESCRIPTION
Resolves # 

- [x] Added or updated tests
- [x] Documented user facing changes

**Changes**

This PR introduces support for Apollo-style declarative authorization directives within Lighthouse. This allows schemas to better align with Apollo Router / Federation standards for authorization handled at the gateway or subgraph level.

Key additions:
- Introduced Apollo Authorization Directives (e.g., `@authenticated`, `@requiresScopes`, `@policy`) to control field and type accessibility.
- Integrated the directive definitions into the schema generation and validation pipeline.
- Added corresponding tests to ensure schema syntax and directive handling work seamlessly with standard Apollo federation setups.

**Breaking changes**

None. This is a purely additive feature and does not affect existing `@can`, `@auth` or `@guard` directives implemented natively by Lighthouse.
