### PR TITLE
Apply can directive action when the field resolves to a promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Apply the `action` of `@canResolved` and friends when the field resolves to a promise, such as a batch loaded relation https://github.com/nuwave/lighthouse/pull/2786
+
 ## v6.69.2
 
 ### Fixed

--- a/src/Auth/BaseCanDirective.php
+++ b/src/Auth/BaseCanDirective.php
@@ -2,6 +2,7 @@
 
 namespace Nuwave\Lighthouse\Auth;
 
+use GraphQL\Executor\Promise\Adapter\SyncPromise;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Nuwave\Lighthouse\Execution\ResolveInfo;
@@ -103,24 +104,36 @@ GRAPHQL;
             try {
                 $resolved = $this->authorizeRequest($root, $args, $context, $resolveInfo, $trackedResolver, $authorizeModel);
                 if ($hasResolved) {
-                    return $resolved;
+                    // A batch loaded relation resolves to a promise, so authorization runs when
+                    // that promise is fulfilled, which is after this try-catch has been left.
+                    // Handle its failure the same way to keep `action` meaningful either way.
+                    return $resolved instanceof SyncPromise
+                        ? $resolved->then(null, fn (\Throwable $throwable): mixed => $this->handleAuthorizationFailure($throwable))
+                        : $resolved;
                 }
             } catch (\Throwable $throwable) {
-                $action = $this->directiveArgValue('action');
-                if ($action === 'EXCEPTION_NOT_AUTHORIZED') {
-                    throw new AuthorizationException(AuthorizationException::MESSAGE, $throwable->getCode(), $throwable);
-                }
-
-                if ($action === 'RETURN_VALUE') {
-                    return $this->directiveArgValue('returnValue');
-                }
-
-                throw $throwable;
+                return $this->handleAuthorizationFailure($throwable);
             }
 
             // Try to resolve the field outside the authorization try-catch block to avoid catching resolver exceptions.
             return $resolver($root, $args, $context, $resolveInfo);
         });
+    }
+
+    /** Apply the configured `action` to an authorization failure. */
+    protected function handleAuthorizationFailure(\Throwable $throwable): mixed
+    {
+        $action = $this->directiveArgValue('action');
+
+        if ($action === 'EXCEPTION_NOT_AUTHORIZED') {
+            throw new AuthorizationException(AuthorizationException::MESSAGE, $throwable->getCode(), $throwable);
+        }
+
+        if ($action === 'RETURN_VALUE') {
+            return $this->directiveArgValue('returnValue');
+        }
+
+        throw $throwable;
     }
 
     /**

--- a/tests/Integration/Auth/CanResolvedDirectiveDBTest.php
+++ b/tests/Integration/Auth/CanResolvedDirectiveDBTest.php
@@ -100,6 +100,52 @@ final class CanResolvedDirectiveDBTest extends DBTestCase
         ]);
     }
 
+    public function testReturnValueActionAppliesToBatchloadedRelation(): void
+    {
+        $viewer = new User();
+        $viewer->name = 'not an admin';
+        $this->be($viewer);
+
+        $company = factory(Company::class)->create();
+
+        $user = factory(User::class)->make();
+        $this->assertInstanceOf(User::class, $user);
+        $user->company()->associate($company);
+        $user->save();
+
+        $this->schema = /** @lang GraphQL */ <<<'GRAPHQL'
+        type Query {
+            company: Company @first
+        }
+
+        type Company {
+            users: [User!]
+                @canResolved(ability: "adminOnly", action: RETURN_VALUE, returnValue: null)
+                @hasMany
+        }
+
+        type User {
+            name: String
+        }
+        GRAPHQL;
+
+        $this->graphQL(/** @lang GraphQL */ <<<'GRAPHQL'
+        {
+            company {
+                users {
+                    name
+                }
+            }
+        }
+        GRAPHQL)->assertJson([
+            'data' => [
+                'company' => [
+                    'users' => null,
+                ],
+            ],
+        ])->assertJsonMissingPath('errors');
+    }
+
     public function testChecksAgainstMissingResolvedModelWithFind(): void
     {
         $user = new User();


### PR DESCRIPTION
Resolves #2758

- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md (skip for docs-only changes)

**Changes**

`BaseCanDirective` decides what to do with an authorization failure based on the `action`
argument, but it only sees failures thrown synchronously:

```php
try {
    $resolved = $this->authorizeRequest(...);
    if ($hasResolved) {
        return $resolved;
    }
} catch (\Throwable $throwable) {
    // EXCEPTION_NOT_AUTHORIZED / RETURN_VALUE handled here
}
```

`CanResolvedDirective` authorizes through `Resolved::handle()`, which chains onto a promise
when it gets one:

```php
if ($resolved instanceof SyncPromise) {
    return $resolved->then($handle);
}

return $handle($resolved);
```

With `batchload_relations` enabled a relation resolves to a `SyncPromise`, so `$handle`
runs when that promise is fulfilled, which is after the try-catch above has been left. The
`AuthorizationException` escapes it, and `action` is ignored: `RETURN_VALUE` never returns
its value and `EXCEPTION_NOT_AUTHORIZED` never rewrites the message. Turning
`batchload_relations` off makes the same schema behave as documented, which is what makes
this surprising.

The `catch` body moves into `handleAuthorizationFailure()` and is also chained onto the
promise as a rejection handler, so the `action` applies whether the field resolves eagerly
or through a batch loader.

The added test covers a batch loaded `@hasMany` guarded by
`@canResolved(action: RETURN_VALUE, returnValue: null)`. On current `master` the field
comes back `null` but an `This action is unauthorized.` error is reported alongside it,
which is exactly the ignored `action`. With this change the field is `null` and no error is
reported.

Verified on PHP 8.3.33 / Laravel 13.23.0 against MySQL and Redis, using the repository's
own Docker setup. All 90 tests across `CanDirective`, `CanFindDirective`, `CanModelDirective`,
`CanQueryDirective`, `CanResolvedDirective` and `CanRootDirective` pass.

**Breaking changes**

None for schemas that behaved correctly already. Fields that previously leaked an
authorization error despite `action: RETURN_VALUE` now return the configured value, which
is the documented behavior and the point of the fix.
