### PR TITLE
Throw client-safe errors for malformed date literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Throw client-safe errors for malformed date literals instead of reporting them as server errors https://github.com/nuwave/lighthouse/pull/2788
+
 ## v6.70.0
 
 ### Changed

--- a/src/Schema/Types/Scalars/DateScalar.php
+++ b/src/Schema/Types/Scalars/DateScalar.php
@@ -45,7 +45,7 @@ abstract class DateScalar extends ScalarType
         try {
             return $this->parse($value);
         } catch (\Exception $exception) {
-            throw Error::createLocatedError($exception, $valueNode);
+            throw new Error($exception->getMessage(), $valueNode);
         }
     }
 

--- a/tests/Unit/Schema/Types/Scalars/DateScalarTestBase.php
+++ b/tests/Unit/Schema/Types/Scalars/DateScalarTestBase.php
@@ -107,6 +107,25 @@ abstract class DateScalarTestBase extends TestCase
         );
     }
 
+    public function testThrowsClientSafeErrorIfParseLiteralInvalidDate(): void
+    {
+        $error = null;
+
+        try {
+            $this->scalarInstance()->parseLiteral(
+                new StringValueNode(['value' => 'rolf']),
+            );
+        } catch (Error $caught) {
+            $error = $caught;
+        }
+
+        $this->assertInstanceOf(Error::class, $error);
+        $this->assertTrue(
+            $error->isClientSafe(),
+            'A malformed date literal is client misuse, so it must not be reported as a server error.',
+        );
+    }
+
     public function testSerializesCarbonInstance(): void
     {
         $now = IlluminateCarbon::now();


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md (skip for docs-only changes)

**Changes**

A malformed date is handled differently depending on whether it arrives as a query **literal** or as a **variable**. As a variable it is a client error. As a literal it is classified as a server fault: the message is masked as `"Internal server error"` and the exception is passed to the application's error reporter.

`parseValue()` → `tryParsingDate()` rethrows without a previous:

```php
throw new $exceptionClass($exception->getMessage()); // previous = null → client-safe
```

`parseLiteral()` preserved it:

```php
throw Error::createLocatedError($exception, $valueNode); // previous = InvalidFormatException
```

`Carbon\Exceptions\InvalidFormatException` does not implement `ClientAware`, so `Error::__construct` sets `isClientSafe = false`. `FormattedError` then masks the message, and `ReportingErrorHandler` forwards the exception to `ExceptionHandler::report()`.

This affects `Date`, `DateTime`, `DateTimeTz` and `DateTimeUtc`, which all inherit `parseLiteral` from `DateScalar`.

The fix throws a client-safe error while keeping `$valueNode`, so `locations` is unchanged:

```php
throw new Error($exception->getMessage(), $valueNode);
```

The added test lives in `DateScalarTestBase`, so it covers all four scalars. It fails on all four before the change:

```
4) Tests\Unit\Schema\Types\Scalars\DateTimeUtcTest::testThrowsClientSafeErrorIfParseLiteralInvalidDate
A malformed date literal is client misuse, so it must not be reported as a server error.
Failed asserting that false is true.

Tests: 4, Assertions: 8, Failures: 4.
```

The existing suite already covered `parseValue` with an invalid date and `parseLiteral` with a non-string node, but not `parseLiteral` with a malformed date string — which is why this went unnoticed.

We hit this on a `Date` query argument in production: roughly 6,200 reported exceptions from one client sending `YYYY/MM/DD`, each surfacing as a masked `"Internal server error"` rather than a usable validation message.

**Breaking changes**

None. Malformed literals still throw an `Error` with the same message and locations; only `isClientSafe` changes, so the error is no longer masked or reported. Valid values, `parseValue` and `serialize` are untouched.