### PR TITLE
Let explicitly resolved directive classes win in classes()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- Add `DirectiveLocator::disable()` to make a directive unavailable, leaving its definition out of the schema https://github.com/nuwave/lighthouse/pull/2787
+
+### Changed
+
+- Let classes passed to `DirectiveLocator::setResolved()` take precedence in `DirectiveLocator::classes()` and thus `DirectiveLocator::definitions()` https://github.com/nuwave/lighthouse/pull/2787
+
 ## v6.69.2
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
-### Added
-
-- Add `DirectiveLocator::disable()` to make a directive unavailable, leaving its definition out of the schema https://github.com/nuwave/lighthouse/pull/2787
-
 ### Changed
 
 - Let classes passed to `DirectiveLocator::setResolved()` take precedence in `DirectiveLocator::classes()` and thus `DirectiveLocator::definitions()` https://github.com/nuwave/lighthouse/pull/2787

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Changed
 
-- Let classes passed to `DirectiveLocator::setResolved()` take precedence in `DirectiveLocator::classes()` and thus `DirectiveLocator::definitions()` https://github.com/nuwave/lighthouse/pull/2787
+- Classes passed to `DirectiveLocator::setResolved()` take precedence in `DirectiveLocator::classes()` and `DirectiveLocator::definitions()` https://github.com/nuwave/lighthouse/pull/2787
 
 ## v6.69.2
 

--- a/docs/master/custom-directives/getting-started.md
+++ b/docs/master/custom-directives/getting-started.md
@@ -103,25 +103,3 @@ When Lighthouse encounters a directive within the schema, it starts looking for 
 
 This means that our directive is already registered, just by matter of defining it in the default namespace.
 Will take precedence over potential other directives with the same name.
-
-## Override A Single Directive
-
-Namespace precedence is coarse: it applies to all directives of a namespace at once.
-To control a single directive name, bind its class explicitly in a service provider:
-
-```php
-namespace App\Providers;
-
-use Illuminate\Support\ServiceProvider;
-use Nuwave\Lighthouse\Schema\DirectiveLocator;
-use Nuwave\Lighthouse\Schema\Directives\PaginateDirective;
-
-class GraphQLServiceProvider extends ServiceProvider
-{
-    public function boot(DirectiveLocator $directiveLocator): void
-    {
-        // Use the built-in directive, even though a plugin defines its own @paginate
-        $directiveLocator->setResolved('paginate', PaginateDirective::class);
-    }
-}
-```

--- a/docs/master/custom-directives/getting-started.md
+++ b/docs/master/custom-directives/getting-started.md
@@ -104,7 +104,7 @@ When Lighthouse encounters a directive within the schema, it starts looking for 
 This means that our directive is already registered, just by matter of defining it in the default namespace.
 Will take precedence over potential other directives with the same name.
 
-## Override Or Disable Directives
+## Override A Single Directive
 
 Namespace precedence is coarse: it applies to all directives of a namespace at once.
 To control a single directive name, bind its class explicitly in a service provider:
@@ -122,12 +122,6 @@ class GraphQLServiceProvider extends ServiceProvider
     {
         // Use the built-in directive, even though a plugin defines its own @paginate
         $directiveLocator->setResolved('paginate', PaginateDirective::class);
-
-        // Forbid @field, e.g. to enforce that resolvers live in the configured namespaces
-        $directiveLocator->disable('field');
     }
 }
 ```
-
-A disabled directive behaves as if it did not exist: its definition is left out of the schema
-and using it fails schema validation with an unknown directive error.

--- a/docs/master/custom-directives/getting-started.md
+++ b/docs/master/custom-directives/getting-started.md
@@ -103,3 +103,31 @@ When Lighthouse encounters a directive within the schema, it starts looking for 
 
 This means that our directive is already registered, just by matter of defining it in the default namespace.
 Will take precedence over potential other directives with the same name.
+
+## Override Or Disable Directives
+
+Namespace precedence is coarse: it applies to all directives of a namespace at once.
+To control a single directive name, bind its class explicitly in a service provider:
+
+```php
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Nuwave\Lighthouse\Schema\DirectiveLocator;
+use Nuwave\Lighthouse\Schema\Directives\PaginateDirective;
+
+class GraphQLServiceProvider extends ServiceProvider
+{
+    public function boot(DirectiveLocator $directiveLocator): void
+    {
+        // Use the built-in directive, even though a plugin defines its own @paginate
+        $directiveLocator->setResolved('paginate', PaginateDirective::class);
+
+        // Forbid @field, e.g. to enforce that resolvers live in the configured namespaces
+        $directiveLocator->disable('field');
+    }
+}
+```
+
+A disabled directive behaves as if it did not exist: its definition is left out of the schema
+and using it fails schema validation with an unknown directive error.

--- a/src/Schema/DirectiveLocator.php
+++ b/src/Schema/DirectiveLocator.php
@@ -79,8 +79,6 @@ class DirectiveLocator
      */
     public function classes(): array
     {
-        $directives = $this->resolvedClassnames;
-
         foreach ($this->namespaces() as $directiveNamespace) {
             /** @var array<class-string> $classesInNamespace */
             $classesInNamespace = ClassFinder::getClassesInNamespace($directiveNamespace);
@@ -96,11 +94,11 @@ class DirectiveLocator
                 }
 
                 // Only add the first directive that was found
-                $directives[self::directiveName($class)] ??= $class;
+                $this->resolvedClassnames[self::directiveName($class)] ??= $class;
             }
         }
 
-        return $directives;
+        return $this->resolvedClassnames;
     }
 
     /**

--- a/src/Schema/DirectiveLocator.php
+++ b/src/Schema/DirectiveLocator.php
@@ -33,16 +33,15 @@ class DirectiveLocator
     /**
      * A map from short directive names to full class names.
      *
-     * Takes precedence over the namespaces, `null` marks a directive as disabled.
+     * Takes precedence over the namespaces.
      *
      * E.g.
      * [
      *   'create' => 'Nuwave\Lighthouse\Schema\Directives\CreateDirective',
      *   'custom' => 'App\GraphQL\Directives\CustomDirective',
-     *   'field' => null,
      * ]
      *
-     * @var array<string, class-string<\Nuwave\Lighthouse\Support\Contracts\Directive>|null>
+     * @var array<string, class-string<\Nuwave\Lighthouse\Support\Contracts\Directive>>
      */
     protected array $resolvedClassnames = [];
 
@@ -96,15 +95,12 @@ class DirectiveLocator
                     continue;
                 }
 
-                // Only add the first directive that was found, keeping disabled ones out
-                $directiveName = self::directiveName($class);
-                if (! array_key_exists($directiveName, $directives)) {
-                    $directives[$directiveName] = $class;
-                }
+                // Only add the first directive that was found
+                $directives[self::directiveName($class)] ??= $class;
             }
         }
 
-        return array_filter($directives);
+        return $directives;
     }
 
     /**
@@ -139,12 +135,7 @@ class DirectiveLocator
     public function resolve(string $directiveName): string
     {
         if (array_key_exists($directiveName, $this->resolvedClassnames)) {
-            $resolvedClassname = $this->resolvedClassnames[$directiveName];
-            if ($resolvedClassname === null) {
-                throw self::noDirectiveFound($directiveName);
-            }
-
-            return $resolvedClassname;
+            return $this->resolvedClassnames[$directiveName];
         }
 
         foreach ($this->namespaces() as $directiveNamespace) {
@@ -163,12 +154,7 @@ class DirectiveLocator
             }
         }
 
-        throw self::noDirectiveFound($directiveName);
-    }
-
-    protected static function noDirectiveFound(string $directiveName): DirectiveException
-    {
-        return new DirectiveException("No directive found for `{$directiveName}`");
+        throw new DirectiveException("No directive found for `{$directiveName}`");
     }
 
     /** Returns the expected class name for a directive name. */
@@ -187,22 +173,12 @@ class DirectiveLocator
         );
     }
 
-    /** @param  class-string<\Nuwave\Lighthouse\Support\Contracts\Directive>|null  $directiveClass */
-    public function setResolved(string $directiveName, ?string $directiveClass): self
+    /** @param  class-string<\Nuwave\Lighthouse\Support\Contracts\Directive>  $directiveClass */
+    public function setResolved(string $directiveName, string $directiveClass): self
     {
         $this->resolvedClassnames[$directiveName] = $directiveClass;
 
         return $this;
-    }
-
-    /**
-     * Make a directive unavailable, as if it did not exist.
-     *
-     * Its definition is left out of the schema and using it fails validation.
-     */
-    public function disable(string $directiveName): self
-    {
-        return $this->setResolved($directiveName, null);
     }
 
     /**

--- a/src/Schema/DirectiveLocator.php
+++ b/src/Schema/DirectiveLocator.php
@@ -33,13 +33,16 @@ class DirectiveLocator
     /**
      * A map from short directive names to full class names.
      *
+     * Takes precedence over the namespaces, `null` marks a directive as disabled.
+     *
      * E.g.
      * [
      *   'create' => 'Nuwave\Lighthouse\Schema\Directives\CreateDirective',
      *   'custom' => 'App\GraphQL\Directives\CustomDirective',
+     *   'field' => null,
      * ]
      *
-     * @var array<string, class-string<\Nuwave\Lighthouse\Support\Contracts\Directive>>
+     * @var array<string, class-string<\Nuwave\Lighthouse\Support\Contracts\Directive>|null>
      */
     protected array $resolvedClassnames = [];
 
@@ -77,7 +80,7 @@ class DirectiveLocator
      */
     public function classes(): array
     {
-        $directives = [];
+        $directives = $this->resolvedClassnames;
 
         foreach ($this->namespaces() as $directiveNamespace) {
             /** @var array<class-string> $classesInNamespace */
@@ -93,12 +96,15 @@ class DirectiveLocator
                     continue;
                 }
 
-                // Only add the first directive that was found
-                $directives[self::directiveName($class)] ??= $class;
+                // Only add the first directive that was found, keeping disabled ones out
+                $directiveName = self::directiveName($class);
+                if (! array_key_exists($directiveName, $directives)) {
+                    $directives[$directiveName] = $class;
+                }
             }
         }
 
-        return $directives;
+        return array_filter($directives);
     }
 
     /**
@@ -133,7 +139,12 @@ class DirectiveLocator
     public function resolve(string $directiveName): string
     {
         if (array_key_exists($directiveName, $this->resolvedClassnames)) {
-            return $this->resolvedClassnames[$directiveName];
+            $resolvedClassname = $this->resolvedClassnames[$directiveName];
+            if ($resolvedClassname === null) {
+                throw self::noDirectiveFound($directiveName);
+            }
+
+            return $resolvedClassname;
         }
 
         foreach ($this->namespaces() as $directiveNamespace) {
@@ -152,7 +163,12 @@ class DirectiveLocator
             }
         }
 
-        throw new DirectiveException("No directive found for `{$directiveName}`");
+        throw self::noDirectiveFound($directiveName);
+    }
+
+    protected static function noDirectiveFound(string $directiveName): DirectiveException
+    {
+        return new DirectiveException("No directive found for `{$directiveName}`");
     }
 
     /** Returns the expected class name for a directive name. */
@@ -171,12 +187,22 @@ class DirectiveLocator
         );
     }
 
-    /** @param  class-string<\Nuwave\Lighthouse\Support\Contracts\Directive>  $directiveClass */
-    public function setResolved(string $directiveName, string $directiveClass): self
+    /** @param  class-string<\Nuwave\Lighthouse\Support\Contracts\Directive>|null  $directiveClass */
+    public function setResolved(string $directiveName, ?string $directiveClass): self
     {
         $this->resolvedClassnames[$directiveName] = $directiveClass;
 
         return $this;
+    }
+
+    /**
+     * Make a directive unavailable, as if it did not exist.
+     *
+     * Its definition is left out of the schema and using it fails validation.
+     */
+    public function disable(string $directiveName): self
+    {
+        return $this->setResolved($directiveName, null);
     }
 
     /**

--- a/tests/Unit/Schema/DirectiveLocatorTest.php
+++ b/tests/Unit/Schema/DirectiveLocatorTest.php
@@ -85,23 +85,6 @@ final class DirectiveLocatorTest extends TestCase
         $this->assertSame(ComplexityDirective::class, $this->directiveLocator->classes()['field']);
     }
 
-    public function testThrowsIfDirectiveIsDisabled(): void
-    {
-        $this->directiveLocator->disable('field');
-
-        $this->expectException(DirectiveException::class);
-        $this->expectExceptionMessage('No directive found for `field`');
-
-        $this->directiveLocator->create('field');
-    }
-
-    public function testOmitsDefinitionOfDisabledDirective(): void
-    {
-        $this->directiveLocator->disable('field');
-
-        $this->assertArrayNotHasKey('field', $this->directiveLocator->classes());
-    }
-
     public function testThrowsIfDirectiveNameCanNotBeResolved(): void
     {
         $this->expectException(DirectiveException::class);

--- a/tests/Unit/Schema/DirectiveLocatorTest.php
+++ b/tests/Unit/Schema/DirectiveLocatorTest.php
@@ -6,6 +6,7 @@ use GraphQL\Language\Parser;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Schema\DirectiveLocator;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Nuwave\Lighthouse\Schema\Directives\ComplexityDirective;
 use Nuwave\Lighthouse\Schema\Directives\FieldDirective;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
@@ -75,6 +76,30 @@ final class DirectiveLocatorTest extends TestCase
             ->first();
 
         $this->assertNotInstanceOf(BaseDirective::class, $directive);
+    }
+
+    public function testResolvesExplicitlySetClassInsteadOfScannedNamespaces(): void
+    {
+        $this->directiveLocator->setResolved('field', ComplexityDirective::class);
+
+        $this->assertSame(ComplexityDirective::class, $this->directiveLocator->classes()['field']);
+    }
+
+    public function testThrowsIfDirectiveIsDisabled(): void
+    {
+        $this->directiveLocator->disable('field');
+
+        $this->expectException(DirectiveException::class);
+        $this->expectExceptionMessage('No directive found for `field`');
+
+        $this->directiveLocator->create('field');
+    }
+
+    public function testOmitsDefinitionOfDisabledDirective(): void
+    {
+        $this->directiveLocator->disable('field');
+
+        $this->assertArrayNotHasKey('field', $this->directiveLocator->classes());
     }
 
     public function testThrowsIfDirectiveNameCanNotBeResolved(): void

--- a/tests/Unit/Schema/DirectiveLocatorTest.php
+++ b/tests/Unit/Schema/DirectiveLocatorTest.php
@@ -6,12 +6,12 @@ use GraphQL\Language\Parser;
 use Nuwave\Lighthouse\Exceptions\DirectiveException;
 use Nuwave\Lighthouse\Schema\DirectiveLocator;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
-use Nuwave\Lighthouse\Schema\Directives\ComplexityDirective;
 use Nuwave\Lighthouse\Schema\Directives\FieldDirective;
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
 use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
 use Nuwave\Lighthouse\Support\Utils;
+use Tests\Integration\Events\FieldDirective as AlternateFieldDirective;
 use Tests\TestCase;
 
 final class DirectiveLocatorTest extends TestCase
@@ -80,9 +80,9 @@ final class DirectiveLocatorTest extends TestCase
 
     public function testResolvesExplicitlySetClassInsteadOfScannedNamespaces(): void
     {
-        $this->directiveLocator->setResolved('field', ComplexityDirective::class);
+        $this->directiveLocator->setResolved('field', AlternateFieldDirective::class);
 
-        $this->assertSame(ComplexityDirective::class, $this->directiveLocator->classes()['field']);
+        $this->assertSame(AlternateFieldDirective::class, $this->directiveLocator->classes()['field']);
     }
 
     public function testThrowsIfDirectiveNameCanNotBeResolved(): void


### PR DESCRIPTION
DirectiveLocator::setResolved() already took precedence in resolve(), but classes() only scanned the namespaces, so definitions() could print a directive definition that differs from the directive that actually executes. This also makes it possible to pin a single directive name across namespaces, e.g. to keep a built-in directive that a plugin shadows.

The branch history starts from an attempt to also add DirectiveLocator::disable(), which turned out to be unsafe and was dropped: Lighthouse resolves the fields generated by @paginate, @node and federation through @field, so disabling @field broke those schemas. Users cannot know which built-ins are used internally, so a ban has to be enforced by whoever parses the hand-written schema instead.