### PR TITLE
Restore error/exception handlers after Rector bootstrap

### DIFF
--- a/src/Rector/RootResolverSignatureRector.php
+++ b/src/Rector/RootResolverSignatureRector.php
@@ -206,11 +206,11 @@ CODE_SAMPLE,
             $type = $type->type;
         }
 
-        if ($type instanceof Identifier && $type->name === 'array') {
-            return false;
+        if (! $type instanceof Identifier) {
+            return true;
         }
 
-        return true;
+        return $type->name !== 'array';
     }
 
     protected function prependRootParam(ClassMethod $method): void

--- a/tests/Unit/Rector/RootResolverSignatureRector/bootstrap.php
+++ b/tests/Unit/Rector/RootResolverSignatureRector/bootstrap.php
@@ -22,6 +22,7 @@ for ($i = 0; $i < 10; ++$i) {
         restore_error_handler();
         break;
     }
+
     restore_error_handler();
     restore_error_handler();
 }
@@ -31,6 +32,7 @@ for ($i = 0; $i < 10; ++$i) {
         restore_exception_handler();
         break;
     }
+
     restore_exception_handler();
     restore_exception_handler();
 }

--- a/tests/Unit/Rector/RootResolverSignatureRector/bootstrap.php
+++ b/tests/Unit/Rector/RootResolverSignatureRector/bootstrap.php
@@ -8,7 +8,7 @@ if (defined('LIGHTHOUSE_RECTOR_BOOTSTRAP_LOADED')) {
 
 define('LIGHTHOUSE_RECTOR_BOOTSTRAP_LOADED', true);
 
-$errorHandler = set_error_handler(static fn () => false);
+$errorHandler = set_error_handler(static fn (): bool => false);
 restore_error_handler();
 $exceptionHandler = set_exception_handler(static fn () => null);
 restore_exception_handler();
@@ -17,16 +17,18 @@ require_once __DIR__ . '/../../../../vendor/larastan/larastan/bootstrap.php';
 
 // Undo handlers registered by Laravel's HandleExceptions bootstrapper
 // to avoid PHPUnit risky test warnings about leaked handlers.
-while (set_error_handler(static fn () => false) !== $errorHandler) {
+while (set_error_handler(static fn (): bool => false) !== $errorHandler) {
     restore_error_handler();
     restore_error_handler();
 }
+
 restore_error_handler();
 
 while (set_exception_handler(static fn () => null) !== $exceptionHandler) {
     restore_exception_handler();
     restore_exception_handler();
 }
+
 restore_exception_handler();
 
 config()->set('lighthouse', require __DIR__ . '/../../../../src/lighthouse.php');

--- a/tests/Unit/Rector/RootResolverSignatureRector/bootstrap.php
+++ b/tests/Unit/Rector/RootResolverSignatureRector/bootstrap.php
@@ -8,27 +8,31 @@ if (defined('LIGHTHOUSE_RECTOR_BOOTSTRAP_LOADED')) {
 
 define('LIGHTHOUSE_RECTOR_BOOTSTRAP_LOADED', true);
 
-$errorHandler = set_error_handler(static fn (): bool => false);
+$errorHandler = set_error_handler(static fn (mixed ...$args): bool => false);
 restore_error_handler();
-$exceptionHandler = set_exception_handler(static fn () => null);
+$exceptionHandler = set_exception_handler(static fn (mixed ...$args) => null);
 restore_exception_handler();
 
 require_once __DIR__ . '/../../../../vendor/larastan/larastan/bootstrap.php';
 
 // Undo handlers registered by Laravel's HandleExceptions bootstrapper
 // to avoid PHPUnit risky test warnings about leaked handlers.
-while (set_error_handler(static fn (): bool => false) !== $errorHandler) {
+for ($i = 0; $i < 10; ++$i) {
+    if (set_error_handler(static fn (mixed ...$args): bool => false) === $errorHandler) {
+        restore_error_handler();
+        break;
+    }
     restore_error_handler();
     restore_error_handler();
 }
 
-restore_error_handler();
-
-while (set_exception_handler(static fn () => null) !== $exceptionHandler) {
+for ($i = 0; $i < 10; ++$i) {
+    if (set_exception_handler(static fn (mixed ...$args) => null) === $exceptionHandler) {
+        restore_exception_handler();
+        break;
+    }
     restore_exception_handler();
     restore_exception_handler();
 }
-
-restore_exception_handler();
 
 config()->set('lighthouse', require __DIR__ . '/../../../../src/lighthouse.php');

--- a/tests/Unit/Rector/RootResolverSignatureRector/bootstrap.php
+++ b/tests/Unit/Rector/RootResolverSignatureRector/bootstrap.php
@@ -8,6 +8,25 @@ if (defined('LIGHTHOUSE_RECTOR_BOOTSTRAP_LOADED')) {
 
 define('LIGHTHOUSE_RECTOR_BOOTSTRAP_LOADED', true);
 
+$errorHandler = set_error_handler(static fn () => false);
+restore_error_handler();
+$exceptionHandler = set_exception_handler(static fn () => null);
+restore_exception_handler();
+
 require_once __DIR__ . '/../../../../vendor/larastan/larastan/bootstrap.php';
+
+// Undo handlers registered by Laravel's HandleExceptions bootstrapper
+// to avoid PHPUnit risky test warnings about leaked handlers.
+while (set_error_handler(static fn () => false) !== $errorHandler) {
+    restore_error_handler();
+    restore_error_handler();
+}
+restore_error_handler();
+
+while (set_exception_handler(static fn () => null) !== $exceptionHandler) {
+    restore_exception_handler();
+    restore_exception_handler();
+}
+restore_exception_handler();
 
 config()->set('lighthouse', require __DIR__ . '/../../../../src/lighthouse.php');


### PR DESCRIPTION
The larastan bootstrap boots a Laravel app which registers HandleExceptions, leaking error and exception handlers onto the global stack. PHPUnit 12 detects this and flags the first test in each Rector test class as risky.

This captures the handler state before the bootstrap include, then pops any handlers that were added afterwards.