### PR TITLE
Cache query AST as an array in store mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Cache the query AST as an array in `query_cache.mode: store`, so restricting `cache.serializable_classes` no longer makes the cached AST come back as `__PHP_Incomplete_Class` https://github.com/nuwave/lighthouse/pull/2785
+
 ## v6.69.2
 
 ### Fixed

--- a/src/Cache/QueryCache.php
+++ b/src/Cache/QueryCache.php
@@ -80,8 +80,24 @@ class QueryCache
     protected function fromStoreOrParse(string $hash, \Closure $parse): DocumentNode
     {
         $store = $this->makeCacheStore();
+        $key = "lighthouse:query:{$hash}";
 
-        return $store->remember(key: "lighthouse:query:{$hash}", ttl: $this->ttl, callback: $parse);
+        // The AST is cached as an array rather than as a DocumentNode instance.
+        // Cache stores serialize objects, and applications may restrict which classes
+        // unserialize() accepts, which would turn the AST into __PHP_Incomplete_Class.
+        // Anything else found under this key predates that and is simply reparsed.
+        $astArray = $store->get(key: $key);
+        if (is_array($astArray)) {
+            $astInstance = AST::fromArray($astArray);
+            assert($astInstance instanceof DocumentNode, 'The cached AST array is expected to convert to a DocumentNode.');
+
+            return $astInstance;
+        }
+
+        $query = $parse();
+        $store->put(key: $key, value: $query->toArray(), ttl: $this->ttl);
+
+        return $query;
     }
 
     /** @param  \Closure(): DocumentNode  $parse */

--- a/tests/Integration/QueryCacheTest.php
+++ b/tests/Integration/QueryCacheTest.php
@@ -54,6 +54,39 @@ final class QueryCacheTest extends TestCase
         $event->assertDispatchedTimes(KeyWritten::class, 1);
     }
 
+    public function testStoreModeWithRestrictedSerializableClasses(): void
+    {
+        $config = $this->app->make(ConfigRepository::class);
+        $config->set('lighthouse.query_cache.enable', true);
+        $config->set('lighthouse.validation_cache.enable', false);
+
+        // Laravel 13 lets applications restrict which classes may be unserialized from the cache.
+        // Any store that serializes values then calls unserialize() with `allowed_classes`,
+        // turning every disallowed object back into __PHP_Incomplete_Class.
+        $config->set('cache.stores.array.serialize', true);
+        $config->set('cache.serializable_classes', []);
+
+        $query = /** @lang GraphQL */ <<<'GRAPHQL'
+        {
+            foo
+        }
+        GRAPHQL;
+
+        // Populates the query cache.
+        $this->graphQL($query)->assertExactJson([
+            'data' => [
+                'foo' => Foo::THE_ANSWER,
+            ],
+        ]);
+
+        // Reads the cached query back out of the store.
+        $this->graphQL($query)->assertExactJson([
+            'data' => [
+                'foo' => Foo::THE_ANSWER,
+            ],
+        ]);
+    }
+
     public function testDifferentQueriesHasDifferentKeys(): void
     {
         $config = $this->app->make(ConfigRepository::class);


### PR DESCRIPTION
Resolves #2782

- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md (skip for docs-only changes)

**Changes**

`query_cache.mode: store` handed the `DocumentNode` straight to the cache store:

```php
return $store->remember(key: "lighthouse:query:{$hash}", ttl: $this->ttl, callback: $parse);
```

Cache stores serialize what they are given. Laravel 13 lets an application limit which
classes come back out again through `cache.serializable_classes`, which every serializing
store reads before unserializing:

```php
// Illuminate\Cache\RedisStore::unserialize(), same in DatabaseStore, FileStore, ArrayStore
if ($this->serializableClasses !== null) {
    return unserialize($value, ['allowed_classes' => $this->serializableClasses]);
}
```

Once that list is set and does not name every AST node class, the cached query comes back
as `__PHP_Incomplete_Class` and `fromStoreOrParse()` fails its return type on the second
request. Whitelisting the AST is not a practical workaround, since it would mean naming
every node class in `webonyx/graphql-php` and keeping that list current.

So this caches the array form instead of the object, which is what `mode: opcache` already
does via `opcacheFileContents()` and `requireOPcacheFile()`. Arrays are unaffected by
`allowed_classes`, so the AST survives regardless of how a store is configured.

The `remember()` call is replaced with the explicit `get()`/`put()` pair that
`fromHybridOrParse()` already uses, so anything found under the key that is not an array
is simply reparsed and overwritten. Caches populated by an older version therefore recover
by themselves on the next request, with no flush needed on upgrade.

Verified on PHP 8.4.20 / Laravel 13.23.0 / webonyx/graphql-php 15.37.1. The added test
fails on current `master` with exactly the reported error and passes with this change:

```
TypeError: Nuwave\Lighthouse\Cache\QueryCache::fromStoreOrParse(): Return value must be
of type GraphQL\Language\AST\DocumentNode, __PHP_Incomplete_Class returned
src/Cache/QueryCache.php:84
src/Cache/QueryCache.php:72
src/GraphQL.php:287
```

It reproduces through the `array` store with `serialize` enabled, so it needs no Redis or
database. The rest of `QueryCacheTest` is unchanged by this commit.

**Breaking changes**

None. The cache key is unchanged, entries written by older versions are detected and
reparsed rather than failing, and the public API is untouched.
