### PR TITLE
Fix SaveAwareArgResolver ignored in nested mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Honour `SaveAwareArgResolver::runBeforeSave()` in nested mutations instead of only at the top level https://github.com/nuwave/lighthouse/pull/2784
+
 ## v6.69.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 ### Fixed
 
 - Honour `SaveAwareArgResolver::runBeforeSave()` in nested mutations instead of only at the top level https://github.com/nuwave/lighthouse/pull/2784
+- Run all pre-save arg resolvers lifted out of `@nest` instead of silently discarding those whose field name collides with a sibling https://github.com/nuwave/lighthouse/pull/2784
 
 ## v6.69.1
 

--- a/src/Cache/QueryCache.php
+++ b/src/Cache/QueryCache.php
@@ -43,14 +43,14 @@ class QueryCache
 
     public function clear(?int $opcacheTTLHours, bool $opcacheOnly): void
     {
-        if (in_array($this->mode, ['store', 'hybrid'], true)
+        if (in_array($this->mode, ['store', 'hybrid'], strict: true)
             && ! $opcacheOnly
         ) {
             $store = $this->makeCacheStore();
             $store->clear();
         }
 
-        if (in_array($this->mode, ['opcache', 'hybrid'], true)) {
+        if (in_array($this->mode, ['opcache', 'hybrid'], strict: true)) {
             $files = $this->filesystem->glob($this->opcacheFilePath('*'));
 
             if (is_int($opcacheTTLHours)) {

--- a/src/Defer/DeferrableDirective.php
+++ b/src/Defer/DeferrableDirective.php
@@ -77,13 +77,13 @@ GRAPHQL;
         }
 
         $skips = (new ClientDirective(Directive::SKIP_NAME))->forField($resolveInfo);
-        if (in_array([Directive::IF_ARGUMENT_NAME => true], $skips, true)) {
+        if (in_array([Directive::IF_ARGUMENT_NAME => true], $skips, strict: true)) {
             return false;
         }
 
         $includes = (new ClientDirective(Directive::INCLUDE_NAME))->forField($resolveInfo);
 
-        return ! in_array([Directive::IF_ARGUMENT_NAME => false], $includes, true);
+        return ! in_array([Directive::IF_ARGUMENT_NAME => false], $includes, strict: true);
     }
 
     /** @param  array<array<string, mixed>|null>  $defers */

--- a/src/Execution/Arguments/ArgPartitioner.php
+++ b/src/Execution/Arguments/ArgPartitioner.php
@@ -20,33 +20,15 @@ class ArgPartitioner
     /**
      * Partition the arguments into nested and regular.
      *
+     * SaveAwareArgResolvers where runBeforeSave() returns true stay in the regular set
+     * so they reach SaveModel for execution before $model->save().
+     *
      * @return array{
      *   0: \Nuwave\Lighthouse\Execution\Arguments\ArgumentSet,
      *   1: \Nuwave\Lighthouse\Execution\Arguments\ArgumentSet,
      * }
      */
     public static function nestedArgResolvers(ArgumentSet $argumentSet, mixed $root): array
-    {
-        static::prepareArgResolvers($argumentSet, $root);
-
-        return static::partition(
-            $argumentSet,
-            static fn (string $name, Argument $argument): bool => isset($argument->resolver),
-        );
-    }
-
-    /**
-     * Like nestedArgResolvers(), but excludes SaveAwareArgResolvers that run before save.
-     *
-     * Used by SaveModel's ResolveNested wrapper so pre-save resolvers stay in the
-     * regular set and reach SaveModel for execution before $model->save().
-     *
-     * @return array{
-     *   0: \Nuwave\Lighthouse\Execution\Arguments\ArgumentSet,
-     *   1: \Nuwave\Lighthouse\Execution\Arguments\ArgumentSet,
-     * }
-     */
-    public static function nestedArgResolversWithoutPreSave(ArgumentSet $argumentSet, mixed $root): array
     {
         $model = static::prepareArgResolvers($argumentSet, $root);
 

--- a/src/Execution/Arguments/ArgPartitioner.php
+++ b/src/Execution/Arguments/ArgPartitioner.php
@@ -198,6 +198,8 @@ class ArgPartitioner
     public static function liftPreSaveResolversFromNest(ArgumentSet $nested, Model $root): array
     {
         $model = new \ReflectionClass($root);
+
+        /** @var list<\Nuwave\Lighthouse\Execution\Arguments\Argument> */
         $lifted = [];
 
         foreach ($nested->arguments as $argument) {
@@ -205,31 +207,43 @@ class ArgPartitioner
                 continue;
             }
 
-            $nestValue = $argument->value;
-            if ($nestValue === null) {
+            array_push($lifted, ...static::liftPreSaveResolversFromNestArgument($argument, $root, $model));
+        }
+
+        return $lifted;
+    }
+
+    /**
+     * Collect the pre-save resolvers within a single @nest argument.
+     *
+     * @param  \ReflectionClass<\Illuminate\Database\Eloquent\Model>  $model
+     *
+     * @return list<\Nuwave\Lighthouse\Execution\Arguments\Argument>
+     */
+    protected static function liftPreSaveResolversFromNestArgument(Argument $nest, Model $root, \ReflectionClass $model): array
+    {
+        $nestValue = $nest->value;
+        if ($nestValue === null) {
+            return [];
+        }
+
+        assert($nestValue instanceof ArgumentSet, 'NestDirective validates that @nest is used on non-list input object types.');
+
+        /** @var list<\Nuwave\Lighthouse\Execution\Arguments\Argument> */
+        $lifted = [];
+
+        foreach ($nestValue->arguments as $childName => $childArgument) {
+            static::attachNestedArgResolver($childName, $childArgument, $model);
+
+            $resolver = $childArgument->resolver;
+
+            if (self::shouldRunBeforeSave($resolver, $root)) {
+                $lifted[] = $childArgument;
                 continue;
             }
 
-            assert($nestValue instanceof ArgumentSet, 'NestDirective validates that @nest is used on non-list input object types.');
-
-            foreach ($nestValue->arguments as $childName => $childArgument) {
-                static::attachNestedArgResolver($childName, $childArgument, $model);
-
-                $resolver = $childArgument->resolver;
-
-                if (self::shouldRunBeforeSave($resolver, $root)) {
-                    $lifted[] = $childArgument;
-                    continue;
-                }
-
-                if ($resolver instanceof NestDirective) {
-                    $childNested = new ArgumentSet();
-                    $childNested->arguments[$childName] = $childArgument;
-
-                    foreach (static::liftPreSaveResolversFromNest($childNested, $root) as $deeplyNested) {
-                        $lifted[] = $deeplyNested;
-                    }
-                }
+            if ($resolver instanceof NestDirective) {
+                array_push($lifted, ...static::liftPreSaveResolversFromNestArgument($childArgument, $root, $model));
             }
         }
 

--- a/src/Execution/Arguments/ArgPartitioner.php
+++ b/src/Execution/Arguments/ArgPartitioner.php
@@ -32,7 +32,7 @@ class ArgPartitioner
     {
         $model = static::prepareArgResolvers($argumentSet, $root);
 
-        [$nested, $regular] = static::partition(
+        return static::partition(
             $argumentSet,
             static function (string $name, Argument $argument) use ($root, $model): bool {
                 $resolver = $argument->resolver;
@@ -53,13 +53,6 @@ class ArgPartitioner
                 return true;
             },
         );
-
-        if ($model !== null) {
-            assert($root instanceof Model);
-            static::liftPreSaveResolversFromNest($nested, $regular, $root, $model);
-        }
-
-        return [$nested, $regular];
     }
 
     /**
@@ -191,13 +184,22 @@ class ArgPartitioner
     }
 
     /**
-     * Recursively traverse @nest arguments and lift pre-save resolvers to the regular set
-     * so they reach SaveModel and execute before $model->save().
+     * Recursively collect the pre-save resolvers within @nest arguments,
+     * so they can run before $root->save() instead of after it.
      *
-     * @param  \ReflectionClass<\Illuminate\Database\Eloquent\Model>  $model
+     * The result is an ordered list rather than a name-keyed set:
+     * field names are unique per input type, not across a whole input tree.
+     *
+     * Leaves the given arguments untouched, as they may be shared with cached
+     * or spread ArgumentSets that the caller still owns.
+     *
+     * @return list<\Nuwave\Lighthouse\Execution\Arguments\Argument>
      */
-    protected static function liftPreSaveResolversFromNest(ArgumentSet $nested, ArgumentSet $regular, Model $root, \ReflectionClass $model): void
+    public static function liftPreSaveResolversFromNest(ArgumentSet $nested, Model $root): array
     {
+        $model = new \ReflectionClass($root);
+        $lifted = [];
+
         foreach ($nested->arguments as $argument) {
             if (! $argument->resolver instanceof NestDirective) {
                 continue;
@@ -216,18 +218,22 @@ class ArgPartitioner
                 $resolver = $childArgument->resolver;
 
                 if (self::shouldRunBeforeSave($resolver, $root)) {
-                    $regular->arguments[$childName] = $childArgument;
-                    unset($nestValue->arguments[$childName]);
+                    $lifted[] = $childArgument;
                     continue;
                 }
 
                 if ($resolver instanceof NestDirective) {
                     $childNested = new ArgumentSet();
                     $childNested->arguments[$childName] = $childArgument;
-                    static::liftPreSaveResolversFromNest($childNested, $regular, $root, $model);
+
+                    foreach (static::liftPreSaveResolversFromNest($childNested, $root) as $deeplyNested) {
+                        $lifted[] = $deeplyNested;
+                    }
                 }
             }
         }
+
+        return $lifted;
     }
 
     /** @return \ReflectionClass<\Illuminate\Database\Eloquent\Model>|null */

--- a/src/Execution/Arguments/DelegatesPreSaveArguments.php
+++ b/src/Execution/Arguments/DelegatesPreSaveArguments.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Execution\Arguments;
+
+use Nuwave\Lighthouse\Support\Contracts\PreSaveArgumentsAware;
+
+/**
+ * Pass pre-save arguments on to the wrapped resolver, which is the one that saves.
+ */
+trait DelegatesPreSaveArguments
+{
+    /** @param  list<\Nuwave\Lighthouse\Execution\Arguments\Argument>  $arguments */
+    public function withPreSaveArguments(array $arguments): ?static
+    {
+        $previous = $this->previous;
+        if (! $previous instanceof PreSaveArgumentsAware) {
+            return null;
+        }
+
+        $previousWithPreSave = $previous->withPreSaveArguments($arguments);
+        if ($previousWithPreSave === null) {
+            return null;
+        }
+
+        $clone = clone $this;
+        $clone->previous = $previousWithPreSave;
+
+        return $clone;
+    }
+}

--- a/src/Execution/Arguments/ResolveNested.php
+++ b/src/Execution/Arguments/ResolveNested.php
@@ -2,8 +2,10 @@
 
 namespace Nuwave\Lighthouse\Execution\Arguments;
 
+use Illuminate\Database\Eloquent\Model;
 use Nuwave\Lighthouse\Schema\Directives\NestDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgResolver;
+use Nuwave\Lighthouse\Support\Contracts\PreSaveArgumentsAware;
 
 class ResolveNested implements ArgResolver
 {
@@ -26,13 +28,43 @@ class ResolveNested implements ArgResolver
         [$nestedArgs, $regularArgs] = ($this->argPartitioner)($args, $root);
         assert($nestedArgs instanceof ArgumentSet);
 
-        if ($this->previous !== null) {
-            $root = ($this->previous)($root, $regularArgs);
+        $previous = $this->previous;
+        $liftedPreSave = [];
+
+        if ($root instanceof Model && $previous instanceof PreSaveArgumentsAware) {
+            $liftable = ArgPartitioner::liftPreSaveResolversFromNest($nestedArgs, $root);
+
+            if ($liftable !== []) {
+                $withPreSave = $previous->withPreSaveArguments($liftable);
+
+                if ($withPreSave !== null) {
+                    $previous = $withPreSave;
+                    $liftedPreSave = $liftable;
+                }
+            }
         }
 
+        if ($previous !== null) {
+            $root = $previous($root, $regularArgs);
+        }
+
+        $this->resolveNestedArguments($root, $nestedArgs, $liftedPreSave);
+
+        return $root;
+    }
+
+    /** @param  list<\Nuwave\Lighthouse\Execution\Arguments\Argument>  $alreadyRun  arguments the saver ran before saving */
+    protected function resolveNestedArguments(mixed $root, ArgumentSet $nestedArgs, array $alreadyRun): void
+    {
         foreach ($nestedArgs->arguments as $nested) {
             $resolver = $nested->resolver;
-            assert($resolver !== null, 'we know the resolver is there because we partitioned for it');
+            if ($resolver === null) {
+                continue;
+            }
+
+            if (in_array($nested, $alreadyRun, true)) {
+                continue;
+            }
 
             $value = $nested->value;
             if ($resolver instanceof NestDirective) {
@@ -42,14 +74,15 @@ class ResolveNested implements ArgResolver
 
                 assert($value instanceof ArgumentSet, 'NestDirective validates that @nest is used on non-list input object types.');
 
-                $nestResolver = new self(null, $this->argPartitioner);
-                $nestResolver($root, $value);
+                // Partitioning attaches the resolvers of the children, including implicitly detected relations.
+                // Its classification is irrelevant here: there is no saver to hand regular arguments to,
+                // and children the saver did not run must still resolve.
+                ($this->argPartitioner)($value, $root);
+                $this->resolveNestedArguments($root, $value, $alreadyRun);
                 continue;
             }
 
             $resolver($root, $value);
         }
-
-        return $root;
     }
 }

--- a/src/Execution/Arguments/ResolveNested.php
+++ b/src/Execution/Arguments/ResolveNested.php
@@ -31,15 +31,17 @@ class ResolveNested implements ArgResolver
         $previous = $this->previous;
         $liftedPreSave = [];
 
-        if ($root instanceof Model && $previous instanceof PreSaveArgumentsAware) {
-            $liftable = ArgPartitioner::liftPreSaveResolversFromNest($nestedArgs, $root);
+        if ($root instanceof Model
+            && $previous instanceof PreSaveArgumentsAware
+        ) {
+            $liftableArguments = ArgPartitioner::liftPreSaveResolversFromNest($nestedArgs, $root);
 
-            if ($liftable !== []) {
-                $withPreSave = $previous->withPreSaveArguments($liftable);
+            if ($liftableArguments !== []) {
+                $previousWithPreSave = $previous->withPreSaveArguments($liftableArguments);
 
-                if ($withPreSave !== null) {
-                    $previous = $withPreSave;
-                    $liftedPreSave = $liftable;
+                if ($previousWithPreSave !== null) {
+                    $previous = $previousWithPreSave;
+                    $liftedPreSave = $liftableArguments;
                 }
             }
         }
@@ -62,7 +64,7 @@ class ResolveNested implements ArgResolver
                 continue;
             }
 
-            if (in_array($nested, $alreadyRun, true)) {
+            if (in_array($nested, $alreadyRun, strict: true)) {
                 continue;
             }
 

--- a/src/Execution/Arguments/SaveModel.php
+++ b/src/Execution/Arguments/SaveModel.php
@@ -9,14 +9,26 @@ use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Nuwave\Lighthouse\Support\Contracts\ArgResolver;
+use Nuwave\Lighthouse\Support\Contracts\PreSaveArgumentsAware;
 use Nuwave\Lighthouse\Support\Contracts\SaveAwareArgResolver;
 
-class SaveModel implements ArgResolver
+class SaveModel implements ArgResolver, PreSaveArgumentsAware
 {
+    /** @var list<\Nuwave\Lighthouse\Execution\Arguments\Argument> */
+    protected array $preSaveArguments = [];
+
     public function __construct(
         /** @var \Illuminate\Database\Eloquent\Relations\Relation<\Illuminate\Database\Eloquent\Model>|null $parentRelation */
         protected ?Relation $parentRelation = null,
     ) {}
+
+    public function withPreSaveArguments(array $arguments): static
+    {
+        $clone = clone $this;
+        $clone->preSaveArguments = $arguments;
+
+        return $clone;
+    }
 
     /**
      * @param  Model  $model
@@ -62,10 +74,10 @@ class SaveModel implements ArgResolver
             $morphToResolver($model, $nestedOperations->value);
         }
 
-        foreach ($preSave->arguments as $nested) {
-            $resolver = $nested->resolver;
+        foreach ([...array_values($preSave->arguments), ...$this->preSaveArguments] as $preSaveArgument) {
+            $resolver = $preSaveArgument->resolver;
             assert($resolver instanceof SaveAwareArgResolver, 'Resolver must be a SaveAwareArgResolver because we partitioned for it.');
-            $resolver($model, $nested->value);
+            $resolver($model, $preSaveArgument->value);
         }
 
         if ($this->parentRelation instanceof HasOneOrMany) {

--- a/src/Execution/Arguments/SaveModel.php
+++ b/src/Execution/Arguments/SaveModel.php
@@ -74,7 +74,10 @@ class SaveModel implements ArgResolver, PreSaveArgumentsAware
             $morphToResolver($model, $nestedOperations->value);
         }
 
-        foreach ([...array_values($preSave->arguments), ...$this->preSaveArguments] as $preSaveArgument) {
+        foreach ([
+            ...array_values($preSave->arguments),
+            ...$this->preSaveArguments,
+        ] as $preSaveArgument) {
             $resolver = $preSaveArgument->resolver;
             assert($resolver instanceof SaveAwareArgResolver, 'Resolver must be a SaveAwareArgResolver because we partitioned for it.');
             $resolver($model, $preSaveArgument->value);

--- a/src/Execution/Arguments/UpdateModel.php
+++ b/src/Execution/Arguments/UpdateModel.php
@@ -9,6 +9,8 @@ use Nuwave\Lighthouse\Support\Contracts\PreSaveArgumentsAware;
 
 class UpdateModel implements ArgResolver, PreSaveArgumentsAware
 {
+    use DelegatesPreSaveArguments;
+
     public const MISSING_PRIMARY_KEY_FOR_UPDATE = 'Missing primary key for update.';
 
     /** @var callable|\Nuwave\Lighthouse\Support\Contracts\ArgResolver */
@@ -18,24 +20,6 @@ class UpdateModel implements ArgResolver, PreSaveArgumentsAware
     public function __construct(callable $previous)
     {
         $this->previous = $previous;
-    }
-
-    public function withPreSaveArguments(array $arguments): ?static
-    {
-        $previous = $this->previous;
-        if (! $previous instanceof PreSaveArgumentsAware) {
-            return null;
-        }
-
-        $previousWithPreSave = $previous->withPreSaveArguments($arguments);
-        if ($previousWithPreSave === null) {
-            return null;
-        }
-
-        $clone = clone $this;
-        $clone->previous = $previousWithPreSave;
-
-        return $clone;
     }
 
     /**

--- a/src/Execution/Arguments/UpdateModel.php
+++ b/src/Execution/Arguments/UpdateModel.php
@@ -5,8 +5,9 @@ namespace Nuwave\Lighthouse\Execution\Arguments;
 use GraphQL\Error\Error;
 use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Support\Contracts\ArgResolver;
+use Nuwave\Lighthouse\Support\Contracts\PreSaveArgumentsAware;
 
-class UpdateModel implements ArgResolver
+class UpdateModel implements ArgResolver, PreSaveArgumentsAware
 {
     public const MISSING_PRIMARY_KEY_FOR_UPDATE = 'Missing primary key for update.';
 
@@ -17,6 +18,24 @@ class UpdateModel implements ArgResolver
     public function __construct(callable $previous)
     {
         $this->previous = $previous;
+    }
+
+    public function withPreSaveArguments(array $arguments): ?static
+    {
+        $previous = $this->previous;
+        if (! $previous instanceof PreSaveArgumentsAware) {
+            return null;
+        }
+
+        $previousWithPreSave = $previous->withPreSaveArguments($arguments);
+        if ($previousWithPreSave === null) {
+            return null;
+        }
+
+        $clone = clone $this;
+        $clone->previous = $previousWithPreSave;
+
+        return $clone;
     }
 
     /**

--- a/src/Execution/Arguments/UpsertModel.php
+++ b/src/Execution/Arguments/UpsertModel.php
@@ -5,10 +5,11 @@ namespace Nuwave\Lighthouse\Execution\Arguments;
 use GraphQL\Error\Error;
 use Illuminate\Database\Eloquent\Model;
 use Nuwave\Lighthouse\Support\Contracts\ArgResolver;
+use Nuwave\Lighthouse\Support\Contracts\PreSaveArgumentsAware;
 
 use function Safe\array_flip;
 
-class UpsertModel implements ArgResolver
+class UpsertModel implements ArgResolver, PreSaveArgumentsAware
 {
     public const MISSING_IDENTIFYING_COLUMNS_FOR_UPSERT = 'All configured identifying columns must be present and non-null for upsert.';
 
@@ -22,6 +23,24 @@ class UpsertModel implements ArgResolver
         protected ?array $identifyingColumns = null,
     ) {
         $this->previous = $previous;
+    }
+
+    public function withPreSaveArguments(array $arguments): ?static
+    {
+        $previous = $this->previous;
+        if (! $previous instanceof PreSaveArgumentsAware) {
+            return null;
+        }
+
+        $previousWithPreSave = $previous->withPreSaveArguments($arguments);
+        if ($previousWithPreSave === null) {
+            return null;
+        }
+
+        $clone = clone $this;
+        $clone->previous = $previousWithPreSave;
+
+        return $clone;
     }
 
     /**

--- a/src/Execution/Arguments/UpsertModel.php
+++ b/src/Execution/Arguments/UpsertModel.php
@@ -11,6 +11,8 @@ use function Safe\array_flip;
 
 class UpsertModel implements ArgResolver, PreSaveArgumentsAware
 {
+    use DelegatesPreSaveArguments;
+
     public const MISSING_IDENTIFYING_COLUMNS_FOR_UPSERT = 'All configured identifying columns must be present and non-null for upsert.';
 
     /** @var callable|\Nuwave\Lighthouse\Support\Contracts\ArgResolver */
@@ -23,24 +25,6 @@ class UpsertModel implements ArgResolver, PreSaveArgumentsAware
         protected ?array $identifyingColumns = null,
     ) {
         $this->previous = $previous;
-    }
-
-    public function withPreSaveArguments(array $arguments): ?static
-    {
-        $previous = $this->previous;
-        if (! $previous instanceof PreSaveArgumentsAware) {
-            return null;
-        }
-
-        $previousWithPreSave = $previous->withPreSaveArguments($arguments);
-        if ($previousWithPreSave === null) {
-            return null;
-        }
-
-        $clone = clone $this;
-        $clone->previous = $previousWithPreSave;
-
-        return $clone;
     }
 
     /**

--- a/src/Schema/Directives/ModelMutationDirective.php
+++ b/src/Schema/Directives/ModelMutationDirective.php
@@ -67,7 +67,6 @@ abstract class ModelMutationDirective extends BaseDirective implements FieldReso
     {
         $update = new ResolveNested(
             $this->makeExecutionFunction($parentRelation),
-            [ArgPartitioner::class, 'nestedArgResolversWithoutPreSave'],
         );
 
         return Utils::mapEach(

--- a/src/Support/Contracts/PreSaveArgumentsAware.php
+++ b/src/Support/Contracts/PreSaveArgumentsAware.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Nuwave\Lighthouse\Support\Contracts;
+
+/**
+ * Implement this on ArgResolvers that can run pre-save arg resolvers
+ * lifted out of a @nest before persisting the model.
+ *
+ * Lifted arguments are passed as an ordered list, not as a name-keyed map:
+ * field names are unique per input type, not across a whole input tree,
+ * so keying them would discard colliding arguments.
+ */
+interface PreSaveArgumentsAware
+{
+    /**
+     * Return a copy of this resolver that runs the given arguments before saving.
+     *
+     * @param  list<\Nuwave\Lighthouse\Execution\Arguments\Argument>  $arguments
+     *
+     * @return static|null null when this resolver can not run pre-save arguments
+     */
+    public function withPreSaveArguments(array $arguments): ?static;
+}

--- a/src/Testing/MakesGraphQLRequests.php
+++ b/src/Testing/MakesGraphQLRequests.php
@@ -261,7 +261,7 @@ trait MakesGraphQLRequests
 
     protected function refreshSchemaCacheIfNecessary(): void
     {
-        if (in_array(RefreshesSchemaCache::class, class_uses_recursive(static::class), true)) {
+        if (in_array(RefreshesSchemaCache::class, class_uses_recursive(static::class), strict: true)) {
             $this->refreshSchemaCache(); // @phpstan-ignore method.notFound (present in RefreshesSchemaCache)
         }
     }

--- a/src/WhereConditions/SQLOperator.php
+++ b/src/WhereConditions/SQLOperator.php
@@ -115,11 +115,11 @@ GRAPHQL;
 
     protected function operatorArity(string $operator): int
     {
-        if (in_array($operator, ['Null', 'NotNull'], true)) {
+        if (in_array($operator, ['Null', 'NotNull'], strict: true)) {
             return 1;
         }
 
-        if (in_array($operator, ['In', 'NotIn', 'Between', 'NotBetween'], true)) {
+        if (in_array($operator, ['In', 'NotIn', 'Between', 'NotBetween'], strict: true)) {
             return 2;
         }
 

--- a/tests/Integration/Schema/Directives/CreateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/CreateDirectiveTest.php
@@ -1149,4 +1149,100 @@ final class CreateDirectiveTest extends DBTestCase
             ],
         ]);
     }
+
+    /**
+     * Lifting pre-save resolvers out of `@nest` keys them by their bare field name,
+     * so a `@nest` child silently replaces a sibling of the same name rather than erroring.
+     * Documents the status quo, not a guarantee - such a schema is ambiguous by design.
+     */
+    public function testNestChildOverwritesSiblingWithSameNameInsideNestedHasMany(): void
+    {
+        $this->schema .= /** @lang GraphQL */ <<<'GRAPHQL'
+        type Task {
+            id: ID!
+            name: String!
+            latitude: Float
+            longitude: Float
+        }
+
+        type User {
+            id: ID!
+            name: String!
+            tasks: [Task!]! @hasMany
+        }
+
+        type Mutation {
+            createUser(input: CreateUserInput! @spread): User @create
+        }
+
+        input CreateUserInput {
+            name: String!
+            tasks: CreateTaskRelation
+        }
+
+        input CreateTaskRelation {
+            create: [CreateTaskInput!]
+        }
+
+        input CreateTaskInput {
+            name: String!
+            location: LocationInput @geocode
+            nested: TaskNestedInput @nest
+        }
+
+        input TaskNestedInput {
+            location: LocationInput @geocode
+        }
+
+        input LocationInput {
+            lat: Float!
+            lng: Float!
+        }
+        GRAPHQL;
+
+        $this->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
+        mutation {
+            createUser(input: {
+                name: "Geo Collision Parent"
+                tasks: {
+                    create: [{
+                        name: "Geo Collision Task"
+                        location: {
+                            lat: 1.0
+                            lng: 2.0
+                        }
+                        nested: {
+                            location: {
+                                lat: 48.1351
+                                lng: 11.5820
+                            }
+                        }
+                    }]
+                }
+            }) {
+                id
+                name
+                tasks {
+                    id
+                    name
+                    latitude
+                    longitude
+                }
+            }
+        }
+        GRAPHQL)->assertJson([
+            'data' => [
+                'createUser' => [
+                    'name' => 'Geo Collision Parent',
+                    'tasks' => [
+                        [
+                            'name' => 'Geo Collision Task',
+                            'latitude' => 48.1351,
+                            'longitude' => 11.582,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
 }

--- a/tests/Integration/Schema/Directives/CreateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/CreateDirectiveTest.php
@@ -876,4 +876,277 @@ final class CreateDirectiveTest extends DBTestCase
             ],
         ]);
     }
+
+    public function testCustomDirectiveSetsModelAttributesBeforeSaveInsideNestedHasMany(): void
+    {
+        $this->schema .= /** @lang GraphQL */ <<<'GRAPHQL'
+        type Task {
+            id: ID!
+            name: String!
+            latitude: Float
+            longitude: Float
+        }
+
+        type User {
+            id: ID!
+            name: String!
+            tasks: [Task!]! @hasMany
+        }
+
+        type Mutation {
+            createUser(input: CreateUserInput! @spread): User @create
+        }
+
+        input CreateUserInput {
+            name: String!
+            tasks: CreateTaskRelation
+        }
+
+        input CreateTaskRelation {
+            create: [CreateTaskInput!]
+        }
+
+        input CreateTaskInput {
+            name: String!
+            location: LocationInput @geocode
+        }
+
+        input LocationInput {
+            lat: Float!
+            lng: Float!
+        }
+        GRAPHQL;
+
+        $this->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
+        mutation {
+            createUser(input: {
+                name: "Geo Parent"
+                tasks: {
+                    create: [{
+                        name: "Geo Task"
+                        location: {
+                            lat: 48.1351
+                            lng: 11.5820
+                        }
+                    }]
+                }
+            }) {
+                id
+                name
+                tasks {
+                    id
+                    name
+                    latitude
+                    longitude
+                }
+            }
+        }
+        GRAPHQL)->assertJson([
+            'data' => [
+                'createUser' => [
+                    'name' => 'Geo Parent',
+                    'tasks' => [
+                        [
+                            'name' => 'Geo Task',
+                            'latitude' => 48.1351,
+                            'longitude' => 11.582,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testCustomDirectiveSetsModelAttributesBeforeSaveInsideNestInsideNestedHasMany(): void
+    {
+        $this->schema .= /** @lang GraphQL */ <<<'GRAPHQL'
+        type Task {
+            id: ID!
+            name: String!
+            latitude: Float
+            longitude: Float
+        }
+
+        type User {
+            id: ID!
+            name: String!
+            tasks: [Task!]! @hasMany
+        }
+
+        type Mutation {
+            createUser(input: CreateUserInput! @spread): User @create
+        }
+
+        input CreateUserInput {
+            name: String!
+            tasks: CreateTaskRelation
+        }
+
+        input CreateTaskRelation {
+            create: [CreateTaskInput!]
+        }
+
+        input CreateTaskInput {
+            name: String!
+            nested: TaskNestedInput @nest
+        }
+
+        input TaskNestedInput {
+            location: LocationInput @geocode
+        }
+
+        input LocationInput {
+            lat: Float!
+            lng: Float!
+        }
+        GRAPHQL;
+
+        $this->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
+        mutation {
+            createUser(input: {
+                name: "Geo Nest Parent"
+                tasks: {
+                    create: [{
+                        name: "Geo Nest Task"
+                        nested: {
+                            location: {
+                                lat: 48.1351
+                                lng: 11.5820
+                            }
+                        }
+                    }]
+                }
+            }) {
+                id
+                name
+                tasks {
+                    id
+                    name
+                    latitude
+                    longitude
+                }
+            }
+        }
+        GRAPHQL)->assertJson([
+            'data' => [
+                'createUser' => [
+                    'name' => 'Geo Nest Parent',
+                    'tasks' => [
+                        [
+                            'name' => 'Geo Nest Task',
+                            'latitude' => 48.1351,
+                            'longitude' => 11.582,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testCustomDirectiveSetsModelAttributesBeforeSaveInsideDeeplyNestedRelation(): void
+    {
+        $this->schema .= /** @lang GraphQL */ <<<'GRAPHQL'
+        type Post {
+            id: ID!
+            title: String!
+            latitude: Float
+            longitude: Float
+        }
+
+        type Task {
+            id: ID!
+            name: String!
+            post: Post @hasOne
+        }
+
+        type User {
+            id: ID!
+            name: String!
+            tasks: [Task!]! @hasMany
+        }
+
+        type Mutation {
+            createUser(input: CreateUserInput! @spread): User @create
+        }
+
+        input CreateUserInput {
+            name: String!
+            tasks: CreateTaskRelation
+        }
+
+        input CreateTaskRelation {
+            create: [CreateTaskInput!]
+        }
+
+        input CreateTaskInput {
+            name: String!
+            post: CreatePostRelation
+        }
+
+        input CreatePostRelation {
+            create: CreatePostInput
+        }
+
+        input CreatePostInput {
+            title: String!
+            location: LocationInput @geocode
+        }
+
+        input LocationInput {
+            lat: Float!
+            lng: Float!
+        }
+        GRAPHQL;
+
+        $this->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
+        mutation {
+            createUser(input: {
+                name: "Geo Deep Parent"
+                tasks: {
+                    create: [{
+                        name: "Geo Deep Task"
+                        post: {
+                            create: {
+                                title: "Geo Deep Post"
+                                location: {
+                                    lat: 48.1351
+                                    lng: 11.5820
+                                }
+                            }
+                        }
+                    }]
+                }
+            }) {
+                id
+                name
+                tasks {
+                    id
+                    name
+                    post {
+                        id
+                        title
+                        latitude
+                        longitude
+                    }
+                }
+            }
+        }
+        GRAPHQL)->assertJson([
+            'data' => [
+                'createUser' => [
+                    'name' => 'Geo Deep Parent',
+                    'tasks' => [
+                        [
+                            'name' => 'Geo Deep Task',
+                            'post' => [
+                                'title' => 'Geo Deep Post',
+                                'latitude' => 48.1351,
+                                'longitude' => 11.582,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
 }

--- a/tests/Integration/Schema/Directives/CreateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/CreateDirectiveTest.php
@@ -1151,11 +1151,10 @@ final class CreateDirectiveTest extends DBTestCase
     }
 
     /**
-     * Lifting pre-save resolvers out of `@nest` keys them by their bare field name,
-     * so a `@nest` child silently replaces a sibling of the same name rather than erroring.
-     * Documents the status quo, not a guarantee - such a schema is ambiguous by design.
+     * The plain sibling `location` and the same-named `@nest` child both run, in that order.
+     * Both write the same columns, so the last write wins.
      */
-    public function testNestChildOverwritesSiblingWithSameNameInsideNestedHasMany(): void
+    public function testNestChildAndSiblingWithSameNameBothRunInsideNestedHasMany(): void
     {
         $this->schema .= /** @lang GraphQL */ <<<'GRAPHQL'
         type Task {
@@ -1241,6 +1240,68 @@ final class CreateDirectiveTest extends DBTestCase
                             'longitude' => 11.582,
                         ],
                     ],
+                ],
+            ],
+        ]);
+    }
+
+    /** A `@nest` child named like a plain sibling writes different columns, so both values must persist. */
+    public function testNestChildNamedLikePlainSiblingKeepsBoth(): void
+    {
+        $this->schema .= /** @lang GraphQL */ <<<'GRAPHQL'
+        type Task {
+            id: ID!
+            name: String!
+            difficulty: Int
+            latitude: Float
+            longitude: Float
+        }
+
+        type Mutation {
+            createTask(input: CreateTaskInput! @spread): Task @create
+        }
+
+        input CreateTaskInput {
+            name: String!
+            difficulty: Int
+            nested: TaskNestedInput @nest
+        }
+
+        input TaskNestedInput {
+            difficulty: LocationInput @geocode
+        }
+
+        input LocationInput {
+            lat: Float!
+            lng: Float!
+        }
+        GRAPHQL;
+
+        $this->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
+        mutation {
+            createTask(input: {
+                name: "Colliding Names"
+                difficulty: 3
+                nested: {
+                    difficulty: {
+                        lat: 48.1351
+                        lng: 11.5820
+                    }
+                }
+            }) {
+                name
+                difficulty
+                latitude
+                longitude
+            }
+        }
+        GRAPHQL)->assertJson([
+            'data' => [
+                'createTask' => [
+                    'name' => 'Colliding Names',
+                    'difficulty' => 3,
+                    'latitude' => 48.1351,
+                    'longitude' => 11.582,
                 ],
             ],
         ]);

--- a/tests/Integration/Schema/Directives/NestDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/NestDirectiveTest.php
@@ -351,6 +351,82 @@ final class NestDirectiveTest extends DBTestCase
         ]);
     }
 
+    /** Same-named children of sibling `@nest` blocks that write different columns must both run. */
+    public function testSiblingNestBlocksWithSameChildNameBothRun(): void
+    {
+        $this->schema .= /** @lang GraphQL */ <<<'GRAPHQL'
+        type Mutation {
+            createUser(input: CreateUserInput! @spread): User @create
+        }
+
+        input CreateUserInput {
+            name: String!
+            alpha: AlphaInput @nest
+            beta: BetaInput @nest
+        }
+
+        input AlphaInput {
+            detail: LocationInput @geocode
+        }
+
+        input BetaInput {
+            detail: EmailAddressInput @emailAddress
+        }
+
+        input LocationInput {
+            lat: Float!
+            lng: Float!
+        }
+
+        input EmailAddressInput {
+            local: String!
+            domain: String!
+        }
+
+        type User {
+            id: ID!
+            name: String!
+            email: String
+            latitude: Float
+            longitude: Float
+        }
+        GRAPHQL;
+
+        $this->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
+        mutation {
+            createUser(input: {
+                name: "Sibling Nest"
+                alpha: {
+                    detail: {
+                        lat: 48.0
+                        lng: 11.0
+                    }
+                }
+                beta: {
+                    detail: {
+                        local: "sibling"
+                        domain: "example.com"
+                    }
+                }
+            }) {
+                name
+                email
+                latitude
+                longitude
+            }
+        }
+        GRAPHQL)->assertJson([
+            'data' => [
+                'createUser' => [
+                    'name' => 'Sibling Nest',
+                    'email' => 'sibling@example.com',
+                    'latitude' => 48.0,
+                    'longitude' => 11.0,
+                ],
+            ],
+        ]);
+    }
+
     public function testNullableNestWithNullValue(): void
     {
         $this->schema .= /** @lang GraphQL */ <<<'GRAPHQL'

--- a/tests/Integration/Schema/Directives/UpdateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/UpdateDirectiveTest.php
@@ -513,4 +513,78 @@ final class UpdateDirectiveTest extends DBTestCase
             ],
         ]);
     }
+
+    /** A `@nest` child named `id` must not clobber the primary key that identifies the row to update. */
+    public function testNestChildNamedIdDoesNotClobberPrimaryKey(): void
+    {
+        $decoy = new Task();
+        $decoy->name = 'Decoy';
+        $decoy->save();
+
+        $task = new Task();
+        $task->name = 'Target';
+        $task->save();
+
+        $this->schema .= /** @lang GraphQL */ <<<'GRAPHQL'
+        type Task {
+            id: ID!
+            name: String!
+            latitude: Float
+            longitude: Float
+        }
+
+        type Mutation {
+            updateTask(input: UpdateTaskInput! @spread): Task @update
+        }
+
+        input UpdateTaskInput {
+            id: ID!
+            name: String
+            nested: TaskNestedInput @nest
+        }
+
+        input TaskNestedInput {
+            id: LocationInput @geocode
+        }
+
+        input LocationInput {
+            lat: Float!
+            lng: Float!
+        }
+        GRAPHQL;
+
+        $this->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
+        mutation ($id: ID!) {
+            updateTask(input: {
+                id: $id
+                name: "Renamed target"
+                nested: {
+                    id: {
+                        lat: 48.1351
+                        lng: 11.5820
+                    }
+                }
+            }) {
+                id
+                name
+                latitude
+                longitude
+            }
+        }
+        GRAPHQL, [
+            'id' => $task->id,
+        ])->assertJson([
+            'data' => [
+                'updateTask' => [
+                    'id' => (string) $task->id,
+                    'name' => 'Renamed target',
+                    'latitude' => 48.1351,
+                    'longitude' => 11.582,
+                ],
+            ],
+        ]);
+
+        $decoy->refresh();
+        $this->assertSame('Decoy', $decoy->name);
+    }
 }

--- a/tests/Integration/Schema/Directives/UpdateDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/UpdateDirectiveTest.php
@@ -423,4 +423,94 @@ final class UpdateDirectiveTest extends DBTestCase
             ],
         ]);
     }
+
+    public function testCustomDirectiveSetsModelAttributesBeforeSaveInsideNestedHasMany(): void
+    {
+        $user = factory(User::class)->create();
+        $this->assertInstanceOf(User::class, $user);
+
+        $task = factory(Task::class)->make();
+        $this->assertInstanceOf(Task::class, $task);
+        $task->user()->associate($user);
+        $task->save();
+
+        $this->schema .= /** @lang GraphQL */ <<<'GRAPHQL'
+        type Task {
+            id: ID!
+            name: String!
+            latitude: Float
+            longitude: Float
+        }
+
+        type User {
+            id: ID!
+            name: String!
+            tasks: [Task!]! @hasMany
+        }
+
+        type Mutation {
+            updateUser(input: UpdateUserInput! @spread): User @update
+        }
+
+        input UpdateUserInput {
+            id: ID!
+            name: String
+            tasks: UpdateTaskRelation
+        }
+
+        input UpdateTaskRelation {
+            update: [UpdateTaskInput!]
+        }
+
+        input UpdateTaskInput {
+            id: ID!
+            name: String
+            location: LocationInput @geocode
+        }
+
+        input LocationInput {
+            lat: Float!
+            lng: Float!
+        }
+        GRAPHQL;
+
+        $this->graphQL(/** @lang GraphQL */ <<<GRAPHQL
+        mutation {
+            updateUser(input: {
+                id: {$user->id}
+                name: "Geo Update Parent"
+                tasks: {
+                    update: [{
+                        id: {$task->id}
+                        name: "Geo Update Task"
+                        location: {
+                            lat: 48.1351
+                            lng: 11.5820
+                        }
+                    }]
+                }
+            }) {
+                name
+                tasks {
+                    name
+                    latitude
+                    longitude
+                }
+            }
+        }
+        GRAPHQL)->assertJson([
+            'data' => [
+                'updateUser' => [
+                    'name' => 'Geo Update Parent',
+                    'tasks' => [
+                        [
+                            'name' => 'Geo Update Task',
+                            'latitude' => 48.1351,
+                            'longitude' => 11.582,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
 }

--- a/tests/Integration/Schema/Directives/UpsertDirectiveTest.php
+++ b/tests/Integration/Schema/Directives/UpsertDirectiveTest.php
@@ -550,6 +550,110 @@ GRAPHQL;
         $this->assertSame('baz', User::firstOrFail()->name);
     }
 
+    public function testCustomDirectiveSetsModelAttributesBeforeSaveInsideNestedHasMany(): void
+    {
+        $user = factory(User::class)->create();
+        $this->assertInstanceOf(User::class, $user);
+
+        $task = factory(Task::class)->make();
+        $this->assertInstanceOf(Task::class, $task);
+        $task->user()->associate($user);
+        $task->save();
+
+        $this->schema .= /** @lang GraphQL */ <<<'GRAPHQL'
+        type Task {
+            id: ID!
+            name: String!
+            latitude: Float
+            longitude: Float
+        }
+
+        type User {
+            id: ID!
+            name: String!
+            tasks: [Task!]! @hasMany
+        }
+
+        type Mutation {
+            updateUser(input: UpdateUserInput! @spread): User @update
+        }
+
+        input UpdateUserInput {
+            id: ID!
+            name: String
+            tasks: UpsertTaskRelation
+        }
+
+        input UpsertTaskRelation {
+            upsert: [UpsertTaskInput!]
+        }
+
+        input UpsertTaskInput {
+            id: ID
+            name: String
+            location: LocationInput @geocode
+        }
+
+        input LocationInput {
+            lat: Float!
+            lng: Float!
+        }
+        GRAPHQL;
+
+        $this->graphQL(/** @lang GraphQL */ <<<GRAPHQL
+        mutation {
+            updateUser(input: {
+                id: {$user->id}
+                name: "Geo Upsert Parent"
+                tasks: {
+                    upsert: [
+                        {
+                            id: {$task->id}
+                            name: "Geo Upserted Task"
+                            location: {
+                                lat: 48.1351
+                                lng: 11.5820
+                            }
+                        }
+                        {
+                            name: "Geo Inserted Task"
+                            location: {
+                                lat: 52.5200
+                                lng: 13.4050
+                            }
+                        }
+                    ]
+                }
+            }) {
+                name
+                tasks {
+                    name
+                    latitude
+                    longitude
+                }
+            }
+        }
+        GRAPHQL)->assertJson([
+            'data' => [
+                'updateUser' => [
+                    'name' => 'Geo Upsert Parent',
+                    'tasks' => [
+                        [
+                            'name' => 'Geo Upserted Task',
+                            'latitude' => 48.1351,
+                            'longitude' => 11.582,
+                        ],
+                        [
+                            'name' => 'Geo Inserted Task',
+                            'latitude' => 52.52,
+                            'longitude' => 13.405,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
     public static function resolveType(): Type
     {
         $typeRegistry = Container::getInstance()->make(TypeRegistry::class);

--- a/tests/Unit/Execution/Arguments/ArgPartitionerTest.php
+++ b/tests/Unit/Execution/Arguments/ArgPartitionerTest.php
@@ -138,31 +138,6 @@ final class ArgPartitionerTest extends TestCase
         );
     }
 
-    public function testSaveAwareArgResolverWithNonModelRootInWithoutPreSave(): void
-    {
-        $argumentSet = new ArgumentSet();
-
-        $regular = new Argument();
-        $argumentSet->arguments['regular'] = $regular;
-
-        $saveAware = new Argument();
-        $saveAware->directives->push(new SaveAwareNested());
-        $argumentSet->arguments['saveAware'] = $saveAware;
-
-        [$nestedArgs, $regularArgs] = ArgPartitioner::nestedArgResolversWithoutPreSave($argumentSet, null);
-
-        $this->assertSame(
-            ['regular' => $regular],
-            $regularArgs->arguments,
-        );
-
-        $this->assertSame(
-            ['saveAware' => $saveAware],
-            $nestedArgs->arguments,
-            'SaveAwareArgResolver should be in nested set when root is not a Model',
-        );
-    }
-
     public function testSaveAwareArgResolverWithModelRoot(): void
     {
         $argumentSet = new ArgumentSet();
@@ -174,7 +149,7 @@ final class ArgPartitionerTest extends TestCase
         $saveAware->directives->push(new SaveAwareNested());
         $argumentSet->arguments['saveAware'] = $saveAware;
 
-        [$nestedArgs, $regularArgs] = ArgPartitioner::nestedArgResolversWithoutPreSave($argumentSet, new User());
+        [$nestedArgs, $regularArgs] = ArgPartitioner::nestedArgResolvers($argumentSet, new User());
 
         $this->assertSame(
             ['regular' => $regular, 'saveAware' => $saveAware],

--- a/tests/Unit/Execution/Arguments/Fixtures/DecliningPreSaveSaver.php
+++ b/tests/Unit/Execution/Arguments/Fixtures/DecliningPreSaveSaver.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Execution\Arguments\Fixtures;
+
+use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
+use Nuwave\Lighthouse\Support\Contracts\ArgResolver;
+use Nuwave\Lighthouse\Support\Contracts\PreSaveArgumentsAware;
+
+final class DecliningPreSaveSaver implements ArgResolver, PreSaveArgumentsAware
+{
+    public bool $wasOfferedPreSaveArguments = false;
+
+    public ?ArgumentSet $receivedArgs = null;
+
+    public function withPreSaveArguments(array $arguments): ?static
+    {
+        $this->wasOfferedPreSaveArguments = true;
+
+        return null;
+    }
+
+    /** @param  ArgumentSet  $args */
+    public function __invoke(mixed $root, $args): mixed
+    {
+        $this->receivedArgs = $args;
+
+        return $root;
+    }
+}

--- a/tests/Unit/Execution/Arguments/ResolveNestedTest.php
+++ b/tests/Unit/Execution/Arguments/ResolveNestedTest.php
@@ -7,6 +7,7 @@ use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
 use Nuwave\Lighthouse\Execution\Arguments\ResolveNested;
 use Nuwave\Lighthouse\Schema\Directives\NestDirective;
 use Tests\TestCase;
+use Tests\Unit\Execution\Arguments\Fixtures\DecliningPreSaveSaver;
 use Tests\Unit\Execution\Arguments\Fixtures\SaveAwareNested;
 use Tests\Utils\Models\User;
 
@@ -53,6 +54,48 @@ final class ResolveNestedTest extends TestCase
             ['name' => $name],
             $passedToSaver->arguments,
             'Savers that cannot run pre-save arguments must not receive them',
+        );
+    }
+
+    /** Savers that decline the lifted arguments must still see their children resolved. */
+    public function testPreSaveResolverInsideNestRunsWhenSaverDeclinesPreSaveArguments(): void
+    {
+        $saveAwareResolver = new SaveAwareNested();
+
+        $preSaveChild = new Argument();
+        $preSaveChild->value = new ArgumentSet();
+        $preSaveChild->directives->push($saveAwareResolver);
+
+        $nestValue = new ArgumentSet();
+        $nestValue->arguments['location'] = $preSaveChild;
+
+        $nest = new Argument();
+        $nest->value = $nestValue;
+        $nest->directives->push(new NestDirective());
+
+        $name = new Argument();
+        $name->value = 'Sepp';
+
+        $argumentSet = new ArgumentSet();
+        $argumentSet->arguments['name'] = $name;
+        $argumentSet->arguments['nested'] = $nest;
+
+        $model = new User();
+        $saver = new DecliningPreSaveSaver();
+
+        $resolveNested = new ResolveNested($saver);
+        $resolveNested($model, $argumentSet);
+
+        $this->assertTrue($saver->wasOfferedPreSaveArguments, 'Pre-save arguments must be offered to savers implementing PreSaveArgumentsAware');
+        $this->assertTrue($saveAwareResolver->wasCalled, 'Pre-save resolvers inside @nest must run even when the saver declines to run them before save');
+        $this->assertSame($model, $saveAwareResolver->receivedRoot);
+
+        $receivedArgs = $saver->receivedArgs;
+        $this->assertInstanceOf(ArgumentSet::class, $receivedArgs);
+        $this->assertSame(
+            ['name' => $name],
+            $receivedArgs->arguments,
+            'Savers that declined the lifted arguments must not receive them',
         );
     }
 }

--- a/tests/Unit/Execution/Arguments/ResolveNestedTest.php
+++ b/tests/Unit/Execution/Arguments/ResolveNestedTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Execution\Arguments;
+
+use Nuwave\Lighthouse\Execution\Arguments\Argument;
+use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
+use Nuwave\Lighthouse\Execution\Arguments\ResolveNested;
+use Nuwave\Lighthouse\Schema\Directives\NestDirective;
+use Tests\TestCase;
+use Tests\Unit\Execution\Arguments\Fixtures\SaveAwareNested;
+use Tests\Utils\Models\User;
+
+final class ResolveNestedTest extends TestCase
+{
+    /** Savers that can not run pre-save arguments must still see their children resolved. */
+    public function testPreSaveResolverInsideNestRunsWhenSaverIsNotPreSaveAware(): void
+    {
+        $saveAwareResolver = new SaveAwareNested();
+
+        $preSaveChild = new Argument();
+        $preSaveChild->value = new ArgumentSet();
+        $preSaveChild->directives->push($saveAwareResolver);
+
+        $nestValue = new ArgumentSet();
+        $nestValue->arguments['location'] = $preSaveChild;
+
+        $nest = new Argument();
+        $nest->value = $nestValue;
+        $nest->directives->push(new NestDirective());
+
+        $name = new Argument();
+        $name->value = 'Sepp';
+
+        $argumentSet = new ArgumentSet();
+        $argumentSet->arguments['name'] = $name;
+        $argumentSet->arguments['nested'] = $nest;
+
+        $model = new User();
+        $passedToSaver = null;
+        $resolveNested = new ResolveNested(static function (mixed $root, ArgumentSet $args) use (&$passedToSaver): mixed {
+            $passedToSaver = $args;
+
+            return $root;
+        });
+
+        $resolveNested($model, $argumentSet);
+
+        $this->assertTrue($saveAwareResolver->wasCalled, 'Pre-save resolvers inside @nest must run even when the saver cannot run them before save');
+        $this->assertSame($model, $saveAwareResolver->receivedRoot);
+
+        $this->assertInstanceOf(ArgumentSet::class, $passedToSaver);
+        $this->assertSame(
+            ['name' => $name],
+            $passedToSaver->arguments,
+            'Savers that cannot run pre-save arguments must not receive them',
+        );
+    }
+}

--- a/tests/Utils/Directives/EmailAddressDirective.php
+++ b/tests/Utils/Directives/EmailAddressDirective.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Utils\Directives;
+
+use Illuminate\Database\Eloquent\Model;
+use Nuwave\Lighthouse\Execution\Arguments\ArgumentSet;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Nuwave\Lighthouse\Support\Contracts\SaveAwareArgResolver;
+
+final class EmailAddressDirective extends BaseDirective implements SaveAwareArgResolver
+{
+    public static function definition(): string
+    {
+        return /** @lang GraphQL */ <<<'GRAPHQL'
+        directive @emailAddress on INPUT_FIELD_DEFINITION
+        GRAPHQL;
+    }
+
+    public function runBeforeSave(Model $model): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param  Model  $model
+     * @param  ArgumentSet|null  $args
+     */
+    public function __invoke($model, $args): void
+    {
+        if ($args === null) {
+            return;
+        }
+
+        $parts = $args->toArray();
+        $model->setAttribute('email', "{$parts['local']}@{$parts['domain']}");
+    }
+}

--- a/tests/Utils/Models/Post.php
+++ b/tests/Utils/Models/Post.php
@@ -21,6 +21,8 @@ use Laravel\Scout\Searchable;
  * Attributes
  * @property string $title
  * @property string|null $body
+ * @property float|null $latitude
+ * @property float|null $longitude
  *
  * Timestamps
  * @property \Illuminate\Support\Carbon $created_at

--- a/tests/Utils/Models/Task.php
+++ b/tests/Utils/Models/Task.php
@@ -22,6 +22,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $name
  * @property int|null $difficulty
  * @property string|null $guard
+ * @property float|null $latitude
+ * @property float|null $longitude
  * @property \Illuminate\Support\Carbon $completed_at
  *
  * Timestamps

--- a/tests/database/migrations/2018_02_28_000003_create_testbench_tasks_table.php
+++ b/tests/database/migrations/2018_02_28_000003_create_testbench_tasks_table.php
@@ -16,6 +16,8 @@ final class CreateTestbenchTasksTable extends Migration
                 ->comment('The purpose of this property is to collide with a native model method name');
             $table->unsignedBigInteger('difficulty')->nullable();
             $table->unsignedBigInteger('user_id')->nullable();
+            $table->double('latitude')->nullable();
+            $table->double('longitude')->nullable();
             $table->timestamp('completed_at')->nullable();
             $table->timestamps();
             $table->softDeletes();

--- a/tests/database/migrations/2018_02_28_000004_create_testbench_posts_table.php
+++ b/tests/database/migrations/2018_02_28_000004_create_testbench_posts_table.php
@@ -15,6 +15,8 @@ final class CreateTestbenchPostsTable extends Migration
             $table->unsignedBigInteger('task_id');
             $table->unsignedBigInteger('user_id')->nullable();
             $table->unsignedBigInteger('parent_id')->nullable();
+            $table->double('latitude')->nullable();
+            $table->double('longitude')->nullable();
             $table->timestamps();
             $table->softDeletes();
         });


### PR DESCRIPTION
Fixes a regression from https://github.com/nuwave/lighthouse/pull/2777 (v6.68.0) where `SaveAwareArgResolver::runBeforeSave()` was only honoured at the top level of a mutation. One level down inside nested HasMany/HasOne/ManyToMany/BelongsTo mutations, the pre-save resolver ran AFTER the child model was already persisted — silently discarding its attribute changes.

The root cause: `ResolveNested` defaulted to a partitioner that unconditionally routed all resolver-bearing args into the post-save set. Only `ModelMutationDirective::executeMutation()` overrode this with the pre-save-aware variant; all 12 nested resolver call sites used the broken default.

The fix collapses `nestedArgResolversWithoutPreSave` into `nestedArgResolvers` so the correct behavior is the default everywhere. When root is not a Model, behavior is unchanged. When root is a Model, `SaveAwareArgResolver` instances with `runBeforeSave=true` stay in the regular set so `SaveModel` executes them before persisting. The now-redundant explicit partitioner in `ModelMutationDirective` is removed.

Coverage spans the `create`, `update` and `upsert` branches of nested relation mutations, since all three build `ResolveNested` with the same default partitioner. Each new test fails without the fix, leaving the attributes null.

## Second fix: silent data loss when a `@nest` child collides with a sibling

Making `nestedArgResolvers` the default widened the reach of a separate, pre-existing bug (from https://github.com/nuwave/lighthouse/pull/2764, v6.68.0): lifting pre-save resolvers out of `@nest` wrote them into the flat regular set keyed by the child's bare field name. Field names are unique per input type, not across an input tree, so a name coincidence silently discarded an argument. Three ways to lose data:

1. A plain sibling `difficulty: Int` next to a `@nest` child `difficulty: LocationInput @geocode` — different columns, no semantic conflict, yet `difficulty` persisted as null.
2. Same-named children of two sibling `@nest` blocks — one resolver silently never ran.
3. A `@nest` child named `id` clobbering the primary key that `UpdateModel` and `UpsertModel` consume to identify the row.

Widening the default also turned case 3 into a hard error where the colliding name matched a relation operation namespace (`create`/`update`/…), since `NestedOneToMany` and friends then iterate an `ArgumentSet` where they expect a list.

Resolvers are not name-addressed — `SaveModel` iterates them by value and discards the keys — so lifted resolvers now travel as an ordered list rather than a name-keyed map, handed to the saver through the new `PreSaveArgumentsAware` interface. Lifting also no longer mutates the nest it reads from, which matters because `FieldValue` caches transformed argument sets per path and `@spread` shares `Argument` objects across rebuilt sets.

The capability check is what keeps this non-regressive: `UpdateModel` and `UpsertModel` forward it to their own `previous` (via the shared `DelegatesPreSaveArguments` trait), and a saver that can not consume the list gets nothing lifted, so its children run post-save exactly as on master. Both declining paths are covered by unit tests: a `previous` that does not implement the interface, and one that implements it but returns `null`. Third-party savers built as `new ResolveNested($closure)` — the pattern documented in `docs/master/concepts/arg-resolvers.md` — fall into the first case.

All colliding resolvers now run in schema order, so the last write wins where two of them target the same column. The interface is deliberately not marked `@api`.

Still open, and out of scope here: `@nest` inside a relation operation namespace has its lifted pre-save resolvers ignored entirely, because `NestedOneToMany` and friends never consume them. The hard error is gone; whether `@nest` should be legal there at all is a separate design question.

One unrelated commit names the `strict` flag on the existing `in_array()` calls in `src/`, which is purely cosmetic and easy to drop if you would rather keep it out.

🤖 Generated with Claude Code