### PR TITLE
Add .claude/skills continuity library for maintainers

### DIFF
--- a/.claude/skills/graphql-laravel-reference/SKILL.md
+++ b/.claude/skills/graphql-laravel-reference/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: graphql-laravel-reference
+description: >-
+  Domain-theory pack for engineers who know PHP/Laravel but not GraphQL internals,
+  or vice versa. Load when a task needs the meaning of GraphQL/graphql-php/Eloquent
+  concepts AS USED IN THIS REPO — SDL and directive definitions, executable schema
+  and introspection, the type-loader vs types callable (laziness), DebugFlag,
+  Eloquent-relation-to-directive mapping, batch loading, pagination types
+  (PAGINATOR/SIMPLE/CONNECTION), Relay/Federation/APQ/tracing/@defer, or the jargon
+  glossary. Anchors every concept to a file path. For design rationale use
+  lighthouse-architecture-contract; for config values use lighthouse-config-and-flags.
+---
+
+# GraphQL + Laravel reference (as applied in Lighthouse)
+
+The knowledge a mid-level engineer or smaller model is missing to work here. Not a textbook — every concept points at a file in this repo.
+
+Ground truth date: 2026-07-07, v6.68.0 (`master` @ a29ff8e).
+
+## 1. GraphQL for this repo
+
+**SDL (Schema Definition Language)** — the text format describing types/fields. Lighthouse is *schema-first*: you write SDL, it builds the runtime. Example: `src/default-schema.graphql`:
+```graphql
+type Query {
+    user(id: ID @eq): User @find
+    users(name: String @where(operator: "like")): [User!]! @paginate(defaultCount: 10)
+}
+```
+
+**Directive** — a `@foo` annotation attached to schema elements that drives server behavior. Every directive is a PHP class whose `definition(): string` returns its own SDL. Real example (`src/Schema/Directives/FieldDirective.php`):
+```graphql
+directive @field(resolver: String!) on FIELD_DEFINITION
+```
+`@field(resolver: "Class@method")` assigns a resolver; method defaults to `__invoke`. The SDL `on FIELD_DEFINITION` part is a **type-system directive location** — where the directive may legally appear. (Contrast **executable directives** like `@include`/`@skip` that appear in client queries.)
+
+**Executable schema** — the in-memory `GraphQL\Type\Schema` object produced from the SDL, used to validate and execute queries. Built by `src/Schema/SchemaBuilder.php`.
+
+**Introspection** — the built-in query API (`__schema`, `__type`) that lets clients discover the schema. It needs the full type list, which is why `SchemaBuilder` registers a `types` callable (`$config->setTypes(...)`). That callable's eager resolution is the crux of #2771.
+
+**GraphQL over HTTP** — Lighthouse serves one endpoint (default `/graphql`), accepting POST (and GET), following the informal spec at graphql.org. Errors come back in the spec shape `{ "errors": [{ "message", "extensions", "locations", "path" }], "data": … }`.
+
+**Operations / variables / fragments** — a request has an operation (query/mutation/subscription), optional named variables, and reusable fragments. In tests these appear as `/** @lang GraphQL */` nowdocs (see `lighthouse-testing-and-qa`).
+
+## 2. webonyx/graphql-php essentials used here
+
+- **`Schema` + `SchemaConfig`** — the config carries `typeLoader` (lazy, per-name: `fn ($name) => $typeRegistry->search($name)`) and `types` (eager list for introspection: `fn () => $typeRegistry->possibleTypes()`). The split of these two is Lighthouse's laziness mechanism; #2771 is the failure of that split under graphql-php ≥ 15.31.
+- **`DocumentNode` / AST** — the parsed SDL. Lighthouse manipulates the AST (`src/Schema/AST/ASTBuilder.php`) — expanding `@paginate`, `@orderBy`, etc. — *before* building the executable schema, so transformations happen once and are cacheable.
+- **`DebugFlag`** — a bitmask (`INCLUDE_DEBUG_MESSAGE`, `INCLUDE_TRACE`, `RETHROW_*`) controlling error verbosity; mapped to integers 0–15 in `src/lighthouse.php` `debug`. Only applied when Laravel `app.debug` is true.
+- **Validation rules** — `QueryComplexity`, `QueryDepth`, `DisableIntrospection` (config `security`, all DISABLED by default).
+- **Default field resolver** — graphql-php's fallback resolver reads array keys / object properties / `offsetExists`; Lighthouse overrides resolution via directives and `FieldValue`.
+- **`ClientAware` errors** — graphql-php interface marking errors safe to show clients. Lighthouse's client-safe exceptions implement it: `src/Exceptions/DefinitionException.php`, `DirectiveException.php`, `RateLimitException.php`, `ClientSafeModelNotFoundException.php`, `SchemaSyntaxErrorException.php`. Non-`ClientAware` exceptions are masked unless a RETHROW debug flag is set.
+
+## 3. Eloquent / Laravel mapped to Lighthouse
+
+**Relations → directives** (all in `src/Schema/Directives/`): `@hasMany`, `@hasOne`, `@hasManyThrough`, `@hasOneThrough`, `@belongsTo`, `@belongsToMany`, `@morphOne`, `@morphMany`, `@morphTo`, `@morphToMany`. Each maps a GraphQL field to the corresponding Eloquent relation.
+
+**Batch loading** — resolving a relation for a list of parents naively causes **N+1** (one query per parent). Lighthouse's `RelationBatchLoader` (`src/Execution/BatchLoader/`) collects all parents and issues one query per relation, then distributes results. Controlled by `batchload_relations` (default on). Model loaders in `src/Execution/ModelsLoader/` (Simple/Paginated/Count/Aggregate) implement the strategies.
+
+**Pagination types** (`src/Pagination/PaginationType.php`): `PAGINATOR` (page-number based, with `paginatorInfo`), `SIMPLE` (has-more without total count), `CONNECTION` (Relay cursor-based). `@paginate(type: …)` selects one. Changing the generated pagination types in the schema is a classic breaking change (see #2104 in `lighthouse-failure-archaeology`).
+
+**Mass assignment & `force_fill`** — Lighthouse uses `forceFill()` in mutations because GraphQL's schema already constrains inputs, making Laravel's `$fillable`/`$guarded` redundant (`force_fill` config, default on).
+
+**Policies / gates → `@can*` family** (`src/Auth/`): `@canModel`, `@canFind`, `@canQuery`, `@canResolved`, `@canRoot` (the old single `@can` is `@deprecated` for v7). These call Laravel Gate/Policy checks at the field level.
+
+**Validation → `@rules`/Validators** (`src/Validation/`): map Laravel validation rules onto arguments/inputs; custom Validator classes live under the `validators` namespace.
+
+**Queues → subscription broadcasts** — subscription broadcasts can be queued (`subscriptions.queue_broadcasts`).
+
+**Laravel vs Lumen** — Lighthouse supports both; hence no Facades in `src/` and DI everywhere (see `lighthouse-architecture-contract`).
+
+## 4. Ecosystem protocols as implemented
+
+- **Relay** — Node interface + global object IDs (`src/GlobalId/`), and cursor **connections** (`src/Pagination/ConnectionField.php`, `PaginationType::CONNECTION`).
+- **Apollo Federation** — Lighthouse can act as a subgraph: `src/Federation/` provides entity resolution (`EntityResolverProvider`, `BatchedEntityResolver`), the federated schema printer (`FederationPrinter`), and `_entities`/`_service` support. Open asks: #2582, #2482.
+- **Automatic Persisted Queries (APQ)** — clients send a query hash; the server caches the full query. Handled in `src/GraphQL.php` (`persisted_queries` config, default on; Apollo-compatible).
+- **Tracing** — `src/Tracing/`: `ApolloTracing` (JSON, current default) and `FederatedTracing` (protobuf `reports.proto`, v7 default).
+- **Incremental delivery (`@defer`)** — `src/Defer/` (`DeferrableDirective`), experimental per the `defer` config comment; streams deferred fields after the initial response.
+
+## 5. Glossary
+
+| Term | One-line meaning |
+|---|---|
+| SDL | GraphQL's schema text format. |
+| AST | Parsed tree of the SDL/query that Lighthouse manipulates. |
+| Directive | `@foo` annotation → `FooDirective` class driving behavior. |
+| Resolver | Function producing a field's value. |
+| Directive locator | Maps directive names ↔ classes by namespace (`DirectiveLocator`). |
+| Type loader | Lazy per-name type factory (`SchemaConfig::setTypeLoader`). |
+| Batch loader | Dedupes relation queries across a result set to kill N+1. |
+| N+1 | One query per parent row instead of one batched query. |
+| Introspection | Built-in schema-discovery query API. |
+| Connection / cursor | Relay pagination shape / opaque position pointer. |
+| Paginator | Page-number pagination with total count. |
+| APQ | Automatic Persisted Queries (send hash, cache full query). |
+| Federation / subgraph | Composing multiple GraphQL services; Lighthouse is a subgraph. |
+| Field middleware | Directives wrapping every field's resolution, ordered. |
+| ClientAware | graphql-php marker for errors safe to expose to clients. |
+| DebugFlag | Bitmask controlling error verbosity. |
+
+## When NOT to use this skill
+
+- WHY the system is built this way / invariants → `lighthouse-architecture-contract`.
+- Config keys and defaults → `lighthouse-config-and-flags`.
+- Diagnosing a live failure → `lighthouse-debugging-playbook`.
+- Writing tests that exercise these features → `lighthouse-testing-and-qa`.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against v6.68.0 (`master` @ a29ff8e). Re-verify with:
+
+```bash
+grep -n "PAGINATOR\|SIMPLE\|CONNECTION" src/Pagination/PaginationType.php
+ls src/Schema/Directives/ | grep -iE "hasmany|belongsto|morph"
+ls src/Federation/ src/Defer/ src/GlobalId/ src/Tracing/
+grep -rln "ClientAware" src/Exceptions/
+grep -n "setTypeLoader\|setTypes" src/Schema/SchemaBuilder.php
+```

--- a/.claude/skills/lighthouse-architecture-contract/SKILL.md
+++ b/.claude/skills/lighthouse-architecture-contract/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: lighthouse-architecture-contract
+description: >-
+  Understand Lighthouse's load-bearing design decisions, the invariants that must
+  hold, and the known-weak points before changing internals. Load when touching the
+  schema build pipeline (ASTBuilder, SchemaBuilder, TypeRegistry, DirectiveLocator),
+  the execution path (BatchLoader, ModelsLoader, Arguments), directive interfaces,
+  service-provider registration, or anything whose correctness depends on laziness,
+  serializability, transaction semantics, or Lumen/Laravel dual support. Explains
+  WHY the system is shaped this way and what breaks if an invariant is violated.
+---
+
+# Lighthouse architecture contract
+
+Lighthouse is a schema-first GraphQL framework for Laravel: you write GraphQL SDL, annotate it with server-side **directives**, and Lighthouse turns that into an executable schema backed by Eloquent.
+This skill is the map of the load-bearing structure — the decisions you must not casually undo and the invariants you must not break.
+
+Ground truth date: 2026-07-07, v6.68.0 (`master` @ a29ff8e). Every path and class below was read from source.
+
+## System map: request lifecycle and owning classes
+
+Reference doc: `docs/master/concepts/request-lifecycle.md`. The runtime path:
+
+| Stage | Owner | Notes |
+|---|---|---|
+| Route registration | `src/Http/routes.php` → `src/Http/GraphQLController.php` | Single endpoint (`lighthouse.route`, default `/graphql`); works under Laravel Router or Lumen Router. |
+| HTTP middleware | `src/Http/Middleware/` (`AcceptJson`, `AttemptAuthentication`, `EnsureXHR`, `LogGraphQLQueries`) | Configured in `lighthouse.route.middleware`. Runs before GraphQL execution. |
+| Request parsing | `laragraph/utils` + `src/Http/` | Parses HTTP into GraphQL operation(s); follows the informal GraphQL-over-HTTP spec. |
+| Schema construction | `src/Schema/Source/SchemaStitcher` → `src/Schema/AST/ASTBuilder.php` → `src/Schema/SchemaBuilder.php` → `src/Schema/TypeRegistry.php` | Cached (see schema cache). Directives manipulate the AST here. |
+| Directive resolution | `src/Schema/DirectiveLocator.php` | Maps `@foo` ↔ `FooDirective` by namespace priority. |
+| Query validation | `webonyx/graphql-php` `DocumentValidator` via `src/GraphQL.php` | Plus `security` rules (complexity/depth/introspection). Cacheable (`validation_cache`). |
+| Field execution | `src/Execution/` + `src/Schema/Factories/FieldFactory.php` | Field middleware pipeline wraps resolvers; batch loading dedupes relation queries. |
+| Error handling | `src/Execution/` error handlers (`error_handlers` config) + `ErrorPool` | Errors collected, subtree aborted, rest continues. |
+| Response assembly | `src/GraphQL.php` (`@api` entrypoint) | Debug flags applied per `lighthouse.debug`. |
+
+`src/GraphQL.php` is the `@api`-marked entrypoint (`executeQueryString`, `executeParsedQuery`, `executeOperationOrOperations`).
+
+## Load-bearing decisions (and WHY)
+
+1. **Schema-first SDL + directive-driven AST manipulation** (not code-first). Users declare intent in `.graphql`; directives rewrite the `DocumentAST` before the executable schema is built (`ASTBuilder`). Why: keeps the schema the single source of truth and makes behavior declarative. Consequence: most features are directives, and schema transformations happen once at build time, not per request.
+
+2. **Directive naming convention + namespace discovery.** `FooDirective` ⇄ `@foo`. `DirectiveLocator::className()` does `Str::studly($name) . 'Directive'`; `directiveName()` is the inverse. Namespaces are tried in priority order (`config('lighthouse.namespaces.directives')` first, then Lighthouse's own — see `DirectiveLocator::namespaces()`), so user directives can override built-ins. Why: zero-registration extensibility.
+
+3. **One service provider per optional feature.** `composer.json` → `extra.laravel.providers` lists ~11 providers (Auth, Cache, GlobalId, OrderBy, Pagination, SoftDeletes, Testing, Validation, Async, Bind, plus the core `LighthouseServiceProvider`). CacheControl, Federation, Pennant, Scout, Subscriptions register conditionally. Why: features stay decoupled and optional; a user who does not need Scout never loads it.
+
+4. **Laziness is a design goal.** `SchemaBuilder::build()` sets `$config->setTypeLoader(fn ($name) => $this->typeRegistry->search($name))` so types are built on demand, not all upfront. This matters because the schema is rebuilt per request under PHP-FPM when the schema cache is cold or disabled. **Known breach:** `$config->setTypes(fn () => $this->typeRegistry->possibleTypes())` (needed for introspection) is a lazy callable, but graphql-php ≥ 15.31 resolves it on the first built-in scalar lookup, defeating laziness — issue **#2771, OPEN** (see Known-weak points).
+
+5. **Field middleware pipeline order is config-defined and significant.** `lighthouse.field_middleware` lists directives that wrap every field, executed in array order: `TrimDirective`, `ConvertEmptyStringsToNullDirective`, `SanitizeDirective`, `ValidateDirective`, `TransformArgsDirective`, `SpreadDirective`, `RenameArgsDirective`, `DropArgsDirective`. Why order matters: sanitization must precede validation; `@spread` must flatten input before renames/drops act on it. Do not reorder without understanding each stage.
+
+6. **Transactional mutations commit after the root field.** `lighthouse.transactional_mutations` (default `true`) wraps built-in model-mutating directives in a DB transaction that is committed **after the root field resolves** — so errors in **nested** fields do **not** roll back the root mutation (documented in the `src/lighthouse.php` comment). This is deliberate; changing it silently changes data-integrity semantics for every user.
+
+7. **`force_fill` over `fill`.** `lighthouse.force_fill` (default `true`) bypasses Laravel mass-assignment protection in mutation directives, because GraphQL already constrains allowed inputs by schema. Why: mass-assignment guards are redundant and would reject valid GraphQL input.
+
+8. **Lumen + Laravel dual support → no Facades, DI everywhere.** CONTRIBUTING.md forbids Facades (Lumen may not enable them) and prefers direct Illuminate classes over helpers. Sanctioned exception: the `response()` helper (DI of `ResponseFactory` does not work in Lumen). `src/Http/routes.php` resolves the router defensively for both frameworks.
+
+9. **Extensibility contract:** `protected` over `private`, never `final` in `src/`, `@api` marks the stable surface (33 annotations). See `lighthouse-change-control` for the enforcement rules.
+
+## Invariants (what must hold, and how to check)
+
+| Invariant | Why it must hold | Breaks if violated | Check |
+|---|---|---|---|
+| Schema consumers never break within a major | Users `composer update` blindly within `^6` | Every downstream API breaks at once | `lighthouse:print-schema` diff = empty (`lighthouse-change-control`) |
+| Types resolve lazily per request | Per-request schema rebuild must be cheap | Latency + memory blow up (see #2771) | `grep -n "setTypeLoader" src/Schema/SchemaBuilder.php` |
+| Every directive has an SDL definition | Schema validation + IDE helper need it | Schema build throws / directive ignored | `src/Support/Contracts/Directive.php` requires `public static function definition(): string` |
+| `DocumentAST` stays serializable | Schema cache serializes it to a PHP file | Schema cache write/read fails | `src/Schema/AST/DocumentAST.php`, `ASTCache` |
+| Nested-field errors don't roll back the root mutation | Documented transaction semantics | Silent data-integrity change | `src/Execution/TransactionalMutations.php`; `src/lighthouse.php` `transactional_mutations` comment |
+| No Facades in `src/` | Lumen compatibility | Lumen apps fatal | `grep -rn "Facade\|Illuminate\\\\Support\\\\Facades" src` should be empty |
+
+## Known-weak points (stated plainly — all OPEN as of 2026-07-07)
+
+- **#2771** — Lazy schema becomes eager on every request with `webonyx/graphql-php` ≥ 15.31. First built-in scalar lookup triggers scalar-override discovery, which resolves the `setTypes` callable → `TypeRegistry::possibleTypes()` builds every type. Measured 1.5–3.4× slower, ~6× PHP work. Fix depends on upstream `SchemaConfig::setScalarOverrides()`. This is the single biggest architectural liability right now.
+- **#2758** — `batchload_relations` bypasses `@canResolved(action: RETURN_VALUE)`; authorization result ignored for batched relations.
+- **#2679** — Laravel 12's `Model::automaticallyEagerLoadRelationships()` is incompatible with Lighthouse's `RelationBatchLoader` (`Collection::relationLoaded does not exist`).
+- **#2744** — Nested mutations run unscoped queries (`$relation->getRelated()::destroy($ids)`, `$model->newQuery()->findOrFail($id)`), letting a mutation touch records outside the parent relationship. Fix is breaking → deferred to v7. See `lighthouse-failure-archaeology`.
+- **MySQL 5.7 test pin** — `docker-compose.yml` pins `mysql:5.7` with `# TODO switch to MySQL 8` (issue #1784).
+- **PHPStan level 8, not max** — `phpstan.neon` `# TODO level up to max`.
+
+## When NOT to use this skill
+
+- Rules for gating/versioning a change → `lighthouse-change-control`.
+- Every config key and its default → `lighthouse-config-and-flags`.
+- GraphQL/Eloquent domain concepts → `graphql-laravel-reference`.
+- The history of how a decision was reached → `lighthouse-failure-archaeology`.
+- Diagnosing a live failure → `lighthouse-debugging-playbook`.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against v6.68.0 (`master` @ a29ff8e). Re-verify with:
+
+```bash
+grep -n "setTypeLoader\|setTypes\|possibleTypes" src/Schema/SchemaBuilder.php
+grep -n "className\|directiveName\|studly" src/Schema/DirectiveLocator.php
+grep -rn "final " src/ | grep -v "finally"          # should be empty in src/
+grep -n "transactional_mutations\|force_fill" src/lighthouse.php
+sed -n '/extra/,/scripts/p' composer.json | grep -i provider   # service provider list
+```

--- a/.claude/skills/lighthouse-build-and-env/SKILL.md
+++ b/.claude/skills/lighthouse-build-and-env/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: lighthouse-build-and-env
+description: >-
+  Recreate and operate the Lighthouse development environment. Load when setting up
+  the project, running make targets, choosing Docker+Make vs native tooling,
+  understanding the docker-compose services (php/mysql/redis/node), configuring the
+  test database, regenerating protobuf or agent config, or diagnosing environment
+  traps (Xdebug slowness, auto-format commits, gitignored phpunit.xml, packagist
+  egress blocks, CI removing dev deps). For what the test suites assert and how to
+  add tests use lighthouse-testing-and-qa; for measurement tools use
+  lighthouse-diagnostics-and-tooling.
+---
+
+# Lighthouse build and environment
+
+Two supported paths: **Docker + Make** (reproducible, recommended) and **native tools**. This skill lets you stand up either from scratch.
+
+Ground truth date: 2026-07-07, v6.68.0 (`master` @ a29ff8e). Verified by reading `Makefile`, `docker-compose.yml`, `php.dockerfile`, `node.dockerfile`, `composer.json`, `phpunit.xml.dist`, `.github/workflows/validate.yml`, and `.ai/`. Commands here were **config-verified, not executed** in the authoring environment (which has no `vendor/`).
+
+## Docker + Make happy path
+
+```bash
+make setup     # build containers + install deps + docs deps + generate agent config
+make it        # the pre-commit gate: vendor + fix + stan + test
+```
+
+### Every Make target (from `Makefile`)
+
+| Target | Does |
+|---|---|
+| `make help` | List targets with descriptions. |
+| `make setup` | `build` + `vendor` + `docs/node_modules` + `ai-sync`. |
+| `make build` | Build Docker images, passing `USER_ID`/`GROUP_ID` (file-ownership; short `id` opts for macOS, PR #2504). |
+| `make it` | `vendor fix stan test` — run before commits. |
+| `make fix` | `rector` + `php-cs-fixer` + `prettier`. |
+| `make rector` | Refactor via Rector. |
+| `make php-cs-fixer` | Format PHP. |
+| `make prettier` | Format docs markdown/js (via `node-docs`). |
+| `make stan` | PHPStan (level 8). |
+| `make test` | PHPUnit. |
+| `make bench` | PHPBench aggregate report. |
+| `make vendor` | `composer update` + `composer validate --strict` + `composer normalize`. |
+| `make php` | Interactive shell in php container. (Denied in `.ai/settings.json` for agents.) |
+| `make node` | Interactive shell in node container. (Denied for agents.) |
+| `make release` | `rm -rf docs/6 && cp -r docs/master docs/6` — **hardcodes `docs/6`**; a new major must edit this. |
+| `make docs` | Dev server for docs (port 8081). |
+| `make docs/node_modules` | Install docs yarn deps. |
+| `make ai-sync` | Regenerate agent config from `.ai/` via `lnai@0.6.7`. |
+| `make proto` | Regenerate protobuf PHP classes with `buf`. |
+| `make proto/update-reports` | Refresh `reports.proto` from Apollo. |
+
+### Single test
+
+```bash
+docker compose run --rm php vendor/bin/phpunit --filter=TestClassName
+docker compose run --rm php vendor/bin/phpunit --filter=testMethodName
+docker compose run --rm php vendor/bin/phpunit tests/Unit/Path/To/TestFile.php
+```
+(From `.ai/AGENTS.md`.)
+
+## Services (`docker-compose.yml`)
+
+| Service | Image / build | Notes |
+|---|---|---|
+| `php` | `php.dockerfile` (`php:8.3-cli` + zip, mysqli, pdo_mysql, intl, bcmath, xdebug, redis; `memory_limit=-1`) | Build args `USER_ID`/`GROUP_ID` for file ownership. |
+| `mysql` | `mysql:5.7`, `tmpfs:/var/lib/mysql`, `platform: linux/amd64` | Pinned 5.7 (`# TODO switch to MySQL 8`, issue #1784). `platform` pin is for Apple Silicon. Empty root password. |
+| `redis` | `redis:6` | Subscription storage / cache tests. |
+| `node-docs` | `node.dockerfile` (`node:22-slim`) | Docs dev server, port 8081. |
+| `node-tools` | `node.dockerfile` | Used by `make ai-sync` (lnai). |
+
+## Native path
+
+Requirements: PHP `^8` with extensions `mbstring, mysqli, pdo_mysql, redis` (from `validate.yml` `REQUIRED_PHP_EXTENSIONS`; `intl`/`bcmath`/`zip` also used per the Dockerfile), Composer 2, MySQL (any Laravel-supported version), Redis 6.
+
+```bash
+composer install
+cp phpunit.xml.dist phpunit.xml       # then edit the <env> DB/Redis params to reach your instances
+vendor/bin/phpunit                     # run tests
+vendor/bin/phpstan --verbose           # static analysis
+vendor/bin/php-cs-fixer fix            # format
+```
+`composer install` runs `post-autoload-dump` → `testbench package:discover` (`composer.json` scripts).
+`phpunit.xml` is **gitignored** (per-developer) — you must copy it.
+
+## Known traps (each verified)
+
+- **Xdebug slows tests ~10×.** The php image installs Xdebug. CONTRIBUTING.md: "Enabling Xdebug slows down tests by an order of magnitude. Stop listening for Debug Connection to speed it back up." Set `XDEBUG_REMOTE_HOST` to your host IP as seen from the container.
+- **The format workflow auto-commits to your branch.** `.github/workflows/format.yml` runs `composer normalize` + Prettier on every push and pushes the result back (`git-auto-commit-action`, `creyD/prettier_action`). After pushing, `git pull` before continuing or you'll hit a non-fast-forward.
+- **`phpunit.xml` is gitignored.** Copy from `phpunit.xml.dist`; your edits stay local.
+- **`vendor/` is absent until `composer install`.** You cannot run phpunit/phpstan/phpbench without it. A cloud/CI sandbox with restricted egress may block packagist entirely (symptom: `composer` fails with a proxy `CONNECT … 403`). If so, dependency-requiring commands can't run there — verify by reading config instead.
+- **CI removes some dev deps.** `validate.yml` runs `composer remove --dev --no-update phpbench/phpbench rector/rector` (and `larastan`, `phpstan-mockery` in the test job) because they conflict on the lowest/oldest matrix cells, and removes `laravel/pennant` on Laravel 9 (incompatible). So CI runs a slightly different dependency set than your local highest-deps install — see `lighthouse-testing-and-qa` for why "green locally" ≠ done.
+- **MySQL 5.7 pin.** Tests target MySQL 5.7; behavior may differ on MySQL 8 until #1784 is resolved.
+- **Proto regeneration needs `buf`.** `make proto` runs `bufbuild/buf` via Docker and `sudo chown`s the output; don't hand-edit `src/Tracing/FederatedTracing/Proto/`.
+
+## Agent configuration (how `.claude` relates to `.ai`)
+
+- `.ai/AGENTS.md` is the **source** of agent guidance; `.ai/config.json` and `.ai/settings.json` configure which tools get generated files and their permissions.
+- `make ai-sync` runs `lnai` to generate tool-specific files. The generated `.claude/CLAUDE.md` and `.claude/settings.json` are **gitignored** (`.gitignore` → `# lnai-generated`).
+- **`.claude/skills/` is version-controlled** — that is where this skill library lives. It is not generated by lnai and is not gitignored.
+
+## When NOT to use this skill
+
+- What the tests assert / how to add one → `lighthouse-testing-and-qa`.
+- Diagnostic/measurement tooling (benchmarks, query counts, tracing) → `lighthouse-diagnostics-and-tooling`.
+- Config option meanings → `lighthouse-config-and-flags`.
+- Running/operating a Lighthouse app as a user would → not covered here; this is the *dev* environment for the library itself.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against v6.68.0 (`master` @ a29ff8e); commands config-verified, not executed. Re-verify with:
+
+```bash
+grep -E "^\.PHONY|##" Makefile | head -40         # target list + descriptions
+grep -n "image:\|platform:\|tmpfs" docker-compose.yml
+grep -n "REQUIRED_PHP_EXTENSIONS\|composer remove" .github/workflows/validate.yml
+grep -n "lnai\|ai-sync" Makefile
+sed -n '/lnai-generated/,/end lnai-generated/p' .gitignore
+```

--- a/.claude/skills/lighthouse-change-control/SKILL.md
+++ b/.claude/skills/lighthouse-change-control/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: lighthouse-change-control
+description: >-
+  Gate and classify any change to Lighthouse before committing or opening a PR.
+  Use when deciding whether a change is a fix/feature/deprecation/breaking change,
+  what target version it belongs in, whether it needs a CHANGELOG or UPGRADE.md entry,
+  or whether it breaks the @api contract or a schema consumer. Load before merging,
+  releasing, bumping a dependency constraint, changing a config default, or altering
+  schema output, response shape, or error messages. Encodes the project's
+  non-negotiables (SemVer, @api stability, no breaking changes for schema consumers)
+  with their rationale and the incidents behind them.
+---
+
+# Lighthouse change control
+
+This is the gate every change passes through.
+Read it before you commit, before you open a PR, and before you cut a release.
+Lighthouse is a widely-deployed library: a bad release breaks thousands of production GraphQL APIs at once, and there is no staged rollout.
+The bar is correctness and backward compatibility, not speed.
+
+Ground truth date: 2026-07-07, verified against v6.68.0 (`master` @ a29ff8e).
+
+## First: classify the change
+
+| Class | CHANGELOG entry? | Tests required? | Docs (`/docs`) | UPGRADE.md | Target version |
+|---|---|---|---|---|---|
+| Docs-only | No (policy) | No | The change itself | No | any |
+| Bug fix | Yes — `Fixed` | Yes — failing test first | If behavior was documented | No | current major, next patch |
+| New feature | Yes — `Added` | Yes | Yes | No | current major, next minor |
+| Deprecation | Yes — `Deprecated` | Keep tests green | Note the replacement | No (until removal) | current major, next minor |
+| Breaking change | Yes — `Changed`/`Removed` | Yes | Yes | **Yes, required** | **next major only** |
+
+The "docs-only changes need no CHANGELOG entry" rule is explicit project policy — see commit `b095405` ("Clarify @search empty/null semantics and docs-only changelog policy") and CONTRIBUTING.md → Changelog.
+
+CHANGELOG entries go at the top of the `## Unreleased` section in `CHANGELOG.md`, in the correct category, and **end with the full PR URL**: `https://github.com/nuwave/lighthouse/pull/<number>`.
+Categories are fixed (Keep a Changelog): `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
+
+## The non-negotiables (with rationale and the incident behind each)
+
+### 1. Semantic Versioning; only the current major gets features and fixes
+
+README → Versioning: "Only the current major version receives new features and bugfixes."
+Minor upgrades must require **no** changes to a user's PHP code or GraphQL schema, and cause **no** breaking behavioral change for API consumers.
+Rationale: users pin `^6` and expect `composer update` within a major to be safe forever.
+
+### 2. The `@api` PHPDoc contract is the code-stability boundary
+
+Code elements marked with the `@api` PHPDoc tag are guaranteed stable until the next major (CONTRIBUTING.md → Internal).
+Everything **not** marked `@api` is internal and may change in any release.
+There are currently 33 `@api` annotations across `src` (`grep -rc "@api" src` to recount).
+Load-bearing examples to respect: `src/Support/Contracts/GraphQLContext.php`, `src/Support/Contracts/ArgResolver.php`, `src/Support/Contracts/SaveAwareArgResolver.php`, `src/Execution/ErrorHandler.php`, `src/Schema/TypeRegistry.php`, `src/Schema/Directives/BaseDirective.php`.
+Before changing any signature, run `grep -n "@api" <file>` — if the method or class carries it, the change is breaking and goes to the next major.
+
+### 3. No breaking changes for schema consumers within a major (the unwritten rule, now written)
+
+This is stronger than the `@api` code contract and is the maintainer's hardest line.
+A client of a running Lighthouse GraphQL API must never observe breakage from a minor/patch upgrade. Frozen surfaces:
+
+- **Schema output** — the printed SDL (types, fields, nullability, directive locations, enum values).
+- **Response shapes** — the JSON structure of query/mutation/subscription results, including pagination wrappers.
+- **Error semantics** — error `message`, `extensions`, categories, and where errors surface.
+
+Incidents that set this rule:
+
+- **`88d8e18f` "Revert breaking schema change in generate pagination types (#2104)"** — a change altered the generated pagination types in the printed schema; it shipped, broke consumers' schemas, and was reverted with entries added to both CHANGELOG.md and UPGRADE.md. Touches `src/Pagination/PaginationManipulator.php`. Lesson: any diff to generated schema types is breaking even if the PHP API is untouched.
+- **`150b5401` "Prevent regression to simple paginator type on fields using `@cache` (#2355)"** — `@cache` combined with pagination silently downgraded the paginator type in the schema; caught and fenced with a regression test. Lesson: feature interactions can break schema output; test the combinations.
+
+How to check before you ship: see "Is my change breaking?" below.
+
+### 4. Full support-matrix compatibility
+
+CI (`.github/workflows/validate.yml`) runs PHPStan and PHPUnit across **PHP 8.0–8.5 × Laravel ^9–^13 × lowest/highest dependencies** (with documented exclusions).
+"Works on my PHP 8.4 / Laravel 12" is not evidence.
+A change is not done until the whole matrix is green.
+Do not drop a supported PHP/Laravel version in a minor — that is breaking (next major only).
+
+### 5. Extensibility guarantees
+
+From CONTRIBUTING.md → Code Guidelines:
+
+- Use `protected` over `private` everywhere in `src/` — subclasses must be able to override.
+- Never use `final` in `src/`; always use `final` in `tests/`.
+- Full namespace in PHPDoc (`@var \Full\Namespace\Class`), imports in code.
+- No Laravel Facades (Lumen compatibility) — inject dependencies. The one sanctioned exception is the `response()` helper.
+
+Violating these does not break users today but removes an escape hatch they rely on, so reviewers treat it as blocking.
+
+## Review and merge gates
+
+Run before every commit:
+
+```bash
+make it        # = vendor + fix + stan + test (the full local gate)
+```
+
+Individually:
+
+```bash
+make fix       # rector + php-cs-fixer + prettier (auto-format)
+make stan      # PHPStan level 8 (phpstan.neon)
+make test      # PHPUnit
+```
+
+- PHPStan runs at **level 8** (`phpstan.neon`; `# TODO level up to max`). Do not lower it. Adding an ignore is acceptable only when it mirrors an existing documented pattern in `phpstan.neon` (e.g. cross-Laravel-version generics noise).
+- A bug fix without a failing-test-first is not acceptable (CONTRIBUTING.md → Testing). Write the test that reproduces the bug, watch it fail, then fix.
+- **The format workflow auto-commits to your branch.** `.github/workflows/format.yml` runs `composer normalize` and Prettier on every push and pushes the result back with `git-auto-commit-action`. After pushing, `git pull` before adding more commits or you will hit a non-fast-forward.
+
+## Release protocol
+
+From CONTRIBUTING.md → "Release a New Version":
+
+1. Review the entries under `CHANGELOG.md` → `## Unreleased`; add any missing ones.
+2. Based on those entries and the previous version, decide the next version number (SemVer) and add it to `CHANGELOG.md` (replace `## Unreleased` header with the version, add a fresh empty `## Unreleased` above).
+3. Draft a new GitHub release.
+4. Use the version number as both git tag and title.
+5. Paste the changelog entries as the description.
+6. Publish.
+
+Breaking changes are documented in `UPGRADE.md` and may only ship in a **major** release.
+A major release also ends feature work on the previous major (README versioning promise) and requires copying `docs/master` to a new numbered docs dir — see `lighthouse-v7-campaign` for the full major-release runbook.
+
+Deprecation path: mark the element with a `@deprecated` PHPDoc tag stating the replacement, add a `Deprecated` CHANGELOG entry, keep it working until the next major, then remove it.
+Real current examples (`grep -rn "@deprecated" src`):
+`src/Console/ClearCacheCommand.php` (`@deprecated in favor of lighthouse:clear-schema-cache`), `src/Auth/CanDirective.php` (`@deprecated TODO remove with v7`), `src/Testing/RefreshesSchemaCache.php`, `src/Testing/MakesGraphQLRequestsLumen.php`.
+
+## Decision aid: "Is my change breaking?"
+
+Answer NO to all of these or it is breaking (→ next major, → UPGRADE.md entry):
+
+- [ ] Printed schema is byte-identical for an unchanged input schema. Verify: `php artisan lighthouse:print-schema` before and after, `diff` the two. Empty diff required for non-breaking work.
+- [ ] No `@api`-annotated signature changed. Verify: `grep -n "@api" <touched files>`.
+- [ ] Response JSON shape unchanged for existing queries/mutations/subscriptions.
+- [ ] No config default in `src/lighthouse.php` changed in a way that alters behavior for an existing app.
+- [ ] No error `message`/`extensions` that a test (or a user) relies on changed.
+- [ ] No supported PHP/Laravel version dropped; no dependency floor raised.
+- [ ] New required arguments/fields were not added to existing directives or generated types.
+
+If any box cannot be checked, the change is breaking. Do not "sneak" it into a minor.
+
+## When NOT to use this skill
+
+- Actually diagnosing a bug → `lighthouse-debugging-playbook`.
+- Turning a report into a failing test → `lighthouse-issue-triage-and-reproduction`.
+- Executing a major release end-to-end → `lighthouse-v7-campaign`.
+- Proving a change is non-breaking with measurements → `lighthouse-proof-and-analysis-toolkit`.
+- The history behind a settled decision → `lighthouse-failure-archaeology`.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against v6.68.0 (`master` @ a29ff8e). Re-verify drift with:
+
+```bash
+grep -n "Release a New Version" CONTRIBUTING.md          # release steps still present
+grep -rc "@api" src                                       # @api surface count (was 33)
+grep -rn "@deprecated" src --include="*.php"              # deprecation inventory
+git show 88d8e18f --stat                                  # pagination-schema revert incident
+git log --oneline -3 -- .github/workflows/format.yml      # auto-format workflow still active
+grep -n "level:" phpstan.neon                             # PHPStan level (was 8)
+```

--- a/.claude/skills/lighthouse-config-and-flags/SKILL.md
+++ b/.claude/skills/lighthouse-config-and-flags/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: lighthouse-config-and-flags
+description: >-
+  The catalog of every Lighthouse configuration option and environment variable —
+  key, default, env var, and whether it is production-ready or experimental. Load
+  when reading, changing, or documenting a config value; when adding a new config
+  option; when a bug depends on a flag (schema_cache, query_cache, batchload_relations,
+  transactional_mutations, force_fill, defer, tracing, subscriptions); or when you
+  need the exact publish command or env-var name. Includes a checklist for adding an
+  option without breaking backward compatibility, plus drift-check commands.
+---
+
+# Lighthouse config and flags
+
+The single source of truth is `src/lighthouse.php` (547 lines). Users publish it to `config/lighthouse.php`.
+Config is read two ways in the codebase: via the `config('lighthouse.…')` helper (e.g. `src/Schema/DirectiveLocator.php:61`) and via an injected `Illuminate\Contracts\Config\Repository` (preferred per the no-Facades rule — the `config()` helper is tolerated).
+
+Ground truth date: 2026-07-07, v6.68.0 (`master` @ a29ff8e). Every default below was read from `src/lighthouse.php`. Env-var defaults are the fallback in the `env(...)` call.
+
+## Publishing the config
+
+```bash
+php artisan vendor:publish --tag=lighthouse-config    # publishes src/lighthouse.php → config/lighthouse.php
+php artisan vendor:publish --tag=lighthouse-schema     # publishes default-schema.graphql → your schema_path
+```
+Tags verified in `src/LighthouseServiceProvider.php` (`lighthouse-config`, `lighthouse-schema`).
+
+## Full option catalog
+
+Legend: **Prod** = stable, safe in production. **Exp** = experimental / handle with care. **Perf** = performance tuning, verify with benchmarks.
+
+| Key | Default | Env var | Class | Notes |
+|---|---|---|---|---|
+| `route.uri` | `/graphql` | — | Prod | The endpoint URI. |
+| `route.name` | `graphql` | — | Prod | Named route. |
+| `route.middleware` | `AcceptJson`, `AttemptAuthentication` (+ commented `EnsureXHR`, `LogGraphQLQueries`) | — | Prod | Runs before execution. `EnsureXHR` is **default-on in v7** (`UPGRADE.md`). |
+| `guards` | `null` | — | Prod | Auth guards for `@guard`/`AttemptAuthentication`; `null` = Laravel default. |
+| `schema_path` | `base_path('graphql/schema.graphql')` | — | Prod | Root `.graphql` file. |
+| `schema_cache.enable` | `env('APP_ENV') !== 'local'` | `LIGHTHOUSE_SCHEMA_CACHE_ENABLE` | Prod/Perf | On by default outside `local`. Stale cache = common trap (`lighthouse-debugging-playbook`). |
+| `schema_cache.path` | `bootstrap/cache/lighthouse-schema.php` | `LIGHTHOUSE_SCHEMA_CACHE_PATH` | Prod | Serialized AST/schema file. |
+| `cache_directive_tags` | `false` | — | Prod | `@cache` uses a tagged cache; requires a taggable store. |
+| `query_cache.enable` | `true` | `LIGHTHOUSE_QUERY_CACHE_ENABLE` | Perf | Caches parsed query strings. |
+| `query_cache.mode` | `store` | `LIGHTHOUSE_QUERY_CACHE_MODE` | Perf | `store` (shared cache) / `opcache` (local PHP files) / `hybrid`. Added #2713; hybrid+APQ fixed #2727. |
+| `query_cache.opcache_path` | `bootstrap/cache` | `LIGHTHOUSE_QUERY_CACHE_OPCACHE_PATH` | Perf | Folder; one file per query. Only for `opcache`/`hybrid`. |
+| `query_cache.store` | `null` | `LIGHTHOUSE_QUERY_CACHE_STORE` | Perf | Cache store; app default if `null`. Not used in `opcache` mode. |
+| `query_cache.ttl` | `86400` (24h) | `LIGHTHOUSE_QUERY_CACHE_TTL` | Perf | Seconds; `null` = forever. |
+| `validation_cache.enable` | `false` | `LIGHTHOUSE_VALIDATION_CACHE_ENABLE` | Perf/Exp | Caches query validation results. Off by default (#2603). |
+| `validation_cache.store` | `null` | `LIGHTHOUSE_VALIDATION_CACHE_STORE` | Perf | |
+| `validation_cache.ttl` | `86400` | `LIGHTHOUSE_VALIDATION_CACHE_TTL` | Perf | |
+| `parse_source_location` | `true` | — | Perf | `false` drops `locations` from errors; slightly faster. |
+| `namespaces.*` | `App\GraphQL\…` per type | — | Prod | Where Lighthouse discovers models, queries, mutations, types, directives, etc. |
+| `security.max_query_complexity` | `DISABLED` (0) | — | Prod | `GraphQL\Validator\Rules\QueryComplexity`. |
+| `security.max_query_depth` | `DISABLED` (0) | — | Prod | `QueryDepth`. |
+| `security.disable_introspection` | `DISABLED` | `LIGHTHOUSE_SECURITY_DISABLE_INTROSPECTION` | Prod | Set env truthy to disable introspection. |
+| `pagination.default_count` | `null` | — | Prod | Default page size; `null` = client must ask. |
+| `pagination.max_count` | `null` | — | Prod | Max items per page; `null` = unrestricted. |
+| `debug` | `INCLUDE_DEBUG_MESSAGE \| INCLUDE_TRACE` | `LIGHTHOUSE_DEBUG` | Prod | Bitmask 0–15; table in the config file. Only applies when Laravel `app.debug=true`. |
+| `error_handlers` | Authentication, Authorization, Validation, Reporting | — | Prod | Pipeline; classes implement `Nuwave\Lighthouse\Execution\ErrorHandler`. |
+| `field_middleware` | Trim, ConvertEmptyStringsToNull, Sanitize, Validate, TransformArgs, Spread, RenameArgs, DropArgs | — | Prod | **Order is significant** (`lighthouse-architecture-contract`). |
+| `global_id_field` | `id` | — | Prod | Node interface global id field name. |
+| `persisted_queries` | `true` | — | Prod | Automatic Persisted Queries (Apollo-compatible). |
+| `transactional_mutations` | `true` | — | Prod | Wraps model mutations in a transaction committed after the root field; nested-field errors don't roll back. |
+| `force_fill` | `true` | — | Prod | `forceFill()` over `fill()` in mutations (GraphQL constrains inputs). |
+| `batchload_relations` | `true` | — | Prod | Batch-loads relations to fight N+1. Interacts with #2758/#2679. |
+| `shortcut_foreign_key_selection` | `false` | — | Perf/Exp | Only works if every model's PK is exactly `id` (see config comment). Opt-in. |
+| `subscriptions.queue_broadcasts` | `true` | `LIGHTHOUSE_QUEUE_BROADCASTS` | Prod | |
+| `subscriptions.broadcasts_queue_name` | `null` | `LIGHTHOUSE_BROADCASTS_QUEUE_NAME` | Prod | |
+| `subscriptions.storage` | `redis` | `LIGHTHOUSE_SUBSCRIPTION_STORAGE` | Prod | Cache driver for subscription storage. |
+| `subscriptions.storage_ttl` | `null` | `LIGHTHOUSE_SUBSCRIPTION_STORAGE_TTL` | Prod | `null` = forever (may leak stale subs). |
+| `subscriptions.encrypted_channels` | `false` | `LIGHTHOUSE_SUBSCRIPTION_ENCRYPTED` | Prod | |
+| `subscriptions.broadcaster` | `pusher` | `LIGHTHOUSE_BROADCASTER` | Prod | `log`/`echo`/`pusher`/`reverb`. `reverb` uses the `pusher` driver. Use `log` to debug. |
+| `subscriptions.exclude_empty` | `true` | `LIGHTHOUSE_SUBSCRIPTION_EXCLUDE_EMPTY` | Prod | |
+| `defer.max_nested_fields` | `0` (unlimited) | — | **Exp** | `@defer` is explicitly experimental (config comment). |
+| `defer.max_execution_ms` | `0` (unlimited) | — | **Exp** | |
+| `federation.entities_resolver_namespace` | `App\GraphQL\Entities` | — | Prod | Apollo Federation `_entities` resolvers. |
+| `tracing.driver` | `ApolloTracing::class` | — | Prod | **v7 default changes to `FederatedTracing`** (config comment). |
+
+## Test-environment variables (NOT library config)
+
+These configure the test DB/Redis, set in `phpunit.xml.dist` and overridden in `.github/workflows/validate.yml`. They are not part of the published config.
+
+| Var | phpunit.xml.dist | validate.yml (CI) |
+|---|---|---|
+| `LIGHTHOUSE_TEST_DB_HOST` | `mysql` | `127.0.0.1` |
+| `LIGHTHOUSE_TEST_DB_PORT` | `3306` | `33060` |
+| `LIGHTHOUSE_TEST_DB_USERNAME` | `root` | `root` |
+| `LIGHTHOUSE_TEST_DB_PASSWORD` | (empty) | `root` |
+| `LIGHTHOUSE_TEST_DB_DATABASE` | `test` | `test` |
+| `LIGHTHOUSE_TEST_REDIS_HOST` | `redis` | `127.0.0.1` |
+| `LIGHTHOUSE_TEST_REDIS_PORT` | `6379` | `63790` |
+
+## How to add a new config option (checklist)
+
+1. **Add the key + a comment block** to `src/lighthouse.php`, matching the existing `/*---*/` banner style. Every option is documented inline.
+2. **Choose a backward-compatible default.** The default must preserve current behavior for existing apps (change-control rule: no behavioral break in a minor). New behavior ships off/neutral by default (precedent: `validation_cache` off, `shortcut_foreign_key_selection` false).
+3. **Decide on an `env()` wrapper.** Pattern in this codebase: deployment-facing toggles get an `env('LIGHTHOUSE_…')` fallback; structural options (namespaces, handler lists) do not.
+4. **Read it via injected `ConfigRepository`** in `src/`, not a Facade.
+5. **Add a test** that exercises both default and set values. Tests set config in `getEnvironmentSetUp($app)` via `$app->make(ConfigRepository::class)->set('lighthouse.…', …)` — see `tests/DBTestCase.php` and `tests/TestCase.php` for the pattern.
+6. **Document** it in `docs/master/` where relevant and add a `CHANGELOG.md` `Added` entry ending with the PR URL.
+7. If it changes generated schema or response shape → it may be breaking; run the checklist in `lighthouse-change-control`.
+
+## Interactions and guards worth flagging
+
+- `schema_cache.enable` default depends on `APP_ENV` — behaves differently in `local` vs prod.
+- `cache_directive_tags=true` requires a **taggable** cache store (Redis/Memcached), not `file`/`array`.
+- `query_cache.mode=opcache|hybrid` needs a writable `opcache_path` folder and OPcache enabled.
+- `subscriptions.broadcaster=reverb` maps to the `pusher` driver with a `reverb` connection.
+- `shortcut_foreign_key_selection=true` is only safe if **every** type's primary key field is literally `id`.
+- `security.*` limits are all DISABLED by default — production hardening is opt-in.
+
+## When NOT to use this skill
+
+- Why a decision (laziness, transaction semantics) is shaped this way → `lighthouse-architecture-contract`.
+- Diagnosing a flag-dependent bug → `lighthouse-debugging-playbook`.
+- Domain meaning of a feature (APQ, federation, connections) → `graphql-laravel-reference`.
+- Gating a config-default change as breaking → `lighthouse-change-control`.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against v6.68.0 (`master` @ a29ff8e). `php -r "require 'src/lighthouse.php'"` does **not** run standalone (it calls `base_path()`), so use grep-based drift checks:
+
+```bash
+grep -nE "^\s*'[a-z_]+' =>" src/lighthouse.php          # top-level + nested keys
+grep -oE "env\('LIGHTHOUSE_[A-Z_]+'" src/lighthouse.php  # env var inventory
+grep -n "vendor:publish\|publishes\|lighthouse-config" src/LighthouseServiceProvider.php
+grep -rn "env(" src --include="*.php" | grep -v lighthouse.php   # env reads outside config (expect none)
+```
+`tracing.driver` default and `EnsureXHR`/test-trait behavior change at v7 — re-check `UPGRADE.md` after any major bump.

--- a/.claude/skills/lighthouse-debugging-playbook/SKILL.md
+++ b/.claude/skills/lighthouse-debugging-playbook/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: lighthouse-debugging-playbook
+description: >-
+  Triage a live Lighthouse failure fast. Load when a GraphQL request errors, a
+  schema won't build, a directive "isn't found", results are stale after editing
+  .graphql files, there are too many DB queries (N+1), subscriptions don't
+  broadcast, errors are hidden or over-exposed, a request is rejected before
+  execution, or a test passes locally but fails in CI. Provides a symptom→cause
+  triage table, the time-wasting traps with their stories, and one-axis-at-a-time
+  discriminating experiments. For turning a confirmed bug into a failing test, use
+  lighthouse-issue-triage-and-reproduction instead.
+---
+
+# Lighthouse debugging playbook
+
+Fast triage for the failure modes that actually occur in this project.
+Every command below is the Docker+Make form (primary) with the native form as an alternative; commands were verified against `Makefile`, `composer.json`, `phpunit.xml.dist`, and source on 2026-07-07, **not** executed here (this authoring environment has no `vendor/`).
+
+Key definitions used throughout: **directive** = a `@foo` annotation in the schema backed by a `FooDirective` PHP class. **AST** = the parsed schema document Lighthouse manipulates before building the executable schema. **N+1** = one query per parent row instead of one batched query for all of them.
+
+## First 5 minutes (do this for every report)
+
+1. Get the exact GraphQL query, variables, and the full error JSON (`errors[].message`, `errors[].extensions`).
+2. Get versions: Lighthouse, `webonyx/graphql-php`, PHP, Laravel. Many bugs are version-boundary bugs (see #2771, #2679).
+3. Reproduce in a test before theorizing — see `lighthouse-issue-triage-and-reproduction`. A red test beats a paragraph of speculation.
+4. Check whether the schema is **cached**: `schema_cache.enable` defaults to `true` when `APP_ENV !== 'local'` (`src/lighthouse.php` ~line 93). A stale cache masquerades as "my change did nothing".
+5. Turn on debug detail: set `LIGHTHOUSE_DEBUG` high (see the DebugFlag table in `src/lighthouse.php`, values 0–15) and ensure Laravel `app.debug = true`.
+
+## Symptom → cause → first move
+
+| Symptom | Likely cause | First move |
+|---|---|---|
+| `DefinitionException` / schema won't build | Invalid SDL, or directive manipulating AST wrongly | Read the message; it names the type/field. `src/Exceptions/DefinitionException.php`. Run `lighthouse:validate-schema`. |
+| `SchemaSyntaxErrorException` | Malformed `.graphql` | Fix syntax at the reported location. `src/Exceptions/SchemaSyntaxErrorException.php`. |
+| "Directive @foo not found" / wrong directive runs | Name→class resolution or namespace priority | `FooDirective` must exist; `DirectiveLocator::className()` = `Str::studly(name).'Directive'`. Check `lighthouse.namespaces.directives`; user namespaces win over Lighthouse's (`DirectiveLocator::namespaces()`). |
+| Schema edits have no effect | Schema cache serving stale AST | Clear it: `lighthouse:clear-schema-cache`. In tests, the schema is refreshed via `RefreshesSchemaCache`. |
+| Too many DB queries / slow list | Batch loading off, or relation not using a relation directive | Confirm `batchload_relations` (default `true`). Assert query count in a `DBTestCase` (`AssertsQueryCounts`). |
+| Batched relation returns error under Laravel 12 | `automaticallyEagerLoadRelationships()` clashes with `RelationBatchLoader` | Known **OPEN #2679**. Workaround: don't enable Laravel auto eager loading with `batchload_relations`. |
+| `@canResolved(action: RETURN_VALUE)` ignored | Authorization bypassed when batching relations | Known **OPEN #2758**. Confirm by toggling `batchload_relations=false`. |
+| Subscriptions don't broadcast | Broadcaster/driver/storage misconfig | Switch `broadcaster` to `log` (`src/Subscriptions/Broadcasters/LogBroadcaster.php`) to see intended broadcasts in the log; isolates transport vs logic. |
+| Errors hidden (no message/trace) | `debug` flag too low, or `app.debug=false` | Raise `LIGHTHOUSE_DEBUG`; debug only applies when Laravel debug is on (`src/lighthouse.php` comment). |
+| Internal exception leaked to client | Error handler / debug flag exposing internals | Review `error_handlers` pipeline (`src/Execution/*ErrorHandler.php`) and debug flag; `ClientAware` errors are safe, others are masked unless RETHROW flags set. |
+| Request rejected before any resolver runs | HTTP middleware | Inspect `lighthouse.route.middleware`: `AcceptJson`, `AttemptAuthentication`, `EnsureXHR` (`src/Http/Middleware/`). |
+| GET or HTML-form POST blocked | `EnsureXHR` middleware | Commented **out** in v6 default config; **default-on in v7** (`UPGRADE.md` → "EnsureXHR is enabled"). If seen in v6, someone enabled it. |
+| Passes locally, fails in CI | Matrix cell you didn't run | See "CI-only failures" below. |
+| Fatal only under Lumen | Facade/helper used in `src/` | Lumen lacks Facades; `grep -rn "Facades" src` must be empty. Use DI. |
+
+## Traps that cost real time (with their stories)
+
+- **The schema cache trap.** Editing a `.graphql` file and seeing no change is almost always a stale schema cache, not a broken change. The cache defaults on outside `local`. In tests, `src/Testing/RefreshesSchemaCache.php` handles refresh (auto in v7). Always clear the cache before concluding your change "doesn't work".
+
+- **The graphql-php version boundary.** Upstream bumps repeatedly cause subtle breakage. #2771: lazy schema silently becomes eager on `webonyx/graphql-php` ≥ 15.31 (huge latency/memory regression, no error thrown). #2679: Laravel 12's auto eager loading breaks batch loaders. Lesson: when perf or behavior changes with no Lighthouse code change, suspect the dependency version first; bisect by pinning constraints. Lighthouse guards such gaps with `method_exists` checks (real example: `src/GraphQL.php:166`, `// TODO remove this check when updating the required version of webonyx/graphql-php`).
+
+- **Batch loading vs authorization/eager-loading.** `batchload_relations` changes how relations are fetched and currently interacts badly with `@canResolved` (#2758) and Laravel auto eager loading (#2679). When a relation-related bug appears, toggling `batchload_relations` is the fastest discriminator.
+
+- **Nested mutation scope.** Nested mutations run unscoped queries (#2744, OPEN) — a mutation can hit records outside the parent relationship. If a user reports "my nested update touched the wrong record", it is likely this known issue, not their misuse. See `lighthouse-failure-archaeology`.
+
+- **CI-only failures.** `validate.yml` runs the **lowest** dependency set (`--prefer-lowest --prefer-stable`) and old Laravel/PHP, and **removes** some dev deps in CI (`composer remove --dev ... larastan phpstan-mockery phpbench rector`; removes `laravel/pennant` on Laravel 9). So a green local run on highest deps proves nothing about the floor. Reproduce the failing cell's PHP+Laravel+lowest combo locally.
+
+## Discriminating experiments (toggle ONE axis)
+
+Change one variable, observe, revert. Each isolates a hypothesis.
+
+| Hypothesis | Experiment |
+|---|---|
+| Stale schema cache | `docker compose run --rm php vendor/bin/artisan lighthouse:clear-schema-cache` (native: `php artisan …`) then retry |
+| Batch loading is the cause | Set `lighthouse.batchload_relations=false`, retry; if fixed, it's a batch-loader interaction (#2679/#2758) |
+| Subscription transport vs logic | Set `lighthouse.subscriptions.broadcaster=log`, retry, read the log |
+| Errors are masked, not absent | Raise `LIGHTHOUSE_DEBUG` (e.g. 3 or 15) with `app.debug=true` |
+| Schema output changed | `php artisan lighthouse:print-schema` before and after your change, `diff` |
+| Isolate one test | `docker compose run --rm php vendor/bin/phpunit --filter=SomeTest` (native: `vendor/bin/phpunit --filter=SomeTest`) |
+| Upstream vs Lighthouse regression | Pin `webonyx/graphql-php` to the prior version in `composer.json`, re-measure |
+
+## When NOT to use this skill
+
+- Turning a confirmed bug into a failing test / triaging an issue report → `lighthouse-issue-triage-and-reproduction`.
+- A battle that's already settled (don't re-diagnose) → `lighthouse-failure-archaeology`.
+- Measuring instead of guessing (query counts, benchmarks, tracing) → `lighthouse-diagnostics-and-tooling`.
+- Proving a fix is correct/non-breaking → `lighthouse-proof-and-analysis-toolkit`.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against v6.68.0 (`master` @ a29ff8e). Re-verify with:
+
+```bash
+ls src/Exceptions/                                        # exception class inventory
+grep -n "className\|studly" src/Schema/DirectiveLocator.php
+grep -n "schema_cache\|batchload_relations\|debug" src/lighthouse.php
+ls src/Subscriptions/Broadcasters/                        # broadcaster drivers (log/echo/pusher)
+grep -rh "\$name = 'lighthouse:clear" src/Console/*.php    # clear commands
+grep -n "method_exists" src/GraphQL.php                   # upstream version guard example
+```
+Issue statuses (#2771, #2679, #2758, #2744) were OPEN on 2026-07-07 — re-check on GitHub before relying on them.

--- a/.claude/skills/lighthouse-diagnostics-and-tooling/SKILL.md
+++ b/.claude/skills/lighthouse-diagnostics-and-tooling/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: lighthouse-diagnostics-and-tooling
+description: >-
+  Measure Lighthouse behavior instead of eyeballing it. Load when you need to inspect
+  or compare the generated schema, validate it, count queries, benchmark performance,
+  trace a request, read PHPStan output, or profile a regression. Catalogs every
+  lighthouse:* artisan command with its exact signature, gives measurement recipes
+  with interpretation guides, and ships runnable scripts (schema-diff, config-keys,
+  bench-report). For what the results should be (acceptance bar) use
+  lighthouse-testing-and-qa; for proof strategy use lighthouse-proof-and-analysis-toolkit.
+---
+
+# Lighthouse diagnostics and tooling
+
+Rule of the house: **measure, don't guess.** This skill lists the instruments and how to read them.
+
+Ground truth date: 2026-07-07, v6.68.0 (`master` @ a29ff8e). Command signatures were read from `src/Console/*.php`. Commands shown are the native `php artisan …` form; under Docker prefix with `docker compose run --rm php vendor/bin/artisan …`.
+
+## Artisan command catalog
+
+| Command | What it does | Reach for it when |
+|---|---|---|
+| `lighthouse:print-schema` | Compile and print the schema. Options: `--write`/`-W`, `--disk=`/`-D`, `--json`, `--federation`, `--sort`. | Comparing schema before/after a change (use `--sort` for stable diffs). |
+| `lighthouse:validate-schema` | "Validate the GraphQL schema definition." | Confirming SDL + directives build cleanly. |
+| `lighthouse:ide-helper` | "Create IDE helper files to improve type checking and autocompletion." | Regenerating directive/type helpers. |
+| `lighthouse:cache` | "Compile the GraphQL schema and cache it." | Warming the schema cache in deploys. |
+| `lighthouse:clear-schema-cache` | "Clear the GraphQL schema cache." | Schema edits not taking effect. |
+| `lighthouse:clear-query-cache` | "Clears the GraphQL query cache." | Stale parsed-query cache. |
+| `lighthouse:clear-cache` | **`@deprecated`** in favor of `lighthouse:clear-schema-cache`. | Legacy; don't use in new work. |
+| `lighthouse:directive/field/query/mutation/subscription/interface/union/scalar/validator` | Generator stubs. | Scaffolding new code. |
+
+## Measurement recipes (with interpretation)
+
+### Schema backward-compatibility check
+```bash
+php artisan lighthouse:print-schema --sort > before.graphql
+# make your change
+php artisan lighthouse:clear-schema-cache
+php artisan lighthouse:print-schema --sort > after.graphql
+diff -u before.graphql after.graphql
+```
+Interpretation: **empty diff = non-breaking for consumers** (the hard rule). Any removed field/type, changed nullability, or changed default is breaking. Use `scripts/schema-diff.sh` to do this across two git refs automatically.
+
+### Schema validity
+```bash
+php artisan lighthouse:validate-schema
+```
+Non-zero exit / thrown `DefinitionException` = your SDL or a directive's AST manipulation is invalid.
+
+### Query counting (N+1)
+Use a `DBTestCase` with `AssertsQueryCounts`:
+```php
+$this->assertQueryCountMatches($expected, function (): void {
+    $this->graphQL(/* ... */);
+});
+```
+Interpretation: build **more than one** parent row, or batching and N+1 look identical. Real usage: `tests/Integration/Execution/DataLoader/RelationBatchLoaderTest.php`. See `lighthouse-testing-and-qa`.
+
+### Benchmarks
+```bash
+make bench      # docker: phpbench run --report=aggregate
+# native: vendor/bin/phpbench run --report=aggregate
+```
+Config: `phpbench.json` (bootstrap `vendor/autoload.php`, path `benchmarks`). Benchmark classes (`@Warmup(1) @Revs(10) @Iterations(10)`):
+- `QueryBench` — base for query execution benchmarks.
+- `HugeResponseBench` — large response assembly cost.
+- `HugeRequestBench` — large request parsing cost.
+- `ASTUnserializationBench` — schema-cache AST unserialize cost (relevant to #2771/schema cache work).
+
+Interpretation discipline: run on the **same machine**, look at the **`rstdev`** (relative standard deviation) column before trusting any delta — a change smaller than rstdev is noise. Baseline first, change, re-run; explain every regression. Use `scripts/bench-report.sh before` / `... after` to capture dated reports.
+
+### Request tracing
+Set `tracing.driver` to `ApolloTracing` (JSON timings per field) or `FederatedTracing` (protobuf; v7 default). Enables per-field resolution timing in the response `extensions`.
+
+### Query logging
+Uncomment `Nuwave\Lighthouse\Http\Middleware\LogGraphQLQueries` in `lighthouse.route.middleware` to log every incoming query.
+
+### Error verbosity
+`LIGHTHOUSE_DEBUG` bitmask 0–15 (table in `src/lighthouse.php`), effective only with Laravel `app.debug=true`. Raise it to surface messages/traces; lower it to reproduce production masking.
+
+### Profiling a performance regression (the #2771 method)
+1. Capture a cachegrind profile (Xdebug) of a minimal operation (e.g. authenticated `{ __typename }`) on the suspect version and the prior version.
+2. Compare total PHP work (cachegrind file size / instruction counts) — #2771 saw 9.1 MB → 57 MB.
+3. **Ablation:** neutralize the suspected cause (e.g. patch `setTypes(fn () => [])`) and re-measure; if the baseline returns, the cause is confirmed. This ablation + before/after comparison is the gold-standard method — see `lighthouse-proof-and-analysis-toolkit`.
+
+## Static analysis
+```bash
+make stan       # docker: vendor/bin/phpstan --verbose
+```
+`phpstan.neon`: **level 8** (`# TODO level up to max`), bootstraps `phpstan-bootstrap.php`, stubs `_ide_helper.php`, scans `benchmarks/src/tests`. `reportUnmatchedIgnoredErrors: false` because multi-Laravel-version support creates version-specific dead spots. Adding an `ignoreErrors` entry is acceptable only when it mirrors an existing documented pattern (e.g. Laravel generics arity noise). Never lower the level.
+
+## Shipped scripts (`scripts/`)
+
+| Script | Purpose | Verified |
+|---|---|---|
+| `schema-diff.sh <ref-before> <ref-after>` | Diff printed schema across two git refs; non-empty diff fails. | `bash -n` OK 2026-07-07 (not executed — needs vendor/). |
+| `config-keys.php [path]` | Tokenizer-based list of config keys in `src/lighthouse.php` (no Laravel boot). | Executed with PHP 8.4 on 2026-07-07 — prints the keys. |
+| `bench-report.sh [label]` | Run PHPBench, tee to a dated `bench-reports/` file. | `bash -n` OK 2026-07-07 (not executed — needs vendor/). |
+
+## When NOT to use this skill
+
+- The acceptance bar / what evidence is required → `lighthouse-testing-and-qa`.
+- Proof strategy (how to combine tools into airtight evidence) → `lighthouse-proof-and-analysis-toolkit`.
+- Triaging a live failure fast → `lighthouse-debugging-playbook`.
+- Config values behind these tools → `lighthouse-config-and-flags`.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against v6.68.0 (`master` @ a29ff8e). Re-verify with:
+
+```bash
+grep -rn "lighthouse:" src/Console/*.php | grep -oE "lighthouse:[a-z-]+" | sort -u   # command names
+sed -n '/protected \$signature/,/SIGNATURE;/p' src/Console/PrintSchemaCommand.php     # print-schema options
+cat phpbench.json ; ls benchmarks/
+grep -n "level:" phpstan.neon
+php .claude/skills/lighthouse-diagnostics-and-tooling/scripts/config-keys.php | wc -l  # re-run the shipped script
+```

--- a/.claude/skills/lighthouse-diagnostics-and-tooling/scripts/bench-report.sh
+++ b/.claude/skills/lighthouse-diagnostics-and-tooling/scripts/bench-report.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# bench-report.sh — run PHPBench and save a timestamped aggregate report.
+#
+# Purpose: capture a benchmark baseline before a change and again after, so perf
+# claims rest on numbers from the SAME machine. Saves each run to a dated file for
+# later comparison. Never trust a delta smaller than the report's rstdev.
+#
+# Usage:
+#   scripts/bench-report.sh [label]
+#   scripts/bench-report.sh before
+#   scripts/bench-report.sh after
+# Output: ./bench-reports/<UTC-timestamp>-<label>.txt
+#
+# Docker users: this wraps `make bench` (which runs phpbench in the php container).
+# Native users: set BENCH="vendor/bin/phpbench run --report=aggregate".
+#
+# Verified with `bash -n` on 2026-07-07; NOT executed in the authoring environment
+# (no vendor/). phpbench config: phpbench.json (bootstrap vendor/autoload.php, path benchmarks).
+set -euo pipefail
+
+LABEL="${1:-run}"
+BENCH="${BENCH:-make bench}"
+OUTDIR="bench-reports"
+mkdir -p "$OUTDIR"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT="$OUTDIR/${STAMP}-${LABEL}.txt"
+
+echo "Running: $BENCH  (label: $LABEL)"
+# tee keeps the report on screen and on disk.
+$BENCH 2>&1 | tee "$OUT"
+echo
+echo "Saved report to $OUT"
+echo "Compare two runs with: diff <(cat $OUTDIR/<before>.txt) <(cat $OUTDIR/<after>.txt)"
+echo "Reminder: only trust deltas larger than the rstdev column; same machine only."

--- a/.claude/skills/lighthouse-diagnostics-and-tooling/scripts/config-keys.php
+++ b/.claude/skills/lighthouse-diagnostics-and-tooling/scripts/config-keys.php
@@ -16,7 +16,6 @@
  * Verified: executed with PHP 8.4 against src/lighthouse.php on 2026-07-07; prints
  * the config keys (route, schema_cache, query_cache, batchload_relations, ...).
  */
-
 $path = $argv[1] ?? 'src/lighthouse.php';
 if (! is_file($path)) {
     fwrite(STDERR, "File not found: {$path}\n");
@@ -25,7 +24,7 @@ if (! is_file($path)) {
 
 $tokens = token_get_all(file_get_contents($path));
 $keys = [];
-for ($i = 0, $n = count($tokens); $i < $n; $i++) {
+for ($i = 0, $n = count($tokens); $i < $n; ++$i) {
     $tok = $tokens[$i];
     if (! is_array($tok) || $tok[0] !== T_CONSTANT_ENCAPSED_STRING) {
         continue;
@@ -33,7 +32,7 @@ for ($i = 0, $n = count($tokens); $i < $n; $i++) {
     // Look ahead past whitespace for a `=>` double arrow.
     $j = $i + 1;
     while ($j < $n && is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
-        $j++;
+        ++$j;
     }
     if ($j < $n && is_array($tokens[$j]) && $tokens[$j][0] === T_DOUBLE_ARROW) {
         $keys[] = trim($tok[1], "'\"");

--- a/.claude/skills/lighthouse-diagnostics-and-tooling/scripts/config-keys.php
+++ b/.claude/skills/lighthouse-diagnostics-and-tooling/scripts/config-keys.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+/**
+ * config-keys.php — list the configuration keys defined in src/lighthouse.php
+ * without booting Laravel, for drift checks against lighthouse-config-and-flags.
+ *
+ * Why token-based, not `require`: src/lighthouse.php calls base_path()/env(), so a
+ * bare `require` fatals outside a Laravel app. This parses the file with the PHP
+ * tokenizer and prints every single-quoted string that is immediately followed by
+ * `=>` (i.e. array keys), which approximates the config option names.
+ *
+ * Usage:
+ *   php scripts/config-keys.php [path/to/lighthouse.php]
+ * Default path: src/lighthouse.php relative to the current directory.
+ *
+ * Verified: executed with PHP 8.4 against src/lighthouse.php on 2026-07-07; prints
+ * the config keys (route, schema_cache, query_cache, batchload_relations, ...).
+ */
+
+$path = $argv[1] ?? 'src/lighthouse.php';
+if (! is_file($path)) {
+    fwrite(STDERR, "File not found: {$path}\n");
+    exit(1);
+}
+
+$tokens = token_get_all(file_get_contents($path));
+$keys = [];
+for ($i = 0, $n = count($tokens); $i < $n; $i++) {
+    $tok = $tokens[$i];
+    if (! is_array($tok) || $tok[0] !== T_CONSTANT_ENCAPSED_STRING) {
+        continue;
+    }
+    // Look ahead past whitespace for a `=>` double arrow.
+    $j = $i + 1;
+    while ($j < $n && is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
+        $j++;
+    }
+    if ($j < $n && is_array($tokens[$j]) && $tokens[$j][0] === T_DOUBLE_ARROW) {
+        $keys[] = trim($tok[1], "'\"");
+    }
+}
+
+$keys = array_values(array_unique($keys));
+sort($keys);
+echo implode("\n", $keys), "\n";
+fwrite(STDERR, count($keys) . " config keys found in {$path}\n");

--- a/.claude/skills/lighthouse-diagnostics-and-tooling/scripts/schema-diff.sh
+++ b/.claude/skills/lighthouse-diagnostics-and-tooling/scripts/schema-diff.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# schema-diff.sh — prove a change does (or does not) alter the printed GraphQL schema.
+#
+# Purpose: the "no breaking changes for schema consumers" rule requires the printed
+# SDL to be byte-identical for non-breaking work. This captures the schema at two git
+# refs and diffs them. An empty diff means the schema surface is unchanged.
+#
+# Usage (run from a Laravel APP that uses Lighthouse, or adapt PHPUNIT path for a fixture app):
+#   scripts/schema-diff.sh <ref-before> <ref-after>
+#   scripts/schema-diff.sh master HEAD
+#
+# Assumptions:
+#   - `php artisan lighthouse:print-schema` works in the current project (needs vendor/ + a schema).
+#   - You are in a clean working tree (the script checks out refs).
+#   - Docker users: prefix the artisan call with `docker compose run --rm php`.
+#
+# This script was syntax-checked with `bash -n` on 2026-07-07. It was NOT executed
+# in the authoring environment (no vendor/). Review before running; it moves git refs.
+set -euo pipefail
+
+BEFORE="${1:?usage: schema-diff.sh <ref-before> <ref-after>}"
+AFTER="${2:?usage: schema-diff.sh <ref-before> <ref-after>}"
+ARTISAN="${ARTISAN:-php artisan}"   # override, e.g. ARTISAN="docker compose run --rm php vendor/bin/artisan"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Working tree is dirty. Commit or stash first." >&2
+  exit 1
+fi
+START_REF="$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)"
+restore() { git checkout --quiet "$START_REF"; }
+trap 'restore; rm -rf "$TMPDIR"' EXIT
+
+for ref in "$BEFORE" "$AFTER"; do
+  git checkout --quiet "$ref"
+  # --sort makes the output order-stable so the diff reflects real changes, not ordering.
+  $ARTISAN lighthouse:clear-schema-cache >/dev/null 2>&1 || true
+  $ARTISAN lighthouse:print-schema --sort > "$TMPDIR/${ref//\//_}.graphql"
+done
+
+echo "Diff of printed schema: $BEFORE -> $AFTER"
+if diff -u "$TMPDIR/${BEFORE//\//_}.graphql" "$TMPDIR/${AFTER//\//_}.graphql"; then
+  echo "SCHEMA UNCHANGED (non-breaking for consumers)."
+else
+  echo "SCHEMA CHANGED — every difference must be traced to an UPGRADE.md entry (breaking) or justified as additive."
+  exit 1
+fi

--- a/.claude/skills/lighthouse-docs-and-writing/SKILL.md
+++ b/.claude/skills/lighthouse-docs-and-writing/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: lighthouse-docs-and-writing
+description: >-
+  Maintain Lighthouse's documents of record and follow house writing style. Load when
+  editing docs/, README, CHANGELOG, UPGRADE, CONTRIBUTING, or SECURITY; registering a
+  new docs page; writing a directive doc, changelog entry, or upgrade note; or making
+  a public claim (performance, "novel", experimental status) that carries a proof
+  obligation. Covers the VuePress docs site mechanics, semantic-line-break style, copy
+  templates, and external-positioning discipline. For the gating rules behind a change
+  use lighthouse-change-control.
+---
+
+# Lighthouse docs and writing
+
+Docs are part of the contract: a user-facing change is not done until the docs of record reflect it.
+This skill covers what to update, how the docs site works, house style, templates, and the discipline around public claims.
+
+Ground truth date: 2026-07-07, v6.68.0 (`master` @ a29ff8e).
+
+## Documents of record — which file, when
+
+| File | Answers | Update trigger |
+|---|---|---|
+| `README.md` | What Lighthouse is; sponsors; versioning promise; repo-transfer notice | Rarely; keep the transfer notice + sponsor links intact |
+| `docs/` (VuePress site) | How to use every feature | Any user-facing behavior/feature change |
+| `CHANGELOG.md` | What changed per release | Every non-docs-only change |
+| `UPGRADE.md` | How to migrate across majors | Every breaking change (majors only) |
+| `CONTRIBUTING.md` | How to contribute, style, release steps | Process/style changes |
+| `SECURITY.md` | How to report a vulnerability | Rarely |
+| `.ai/AGENTS.md` | Guidance for coding agents | When conventions change (then `make ai-sync`) |
+
+## Docs site mechanics (VuePress)
+
+- Layout: `docs/master/` = current version; numbered dirs (`docs/6`, `docs/5`, …) = archived majors; `docs/pages/` = version-independent. Reference: `docs/.github/README.md`.
+- **New page:** create the `.md` under `docs/master/<section>/` and register it in `docs/master/sidebar.js`. The sidebar is an array of `{ title, children: [...] }`; children are page paths (string) or `[path, "Custom Label"]` pairs. Example section:
+  ```js
+  { title: "Eloquent", children: [
+      ["eloquent/getting-started", "Getting Started"],
+      "eloquent/nested-mutations",
+  ]},
+  ```
+- **Develop:** `make docs` (dev server, port 8081).
+- **Cut a major's docs:** `make release` runs `rm -rf docs/6 && cp -r docs/master docs/6` — it **hardcodes `docs/6`**. A new major (v7) requires editing this target to `docs/7` before running (see `lighthouse-v7-campaign`).
+- **Prettier runs in CI** over docs (`.github/workflows/format.yml`, `--tab-width=2`) and **auto-commits** the result to your branch. `git pull` after pushing.
+
+## House style
+
+- **Semantic line breaks** (sembr.org): one sentence per line in `*.md` and multiline PHPDoc/comment prose. Do **not** wrap at a column, and do not split a sentence at commas. Adopted project-wide in #2753 (`87a39be`). Do **not** reflow code blocks, snippets, or PHPDoc tags (`@param`/`@return`/`@throws`).
+- **Directive docs** follow a fixed shape (`docs/master/api-reference/directives.md`): an `## @directiveName` heading, then the directive's SDL `definition()` verbatim in a ```graphql block (with the doc-comment descriptions), then usage examples. Keep the doc's SDL identical to the class's `definition()`.
+- **CHANGELOG entries:** correct Keep-a-Changelog category, one sentence, ending in the full PR URL.
+- `@api` PHPDoc marks the stable code surface — don't document internal (non-`@api`) classes as if stable.
+
+## Templates (copy these)
+
+CHANGELOG entry (top of `## Unreleased`, correct category):
+```markdown
+### Fixed
+
+- Handle explicit `null` for `page` argument in paginated queries https://github.com/nuwave/lighthouse/pull/2735
+```
+
+UPGRADE.md breaking-change section:
+```markdown
+### <Short imperative title of the break>
+
+<One or two sentences, semantic line breaks, on what changed and why.>
+
+```diff
+-   old(usage)
++   new(usage)
+```
+```
+
+Directive doc section (in `api-reference/directives.md`):
+```markdown
+## @myDirective
+
+```graphql
+"""
+<Description matching the class definition() doc comment.>
+"""
+directive @myDirective(
+  arg: String!
+) on FIELD_DEFINITION
+```
+
+<Usage example and notes.>
+```
+
+GitHub release notes (CONTRIBUTING → Release a New Version): tag + title = version number; body = the changelog entries for that version.
+
+## External positioning and claims discipline
+
+- **"Faster" needs evidence.** Any performance claim in docs/release notes must rest on PHPBench numbers (`lighthouse-diagnostics-and-tooling`). No unbenchmarked speed claims.
+- **Experimental stays labeled experimental.** `@defer` is experimental (config comment); docs must say so. Don't present experimental features as stable.
+- **Nothing promises beyond the contract.** Docs must not imply stability for non-`@api` internals or guarantee behavior that SemVer/schema-consumer rules don't (see `lighthouse-change-control`).
+- **Repo-transfer notice** (README head, discussion #2767): the project is planned to move to `spawnia/lighthouse`. Keep the notice until the transfer completes; don't remove it as "stale".
+- **Sponsor links are load-bearing** (README Sponsors, `.github/FUNDING.yml`) — don't drop them.
+- **Upstream-first ethos.** Problems rooted in `webonyx/graphql-php` get an upstream issue/PR plus a local `method_exists` guard, not a local hack that forks behavior (pattern: #2771 proposal following #2637). Document the guard's TODO so it's removed when the constraint is bumped.
+
+## When NOT to use this skill
+
+- Deciding whether a change needs a changelog/upgrade entry at all → `lighthouse-change-control`.
+- Producing the benchmark numbers a claim needs → `lighthouse-diagnostics-and-tooling`.
+- Positioning research/novelty claims about future work → `lighthouse-research-frontier`.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against v6.68.0 (`master` @ a29ff8e). Re-verify with:
+
+```bash
+sed -n '1,20p' docs/master/sidebar.js                  # sidebar shape
+grep -n "release:" -A2 Makefile                         # docs/6 hardcode still there
+grep -n "tab-width\|prettier" .github/workflows/format.yml
+sed -n '44,50p' docs/master/eloquent/nested-mutations.md   # a real doc section
+head -2 CHANGELOG.md ; grep -n "pull/" CHANGELOG.md | head -1   # entry format
+cat SECURITY.md
+```

--- a/.claude/skills/lighthouse-failure-archaeology/SKILL.md
+++ b/.claude/skills/lighthouse-failure-archaeology/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: lighthouse-failure-archaeology
+description: >-
+  The chronicle of settled battles — past investigations, dead ends, reverts, and
+  the reasons behind them. Load BEFORE proposing a fix or refactor in schema caching,
+  nested mutations, pagination-type generation, resolver-efficiency rewrites, directive
+  additions, or graphql-php version handling, so you don't re-fight a decided battle or
+  re-introduce a reverted change. Each entry is symptom → root cause → evidence
+  (commit/PR/issue) → status → lesson. For diagnosing a NEW live failure use
+  lighthouse-debugging-playbook; for the rules on making changes use lighthouse-change-control.
+---
+
+# Lighthouse failure archaeology
+
+The purpose of this file: **nobody should re-fight a settled battle.**
+Before you "fix" something in these areas, check whether it was already tried, reverted, or deliberately left alone.
+
+Ground truth date: 2026-07-07, v6.68.0 (`master` @ a29ff8e). Every commit SHA and PR below was verified with `git show`/`git log` or a `CHANGELOG.md` grep. Full history (3,928 commits) is available.
+
+Reading key: **Status** is one of *fixed in vX.Y* / *OPEN as of 2026-07-07* / *rejected/reverted*.
+
+---
+
+## Saga 1 — Schema caching (the longest-running effort)
+
+Schema building (parse + AST manipulation) is expensive, so the final schema is cached to a PHP file. Making that cache correct and safe took years of incremental fixes.
+
+- **Schema cache v1 removed.** Symptom: two cache mechanisms coexisted, confusing and redundant. Root cause: v2 (AST-based) superseded v1. Evidence: `19ec1d1a` "Remove schema cache v1 (#2321)", documented in `c743aef8` (#2322); trait `ClearsSchemaCache` removed (CHANGELOG). **Status: done.** Lesson: retire the old mechanism once the replacement is proven — don't carry both.
+
+- **Non-atomic cache writes → corruption/races.** Symptom: partially-written schema/query cache files read by concurrent requests. Root cause: write-in-place is not atomic. Evidence: `d5ea91d6` "Use exclusive lock when writing the parsed schema to a file in `ASTCache`" (#2685); `f6b214fd` "Write schema cache to temporary file before atomically updating it (#2703)"; `2de0a54b` "Use atomic file writes for query cache (#2716)". **Status: fixed (v6.63.x).** Lesson: cache writes must be write-temp-then-rename (atomic on POSIX). See the proof recipe in `lighthouse-proof-and-analysis-toolkit`.
+
+- **OPcache-backed query cache added, then hardened.** Symptom: parsing query strings on every request is slow. Root cause: no local cache leveraging OPcache. Evidence: `780da320` "Add a file based query cache to leverage OPcache for improved performance (#2713)" — which also deprecated `lighthouse:clear-cache` in favor of `lighthouse:clear-query-cache`/`lighthouse:clear-schema-cache`; hardened by #2716 (atomic writes) and `910a2184` "Make Automatic Persisted Queries work with hybrid cache mode (#2727)". **Status: shipped (v6.63.0+).** Lesson: a feature ships, a flaw is found, it's fixed forward — the follow-up PRs are part of the feature.
+
+- **Validation cache.** Symptom: re-validating identical queries wastes time. Evidence: `bebb209b` "Cache query validation results" (#2603); config `validation_cache` (default **off**). **Status: shipped, opt-in.** Lesson: perf features that change behavior ship off-by-default first.
+
+- **Octane memory exhaustion.** Symptom: with the schema cache enabled under Laravel Octane, memory climbs until fatal (`Allowed memory size … exhausted`). Root cause: unconfirmed (reporter suspects GC not running with cache on). Evidence: issue **#2436**, labeled *needs reproduction*. **Status: OPEN as of 2026-07-07.** Lesson: no conclusive minimal reproduction yet — see `lighthouse-proof-and-analysis-toolkit` for what a conclusive Octane memory repro must show.
+
+- **Test-time schema cache refresh.** Symptom: cached schema leaks between tests / parallel test workers. Evidence: `318ad4d4` (#2076), `299a3690` (#1920), lazy refresh `03f3dab5`/#2702; trait `src/Testing/RefreshesSchemaCache.php`. In **v7** this setup becomes automatic (its `bootRefreshesSchemaCache()` is `@deprecated`; `UPGRADE.md` → "Leverage automatic test trait setup"). **Status: fixed; auto in v7.**
+
+---
+
+## Saga 2 — Nested mutation semantics (the most error-prone area)
+
+Nested mutations (`create`/`update`/`upsert`/`delete`/`connect`/`disconnect`/`sync` on related models) live in `src/Execution/Arguments/Nested*.php`. Edge cases have bitten repeatedly.
+
+- **Null handling reverted.** Symptom: a fix for nested operations receiving `null` caused regressions. Evidence: `c0eac85e` "Revert 'Fix handling of nested mutation operations that receive `null`'" — touched `NestedBelongsTo`, `NestedManyToMany`, `NestedMorphTo`, `NestedOneToMany`. **Status: reverted.** Lesson: null semantics in nested mutations are subtle; a fix that passes its own test can break others — demand adversarial testing across all Nested* handlers.
+
+- **Flatten-in-create/update reverted in favor of `@spread`.** Symptom: attempt to auto-flatten nested input. Evidence: `a6ae1e29` "Revert trying to properly flatten in create/update, @spread is preferred". **Status: rejected** — the sanctioned mechanism is the `@spread` directive, not implicit flattening. Lesson: don't re-add implicit flattening.
+
+- **HasOne upsert vs create.** Symptom: `upsert` on a `HasOne` created a new record instead of updating when no `id` given; `create` on a `HasOne` with an existing related record didn't error. Evidence: CHANGELOG v6.64.3, PR #2742. **Status: fixed (v6.64.3).**
+
+- **Upsert identifying columns.** Evidence: "Specify identifying columns on nested mutation upserts with `@upsert`/`@upsertMany`", PR #2426 (v6.65.0). **Status: shipped.**
+
+- **Pre/post-save timing for nested arg resolvers.** Symptom: nested arg resolvers needed to run before the parent model is saved. Evidence: `961aecf` "Allow nested arg resolvers to run before parent model is saved (#2777)" — added the `SaveAwareArgResolver` interface (v6.68.0). **Status: shipped (v6.68.0).**
+
+- **Unscoped nested operations (security).** Symptom: a nested `update`/`delete`/`connect`/etc. can affect records **outside** the parent relationship (e.g. update another user's task by id). Root cause: unscoped queries — `$relation->getRelated()::destroy($ids)`, `$model->newQuery()->findOrFail($id)`. Evidence: issue **#2744** (supersedes #1400, which reported only the HasMany delete case). The behavior is documented under "Security considerations" in `docs/master/eloquent/nested-mutations.md`, but is accepted as a real issue. Fix (scope through the relation) is **breaking** → deferred to v7 (options: major default / opt-in flag / new directive). **Status: OPEN as of 2026-07-07, accepted-as-real, unfixed.** Lesson: this is settled as a real problem — don't re-litigate whether it's a bug; the open question is only *how* to fix without breaking (see `lighthouse-v7-campaign`).
+
+---
+
+## Reverts and dead ends (shorter)
+
+- **`@cacheControl` — reverted, then re-added.** First added (`f4439f46`), reverted (`315392fd` "Revert 'Add `@cacheControl` directive'"), then successfully re-added via `59187c79` (#2136). It now lives in `src/CacheControl/`. **Status: shipped.** Lesson: a revert is not always permanent — the second attempt landed. Don't assume "reverted" = "forbidden forever"; check current `src/`.
+
+- **`@namespaced` — reverted, then re-added.** Reverted in `198afbff`, later re-added (`90950d1a`, #2478). Both `src/Schema/Directives/NamespacedDirective.php` and `NamespaceDirective.php` exist today and it's documented (`docs/master/api-reference/directives.md`). **Status: shipped.** Lesson: same as above — verify against current source, not just the revert commit.
+
+- **"Resolve fields more efficiently (#961)" reverted.** A performance rewrite of `src/Schema/TypeRegistry.php` was reverted: `7cfd7922` "Revert 'Resolve fields more efficiently (#961)'" (12 insertions / 13 deletions restored). **Status: rejected.** Lesson: resolver-efficiency rewrites of `TypeRegistry` have failed before — treat that hot path with extreme caution and demand benchmarks + full behavioral tests (see `lighthouse-research-frontier` item 1).
+
+- **Pagination schema-type change reverted.** `88d8e18f` "Revert breaking schema change in generate pagination types (#2104)" — altered generated pagination types in the printed schema, broke consumers. Also see `790` CHANGELOG entry "Prevent regression to simple paginator type on fields using `@cache` (#2354/#2355)". **Status: reverted / fenced with regression test.** Lesson: any change to generated schema types is breaking. This is the canonical incident behind the "no breaking changes for schema consumers" rule in `lighthouse-change-control`.
+
+- **`IdeHelperCommandTest` suite move reverted.** `107504ee` "Revert 'Move slow IdeHelperCommandTest to integration suite'". Minor; recorded so it isn't retried blindly.
+
+---
+
+## graphql-php upstream friction
+
+- **Lazy schema eager on ≥ 15.31 (#2771, OPEN).** Full mechanism and measured impact in `lighthouse-architecture-contract` and the campaign skill. Fix awaits upstream `SchemaConfig::setScalarOverrides()`.
+- **The version-guard pattern.** When behavior depends on the installed graphql-php version, Lighthouse guards with `method_exists`. Real example: `src/GraphQL.php:166` — `method_exists($queryComplexityRule, 'getQueryComplexity')` with `// TODO remove this check when updating the required version of webonyx/graphql-php`. Introduced alongside #2637. #2771's proposed fix follows the same pattern. Lesson: don't bump the graphql-php floor to clear a TODO in a minor (breaking for users on older 15.x) — guard instead.
+
+## How to extend this chronicle
+
+```bash
+git log --oneline -i --grep="revert"           # find reverts
+git show <sha> --stat                           # what a commit touched
+git log --oneline -- src/<area>                 # history of a subsystem
+grep -n "<keyword>" CHANGELOG.md                # released-change record (v3 → v6.68)
+```
+When you resolve or reject something significant, add an entry here with its evidence.
+
+## When NOT to use this skill
+
+- Diagnosing a NEW, unclassified live failure → `lighthouse-debugging-playbook`.
+- The rules/gates for making a change → `lighthouse-change-control`.
+- Planning the v7 breaking changes → `lighthouse-v7-campaign`.
+- Turning a report into a failing test → `lighthouse-issue-triage-and-reproduction`.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against v6.68.0 (`master` @ a29ff8e). Re-verify with:
+
+```bash
+git show 88d8e18f --stat        # pagination schema revert
+git show 7cfd7922 --stat        # #961 resolver-efficiency revert
+git show c0eac85e --stat        # nested null-handling revert
+git log --oneline -- src/CacheControl | tail        # @cacheControl revert+re-add
+ls src/Schema/Directives/ | grep -i namespac        # @namespaced re-added
+grep -n "2744\|2436\|2771" CHANGELOG.md             # confirm still unreleased/open
+```
+Open issues (#2744, #2436, #2771, #2758, #2679) were OPEN on 2026-07-07 — re-check GitHub.

--- a/.claude/skills/lighthouse-issue-triage-and-reproduction/SKILL.md
+++ b/.claude/skills/lighthouse-issue-triage-and-reproduction/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: lighthouse-issue-triage-and-reproduction
+description: >-
+  Turn a Lighthouse bug report or issue into a triaged, reproduced, failing test —
+  the core maintenance loop. Load when handling an incoming issue or bug report:
+  classifying it (bug/enhancement/question/security/needs-reproduction), checking for
+  duplicates, deciding severity, and writing a minimal failing test from the report.
+  Provides the triage decision tree, copy-paste test skeletons anchored to real base
+  classes, and the security-report route. For fast live-failure triage use
+  lighthouse-debugging-playbook; for the fix-PR gating rules use lighthouse-change-control.
+---
+
+# Lighthouse issue triage and reproduction
+
+The maintenance workflow: report → classify → check for duplicates → reproduce as a failing test → hand to a fix. A reproduction is the deliverable; opinions without a red test don't move an issue.
+
+Ground truth date: 2026-07-07, v6.68.0 (`master` @ a29ff8e).
+
+## Triage decision tree
+
+1. **Security vulnerability?** → Do **not** discuss in public. Route to GitHub private vulnerability reporting: `https://github.com/nuwave/lighthouse/security/advisories/new` (per `SECURITY.md`). Never open or comment on a public issue for it.
+2. **Bug** (Lighthouse behaves incorrectly)? → Reproduce (below). Label `bug`.
+3. **Enhancement / feature request?** → Label `enhancement`; no reproduction needed, but a concrete use case is. Route through the feature-proposal template.
+4. **Question / usage help?** → Label `question`/`discussion`; point to docs / GitHub discussions (the bug template itself says questions belong on Stack Overflow / Slack / discussions).
+5. **Can't reproduce from the report?** → Label `needs reproduction`; ask for a minimal repro (schema + query + versions).
+
+Issue templates live in `.github/ISSUE_TEMPLATE/` (`bug_report.md`, `feature_proposal.md`, `config.yml`). The bug template asks for: description, expected behavior, steps to reproduce, output/logs, Lighthouse version, Laravel version.
+
+Observed labels in use: `bug`, `enhancement`, `discussion`, `question`, `needs reproduction`, `docs`.
+
+**Duplicate check (do this first):**
+```bash
+grep -n "<keyword>" CHANGELOG.md          # already fixed in a release?
+git log --oneline -i --grep="<keyword>"   # already attempted/reverted?
+```
+Plus search open issues on GitHub. Currently-known OPEN majors (don't re-file): #2771 (lazy schema eager), #2758 (@canResolved + batchload), #2744 (unscoped nested mutations), #2679 (Laravel 12 auto eager loading), #2436 (Octane memory). See `lighthouse-failure-archaeology` for settled ones.
+
+## Severity grading
+
+| Severity | Signals | Examples |
+|---|---|---|
+| Critical | Security, data integrity, silent data loss | #2744 (nested mutations touch wrong records) → but note it's already documented/known |
+| High | Silent performance regression, broad breakage | #2771 (per-request eager schema) |
+| Normal | Feature bug with a workaround | most `bug`-labeled issues |
+| Low | Cosmetic, docs, edge case | typos, unclear docs |
+
+Security and data-integrity issues jump the queue. Do not promise release timing.
+
+## Reproduction runbook
+
+1. Extract from the report: the **schema**, the **query + variables**, expected vs actual, and versions.
+2. Pick the base class and suite (see `lighthouse-testing-and-qa`).
+3. Write the smallest test that fails for the reported reason. Watch it fail.
+4. That failing test is the reproduction; attach it to the issue or the fix PR.
+
+### Skeleton A — schema/resolver bug (no DB)
+```php
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\<Area>;
+
+use Tests\TestCase;
+
+final class SomeBugTest extends TestCase
+{
+    public function testDescribesTheBug(): void
+    {
+        $this->schema = /** @lang GraphQL */ <<<'GRAPHQL'
+        type Query {
+            foo: String @field(resolver: "Tests\\Utils\\Queries\\Foo")
+        }
+        GRAPHQL;
+
+        $this->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
+        { foo }
+        GRAPHQL)->assertJson([
+            'data' => ['foo' => 'expected'],
+        ]);
+    }
+}
+```
+
+### Skeleton B — Eloquent / DB bug
+```php
+<?php declare(strict_types=1);
+
+namespace Tests\Integration\<Area>;
+
+use Tests\DBTestCase;
+use Tests\Utils\Models\User;
+
+final class SomeDbBugTest extends DBTestCase
+{
+    public function testDescribesTheBug(): void
+    {
+        // Build data via relations/properties, not FK arrays (CONTRIBUTING style).
+        $user = new User();
+        $user->name = 'Sepp';
+        $user->save();
+
+        $this->schema = /** @lang GraphQL */ <<<'GRAPHQL'
+        type User { id: ID! name: String! }
+        type Query { users: [User!]! @all }
+        GRAPHQL;
+
+        $this->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
+        { users { id name } }
+        GRAPHQL)->assertJsonCount(1, 'data.users');
+    }
+}
+```
+
+### Skeleton C — config-dependent bug
+```php
+protected function getEnvironmentSetUp($app): void
+{
+    parent::getEnvironmentSetUp($app);
+    $app->make(\Illuminate\Contracts\Config\Repository::class)
+        ->set('lighthouse.batchload_relations', false);
+}
+```
+(The `getEnvironmentSetUp` + `ConfigRepository::set` pattern is how `tests/DBTestCase.php` and others toggle config.)
+
+**Placement:** mirror the `src/` module — pagination → `tests/*/Pagination/`, auth → `tests/*/Auth/`, batch loading → `tests/Integration/Execution/DataLoader/`. Fixtures under `tests/Utils/`; migrations under `tests/database/migrations`.
+
+## What a good fix PR contains
+
+Failing test (now passing) + the fix + `CHANGELOG.md` entry (`Fixed`, with PR URL) + docs update if user-facing. Gate it through `lighthouse-change-control` (is it breaking? then it's v7-only).
+
+## Fences (don't do these)
+
+- Don't label something a bug if it's **documented behavior** — *but* documented ≠ acceptable. Worked example: #2744 (unscoped nested mutations) is documented under "Security considerations" in `docs/master/eloquent/nested-mutations.md` ("Lighthouse has no mechanism for fine-grained permissions of nested mutation operations … Make sure that fields with nested mutations are only available to users who are allowed to execute all reachable nested mutations."), yet it is still accepted as a real security issue to fix in v7. The nuance: a documented limitation can still be a legitimate issue when it violates user expectations of safety. Note the tension in triage rather than closing as "works as documented".
+- Don't promise a version/date.
+- Don't discuss security issues in public threads.
+
+## When NOT to use this skill
+
+- Fast triage of a live failure you're actively debugging → `lighthouse-debugging-playbook`.
+- Whether/how the fix is breaking and where it targets → `lighthouse-change-control`.
+- Test infrastructure details and assertions → `lighthouse-testing-and-qa`.
+- History of an area before reproducing → `lighthouse-failure-archaeology`.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against v6.68.0 (`master` @ a29ff8e). Re-verify with:
+
+```bash
+ls .github/ISSUE_TEMPLATE/ ; head -30 .github/ISSUE_TEMPLATE/bug_report.md
+cat SECURITY.md
+sed -n '44,50p' docs/master/eloquent/nested-mutations.md
+grep -n "getEnvironmentSetUp\|ConfigRepository" tests/DBTestCase.php
+```
+Open-issue list above was current 2026-07-07 — re-check GitHub.

--- a/.claude/skills/lighthouse-proof-and-analysis-toolkit/SKILL.md
+++ b/.claude/skills/lighthouse-proof-and-analysis-toolkit/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: lighthouse-proof-and-analysis-toolkit
+description: >-
+  First-principles methods to PROVE a claim about Lighthouse instead of asserting it.
+  Load when you must demonstrate — with evidence, not vibes — that schema building is
+  lazy, that an N+1 is present or absent, that a change is backward compatible in
+  schema or response shape, that a race/concurrency fix is sound, that a performance
+  or memory claim holds, or that a bug is upstream (graphql-php) vs local. Each method
+  is a recipe with a worked example from this repo's history. For the tools themselves
+  use lighthouse-diagnostics-and-tooling; for the evidence bar and idea lifecycle use
+  lighthouse-research-methodology.
+---
+
+# Lighthouse proof and analysis toolkit
+
+"Prove it, don't just install it." This skill turns tools into airtight evidence. Each recipe: **Goal → Method → Commands/code → Worked example → Pitfalls.**
+
+Ground truth date: 2026-07-07, v6.68.0 (`master` @ a29ff8e). Historical citations verified via `git show`/`CHANGELOG.md`.
+
+The meta-rule (applies to every recipe): **one mechanism must explain ALL observations, including the negative ones.** If an observation doesn't fit your mechanism, the proof isn't done. See `lighthouse-research-methodology`.
+
+## 1. Prove laziness (or eagerness) of schema building
+
+- **Goal:** show whether building the executable schema builds all types (eager) or only what's needed (lazy).
+- **Method:** spy on `TypeRegistry::possibleTypes()` vs `search()`; run a minimal operation; then **ablate** — replace the `types` callable with `fn () => []` and re-measure. If cost collapses, the `types` callable was the driver.
+- **Commands/code:** profile a minimal op (`{ __typename }`) with Xdebug cachegrind on two library versions; compare cachegrind size / instruction count; patch `SchemaBuilder::build()`'s `setTypes(...)` to `fn () => []` for the ablation run.
+- **Worked example (#2771, OPEN):** on `webonyx/graphql-php` ≥ 15.31, the first built-in scalar lookup resolves the `setTypes` callable → `possibleTypes()` builds every type. Measured 9.1 MB → 57 MB cachegrind for an authenticated `{ __typename }`, 1.5–3.4× wall clock. The ablation `setTypes(fn () => [])` restored the 15.30.2 baseline — proving the `types` callable is the cause, not "graphql-php got slower generally."
+- **Pitfalls:** measure the *same* operation; disable the schema cache (a warm cache hides the rebuild cost you're studying); one op at a time.
+
+## 2. Prove presence/absence of N+1
+
+- **Goal:** show a relation is (or isn't) batch-loaded.
+- **Method:** `DBTestCase` + `assertQueryCountMatches($n, fn () => …)` around the operation, with a dataset of **more than one** parent row.
+- **Worked example:** `tests/Integration/Execution/DataLoader/RelationBatchLoaderTest.php` parametrizes `userCount`/`tasksPerUser` and asserts an exact count, precisely so batching is distinguishable from N+1.
+- **Pitfalls:** with one parent row, N+1 and batched both issue the same number of queries — the test proves nothing. Always use ≥ 2 parents.
+
+## 3. Prove schema backward compatibility
+
+- **Goal:** show a change does not break schema consumers.
+- **Method:** `lighthouse:print-schema --sort` before and after (or across two git refs via `scripts/schema-diff.sh`); diff.
+- **What counts as breaking:** removed field/type/enum value, tightened nullability (`String` → `String!` on output is safe; `String!` → `String` on an input arg is safe; the reverse breaks), changed argument defaults, changed directive locations. **Safe/additive:** new nullable field, new type, new optional argument.
+- **Worked example:** #2104 (`88d8e18f`) altered generated pagination types in the printed schema and had to be reverted — the print-schema diff is exactly what would have caught it pre-merge.
+- **Pitfalls:** without `--sort`, ordering noise masks real diffs. Clear the schema cache between runs.
+
+## 4. Prove response-shape backward compatibility
+
+- **Goal:** show existing queries return the same JSON structure.
+- **Method:** characterization test. Use `assertExactJson([...])` when the whole shape must be frozen; `assertJson([...])` when you only assert a subset. Both are available on the `TestResponse`.
+- **Pitfalls:** `assertJson` passes even if extra keys appear — use it when additive keys are acceptable; use `assertExactJson` to catch any shape drift.
+
+## 5. Prove a race / concurrency fix
+
+- **Goal:** show a cache write can't be observed half-written by a concurrent request.
+- **Method:** reason from atomicity — write to a temp file then `rename()` (atomic on POSIX: a reader sees either the old or the new file, never a partial one). Demonstrate the pre-fix race by simulating concurrent writers/readers.
+- **Worked example:** `f6b214fd` "Write schema cache to temporary file before atomically updating it (#2703)" and `2de0a54b` "Use atomic file writes for query cache (#2716)"; `d5ea91d6` adds an exclusive lock in `ASTCache`. Before: in-place writes let a concurrent request read a truncated cache file. After: temp+rename makes the swap atomic.
+- **Pitfalls:** `rename()` is only atomic within the same filesystem; a temp file on a different mount defeats it.
+
+## 6. Prove a performance claim
+
+- **Goal:** show a change is actually faster (or not slower).
+- **Method:** PHPBench baseline on unchanged code, N iterations, then the change, then compare the aggregate report. Gate on **rstdev** — a delta smaller than the relative standard deviation is noise. Ablate to isolate cause. Never compare across machines or PHP versions.
+- **Worked example:** the `benchmarks/` suite — `QueryBench`, `HugeResponseBench`, `HugeRequestBench`, `ASTUnserializationBench` (each `@Warmup(1) @Revs(10) @Iterations(10)`). `ASTUnserializationBench` answers "did schema-cache unserialize get slower?"; `HugeRequestBench` answers "did parsing regress?". Use `bench-report.sh before` / `... after`.
+- **Pitfalls:** noisy CI runners; single-iteration measurements; comparing highest-deps to lowest-deps runs.
+
+## 7. Prove memory behavior in long-lived processes
+
+- **Goal:** distinguish a true leak (monotonic growth) from a high watermark (bounded).
+- **Method:** loop the same operation many times in one process (Octane-style), sample `memory_get_usage(true)` each iteration, plot. Flat-after-warmup = watermark; monotonic climb = leak.
+- **Worked example (#2436, OPEN):** reporter shows memory climbing to OOM with the schema cache enabled under Octane. A conclusive repro must add: the per-iteration memory series (to show monotonicity), and an ablation (cache off vs on) isolating the cache as the driver. Until that exists, the root cause is unproven — the issue is correctly labeled *needs reproduction*.
+- **Pitfalls:** GC timing makes a few samples misleading; sample many iterations; force GC to separate "not collected yet" from "cannot be collected."
+
+## 8. Prove a bug is upstream (graphql-php) vs Lighthouse
+
+- **Goal:** locate the fault boundary.
+- **Method:** build a minimal repro against **bare** `webonyx/graphql-php` (no Lighthouse). If it reproduces, it's upstream. Bisect by pinning graphql-php constraints to find the version boundary. Fix pattern: report/PR upstream, guard locally with `method_exists` until the constraint can be bumped.
+- **Worked example:** #2771 identifies the boundary at graphql-php 15.30.2 → 15.31 and proposes an upstream API (`setScalarOverrides`) plus a local `method_exists` guard. Precedent for the guard: `src/GraphQL.php:166` (`method_exists($queryComplexityRule, 'getQueryComplexity')`, `// TODO remove this check when updating the required version of webonyx/graphql-php`), introduced with #2637.
+- **Pitfalls:** don't bump the graphql-php floor to "fix" it in a minor — that's breaking for users on older 15.x (see `lighthouse-v7-campaign`).
+
+## When NOT to use this skill
+
+- The tools/commands themselves → `lighthouse-diagnostics-and-tooling`.
+- The evidence bar, predict-first discipline, idea lifecycle → `lighthouse-research-methodology`.
+- What acceptance requires for a normal change → `lighthouse-testing-and-qa`.
+- Whether a proven change is breaking → `lighthouse-change-control`.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against v6.68.0 (`master` @ a29ff8e). Re-verify with:
+
+```bash
+git show f6b214fd --stat ; git show 2de0a54b --stat      # atomic cache writes
+grep -n "assertQueryCountMatches" tests/Integration/Execution/DataLoader/RelationBatchLoaderTest.php
+grep -n "setTypes\|possibleTypes" src/Schema/SchemaBuilder.php
+grep -n "method_exists" src/GraphQL.php
+ls benchmarks/
+```
+Issues #2771 and #2436 were OPEN on 2026-07-07.

--- a/.claude/skills/lighthouse-research-frontier/SKILL.md
+++ b/.claude/skills/lighthouse-research-frontier/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: lighthouse-research-frontier
+description: >-
+  Open problems where Lighthouse could advance the state of the art, framed as
+  falsifiable projects. Load when scoping ambitious/long-horizon work beyond the next
+  release: for each frontier item, why current SOTA falls short, Lighthouse's specific
+  asset, the first three concrete steps in THIS repo, and a "you have a result when…"
+  milestone. Every item is a CANDIDATE pending maintainer ratification. For the actual
+  v7 release use lighthouse-v7-campaign; for day-to-day changes use
+  lighthouse-change-control.
+---
+
+# Lighthouse research frontier
+
+Where could Lighthouse go beyond the current state of the art? This skill frames the open bets as falsifiable projects, not aspirations.
+
+**Important:** the maintainer's own definition of "beyond state of the art" was not captured (the intake question could not be delivered). Every item below is a **CANDIDATE** framing derived from the repo's open issues and architecture — treat it as a proposal to ratify, not a settled roadmap. Do not present these as the maintainer's stated goals.
+
+Ground truth date: 2026-07-07, v6.68.0 (`master` @ a29ff8e). Repo facts verified; issue statuses OPEN on that date.
+
+## 1. Zero per-request schema work under PHP-FPM (CANDIDATE)
+
+- **Why SOTA falls short:** graphql-php's lazy type loading is defeated in Lighthouse by the `types` callable resolving on the first scalar lookup (#2771). Every request rebuilds the whole type set when the schema cache is cold.
+- **Lighthouse's asset:** an existing OPcache-backed query cache (#2713) and AST schema cache (`src/Schema/AST/ASTCache.php`) prove the OPcache-native caching approach; #2771 provides a documented ablation baseline (`setTypes(fn () => [])`).
+- **First three steps in this repo:** (a) land the `setScalarOverrides` fix behind a `method_exists` guard once upstream ships it; (b) add a regression test asserting `TypeRegistry::possibleTypes()` is **not** invoked on a simple execution; (c) prototype an OPcache-native cache of the fully-built schema, measured against the ablation baseline.
+- **Result when:** an authenticated `{ __typename }` allocates within a small, stated % of the `setTypes(fn () => [])` ablation baseline, measured per `lighthouse-proof-and-analysis-toolkit` recipe 1.
+- **Known wrong path:** resolver-efficiency rewrites of `TypeRegistry` have been reverted before (#961, `7cfd7922`) — demand benchmarks + full behavioral tests.
+
+## 2. Secure-by-default nested mutations (CANDIDATE)
+
+- **Why SOTA falls short:** major GraphQL mutation frameworks (including Lighthouse today) leave relation scoping to the developer; nested operations can touch records outside the parent (#2744).
+- **Lighthouse's asset:** #2744 already contains a complete scope-of-impact table and a proposed fix (scope every id-based operation through the relation).
+- **First three steps:** (a) write characterization tests of current nested-mutation behavior alongside the existing ones in `tests/Integration/Execution/MutationExecutor/` and `tests/Integration/Schema/Directives/`; (b) implement relation-scoped queries behind an opt-in flag; (c) propose default-on for v7 (see `lighthouse-v7-campaign` item 7).
+- **Result when:** the #2744 exploitation example fails with an authorization/scope error **and** every existing nested-mutation test still passes.
+- **Known wrong path:** shipping the scoping default-on in a v6 minor (breaking) — v7 or opt-in only.
+
+## 3. First-class long-lived runtimes (Octane/Reverb era) (CANDIDATE)
+
+- **Why SOTA falls short:** Lighthouse's design assumes per-request lifecycle; long-lived workers expose state-retention and memory issues (#2436 memory; `phpstan.neon` has `checkOctaneCompatibility` commented out).
+- **Lighthouse's asset:** singletons are registered in `LighthouseServiceProvider`; the state-holding ones (e.g. request-scoped registries/pools) are enumerable — audit which hold request state across requests. (Verify the actual list before claiming; don't assume.)
+- **First three steps:** (a) build the loop-request memory harness (recipe 7); (b) enable `checkOctaneCompatibility` in a dedicated PHPStan run and triage findings; (c) audit singleton lifetimes for request-state leakage.
+- **Result when:** steady-state RSS is flat (within a stated bound) over N identical requests in one worker, cache enabled — resolving #2436.
+
+## 4. Incremental delivery per spec (CANDIDATE)
+
+- **Why SOTA falls short:** `@defer`/`@stream` are still stabilizing across the GraphQL ecosystem; Lighthouse's `@defer` is experimental (`src/Defer/`, config comment).
+- **Lighthouse's asset:** a working experimental `@defer` and a streaming test helper (`streamGraphQL`).
+- **First three steps:** (a) inventory current `@defer` behavior vs the incremental-delivery-over-HTTP draft; (b) add conformance tests; (c) decide on `@stream`.
+- **Result when:** a conformance test suite for the incremental-delivery draft passes.
+
+## 5. Federation completeness (CANDIDATE)
+
+- **Why SOTA falls short:** federation moves fast; open asks exist (#2582 reserved-keyword entity types, #2482 context in entity resolvers).
+- **Lighthouse's asset:** `src/Federation/` already provides entity resolution, a federated schema printer, and `_entities`/`_service`.
+- **First three steps:** (a) map current `src/Federation/` capabilities against the federation spec version targeted; (b) close #2582/#2482; (c) add a compatibility test harness (the Apollo federation-compatibility suite is a candidate harness — confirm availability before committing to it).
+- **Result when:** the chosen federation-compatibility suite passes.
+
+## 6. Expressive-but-safe query building (CANDIDATE)
+
+- **Why SOTA falls short:** richer `@whereConditions`/`@orderBy` (enum columns #2723, null-ordering #2486, aggregate/column validation #2487) risk expanding the SQL-injection / query-complexity surface.
+- **Lighthouse's asset:** `src/WhereConditions/` and `src/OrderBy/` already constrain conditions to schema-defined columns.
+- **First three steps:** (a) prototype enum-typed condition columns (#2723); (b) prove the enum eliminates a class of invalid queries with tests; (c) add complexity/safety bounds.
+- **Result when:** enum-typed condition columns make an invalid-column query a schema/validation error rather than a runtime/SQL error.
+- **Known wrong path:** the `@cacheControl` revert (`315392fd`) shows caching/expressiveness features can ship broken — land behind flags and prove semantics first.
+
+## When NOT to use this skill
+
+- The concrete next release → `lighthouse-v7-campaign`.
+- Making any change today → `lighthouse-change-control`.
+- Proving a result → `lighthouse-proof-and-analysis-toolkit`.
+- The discipline for turning a bet into an accepted change → `lighthouse-research-methodology`.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against v6.68.0 (`master` @ a29ff8e). All items are CANDIDATE pending maintainer ratification. Re-verify with:
+
+```bash
+ls src/Defer/ src/Federation/ src/WhereConditions/ src/OrderBy/
+grep -n "checkOctaneCompatibility" phpstan.neon
+grep -n "possibleTypes\|setTypes" src/Schema/SchemaBuilder.php
+ls tests/Integration/Execution/MutationExecutor/
+```
+Referenced issues (#2771, #2744, #2436, #2582, #2482, #2723, #2486, #2487) were OPEN on 2026-07-07 — re-check GitHub before investing.

--- a/.claude/skills/lighthouse-research-methodology/SKILL.md
+++ b/.claude/skills/lighthouse-research-methodology/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: lighthouse-research-methodology
+description: >-
+  The discipline that turns a hunch into an accepted change in Lighthouse. Load when
+  investigating a hard problem, forming a hypothesis, or deciding whether an
+  explanation is good enough to act on — especially when tempted to declare victory
+  early. Covers the evidence bar (one mechanism explains ALL observations including
+  negatives, survives adversarial refutation), predicting numbers before running,
+  bisect-vs-reason, upstream-vs-local, and the idea lifecycle from experiment flag to
+  adopted change or documented retirement. For concrete proof recipes use
+  lighthouse-proof-and-analysis-toolkit; for settled outcomes use lighthouse-failure-archaeology.
+---
+
+# Lighthouse research methodology
+
+Smaller/faster models (and tired humans) declare victory early. This skill is the guardrail: what it takes for a hunch to become an accepted change here.
+
+Ground truth date: 2026-07-07, v6.68.0 (`master` @ a29ff8e). History cited was verified via `git show`/`CHANGELOG.md`.
+
+## The evidence bar
+
+A claim is accepted only when:
+
+1. **One mechanism explains ALL observations — including the negatives.** Not just "the failing case fails"; also "the passing case passes for the reason the mechanism predicts," and "the ablation removes the effect." A mechanism that explains the positives but not the negatives is incomplete.
+2. **It survives assigned adversarial refutation.** A second session or reviewer actively tries to break it: constructs the counter-case, checks the matrix edges (lowest deps, Lumen, cache on/off, batch loading on/off, PHP 8.0). If nobody tried to break it, it isn't proven.
+
+**Worked positive example (#2771).** Hypothesis: graphql-php ≥ 15.31's scalar-override discovery resolves Lighthouse's `types` callable, building every type per request.
+- Positive: every operation, even `{ __typename }`, is slower — explained (any op does a built-in scalar lookup).
+- Version boundary: 15.30.2 fine, 15.31 slow — explained (the discovery was introduced there).
+- Negative/ablation: `setTypes(fn () => [])` restores the baseline — explained (removes the callable the discovery resolves).
+A weaker hypothesis, "graphql-php just got slower," fails the negatives: it can't explain why the boundary is exactly 15.31, nor why an ablation of *one specific callable* fully restores performance. That's how you know the strong hypothesis is the right one.
+
+## Predict numbers before you run
+
+Before running an experiment, **write down the expected observation.** If the result differs, suspect the **hypothesis** first, not the measurement (verify the measurement, then revise the hypothesis). #2771's measured-impact table (predicted multipliers, then measured 1.5–3.4× wall / ~6× work) models this.
+
+Template (fill before running):
+```
+Hypothesis:   <one sentence, falsifiable>
+Mechanism:    <the causal chain, in code terms>
+Predictions:  <numbers/observations you expect, incl. what the NEGATIVE/ablation should show>
+Experiment:   <exact command or test>
+Observed:     <fill after>
+Verdict:      <confirmed / refuted / mechanism revised — and why>
+```
+
+## Bisect vs reason
+
+- **Reason first** when the mechanism is legible in source (you can read the causal chain). Cheaper and more explanatory.
+- **`composer`-constraint bisection** for upstream regressions: pin `webonyx/graphql-php` to successive versions to find the boundary (the #2771 method: 15.30.2 vs 15.31).
+- **`git bisect`** for local regressions: `git bisect start; git bisect bad; git bisect good <old-tag>`; run the failing test at each step.
+- Combine: bisect to localize, then reason to explain. A boundary without a mechanism is a lead, not a conclusion.
+
+## Upstream vs local
+
+Decision rule: if a minimal repro reproduces against **bare** graphql-php (no Lighthouse), it's upstream → file/fix upstream and guard locally with `method_exists` until the constraint can be bumped. Precedent: `src/GraphQL.php:166` guards `getQueryComplexity` with the TODO to remove on a version bump (introduced with #2637); #2771 proposes the same pattern. Never bump the graphql-php floor in a minor to "clear" a guard — breaking for users on older 15.x (see `lighthouse-change-control`).
+
+## The idea lifecycle in this repo
+
+Each stage has real precedent:
+
+1. **Origin** — production users' issues and upstream releases. Most CHANGELOG `Fixed`/`Added` entries trace to a user issue or a dependency change (e.g. #2735 null-`page` handling, #2769 class-finder support, #2766 Laravel 13 support). Good ideas come from real pain, not speculation.
+2. **Design** — an issue/discussion frames the problem before code (labels `discussion`/`enhancement`).
+3. **Experimental introduction** — ship flagged or explicitly experimental, off/neutral by default. Precedent: `@defer` is experimental (`src/lighthouse.php` `defer` comment); `validation_cache` defaults off; `shortcut_foreign_key_selection` defaults false.
+4. **Hardening** — a shipped feature reveals a flaw, fixed forward. Precedent: file-based query cache (#2713) → atomic writes (#2716); schema cache write → temp-file+rename (#2703) → exclusive lock (`d5ea91d6`).
+5. **Adoption as default OR retirement:**
+   - *Adopted:* schema cache v2 proved out, then v1 was removed (#2321, `19ec1d1a`).
+   - *Retired then revived:* `@cacheControl` reverted (`315392fd`) then re-added (#2136); `@namespaced` reverted (`198afbff`) then re-added (#2478). A revert is not always final — verify current `src/`.
+   - *Retired for good:* implicit create/update flattening rejected in favor of `@spread` (`a6ae1e29`); the #961 resolver-efficiency rewrite reverted (`7cfd7922`).
+
+Every retirement gets a tombstone in `lighthouse-failure-archaeology` so it is never silently re-fought.
+
+## Retirement discipline
+
+When you reject or abandon an idea, record it: symptom → root cause → why rejected → evidence, added to `lighthouse-failure-archaeology`. An undocumented dead end will be rediscovered and re-attempted, wasting the next session's time. The archaeology chronicle is a first-class deliverable, not an afterthought.
+
+## When NOT to use this skill
+
+- The concrete proof recipes (how to measure laziness, N+1, BC, races) → `lighthouse-proof-and-analysis-toolkit`.
+- The settled outcomes to avoid re-fighting → `lighthouse-failure-archaeology`.
+- Ratifying/gating the resulting change → `lighthouse-change-control`.
+- Long-horizon problem selection → `lighthouse-research-frontier`.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against v6.68.0 (`master` @ a29ff8e). Re-verify with:
+
+```bash
+git show 19ec1d1a --stat        # schema cache v1 removed after v2 adopted
+git log --oneline -- src/CacheControl | tail    # @cacheControl retire→revive
+grep -n "method_exists" src/GraphQL.php          # upstream-vs-local guard pattern
+grep -n "defer\|validation_cache\|shortcut_foreign_key" src/lighthouse.php  # experimental defaults
+```

--- a/.claude/skills/lighthouse-testing-and-qa/SKILL.md
+++ b/.claude/skills/lighthouse-testing-and-qa/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: lighthouse-testing-and-qa
+description: >-
+  What counts as evidence in Lighthouse and how to produce it. Load when writing or
+  running tests, choosing between TestCase and DBTestCase, using the GraphQL test
+  helpers ($this->graphQL, assertGraphQL* mixins, mockResolver, query-count
+  assertions), reproducing a bug as a failing test, or interpreting the CI matrix
+  and why "passes locally" isn't done. Covers suite anatomy, testing conventions,
+  and the acceptance bar. For measurement tooling (benchmarks, tracing) use
+  lighthouse-diagnostics-and-tooling; for proof methods use
+  lighthouse-proof-and-analysis-toolkit.
+---
+
+# Lighthouse testing and QA
+
+Tests are the currency of this project: a bug fix without a failing-test-first is not accepted, and a feature without tests does not merge.
+This skill is how you produce evidence the maintainer will trust.
+
+Ground truth date: 2026-07-07, v6.68.0 (`master` @ a29ff8e). Trait/method names below were read from `src/Testing/` and real tests.
+
+## The evidence bar
+
+| Claim | Required evidence |
+|---|---|
+| "This bug is fixed" | A test that **failed before** your change and **passes after** (CONTRIBUTING.md → Testing: write the failing test first). |
+| "No N+1 / query count is bounded" | A `DBTestCase` using `assertQueryCountMatches(...)` with **>1 parent row** (see below). |
+| "Schema unchanged / non-breaking" | `lighthouse:print-schema` diff (see `lighthouse-change-control`) and/or characterization test with `assertExactJson`. |
+| "This is faster" | PHPBench numbers, same machine, rstdev checked (`lighthouse-diagnostics-and-tooling`). |
+
+## Suite anatomy
+
+Suites (`phpunit.xml.dist`): **Unit** (`tests/Unit`), **Integration** (`tests/Integration`), **Console** (`tests/Console`).
+
+- **`tests/TestCase.php`** — base for schema/resolver tests. Extends Orchestra Testbench. Registers Lighthouse's service providers (Auth, Async, Bind, Cache, CacheControl, GlobalId, OrderBy, Pagination, SoftDeletes, Testing, Validation, plus Scout/Redis). Uses traits `MakesGraphQLRequests`, `MocksResolvers`, `UsesTestSchema`. Adds a default `PLACEHOLDER_QUERY` (`type Query { foo: Int }`) so a schema is always present.
+- **`tests/DBTestCase.php`** — base for anything hitting the database. Extends `TestCase`, adds `AssertsQueryCounts` (from `mattiasgeniar/phpunit-query-count-assertions`). Runs `migrate:fresh` **once** (`static $migrated`), then **TRUNCATEs every table** at the start of each test. Why truncate instead of transactions: transactions "do not reset autoincrement" (code comment), and stable ids matter for assertions. Consequence: DB tests are slower and start from a clean, id-reset slate. Connections: `mysql` (default) and `alternate` (for multi-connection tests).
+
+Pick `TestCase` unless you touch the database; then `DBTestCase`.
+
+## The testing toolkit (verified against `src/Testing/`)
+
+Set a schema for the test:
+```php
+use Nuwave\Lighthouse\Testing\UsesTestSchema;   // provided via TestCase
+
+$this->schema = /** @lang GraphQL */ <<<'GRAPHQL'
+type Query {
+    foo: String @field(resolver: "Tests\\Utils\\Queries\\Foo")
+}
+GRAPHQL;
+```
+
+Execute and assert (`MakesGraphQLRequests`; helpers are `protected`):
+```php
+$this->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
+{ foo }
+GRAPHQL)->assertJson([
+    'data' => ['foo' => 'bar'],
+]);
+```
+Other helpers: `postGraphQL(array $data, …)`, `multipartGraphQL(...)` (file uploads), `introspect()`, `introspectType($name)`, `introspectDirective($name)`, `streamGraphQL(...)` (`@defer`), `rethrowGraphQLErrors()`.
+
+Mock resolvers (`MocksResolvers`): `mockResolver($resolverOrValue, $key = 'default')` and `mockResolverExpects($invocationOrder, $key)` — return a PHPUnit InvocationMocker/Stubber so you can assert call counts.
+
+Assertion mixins (`TestResponseMixin`, callable on the `TestResponse`):
+`assertGraphQLError`, `assertGraphQLErrorMessage`, `assertGraphQLErrorFree`, `assertGraphQLDebugMessage`, `assertGraphQLValidationError`, `assertGraphQLValidationKeys`, `assertGraphQLValidationPasses`, `assertGraphQLBroadcasted`, `assertGraphQLNotBroadcasted`, `assertGraphQLSubscriptionAuthorized`, `assertGraphQLSubscriptionNotAuthorized`.
+
+Subscriptions: use the `TestsSubscriptions` trait (in v6 you may see `setUpSubscriptionEnvironment()`; that explicit call is removed in v7 — `UPGRADE.md`).
+
+Query counting (real example — `tests/Integration/Execution/DataLoader/RelationBatchLoaderTest.php`):
+```php
+$this->assertQueryCountMatches($expectedQueryCount, function () use (...): void {
+    // run the GraphQL operation
+});
+```
+
+Schema cache in tests: handled by `RefreshesSchemaCache` (wired through `MakesGraphQLRequests`); its explicit `bootRefreshesSchemaCache()` is `@deprecated` and becomes automatic in v7.
+
+## Conventions (CONTRIBUTING.md + `.ai/AGENTS.md`)
+
+- **Relations over foreign-key arrays.** Build related models via `->associate()`/relation methods, not `['user_id' => …]`.
+- **Properties over create-arrays.** `$user = new User(); $user->name = 'Sepp'; $user->save();` not `User::create([...])`.
+- **GraphQL literals:** annotate every GraphQL string with `/** @lang GraphQL */`; use nowdoc `<<<'GRAPHQL'` by default, heredoc `<<<GRAPHQL` only when interpolating; preserve intentional whitespace in schema/assertion-sensitive cases.
+- **`final` in tests, never in `src/`.**
+- **Test placement mirrors `src/` modules.** E.g. pagination internals → `tests/Integration/Pagination/…` and `tests/Unit/Pagination/…`; batch loading → `tests/Integration/Execution/DataLoader/`. Fixtures (Models, Queries, Mutations, Policies, Validators) live in `tests/Utils/`; migrations in `tests/database/migrations`; factories in `tests/database/factories`.
+
+## CI matrix discipline
+
+`.github/workflows/validate.yml` runs PHPStan + PHPUnit across **PHP 8.0–8.5 × Laravel ^9–^13 × lowest/highest deps** (with exclusions), plus a coverage job (PHP 8.5 / Laravel ^13, Codecov) and a phpbench job. MySQL 5.7 + Redis 6 as services.
+
+Why "passes locally" ≠ done:
+- CI runs the **lowest** dependency set (`--prefer-lowest`), which your local highest-deps install never exercises.
+- CI **removes** some dev deps (`phpbench`, `rector`, `larastan`, `phpstan-mockery`) and removes `laravel/pennant` on Laravel 9.
+- The PHP floor is 8.0; a feature using 8.1+ syntax fails there.
+
+When one cell fails: reproduce that exact PHP + Laravel + lowest/highest combination locally before theorizing. Don't "fix" by disabling the cell.
+
+## How to add a test (checklist)
+
+1. Pick the suite/base class: schema/resolver → `TestCase`; DB → `DBTestCase`; artisan command → `tests/Console` (+ `TestCase`).
+2. Place it mirroring the `src/` module under test.
+3. Add fixtures under `tests/Utils/`; migrations under `tests/database/migrations` if new tables are needed.
+4. Set `$this->schema`, run with `$this->graphQL(...)`, assert with the mixins.
+5. For a bug fix: confirm it **fails** first.
+6. Run it single: `docker compose run --rm php vendor/bin/phpunit --filter=YourTest` (native: `vendor/bin/phpunit --filter=YourTest`).
+7. Then `make it` to run the full local gate.
+
+Important for N+1 tests: build **more than one** parent row. With one parent, one-query-per-parent and one-batched-query are indistinguishable — the test can't tell N+1 from correct batching. Real batch-loader tests parametrize `userCount`/`tasksPerUser` for exactly this reason.
+
+## When NOT to use this skill
+
+- Standing up the environment / running tests via Docker → `lighthouse-build-and-env`.
+- Benchmarks, tracing, query profiling as tools → `lighthouse-diagnostics-and-tooling`.
+- Proof methods (laziness, BC, race conditions) → `lighthouse-proof-and-analysis-toolkit`.
+- Turning an issue report into a repro → `lighthouse-issue-triage-and-reproduction`.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against v6.68.0 (`master` @ a29ff8e). Re-verify with:
+
+```bash
+ls src/Testing/                                              # trait inventory
+grep -oh "function assertGraphQL[A-Za-z]*" src/Testing/TestResponseMixin.php | sort -u
+grep -n "protected function graphQL\|multipartGraphQL\|introspect" src/Testing/MakesGraphQLRequests.php
+grep -rn "assertQueryCountMatches" tests | head            # real query-count usage
+grep -n "static.*migrated\|truncate" tests/DBTestCase.php
+grep -n "php-version\|laravel-version\|prefer-lowest" .github/workflows/validate.yml
+```

--- a/.claude/skills/lighthouse-v7-campaign/SKILL.md
+++ b/.claude/skills/lighthouse-v7-campaign/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: lighthouse-v7-campaign
+description: >-
+  The executable, decision-gated campaign for shipping Lighthouse v7 (the current
+  hardest live problem). Load when planning, scoping, or executing the next major
+  release: what breaking changes are already committed, what candidates are on the
+  table (nested-mutation scoping #2744, graphql-php constraint bump, support-matrix
+  drops), the per-change proof obligations, the release gates with measurable pass
+  criteria, and the wrong paths that are fenced off. Routes all promotion through
+  lighthouse-change-control. This is the most volatile skill — re-verify its
+  inventory before acting.
+---
+
+# Lighthouse v7 campaign
+
+Goal: ship a correct v7 major with every breaking change justified, proven non-accidental, and documented in `UPGRADE.md`.
+Success is measurable (green matrix, traced schema diff, complete changelog), never judged by eye.
+This skill does not authorize anything — every promotion routes through `lighthouse-change-control`.
+
+Ground truth date: 2026-07-07, v6.68.0 (`master` @ a29ff8e). All inventory below was verified against source on that date.
+
+## Phase 0 — Preconditions (get sign-off first)
+
+- **Repo transfer.** The project is planned to move to `spawnia/lighthouse` (README notice, discussion #2767). Whether v7 ships before or after the transfer is a **maintainer decision** — do not assume. Confirm before starting.
+- **This skill may not route around change control.** Every item lands via `lighthouse-change-control`'s gates.
+- **v7 ends v6 feature work** (README versioning promise: only the current major gets features/fixes). Confirm the maintainer accepts closing v6 to features on release.
+
+If transfer status is unresolved → **stop and ask the maintainer**; do not start renaming/removing.
+
+## Phase 1 — Inventory (run these; compare to the expected findings)
+
+```bash
+# Already-committed v7 breaking changes:
+awk '/## v6 to v7/,/## v5 to v6/' UPGRADE.md | grep "^###"
+# Deprecation removal candidates:
+grep -rn "@deprecated" src --include="*.php"
+# graphql-php version guards that a constraint bump would clear:
+grep -n "graphql-php\|webonyx" src/GraphQL.php
+# Current graphql-php constraint:
+grep "webonyx/graphql-php" composer.json
+```
+
+**Expected findings on 2026-07-07 (if these changed, update the cut-list first):**
+
+Committed v7 breaks in `UPGRADE.md` — all four have their v6 groundwork already in `src`:
+1. *Leverage automatic test trait setup* — `RefreshesSchemaCache::bootRefreshesSchemaCache()` is `@deprecated`; auto-setup replaces it.
+2. *`EnsureXHR` enabled in default config* — middleware exists (`src/Http/Middleware/EnsureXHR.php`), currently **commented out** in `src/lighthouse.php:32`. v7 uncomments it.
+3. *`@can` → `@can*` split* — the specialized directives already exist (`src/Auth/CanFindDirective.php`, `CanModelDirective`, `CanQueryDirective`, `CanResolvedDirective`, `CanRootDirective`); `src/Auth/CanDirective.php` is `@deprecated TODO remove with v7`.
+4. *`lighthouse:clear-cache` → `lighthouse:clear-schema-cache`* — `src/Console/ClearCacheCommand.php` is `@deprecated in favor of lighthouse:clear-schema-cache`.
+
+Deprecation inventory (removal candidates): `src/Auth/CanDirective.php`, `src/Console/ClearCacheCommand.php`, `src/Testing/RefreshesSchemaCache.php` (the boot method), `src/Testing/MakesGraphQLRequests.php` (`@deprecated use TestsSubscriptions`), `src/Testing/MakesGraphQLRequestsLumen.php` (Lumen support "removed in the next major").
+
+Config default change: `tracing.driver` v7 default → `FederatedTracing` (comment in `src/lighthouse.php`).
+
+graphql-php constraint: currently `^15`. Version guards to clear on a bump: `src/GraphQL.php:166` (`method_exists(... 'getQueryComplexity')`) and the `@phpstan-ignore` TODOs at lines ~399/405/424. A bump would also enable the clean #2771 fix (`SchemaConfig::setScalarOverrides()`).
+
+If the deprecation grep returns hits not listed above → add them to the cut-list before proceeding.
+
+## Phase 2 — The cut-list decision menu
+
+Ranked: committed items first, then proposals. Each needs its proof obligation met before merge.
+
+| # | Candidate | Motivation | Proof obligation | Blast radius | Decision |
+|---|---|---|---|---|---|
+| 1 | Enable `EnsureXHR` by default | CSRF hardening | Full matrix green; UPGRADE entry (exists); doc note that GET/HTML-form POST break | Medium (rejects some request shapes) | Committed |
+| 2 | Remove `@can`, keep `@can*` | Clearer authorization directives | Grep no `CanDirective` refs in src/docs; UPGRADE diff (exists) | Medium (schema authors migrate) | Committed |
+| 3 | Auto test-trait setup | Simpler test API | Test suite green without the boot calls; UPGRADE entry (exists) | Low (test code only) | Committed |
+| 4 | Rename clear-cache command | Consistency | Command removed; help text updated | Low | Committed |
+| 5 | `tracing.driver` → FederatedTracing default | Federation-first | Tracing tests green under new default; UPGRADE entry | Low–Medium (tracing consumers) | Committed (config comment) |
+| 6 | Drop Lumen support | Lumen support is `@deprecated` | Remove `MakesGraphQLRequestsLumen`; matrix drops Lumen cells | Medium (Lumen users) | **OPEN — maintainer call** |
+| 7 | **#2744 scope nested mutations to parent** | Security: prevents cross-parent writes | Repro test from #2744 fails-then-passes; ALL existing nested-mutation tests still green; UPGRADE entry; decide default-on vs opt-in | High (changes mutation behavior) | **OPEN — maintainer call** |
+| 8 | Bump `webonyx/graphql-php` floor past `^15` | Clears version guards; enables clean #2771 fix | Verify target release ships `setScalarOverrides`; matrix green on new floor | High (users on older 15.x) | **OPEN — depends on upstream** |
+| 9 | Drop EOL PHP/Laravel from matrix | Simplifies support | State exactly what's dropped; matrix updated | Medium | **OPEN — maintainer call** |
+
+## Phase 3 — Execution order and per-change gates
+
+For each item, in this order (low-risk first):
+
+1. Write the change on a branch (never `master` directly).
+2. If behavioral: **failing test / characterization test first** (see `lighthouse-testing-and-qa`).
+3. Land the `UPGRADE.md` entry **in the same PR** (PR template requires documenting breaking changes).
+4. `make it` green locally, then full CI matrix green.
+5. For #2744 specifically: implement behind the maintainer's chosen mechanism (default-on / opt-in flag / new directive); the #2744 exploitation example must fail with an authorization/scope error while **every** existing nested-mutation test still passes (they live in `tests/Integration/Execution/MutationExecutor/` — `HasManyTest`, `BelongsToTest`, `MorphToTest`, etc. — and `tests/Integration/Schema/Directives/` — `CreateDirectiveTest`, `UpsertDirectiveTest`, …). Prove via `lighthouse-proof-and-analysis-toolkit`.
+6. For the graphql-php bump (#8): first confirm the target upstream release exists and ships `setScalarOverrides`; only then bump the constraint and replace the `method_exists` guards.
+
+## Phase 4 — Release gates (all must pass, measurably)
+
+- [ ] CI matrix **fully green** on the release SHA (all PHP×Laravel×lowest/highest cells).
+- [ ] `php artisan lighthouse:print-schema --sort` diff of v6→v7 reviewed; **every** difference traced to an `UPGRADE.md` entry (use `scripts/schema-diff.sh` from `lighthouse-diagnostics-and-tooling`).
+- [ ] `CHANGELOG.md` has a complete `## v7.0.0` section; every entry ends in a PR URL.
+- [ ] Docs copied to `docs/7` **and** the `Makefile` `release` target updated from `docs/6` to `docs/7`.
+- [ ] Benchmarks within noise (rstdev) of the v6 baseline, or each regression explained (`bench-report.sh`).
+- [ ] All `@deprecated`-for-v7 elements removed; `grep -rn "@deprecated.*v7\|remove with v7" src` returns nothing stale.
+- [ ] The #2771 fix landed (if graphql-php bumped) with a regression test asserting `possibleTypes()` is not invoked on a simple execution.
+
+## Wrong paths (fenced off — with why)
+
+- **Reusing the `@can` name for changed semantics.** `@can` is being removed, not repurposed. A directive that changed behavior under the same name silently breaks every schema. Keep the `@can*` split.
+- **Shipping #2744 scoping default-on in a v6 minor.** It changes mutation behavior → breaking → v6-minor is forbidden. v7 or opt-in only.
+- **Bumping the graphql-php floor in a v6 minor.** Current constraint is `^15`; raising the floor breaks users on older 15.x → breaking. Guard with `method_exists` in v6 (precedent: #2637); bump only in v7.
+- **Deleting `docs/6`.** Archived-major docs stay; `make release` copies master into the *new* dir, it doesn't remove old ones (beyond the one it's writing).
+- **Skipping UPGRADE entries for "small" breaks.** Every break, however small, gets an entry — that's how users survive the upgrade.
+
+## Branches: "if you see X instead → Y"
+
+- Phase 1 grep shows a new `@deprecated` not in the inventory → add it to the cut-list (Phase 2) before executing.
+- The schema diff (Phase 4) shows a difference with no UPGRADE entry → **stop**; either revert that change or add the entry; an undocumented break must not ship.
+- A benchmark regresses beyond rstdev with no explanation → **stop**; treat as a regression, bisect (`lighthouse-proof-and-analysis-toolkit`), don't ship.
+- Upstream `setScalarOverrides` not released yet → keep #2771 on the `method_exists`-guard path; do not bump the floor.
+
+## When NOT to use this skill
+
+- Day-to-day, non-major changes → `lighthouse-change-control`.
+- Proving a single change's correctness/BC → `lighthouse-proof-and-analysis-toolkit`.
+- History of why an item is where it is → `lighthouse-failure-archaeology`.
+- Longer-horizon "beyond SOTA" work (not the v7 release) → `lighthouse-research-frontier`.
+
+## Provenance and maintenance
+
+**Most volatile skill — re-verify the whole inventory before acting.** Verified 2026-07-07 against v6.68.0 (`master` @ a29ff8e).
+
+```bash
+awk '/## v6 to v7/,/## v5 to v6/' UPGRADE.md | grep "^###"   # committed v7 breaks
+grep -rn "@deprecated" src --include="*.php"                  # removal candidates
+grep -n "EnsureXHR" src/lighthouse.php                        # still commented out?
+ls src/Auth/ | grep Can                                       # @can* directives present
+grep "webonyx/graphql-php" composer.json                      # constraint (was ^15)
+grep -n "tracing" -A15 src/lighthouse.php | grep -i "v7\|FederatedTracing"
+grep -n "release:" -A2 Makefile                               # docs/6 hardcode
+```
+Open decisions left to the maintainer: transfer timing (Phase 0); #2744 mechanism and default (item 7); Lumen drop (item 6); graphql-php floor bump (item 8, also gated on upstream); matrix drops (item 9).


### PR DESCRIPTION
The result of what Fable 5 (+ Opus 4.8 after my usage limit blew out) did with https://github.com/tomicz/fable-5-train-opus-skills-after-it-retires.

Will definitely not merge as-is, but might use bits and pieces.